### PR TITLE
Implement node order over OPC UA

### DIFF
--- a/core/opendaq/opendaq/mocks/CMakeLists.txt
+++ b/core/opendaq/opendaq/mocks/CMakeLists.txt
@@ -14,6 +14,8 @@ set(MOCK_HEADERS mock_device_module.h
                  mock_server_factory.h
                  mock_streaming.h
                  mock_streaming_factory.h
+                 default_mocks.h
+                 default_mocks_factory.h
 )
 
 opendaq_prepend_path(include/${SDK_TARGET_NAME}/mock MOCK_HEADERS)
@@ -27,6 +29,7 @@ set(MOCK_SOURCES mock_device_module.cpp
                  mock_server_module.cpp
                  mock_server.cpp
                  mock_streaming.cpp
+                 default_mocks.cpp
 )
 
 source_group("mock" FILES ${MOCK_HEADERS}

--- a/core/opendaq/opendaq/mocks/default_mocks.cpp
+++ b/core/opendaq/opendaq/mocks/default_mocks.cpp
@@ -1,0 +1,33 @@
+#include <opendaq/mock/default_mocks.h>
+#include <opendaq/channel_impl.h>
+#include <opendaq/device_impl.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
+    INTERNAL_FACTORY, Channel,
+    IChannel, createDefaultChannel,
+    IFunctionBlockType*, fbType,
+    IContext*, context,
+    IComponent*, parent,
+    IString*, localId
+)
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
+    INTERNAL_FACTORY, FunctionBlock,
+    IFunctionBlock, createDefaultFunctionBlock,
+    IFunctionBlockType*, fbType,
+    IContext*, context,
+    IComponent*, parent,
+    IString*, localId
+)
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
+    INTERNAL_FACTORY, DefaultDevice,
+    IDevice, createDefaultDevice,
+    IContext*, context,
+    IComponent*, parent,
+    IString*, localId
+)
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/default_mocks.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/default_mocks.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <opendaq/channel.h>
+#include <opendaq/device.h>
+#include <opendaq/device_impl.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+DECLARE_OPENDAQ_INTERFACE(IMockDefaultDevice, IBaseObject)
+{
+    virtual void addCustomComponent(const ComponentPtr& component) = 0;
+};
+
+class DefaultDevice : public DeviceBase<IMockDefaultDevice>
+{
+public:
+
+    DefaultDevice(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+        : DeviceBase<IMockDefaultDevice>(ctx, parent, localId)
+    {
+    }
+
+    DeviceInfoPtr onGetInfo() override
+    {
+        return DeviceInfo("", "default_dev");
+    }
+
+    void addCustomComponent(const ComponentPtr& component) override
+    {
+        this->components.emplace_back(component);
+    }
+};
+
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    INTERNAL_FACTORY, DefaultChannel, IChannel,
+    IFunctionBlockType*, fbType,
+    IContext*, context,
+    IComponent*, parent,
+    IString*, localId
+)
+
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    INTERNAL_FACTORY, DefaultFunctionBlock, IFunctionBlock,
+    IFunctionBlockType*, fbType,
+    IContext*, context,
+    IComponent*, parent,
+    IString*, localId
+)
+
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    INTERNAL_FACTORY, DefaultDevice, IDevice,
+    IContext*, context,
+    IComponent*, parent,
+    IString*, localId
+)
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/default_mocks_factory.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/default_mocks_factory.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <opendaq/channel_ptr.h>
+#include <opendaq/device_ptr.h>
+#include <opendaq/mock/default_mocks.h>
+#include <opendaq/function_block_type_factory.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+inline ChannelPtr DefaultChannel(const daq::ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+{
+    
+    ChannelPtr obj(DefaultChannel_Create(FunctionBlockType("default_ch", "default_ch", ""), ctx, parent, localId));
+    return obj;
+}
+
+inline FunctionBlockPtr DefaultFunctionBlock(const daq::ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+{
+    
+    FunctionBlockPtr obj(DefaultFunctionBlock_Create(FunctionBlockType("default_fb", "default_fb", ""), ctx, parent, localId));
+    return obj;
+}
+
+inline DevicePtr DefaultDevice(const daq::ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+{
+    
+    DevicePtr obj(DefaultDevice_Create(ctx, parent, localId));
+    return obj;
+}
+
+END_NAMESPACE_OPENDAQ

--- a/shared/libraries/opcua/opcuashared/include/opcuashared/opcuavariant.h
+++ b/shared/libraries/opcua/opcuashared/include/opcuashared/opcuavariant.h
@@ -107,6 +107,7 @@ public:
     OpcUaVariant();
 
     explicit OpcUaVariant(const uint16_t& value);
+    explicit OpcUaVariant(const uint32_t& value);
     explicit OpcUaVariant(const int32_t& value);
     explicit OpcUaVariant(const int64_t& value);
     explicit OpcUaVariant(const char* value);

--- a/shared/libraries/opcua/opcuashared/src/opcuavariant.cpp
+++ b/shared/libraries/opcua/opcuashared/src/opcuavariant.cpp
@@ -19,6 +19,11 @@ OpcUaVariant::OpcUaVariant(const uint16_t& value)
     UA_Variant_setScalarCopy(&this->value, &value, &UA_TYPES[UA_TYPES_UINT16]);
 }
 
+OpcUaVariant::OpcUaVariant(const uint32_t& value)
+{
+    UA_Variant_setScalarCopy(&this->value, &value, &UA_TYPES[UA_TYPES_UINT32]);
+}
+
 OpcUaVariant::OpcUaVariant(const int32_t& value)
     : OpcUaVariant()
 {

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_folder_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_folder_impl.h
@@ -31,7 +31,7 @@ public:
                                  const opcua::OpcUaNodeId& nodeId,
                                  bool customFolderType);
 private:
-    void findAndCreateFolders();
+    void findAndCreateFolders(std::map<uint32_t, ComponentPtr>& orderedComponents, std::vector<ComponentPtr>& unorderedComponents);
 };
 
 END_NAMESPACE_OPENDAQ_OPCUA_TMS

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_io_folder_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_io_folder_impl.h
@@ -30,8 +30,8 @@ public:
                                  const opcua::OpcUaNodeId& nodeId);
 
 protected:
