### PR TITLE
Split Python bindings for IBaseObject into its own file

### DIFF
--- a/bindings/python/core_types/CMakeLists.txt
+++ b/bindings/python/core_types/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRC_Cpp
     src/py_opendaq_daq.cpp
     src/py_converter.cpp
     #
+    src/py_base_object.cpp
     src/py_integer.cpp
     src/py_float.cpp
     src/py_boolean.cpp

--- a/bindings/python/core_types/include/py_core_types/py_core_types.h
+++ b/bindings/python/core_types/include/py_core_types/py_core_types.h
@@ -22,6 +22,8 @@
 #include "py_core_types/py_procedure.h"
 #include "py_core_types/py_converter.h"
 
+void declareAndDefineIBaseObject(pybind11::module_ m);
+
 PyDaqIntf<daq::IInteger> declareIInteger(pybind11::module_ m);
 PyDaqIntf<daq::IFloat> declareIFloat(pybind11::module_ m);
 PyDaqIntf<daq::IBoolean> declareIBoolean(pybind11::module_ m);

--- a/bindings/python/core_types/src/py_base_object.cpp
+++ b/bindings/python/core_types/src/py_base_object.cpp
@@ -1,0 +1,84 @@
+#include "py_core_types/py_core_types.h"
+
+void declareAndDefineIBaseObject(pybind11::module_ m)
+{
+    auto cls = py::class_<daq::IBaseObject, InterfaceWrapper<daq::IBaseObject>>(m, "IBaseObject");
+
+    cls.doc() = "Extends `IUnknown` by providing additional methods for borrowing interfaces, hashing, and equality comparison. "
+                "All openDAQ objects implement `IBaseObject` interface or its descendants. "
+                "Hashing and equality comparison provides the ability to use the object as an element in dictionaries and lists. "
+                "Classes that implement any interface derived from `IBaseObject` should be derived from `ImplementationOf` class, "
+                "which provides the default implementation of `IBaseObject` interface methods.";
+
+    m.def("BaseObject", &daq::BaseObject_Create);
+
+    cls.def(py::init(
+        [](daq::IBaseObject* obj)
+        {
+            obj->addRef();
+            return obj;
+        }));
+    cls.def("__str__",
+        [](daq::IBaseObject* obj)
+        {
+            return getString(obj);
+        });
+    cls.def("__hash__",
+        [](daq::IBaseObject* obj)
+        {
+            return daq::BaseObjectPtr::Borrow(obj).getHashCode();
+        });
+    cls.def("__int__",
+        [](daq::IBaseObject* obj)
+        {
+            return static_cast<daq::Int>(daq::BaseObjectPtr::Borrow(obj));
+        });
+    cls.def("__float__",
+        [](daq::IBaseObject* obj)
+        {
+            return static_cast<daq::Float>(daq::BaseObjectPtr::Borrow(obj));
+        });
+    cls.def("__eq__",
+        [](daq::IBaseObject* obj, const py::object& other)
+        {
+            const auto objPtr = daq::BaseObjectPtr::Borrow(obj);
+
+            try
+            {
+                if (auto intf = pyQI<daq::IBaseObject>(other))
+                {
+                    const auto otherPtr = daq::ObjectPtr(std::move(intf));
+                    return objPtr == otherPtr;  // this will trigger IBaseObject.equals
+                }
+
+                if (py::isinstance<py::int_>(other))
+                    return static_cast<daq::Int>(objPtr) == static_cast<daq::Int>(py::int_(other));
+
+                if (py::isinstance<py::float_>(other))
+                    return static_cast<daq::Float>(objPtr) == static_cast<daq::Float>(py::float_(other));
+
+                if (py::isinstance<py::str>(other))
+                    return static_cast<std::string>(objPtr) == static_cast<std::string>(py::str(other));
+
+                return false;
+            }
+            catch (std::exception&)
+            {
+                return false;
+            }
+        });
+    cls.def_property_readonly("core_type",
+        [](daq::IBaseObject* obj)
+        {
+            return daq::BaseObjectPtr::Borrow(obj).getCoreType();
+        });
+    cls.def_static("cast_from",
+        [](daq::IBaseObject* obj)
+        {
+            return castFrom<daq::IBaseObject>(obj);
+        });
+    cls.def_static("can_cast_from",
+        [](daq::IBaseObject* obj) {
+            return canCastFrom<daq::IBaseObject>(obj);
+        });
+}

--- a/bindings/python/core_types/src/py_core_types.cpp
+++ b/bindings/python/core_types/src/py_core_types.cpp
@@ -18,6 +18,8 @@ void wrapDaqComponentCoreTypes(pybind11::module_ m)
         .value("ctStruct", daq::CoreType::ctStruct)
         .value("ctUndefined", daq::CoreType::ctUndefined);
 
+    declareAndDefineIBaseObject(m);
+
     auto classIInteger = declareIInteger(m);
     auto classIFloat = declareIFloat(m);
     auto classIBoolean = declareIBoolean(m);

--- a/bindings/python/py_opendaq_daq/src/opendaq_daq.cpp
+++ b/bindings/python/py_opendaq_daq/src/opendaq_daq.cpp
@@ -11,52 +11,6 @@ PYBIND11_MODULE(opendaq, m)
     blueberry_daq_module = m;
     python_class_fraction = py::module_::import("fractions").attr("Fraction");
 
-    py::class_<daq::IBaseObject, InterfaceWrapper<daq::IBaseObject>>(m, "IBaseObject")
-        .def(py::init(
-            [](daq::IBaseObject* obj)
-            {
-                obj->addRef();
-                return obj;
-            }))
-        .def("__str__", [](daq::IBaseObject* obj) { return getString(obj); })
-        .def_static("cast_from", [](daq::IBaseObject* obj) { return castFrom<daq::IBaseObject>(obj); })
-        .def_static("can_cast_from", [](daq::IBaseObject* obj) { return canCastFrom<daq::IBaseObject>(obj); })
-        .def("__hash__", [](daq::IBaseObject* obj) { return daq::BaseObjectPtr::Borrow(obj).getHashCode(); })
-        .def("__int__", [](daq::IBaseObject* obj) { return static_cast<daq::Int>(daq::BaseObjectPtr::Borrow(obj)); })
-        .def("__float__", [](daq::IBaseObject* obj) { return static_cast<daq::Float>(daq::BaseObjectPtr::Borrow(obj)); })
-        .def_property_readonly("core_type", [](daq::IBaseObject* obj) { return daq::BaseObjectPtr::Borrow(obj).getCoreType(); })
-        .def("__eq__",
-             [](daq::IBaseObject* obj, const py::object& other)
-             {
-                 const auto objPtr = daq::BaseObjectPtr::Borrow(obj);
-
-                 try
-                 {
-                     if (auto intf = pyQI<daq::IBaseObject>(other))
-                     {
-                         const auto otherPtr = daq::ObjectPtr(std::move(intf));
-                         return objPtr == otherPtr;  // this will trigger IBaseObject.equals
-                     }
-
-                     if (py::isinstance<py::int_>(other))
-                         return static_cast<daq::Int>(objPtr) == static_cast<daq::Int>(py::int_(other));
-
-                     if (py::isinstance<py::float_>(other))
-                         return static_cast<daq::Float>(objPtr) == static_cast<daq::Float>(py::float_(other));
-
-                     if (py::isinstance<py::str>(other))
-                         return static_cast<std::string>(objPtr) == static_cast<std::string>(py::str(other));
-
-                     return false;
-                 }
-                 catch (std::exception&)
-                 {
-                     return false;
-                 }
-             });
-
-    m.def("BaseObject", &daq::BaseObject_Create);
-
     m.def("get_tracked_object_count", &daqGetTrackedObjectCount);
     m.def("print_tracked_objects", &daqPrintTrackedObjects);
     m.def("clear_error_info", &daqClearErrorInfo);


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:

This should fix the order of function declaration, so that `CoreType` enum is known to pybind11 before `IBaseObject` gets mapped. It should fix the error
```
pybind11_stubgen - [  ERROR] In opendaq.opendaq.IBaseObject.core_type. : Invalid expression 'daq::CoreType'
```
but it makes sense to have this one inside its own file/function anyway.

After adding support for `INumber` and this, the list of remaining errors for `pybind11_stubgen` is
```
pybind11_stubgen - [  ERROR] In opendaq.opendaq.ExternalAllocator : Can't find/import 'capsule'
pybind11_stubgen - [  ERROR] In opendaq.opendaq.IAllocator.allocate : Can't find/import 'capsule'
pybind11_stubgen - [  ERROR] In opendaq.opendaq.IAllocator.free : Can't find/import 'capsule'

pybind11_stubgen - [  ERROR] In opendaq.opendaq.ExternalAllocator : Invalid expression 'daq::IDeleter'
pybind11_stubgen - [  ERROR] In opendaq.opendaq.FolderWithItemType : Invalid expression 'daq::IntfID'
pybind11_stubgen - [  ERROR] In opendaq.opendaq.IComplexNumber.equals_value : Invalid expression 'daq::Complex_Number<double>'
pybind11_stubgen - [  ERROR] In opendaq.opendaq.ILoggerComponent.log_message : Invalid expression 'daq::SourceLocation'
pybind11_stubgen - [  ERROR] In opendaq.opendaq.IModule.version_info. : Invalid expression 'daq::IVersionInfo'
pybind11_stubgen - [  ERROR] In opendaq.opendaq.StreamReader : Invalid expression '<ReadTimeoutType.All: 1>'
Warning: stubgen - [WARNING] Enum-like str representations were found with no matching mapping to the enum class location.
Use `--enum-class-locations` to specify full path to the following enum(s):
 - ReadTimeoutType
Warning: stubgen - [WARNING] Raw C++ types/values were found in signatures extracted from docstrings.
```