-    void findAndCreateChannels();
-    void findAndCreateIoFolders();
+    void findAndCreateChannels(std::map<uint32_t, ComponentPtr>& orderedComponents, std::vector<ComponentPtr>& unorderedComponents);
+    void findAndCreateIoFolders(std::map<uint32_t, ComponentPtr>& orderedComponents, std::vector<ComponentPtr>& unorderedComponents);
 };
 
 END_NAMESPACE_OPENDAQ_OPCUA_TMS

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_object_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_object_impl.h
@@ -41,7 +41,9 @@ protected:
     void writeValue(const std::string& nodeName, const opcua::OpcUaVariant& value);
     opcua::OpcUaVariant readValue(const std::string& nodeName);
     virtual void subscriptionStatusChangeCallback(UA_StatusChangeNotification* notification);
-
+    uint32_t tryReadChildNumberInList(const std::string& nodeName);
+    uint32_t tryReadChildNumberInList(const opcua::OpcUaNodeId& nodeId);
+    
     /*!
     * @brief Returns child nodes of a specific type. By default it returns also the nodes which are a
     *        a subtype of the specific type. It can be disabled.

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
@@ -114,8 +114,11 @@ protected:
     std::unordered_map<std::string, opcua::OpcUaNodeId> objectTypeIdMap;
     opcua::OpcUaNodeId methodParentNodeId;
 
-    void addProperties(const tsl::ordered_map<opcua::OpcUaNodeId, opcua::OpcUaObject<UA_ReferenceDescription>>& references);
-    void addMethodProperties(const tsl::ordered_map<opcua::OpcUaNodeId, opcua::OpcUaObject<UA_ReferenceDescription>>& references, const opcua::OpcUaNodeId& parentNodeId);
+    void addProperties(const tsl::ordered_map<opcua::OpcUaNodeId, opcua::OpcUaObject<UA_ReferenceDescription>>& references,
+                       std::map<uint32_t, PropertyPtr>& orderedProperties,
+                       std::vector<PropertyPtr> unorderedProperties);
+    void addMethodProperties(const tsl::ordered_map<opcua::OpcUaNodeId, opcua::OpcUaObject<UA_ReferenceDescription>>& references,
+                             const opcua::OpcUaNodeId& parentNodeId);
     void browseRawProperties();
     ErrCode INTERFACE_FUNC setPropertyValueInternal(IString* propertyName, IBaseObject* value, bool protectedWrite);
 };

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
@@ -118,7 +118,10 @@ protected:
                        std::map<uint32_t, PropertyPtr>& orderedProperties,
                        std::vector<PropertyPtr> unorderedProperties);
     void addMethodProperties(const tsl::ordered_map<opcua::OpcUaNodeId, opcua::OpcUaObject<UA_ReferenceDescription>>& references,
-                             const opcua::OpcUaNodeId& parentNodeId);
+                             const opcua::OpcUaNodeId& parentNodeId,
+                             std::map<uint32_t, PropertyPtr>& orderedProperties,
+                             std::vector<PropertyPtr> unorderedProperties,
+                             std::unordered_map<std::string, BaseObjectPtr>& functionPropValues);
     void browseRawProperties();
     ErrCode INTERFACE_FUNC setPropertyValueInternal(IString* propertyName, IBaseObject* value, bool protectedWrite);
 };

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_object_impl.cpp
@@ -78,6 +78,40 @@ void TmsClientObjectImpl::subscriptionStatusChangeCallback(UA_StatusChangeNotifi
     //TODO report on disconnect
 }
 
+uint32_t TmsClientObjectImpl::tryReadChildNumberInList(const std::string& nodeName)
+{
+    try
+    {
+        const auto childId = this->getNodeId(nodeName);
+        return tryReadChildNumberInList(childId);
+    }
+    catch(...)
+    {
+    }
+
+    return std::numeric_limits<uint32_t>::max();
+}
+
+uint32_t TmsClientObjectImpl::tryReadChildNumberInList(const opcua::OpcUaNodeId& nodeId)
+{
+    try
+    {
+        const auto& childReferences = referenceUtils.getReferences(nodeId);
+        for (auto& [addedPropChildId, addedPropChildRef] : childReferences)
+        {
+            if (client->readBrowseName(addedPropChildId) == "NumberInList")
+            {
+                return VariantConverter<IInteger>::ToDaqObject(client->readValue(addedPropChildId));
+            }
+        }
+    }
+    catch(...)
+    {
+    }
+
+    return std::numeric_limits<uint32_t>::max();
+}
+
 std::vector<daq::opcua::OpcUaNodeId> TmsClientObjectImpl::getChildNodes(const opcua::OpcUaClientPtr& client,
                                                                         const opcua::OpcUaNodeId& nodeId,
                                                                         const opcua::OpcUaNodeId& typeId,

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
@@ -108,9 +108,6 @@ void TmsServerComponent<Ptr>::bindCallbacks()
             return UA_STATUSCODE_GOOD;
         });
     }
-
-    // TODO
-    this->addReadCallback("NumberInList", [this]() { return VariantConverter<IInteger>::ToVariant(0); });
 }
 
 template <typename Ptr>

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
@@ -64,6 +64,7 @@ public:
         const opcua::OpcUaNodeId& parentNodeId = opcua::OpcUaNodeId(UA_NS0ID_OBJECTSFOLDER));
     opcua::OpcUaNodeId registerToExistingOpcUaNode(const opcua::OpcUaNodeId& nodeId);
     opcua::OpcUaNodeId getNodeId();
+    void setNumberInList(uint32_t numberInList);
 
     void addHierarchicalReference(const opcua::OpcUaNodeId& parent);
     virtual void createNonhierarchicalReferences();
@@ -133,8 +134,11 @@ protected:
     std::mutex valueMutex;
     opcua::OpcUaNodeId nodeId;
     ContextPtr daqContext;
+    uint32_t numberInList;
 
 private:
+    void bindCallbacksInternal();
+
     std::unordered_map<opcua::OpcUaNodeId, ReadVariantCallback> readCallbacks;
     std::unordered_map<opcua::OpcUaNodeId, WriteVariantCallback> writeCallbacks;
     std::unordered_map<std::string, opcua::OpcUaObject<UA_ReferenceDescription>> references;

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
@@ -110,6 +110,7 @@ protected:
     template <class TMS_T, class DAQ_T, class... Params>
     std::shared_ptr<TMS_T> registerTmsObjectOrAddReference(const opcua::OpcUaNodeId& parentNodeId,
                                                            const DAQ_T& daqObject,
+                                                           uint32_t numberInList,
                                                            Params... params)
     {
         auto tmsObjectNodeId = findTmsObjectNodeId(daqObject);
@@ -125,6 +126,8 @@ protected:
         {
             auto tmsObject = std::make_shared<TMS_T>(daqObject, this->server, daqContext, std::forward<Params>(params)...);
             tmsObject->registerOpcUaNode(parentNodeId);
+            if(numberInList != std::numeric_limits<uint32_t>::max())
+                tmsObject->setNumberInList(numberInList);
             return tmsObject;
         }
     }

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
@@ -107,6 +107,8 @@ protected:
             item->createNonhierarchicalReferences();
     }
 
+    // TODO: NumberInList is configured only when object is registered. Order of nodes on objects of which child nodes
+    // reference other ones will not be correct!
     template <class TMS_T, class DAQ_T, class... Params>
     std::shared_ptr<TMS_T> registerTmsObjectOrAddReference(const opcua::OpcUaNodeId& parentNodeId,
                                                            const DAQ_T& daqObject,

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_property.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_property.h
@@ -30,12 +30,19 @@ class TmsServerProperty : public TmsServerVariable<PropertyPtr>
 {
 public:
     using Super = TmsServerVariable<PropertyPtr>;
-
-    TmsServerProperty(const PropertyPtr& object, const opcua::OpcUaServerPtr& server, const ContextPtr& context);
+    
+    TmsServerProperty(const PropertyPtr& object,
+                      const opcua::OpcUaServerPtr& server,
+                      const ContextPtr& context);
     TmsServerProperty(const PropertyPtr& object,
                       const opcua::OpcUaServerPtr& server,
                       const ContextPtr& context,
-                      const PropertyObjectPtr& parent);
+                      const std::unordered_map<std::string, uint32_t>& propOrder);
+    TmsServerProperty(const PropertyPtr& object,
+                      const opcua::OpcUaServerPtr& server,
+                      const ContextPtr& context,
+                      const PropertyObjectPtr& parent,
+                      const std::unordered_map<std::string, uint32_t>& propOrder);
 
     std::string getBrowseName() override;
     void bindCallbacks() override;
@@ -72,6 +79,7 @@ private:
 
     std::unordered_set<std::string> HiddenNodes = {"FieldCoercionExpression", "FieldValidationExpression", "<BaseDataVariable>"};
     std::unordered_map<opcua::OpcUaNodeId, TmsServerPropertyPtr> childProperties;
+    std::unordered_map<std::string, uint32_t> propOrder;
 };
 
 END_NAMESPACE_OPENDAQ_OPCUA_TMS

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_property_object.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_property_object.h
@@ -61,7 +61,7 @@ protected:
 
 private:
     void registerEvalValueNode(const std::string& nodeName, TmsServerEvalValue::ReadCallback readCallback);
-    void addMethodPropertyNode(const PropertyPtr& prop);
+    void addMethodPropertyNode(const PropertyPtr& prop, uint32_t numberInList);
     void bindMethodCallbacks();
 
     StringPtr name;

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
@@ -224,10 +224,8 @@ void TmsServerDevice::populateStreamingOptions()
     for (const auto& streamingOption : streamingOptions)
     {
         auto tmsStreamingOption = registerTmsObjectOrAddReference<TmsServerPropertyObject>(
-            streamingOptionsNodeId, streamingOption.asPtr<IPropertyObject>(), streamingOption.getProtocolId());
-        tmsStreamingOption->setNumberInList(numberInList);
+            streamingOptionsNodeId, streamingOption.asPtr<IPropertyObject>(), numberInList++, streamingOption.getProtocolId());
         this->streamingOptions.push_back(std::move(tmsStreamingOption));
-        numberInList++;
     }
 }
 
@@ -241,8 +239,7 @@ void TmsServerDevice::addChildNodes()
     uint32_t numberInList = 0;
     for (const auto& device : object.getDevices())
     {
-        auto tmsDevice = registerTmsObjectOrAddReference<TmsServerDevice>(nodeId, device);
-        tmsDevice->setNumberInList(numberInList++);
+        auto tmsDevice = registerTmsObjectOrAddReference<TmsServerDevice>(nodeId, device, numberInList++);
         devices.push_back(std::move(tmsDevice));
     }
 
@@ -251,8 +248,7 @@ void TmsServerDevice::addChildNodes()
     numberInList = 0;
     for (const auto& functionBlock : object.getFunctionBlocks())
     {
-        auto tmsFunctionBlock = registerTmsObjectOrAddReference<TmsServerFunctionBlock<>>(functionBlockNodeId, functionBlock);
-        tmsFunctionBlock->setNumberInList(numberInList++);
+        auto tmsFunctionBlock = registerTmsObjectOrAddReference<TmsServerFunctionBlock<>>(functionBlockNodeId, functionBlock, numberInList++);
         functionBlocks.push_back(std::move(tmsFunctionBlock));
     }
 
@@ -261,8 +257,7 @@ void TmsServerDevice::addChildNodes()
     numberInList = 0;
     for (const auto& signal : object.getSignals())
     {
-        auto tmsSignal = registerTmsObjectOrAddReference<TmsServerSignal>(signalsNodeId, signal);
-        tmsSignal->setNumberInList(numberInList++);
+        auto tmsSignal = registerTmsObjectOrAddReference<TmsServerSignal>(signalsNodeId, signal, numberInList++);
         signals.push_back(std::move(tmsSignal));
     }
 
@@ -283,14 +278,12 @@ void TmsServerDevice::addChildNodes()
 
         if (component.asPtrOrNull<IFolder>().assigned())
         {
-            auto folderNode = registerTmsObjectOrAddReference<TmsServerFolder>(nodeId, component);
-            folderNode->setNumberInList(numberInList++);
+            auto folderNode = registerTmsObjectOrAddReference<TmsServerFolder>(nodeId, component, numberInList++);
             folders.push_back(std::move(folderNode));
         }
         else
         {
-            auto componentNode = registerTmsObjectOrAddReference<TmsServerComponent<>>(nodeId, component);
-            componentNode->setNumberInList(numberInList++);
+            auto componentNode = registerTmsObjectOrAddReference<TmsServerComponent<>>(nodeId, component, numberInList++);
             components.push_back(std::move(componentNode));
         }
     }

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
@@ -219,11 +219,15 @@ void TmsServerDevice::populateStreamingOptions()
 
     ListPtr<IStreamingInfo> streamingOptions;
     devicePrivatePtr->getStreamingOptions(&streamingOptions);
+
+    uint32_t numberInList = 0;
     for (const auto& streamingOption : streamingOptions)
     {
         auto tmsStreamingOption = registerTmsObjectOrAddReference<TmsServerPropertyObject>(
             streamingOptionsNodeId, streamingOption.asPtr<IPropertyObject>(), streamingOption.getProtocolId());
+        tmsStreamingOption->setNumberInList(numberInList);
         this->streamingOptions.push_back(std::move(tmsStreamingOption));
+        numberInList++;
     }
 }
 
@@ -234,25 +238,31 @@ void TmsServerDevice::addChildNodes()
     auto methodSetNodeId = getChildNodeId("MethodSet");
     tmsPropertyObject->setMethodParentNodeId(methodSetNodeId);
 
+    uint32_t numberInList = 0;
     for (const auto& device : object.getDevices())
     {
         auto tmsDevice = registerTmsObjectOrAddReference<TmsServerDevice>(nodeId, device);
+        tmsDevice->setNumberInList(numberInList++);
         devices.push_back(std::move(tmsDevice));
     }
 
     auto functionBlockNodeId = getChildNodeId("FunctionBlocks");
     assert(!functionBlockNodeId.isNull());
+    numberInList = 0;
     for (const auto& functionBlock : object.getFunctionBlocks())
     {
         auto tmsFunctionBlock = registerTmsObjectOrAddReference<TmsServerFunctionBlock<>>(functionBlockNodeId, functionBlock);
+        tmsFunctionBlock->setNumberInList(numberInList++);
         functionBlocks.push_back(std::move(tmsFunctionBlock));
     }
 
     auto signalsNodeId = getChildNodeId("Signals");
     assert(!signalsNodeId.isNull());
+    numberInList = 0;
     for (const auto& signal : object.getSignals())
     {
         auto tmsSignal = registerTmsObjectOrAddReference<TmsServerSignal>(signalsNodeId, signal);
+        tmsSignal->setNumberInList(numberInList++);
         signals.push_back(std::move(tmsSignal));
     }
 
@@ -263,7 +273,8 @@ void TmsServerDevice::addChildNodes()
     auto inputsOutputsNode = std::make_unique<TmsServerFolder>(topFolder, server, daqContext);
     inputsOutputsNode->registerToExistingOpcUaNode(inputsOutputsNodeId);
     folders.push_back(std::move(inputsOutputsNode));
-
+    
+    numberInList = 0;
     for (auto component : object.getItems())
     {
         auto id = component.getName();
@@ -273,11 +284,13 @@ void TmsServerDevice::addChildNodes()
         if (component.asPtrOrNull<IFolder>().assigned())
         {
             auto folderNode = registerTmsObjectOrAddReference<TmsServerFolder>(nodeId, component);
+            folderNode->setNumberInList(numberInList++);
             folders.push_back(std::move(folderNode));
         }
         else
         {
             auto componentNode = registerTmsObjectOrAddReference<TmsServerComponent<>>(nodeId, component);
+            componentNode->setNumberInList(numberInList++);
             components.push_back(std::move(componentNode));
         }
     }

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_folder.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_folder.cpp
@@ -15,6 +15,7 @@ TmsServerFolder::TmsServerFolder(const FolderPtr& object, const OpcUaServerPtr& 
 
 void TmsServerFolder::addChildNodes()
 {
+    uint32_t numberInList = 0;
     for (auto item : object.getItems())
     {
         auto folder = item.asPtrOrNull<IFolder>();
@@ -24,16 +25,19 @@ void TmsServerFolder::addChildNodes()
         if (channel.assigned())
         {
             auto tmsChannel = registerTmsObjectOrAddReference<TmsServerChannel>(this->nodeId, channel);
+            tmsChannel->setNumberInList(numberInList++);
             channels.push_back(std::move(tmsChannel));
         }
         else if (folder.assigned()) // It is important to test for folder last as a channel also is a folder!
         {
             auto tmsFolder = registerTmsObjectOrAddReference<TmsServerFolder>(this->nodeId, folder);
+            tmsFolder->setNumberInList(numberInList++);
             folders.push_back(std::move(tmsFolder));
         }
         else if (component.assigned())  // It is important to test for component after folder!
         {
             auto tmsComponent = registerTmsObjectOrAddReference<TmsServerComponent<>>(this->nodeId, component);
+            tmsComponent->setNumberInList(numberInList++);
             components.push_back(std::move(tmsComponent));
         }
         else

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_folder.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_folder.cpp
@@ -24,20 +24,17 @@ void TmsServerFolder::addChildNodes()
 
         if (channel.assigned())
         {
-            auto tmsChannel = registerTmsObjectOrAddReference<TmsServerChannel>(this->nodeId, channel);
-            tmsChannel->setNumberInList(numberInList++);
+            auto tmsChannel = registerTmsObjectOrAddReference<TmsServerChannel>(this->nodeId, channel, numberInList++);
             channels.push_back(std::move(tmsChannel));
         }
         else if (folder.assigned()) // It is important to test for folder last as a channel also is a folder!
         {
-            auto tmsFolder = registerTmsObjectOrAddReference<TmsServerFolder>(this->nodeId, folder);
-            tmsFolder->setNumberInList(numberInList++);
+            auto tmsFolder = registerTmsObjectOrAddReference<TmsServerFolder>(this->nodeId, folder, numberInList++);
             folders.push_back(std::move(tmsFolder));
         }
         else if (component.assigned())  // It is important to test for component after folder!
         {
-            auto tmsComponent = registerTmsObjectOrAddReference<TmsServerComponent<>>(this->nodeId, component);
-            tmsComponent->setNumberInList(numberInList++);
+            auto tmsComponent = registerTmsObjectOrAddReference<TmsServerComponent<>>(this->nodeId, component, numberInList++);
             components.push_back(std::move(tmsComponent));
         }
         else

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_function_block.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_function_block.cpp
@@ -52,8 +52,7 @@ void TmsServerFunctionBlock<T>::addChildNodes()
     uint32_t numberInList = 0;
     for (const auto& signal : this->object.getSignals())
     {
-        auto tmsSignal = this->template registerTmsObjectOrAddReference<TmsServerSignal>(signalsNodeId, signal);
-        tmsSignal->setNumberInList(numberInList++);
+        auto tmsSignal = this->template registerTmsObjectOrAddReference<TmsServerSignal>(signalsNodeId, signal, numberInList++);
         signals.push_back(std::move(tmsSignal));
     }
 
@@ -63,16 +62,14 @@ void TmsServerFunctionBlock<T>::addChildNodes()
     numberInList = 0;
     for (const auto& inputPort : this->object.getInputPorts())
     {
-        auto tmsInputPort = this->template registerTmsObjectOrAddReference<TmsServerInputPort>(inputPortsNodeId, inputPort);
-        tmsInputPort->setNumberInList(numberInList++);
+        auto tmsInputPort = this->template registerTmsObjectOrAddReference<TmsServerInputPort>(inputPortsNodeId, inputPort, numberInList++);
         inputPorts.push_back(std::move(tmsInputPort));
     }
     
     numberInList = 0;
     for (const auto& fb : this->object.getFunctionBlocks())
     {
-        auto tmsFunctionBlock = this->template registerTmsObjectOrAddReference<TmsServerFunctionBlock<>>(this->nodeId, fb);
-        tmsFunctionBlock->setNumberInList(numberInList++);
+        auto tmsFunctionBlock = this->template registerTmsObjectOrAddReference<TmsServerFunctionBlock<>>(this->nodeId, fb, numberInList++);
         functionBlocks.push_back(std::move(tmsFunctionBlock));
     }
 

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_function_block.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_function_block.cpp
@@ -48,25 +48,31 @@ void TmsServerFunctionBlock<T>::addChildNodes()
 {
     auto signalsNodeId = this->getChildNodeId("OutputSignals");
     assert(!signalsNodeId.isNull());
-
+    
+    uint32_t numberInList = 0;
     for (const auto& signal : this->object.getSignals())
     {
         auto tmsSignal = this->template registerTmsObjectOrAddReference<TmsServerSignal>(signalsNodeId, signal);
+        tmsSignal->setNumberInList(numberInList++);
         signals.push_back(std::move(tmsSignal));
     }
 
     auto inputPortsNodeId = this->getChildNodeId("InputPorts");
     assert(!inputPortsNodeId.isNull());
-
+    
+    numberInList = 0;
     for (const auto& inputPort : this->object.getInputPorts())
     {
         auto tmsInputPort = this->template registerTmsObjectOrAddReference<TmsServerInputPort>(inputPortsNodeId, inputPort);
+        tmsInputPort->setNumberInList(numberInList++);
         inputPorts.push_back(std::move(tmsInputPort));
     }
-
+    
+    numberInList = 0;
     for (const auto& fb : this->object.getFunctionBlocks())
     {
         auto tmsFunctionBlock = this->template registerTmsObjectOrAddReference<TmsServerFunctionBlock<>>(this->nodeId, fb);
+        tmsFunctionBlock->setNumberInList(numberInList++);
         functionBlocks.push_back(std::move(tmsFunctionBlock));
     }
 

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_object.cpp
@@ -2,8 +2,7 @@
 #include <opendaq/instance_ptr.h>
 #include <opendaq/signal_ptr.h>
 #include <coreobjects/eval_value_ptr.h>
-#include <coreobjects/property_object_ptr.h>
-#include <coreobjects/property_object.h>
+#include "opcuatms/converters/variant_converter.h"
 #include "open62541/server.h"
 #include "open62541/tmsbsp_nodeids.h"
 
@@ -15,6 +14,7 @@ namespace opcua_utils = opcua::utils;
 TmsServerObject::TmsServerObject(const OpcUaServerPtr& server, const ContextPtr& context)
     : server(server)
     , daqContext(context)
+    , numberInList(0)
 {
 }
 
@@ -58,6 +58,7 @@ OpcUaNodeId TmsServerObject::registerToExistingOpcUaNode(const OpcUaNodeId& node
     browseReferences();
     addChildNodes();
     browseReferences();
+    bindCallbacksInternal();
     bindCallbacks();
     bindReadWriteCallbacks();
     return this->nodeId;
@@ -66,6 +67,11 @@ OpcUaNodeId TmsServerObject::registerToExistingOpcUaNode(const OpcUaNodeId& node
 OpcUaNodeId TmsServerObject::getNodeId()
 {
     return nodeId;
+}
+
+void TmsServerObject::setNumberInList(uint32_t numberInList)
+{
+    this->numberInList = numberInList;
 }
 
 void TmsServerObject::addHierarchicalReference(const OpcUaNodeId& parent)
@@ -145,6 +151,12 @@ OpcUaNodeId TmsServerObject::getChildNodeId(const std::string& nodeName)
 OpcUaNodeId TmsServerObject::findSignalNodeId(const SignalPtr& signal) const
 {
     return findTmsObjectNodeId(signal);
+}
+
+void TmsServerObject::bindCallbacksInternal()
+{
+    if (hasChildNode("NumberInList"))
+        this->addReadCallback("NumberInList", [this]() { return VariantConverter<IInteger>::ToVariant(numberInList); });
 }
 
 void TmsServerObject::bindCallbacks()

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property.cpp
@@ -251,7 +251,7 @@ void TmsServerProperty::addReferenceTypeChildNodes()
         auto prop = parent.getRef().getProperty(propName);
         if (prop.getValueType() != ctObject)
         {
-            auto serverInfo = registerTmsObjectOrAddReference<TmsServerProperty>(nodeId, prop, parent.getRef(), propOrder);
+            auto serverInfo = registerTmsObjectOrAddReference<TmsServerProperty>(nodeId, prop, std::numeric_limits<uint32_t>::max(), parent.getRef(),propOrder);
             auto childNodeId = serverInfo->getNodeId();
             childProperties.insert({childNodeId, serverInfo});
         }

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property.cpp
@@ -26,14 +26,24 @@ TmsServerProperty::TmsServerProperty(const PropertyPtr& object, const opcua::Opc
         hideSelectionTypeChildren();
     if (isStructureType())
         hideStructureTypeChildren();
-
 }
 
 TmsServerProperty::TmsServerProperty(const PropertyPtr& object,
                                      const opcua::OpcUaServerPtr& server,
                                      const ContextPtr& context,
-                                     const PropertyObjectPtr& parent)
-    : TmsServerProperty(object, server, context)
+                                     const std::unordered_map<std::string, uint32_t>& propOrder)
+    : TmsServerProperty(object, server, context) 
+{
+    this->propOrder = propOrder;
+    this->numberInList = propOrder.at(object.getName());
+}
+
+TmsServerProperty::TmsServerProperty(const PropertyPtr& object,
+                                     const opcua::OpcUaServerPtr& server,
+                                     const ContextPtr& context,
+                                     const PropertyObjectPtr& parent,
+                                     const std::unordered_map<std::string, uint32_t>& propOrder)
+    : TmsServerProperty(object, server, context, propOrder)
 {
     this->parent = parent;
 }
@@ -241,7 +251,7 @@ void TmsServerProperty::addReferenceTypeChildNodes()
         auto prop = parent.getRef().getProperty(propName);
         if (prop.getValueType() != ctObject)
         {
-            auto serverInfo = registerTmsObjectOrAddReference<TmsServerProperty>(nodeId, prop, parent.getRef());
+            auto serverInfo = registerTmsObjectOrAddReference<TmsServerProperty>(nodeId, prop, parent.getRef(), propOrder);
             auto childNodeId = serverInfo->getNodeId();
             childProperties.insert({childNodeId, serverInfo});
         }

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
@@ -101,7 +101,7 @@ void TmsServerPropertyObject::addChildNodes()
             }
             else
             {
-                serverInfo = registerTmsObjectOrAddReference<TmsServerProperty>(nodeId, prop, object, propOrder);
+                serverInfo = registerTmsObjectOrAddReference<TmsServerProperty>(nodeId, prop, std::numeric_limits<uint32_t>::max(), object, propOrder);
                 childNodeId = serverInfo->getNodeId();
             }
             
@@ -111,9 +111,8 @@ void TmsServerPropertyObject::addChildNodes()
         {
             const auto propName = prop.getName();
             PropertyObjectPtr obj = object.getPropertyValue(propName);
-            auto serverInfo = registerTmsObjectOrAddReference<TmsServerPropertyObject>(nodeId, obj, propName, prop);
+            auto serverInfo = registerTmsObjectOrAddReference<TmsServerPropertyObject>(nodeId, obj, propOrder[propName], propName, prop);
             auto childNodeId = serverInfo->getNodeId();
-            serverInfo->setNumberInList(propOrder[propName]);
             childObjects.insert({childNodeId, serverInfo});
         }
     }

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_property_object_advanced.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_property_object_advanced.cpp
@@ -749,3 +749,17 @@ TEST_F(TmsPropertyObjectAdvancedTest, StructureSet)
     ASSERT_EQ(clientObj.getPropertyValue("CustomRuleDescriptionStructure"), obj.getPropertyValue("CustomRuleDescriptionStructure"));
     ASSERT_EQ(clientObj.getPropertyValue("AdditionalParametersType"), obj.getPropertyValue("AdditionalParametersType"));
 }
+
+TEST_F(TmsPropertyObjectAdvancedTest, PropertyOrder)
+{
+    const auto obj = PropertyObject(manager, "TestClass");
+    auto [serverObj, clientObj] = registerPropertyObject(obj);
+
+    auto serverProps = obj.getAllProperties();
+    auto clientProps = clientObj.getAllProperties();
+
+    ASSERT_EQ(serverProps.getCount(), clientProps.getCount());
+
+    for (SizeT i = 0; i < serverProps.getCount(); ++i)
+        ASSERT_EQ(serverProps[i].getName(), clientProps[i].getName());
+}

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_amplifier.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_amplifier.cpp
@@ -745,3 +745,31 @@ TEST_F(TMSAmplifierTest, GetRefPropSelectionValuesAfterChange)
     stgAmpl.setPropertyValue("Measurement", 1);
     ASSERT_EQ(rangeProp.getSelectionValues(), bridgeRangeValues);
 }
+
+TEST_F(TMSAmplifierTest, PropertyOrder1)
+{
+    const auto obj = PropertyObject(objManager, "StgAmp");
+    auto [serverObj, stgAmpl] = registerPropertyObject(obj);
+
+    auto serverProps = obj.getAllProperties();
+    auto clientProps = stgAmpl.getAllProperties();
+
+    ASSERT_EQ(serverProps.getCount(), clientProps.getCount());
+
+    for (SizeT i = 0; i < serverProps.getCount(); ++i)
+        ASSERT_EQ(serverProps[i].getName(), clientProps[i].getName());
+}
+
+TEST_F(TMSAmplifierTest, PropertyOrder2)
+{
+    const auto obj = PropertyObject(objManager, "LvAmp");
+    auto [serverObj, lvAmpl] = registerPropertyObject(obj);
+
+    auto serverProps = obj.getAllProperties();
+    auto clientProps = lvAmpl.getAllProperties();
+
+    ASSERT_EQ(serverProps.getCount(), clientProps.getCount());
+
+    for (SizeT i = 0; i < serverProps.getCount(); ++i)
+        ASSERT_EQ(serverProps[i].getName(), clientProps[i].getName());
+}

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
@@ -136,6 +136,7 @@ TEST_F(TmsDeviceTest, Property)
     auto ctx = NullContext();
     auto clientDevice = TmsClientRootDevice(ctx, nullptr, "dev", clientContext, nodeId, nullptr);
 
+    auto serverVisibleProps = serverDevice.getVisibleProperties();
     auto visibleProperties = clientDevice.getVisibleProperties();
     ASSERT_EQ(visibleProperties.getCount(), 3u);
     ASSERT_EQ(visibleProperties[2].getName(), "SampleRate");

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_folder.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_folder.cpp
@@ -148,3 +148,42 @@ TEST_F(TmsFolderTest, IOFolder)
     ASSERT_TRUE(folder.serverFolder.getItems()[0].asPtrOrNull<IFolder>().getItems()[0].asPtrOrNull<IChannel>().assigned());
     ASSERT_TRUE(folder.clientFolder.getItems()[0].asPtrOrNull<IFolder>().getItems()[0].asPtrOrNull<IChannel>().assigned());
 }
+
+TEST_F(TmsFolderTest, IOFolderNodeOrder)
+{
+    auto folder = IoFolder(NullContext(), nullptr, "parent");
+    for (int i = 0; i < 100; ++i)
+    {
+        folder.addItem(IoFolder(NullContext(), folder, "child" + std::to_string(i)));
+    }
+
+    for (int i = 0; i < 10; ++i)
+    {
+        folder.addItem(MockChannel(NullContext(), folder, "channel" + std::to_string(i)));
+    }
+
+    auto registered = registerTestFolder(folder);
+
+    auto serverItems = folder.getItems();
+    auto clientItems = registered.clientFolder.getItems();
+
+    for (SizeT i = 0; i < serverItems.getCount(); ++i)
+        ASSERT_EQ(serverItems[i].getName(), clientItems[i].getName());
+}
+
+TEST_F(TmsFolderTest, FolderNodeOrder)
+{
+    auto folder = Folder(NullContext(), nullptr, "parent");
+    for (int i = 0; i < 100; ++i)
+    {
+        folder.addItem(Folder(NullContext(), folder, "child" + std::to_string(i)));
+    }
+
+    auto registered = registerTestFolder(folder);
+
+    auto serverItems = folder.getItems();
+    auto clientItems = registered.clientFolder.getItems();
+
+    for (SizeT i = 0; i < serverItems.getCount(); ++i)
+        ASSERT_EQ(serverItems[i].getName(), clientItems[i].getName());
+}

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_function_block.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_function_block.cpp
@@ -118,6 +118,7 @@ TEST_F(TmsFunctionBlockTest, MethodGetSignals)
 
     auto clientFunctionBlock = TmsClientFunctionBlock(NullContext(), nullptr, "mockfb", clientContext, functionBlockNodeId);
 
+    ListPtr<ISignal> serverSignals = serverFunctionBlock.getSignals();
     ListPtr<ISignal> signals;
     ASSERT_NO_THROW(signals = clientFunctionBlock.getSignals());
     ASSERT_TRUE(signals.assigned());


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

Allows for preservation of object order from openDAQ devices to openDAQ clients using the OPC UA modules. 

# Known issues:

Currently, when an openDAQ component is referenced by two or more objects (where one is the owner of the component), the node order of all but the object highest up in the openDAQ tree will be incorrect.