### PR TITLE
<SWCORE-12188> Add the raw value option to MultiReader that just copies whatever is in the value packet

### DIFF
--- a/bindings/python/opendaq/generated/reader/py_sample_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_sample_reader.cpp
@@ -31,8 +31,9 @@
 PyDaqIntf<daq::ISampleReader, daq::IReader> declareISampleReader(pybind11::module_ m)
 {
     py::enum_<daq::ReadMode>(m, "ReadMode")
-        .value("Raw", daq::ReadMode::Raw)
-        .value("Scaled", daq::ReadMode::Scaled);
+        .value("Unscaled", daq::ReadMode::Unscaled)
+        .value("Scaled", daq::ReadMode::Scaled)
+        .value("RawValue", daq::ReadMode::RawValue);
 
     return wrapInterface<daq::ISampleReader, daq::IReader>(m, "ISampleReader");
 }

--- a/changelog/changelog_1.0.0-2.0.0.txt
+++ b/changelog/changelog_1.0.0-2.0.0.txt
@@ -1,3 +1,11 @@
+14.11.2023
+
+Description:
+Added Multi-reader support for reading raw signal values (no scaling or conversion)
+
+-m enum class ReadMode { Raw, Scaled }
++m enum class ReadMode { Unscaled, Scaled, RawValue }
+
 12.10.2023
 
 Description:

--- a/cmake/DaqUtils.cmake
+++ b/cmake/DaqUtils.cmake
@@ -69,7 +69,7 @@ function(create_version_header LIB_NAME)
     set(INCLUDE_FOLDER_NAME ${TARGET_FOLDER_NAME})
 
     set(options ONLY_RC NO_RC)
-    set(oneValueArgs INCLUDE_FOLDER)
+    set(oneValueArgs INCLUDE_FOLDER HEADER_NAME_PREFIX)
     set(multiValueArgs VARIANTS)
     cmake_parse_arguments(GENERATE_VERSION "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -78,6 +78,11 @@ function(create_version_header LIB_NAME)
         set(INCLUDE_FOLDER_NAME ${GENERATE_VERSION_INCLUDE_FOLDER})
         set(HEADER_NAME_PREFIX "${TARGET_FOLDER_NAME}_")
     endif()
+
+    if (DEFINED GENERATE_VERSION_HEADER_NAME_PREFIX)
+        set(HEADER_NAME_PREFIX ${GENERATE_VERSION_HEADER_NAME_PREFIX})
+    endif()
+    string(STRIP "${HEADER_NAME_PREFIX}" HEADER_NAME_PREFIX)
 
     set(GENERATE_RC ON)
     set(GENERATE_HEADER ON)

--- a/core/coreobjects/include/coreobjects/component_type_impl.h
+++ b/core/coreobjects/include/coreobjects/component_type_impl.h
@@ -29,7 +29,7 @@ template <typename Intf = IComponentType, typename... Interfaces>
 class GenericComponentTypeImpl : public GenericStructImpl<Intf, IStruct, Interfaces...>
 {
 public:
-    explicit GenericComponentTypeImpl(const StructTypePtr& structType,
+    explicit GenericComponentTypeImpl(const StructTypePtr& type,
                                       const StringPtr& id,
                                       const StringPtr& name,
                                       const StringPtr& description,
@@ -48,13 +48,13 @@ protected:
 };
 
 template <class Intf, class... Interfaces>
-GenericComponentTypeImpl<Intf, Interfaces...>::GenericComponentTypeImpl(const StructTypePtr& structType,
+GenericComponentTypeImpl<Intf, Interfaces...>::GenericComponentTypeImpl(const StructTypePtr& type,
                                                                         const StringPtr& id,
                                                                         const StringPtr& name,
                                                                         const StringPtr& description,
                                                                         const FunctionPtr& createDefaultConfigCallback)
     : GenericStructImpl<Intf, IStruct, Interfaces...>(
-          structType, Dict<IString, IBaseObject>({{"id", id}, {"name", name}, {"description", description}}))
+          type, Dict<IString, IBaseObject>({{"id", id}, {"name", name}, {"description", description}}))
     , id(id)
     , name(name)
     , description(description)

--- a/core/coreobjects/src/coreobjects.natvis
+++ b/core/coreobjects/src/coreobjects.natvis
@@ -5,17 +5,15 @@
         <Expand>
             <Item IncludeView="withRefCount" Name="[refCount]">refCount,na</Item>
             <Item Name="[className]" Condition="className.object != nullptr">className.object,na</Item>
-            <Item Name="[localProperties]">localProperties</Item>
+            <Item Name="[localProperties]">localProperties,view(simple)</Item>
             <Item Name="[owner]">owner</Item>
-            <ExpandedItem>propValues._List,view(PropsView)</ExpandedItem>
+            <ExpandedItem>propValues._List,view(MapHelper)</ExpandedItem>
         </Expand>
     </Type>
     <Type Name="daq::PropertyImpl">
-        <DisplayString Condition="frozen == true">{{ name={name}, {valueType,en}, &lt;{refCount}&gt; [Frozen] }}</DisplayString>
-        <DisplayString Condition="frozen == false">{{ name={name}, {valueType,en}, &lt;{refCount}&gt;}}</DisplayString>
+        <DisplayString>{{ Property {name}, {valueType,en}, &lt;{refCount}&gt;}}</DisplayString>
         <Expand>
             <Item IncludeView="withRefCount" Name="[refCount]">refCount,na</Item>
-            <Item Name="[frozen]">frozen</Item>
             <Item Name="(onValueWrite)">onValueWrite</Item>
             <Item Name="(onValueRead)">onValueRead</Item>
             <Item Name="name">name</Item>
@@ -56,4 +54,22 @@
           <Item Name="[changeType]">type</Item>
         </Expand>
     </Type>
+    <Type Name="daq::GenericComponentTypeImpl&lt;*&gt;">
+        <DisplayString>{{ ComponentType: {name}, &lt;{refCount}&gt; }}</DisplayString>
+        <Expand>
+            <Item Name="[refCount]">refCount</Item>
+            <Item Name="id">id</Item>
+            <Item Name="name">name</Item>
+            <Item Name="description">description</Item>
+            <Item Name="createDefaultConfigCallback">createDefaultConfigCallback</Item>
+        </Expand>
+    </Type>
+  <Type Name="daq::UnitImpl">
+    <DisplayString>{{ Unit &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="structType">structType</Item>
+      <ExpandedItem>((daq::DictImpl*)fields.object)->hashTable</ExpandedItem>
+    </Expand>
+  </Type>
 </AutoVisualizer>

--- a/core/coretypes/src/coretypes.natvis
+++ b/core/coretypes/src/coretypes.natvis
@@ -1,172 +1,202 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
-    <Type Name="daq::StringImpl">
-        <!--<DisplayString ExcludeView="simple">{{ {str,s}, &lt;{refCount}&gt; }}</DisplayString>-->
-        <DisplayString ExcludeView="simple">{str,s8}</DisplayString>
-        <StringView>str</StringView>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="value">str,s8</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::ListImpl">
-        <DisplayString>List {{ {list}, &lt;{refCount}&gt; }}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="[elementId]">iid</Item>          
-            <ExpandedItem>list</ExpandedItem>
-        </Expand>
-    </Type>
-    <Type Name="daq::CustomProcedureImpl&lt;*,*&gt;">
-        <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="proc">proc</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::ProcedureImpl&lt;*,*&gt;">
-        <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="proc">functor</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::CustomFunctionImpl&lt;*,*&gt;">
-        <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="proc">functor</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::FunctionImpl&lt;*,*&gt;">
-        <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="proc">functor</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::DictImpl">
-        <DisplayString>{{ dict={hashTable}, &lt;{refCount}&gt; }}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="[keyId]">keyId</Item>
-            <Item Name="[valueId]">valueId</Item>
-            <ExpandedItem>hashTable</ExpandedItem>
-        </Expand>
-    </Type>
-    <Type Name="daq::RatioImpl">
-        <DisplayString>{{ num={numerator}, den={denominator}, &lt;{refCount}&gt; }}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="numerator">numerator</Item>
-            <Item Name="denominator">denominator</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::EventImpl">
-        <DisplayString>{{ Event, &lt;{refCount}&gt; }}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="[frozen]">frozen</Item>
-            <Item Name="muted">muted</Item>
-            <Item Name="handlers">handlers</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::EventHandlerImpl&lt;*,*&gt;">
-        <DisplayString>{{ EventHander, hash={subscription.hashCode,x}, &lt;{refCount}&gt; }}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="hashCode">subscription.hashCode</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::WeakRefImpl">
-        <DisplayString Condition="(*refCount).strong._My_val > 0">{object} &lt;{(*refCount).strong}, {(*refCount).weak}&gt;</DisplayString>
-        <DisplayString Condition="(*refCount).strong._My_val == 0">Expired &lt;{(*refCount).strong}, {(*refCount).weak}&gt;</DisplayString>
-        <Expand>
-            <Item Name="[strongRefCount]">(*refCount).strong</Item>
-            <Item Name="[weakRefCount]">(*refCount).weak</Item>
-            <ExpandedItem Condition="(*refCount).strong._My_val > 0">(*object),na</ExpandedItem>
-        </Expand>
-    </Type>
-    <Type Name="daq::OrdinalObjectImpl&lt;unsigned char,*&gt;">
-        <DisplayString Condition="value==0">False</DisplayString>
-        <DisplayString Condition="value==1">True</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="value" Condition="value==0">false</Item>
-            <Item Name="value" Condition="value==1">true</Item>
-            <Item Name="value" Condition="value!=1&amp;&amp;value!=0">value</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::OrdinalObjectImpl&lt;*,*&gt;">
-        <DisplayString>{value}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="value">value,na</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::ObjectDecorator&lt;*,*&gt;">
-        <DisplayString>{{ {object} }}</DisplayString>
-        <Expand>
-            <ExpandedItem>object,na</ExpandedItem>
-        </Expand>
-    </Type>
-    <Type Name="daq::ObjInstance&lt;*&gt;">
-        <DisplayString>{{ &lt;{refCount}&gt; }}</DisplayString>
-    </Type>
-    <Type Name="daq::ObjectPtr&lt;*&gt;">
-        <DisplayString Condition="object == nullptr">empty</DisplayString>
-        <DisplayString>{object,na}</DisplayString>
-        <StringView>object</StringView>
-        <Expand>
-            <Item Name="[borrowed]">borrowed</Item>
-            <ExpandedItem>object,na</ExpandedItem>
-        </Expand>
-    </Type>
-    <Type Name="daq::EventArgsImplTemplate&lt;*&gt;">
-        <DisplayString>{{ {eventName}, &lt;{refCount}&gt; }}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="eventId">eventId</Item>
-        <Item Name="eventName">eventName</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::ConstexprString&lt;*&gt;">
-        <DisplayString>{{{string._Elems,[$T1]} size={$T1} }}</DisplayString>
-        <StringView>string._Elems,s8</StringView>
-        <Expand>
-            <ExpandedItem>string</ExpandedItem>
-        </Expand>
-    </Type>
-    <Type Name="daq::VersionInfoImpl">
-        <DisplayString>VersionInfo {{ v{major}.{minor}.{patch}, &lt;{refCount}&gt; }}</DisplayString>
-        <Expand>
-            <Item Name="[refCount]">refCount</Item>
-            <Item Name="major">major,d</Item>
-            <Item Name="minor">minor,d</Item>
-            <Item Name="patch">patch,d</Item>
-        </Expand>
-    </Type>
-    <Type Name="daq::IteratorBaseImpl&lt;*,*&gt;">
-      <DisplayString>{{ Iterator, &lt;{refCount}&gt; }}</DisplayString>
-      <Expand>
-        <Item Name="[refCount]">refCount</Item>
-        <Item Name="[container]">coreContainer</Item>
-        <Item Name="current">*it</Item>
-        <Item Name="end">*end</Item>
-        <Item Name="started">started</Item>
-      </Expand>
-    </Type>
-    <Type Name="daq::NativeIterator&lt;*&gt;">
-      <DisplayString>{iterator}</DisplayString>
-      <Expand>
-        <ExpandedItem>iterator</ExpandedItem>
-      </Expand>
-    </Type>
-    <Type Name="daq::RefCount">
-      <DisplayString>{{ strong={strong} weak={weak} }}</DisplayString>
-      <Expand>
-        <Item Name="strong">strong</Item>
-        <Item Name="weak">weak</Item>
-      </Expand>
-    </Type>
+  <Type Name="daq::StringImpl">
+    <!--<DisplayString ExcludeView="simple">{{ {str,s}, &lt;{refCount}&gt; }}</DisplayString>-->
+    <DisplayString ExcludeView="simple">{str,s8}</DisplayString>
+    <StringView>str</StringView>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="value">str,s8</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::ListImpl">
+    <DisplayString>List {{ {list}, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="[elementId]">iid</Item>
+      <ExpandedItem>list</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::CustomProcedureImpl&lt;*,*&gt;">
+    <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="proc">proc</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::ProcedureImpl&lt;*,*&gt;">
+    <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="proc">functor</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::CustomFunctionImpl&lt;*,*&gt;">
+    <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="proc">functor</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::FunctionImpl&lt;*,*&gt;">
+    <DisplayString>Procedure, &lt;{refCount}&gt;</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="proc">functor</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::DictImpl">
+    <DisplayString>{{ dict={hashTable}, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="[keyId]">keyId</Item>
+      <Item Name="[valueId]">valueId</Item>
+      <ExpandedItem>hashTable</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::RatioImpl">
+    <DisplayString>{{ num={numerator}, den={denominator}, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="numerator">numerator</Item>
+      <Item Name="denominator">denominator</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::EventImpl">
+    <DisplayString>{{ Event, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="[frozen]">frozen</Item>
+      <Item Name="muted">muted</Item>
+      <Item Name="handlers">handlers</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::EventHandlerImpl&lt;*,*&gt;">
+    <DisplayString>{{ EventHander, hash={subscription.hashCode,x}, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="hashCode">subscription.hashCode</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::WeakRefImpl">
+    <DisplayString Condition="(*refCount).strong._My_val > 0">{object} &lt;{(*refCount).strong}, {(*refCount).weak}&gt;</DisplayString>
+    <DisplayString Condition="(*refCount).strong._My_val == 0">Expired &lt;{(*refCount).strong}, {(*refCount).weak}&gt;</DisplayString>
+    <Expand>
+      <Item Name="[strongRefCount]">(*refCount).strong</Item>
+      <Item Name="[weakRefCount]">(*refCount).weak</Item>
+      <ExpandedItem Condition="(*refCount).strong._My_val > 0">(*object),na</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::OrdinalObjectImpl&lt;unsigned char,*&gt;">
+    <DisplayString Condition="value==0">False</DisplayString>
+    <DisplayString Condition="value==1">True</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="value" Condition="value==0">false</Item>
+      <Item Name="value" Condition="value==1">true</Item>
+      <Item Name="value" Condition="value!=1&amp;&amp;value!=0">value</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::OrdinalObjectImpl&lt;*,*&gt;">
+    <DisplayString>{value}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="value">value,na</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::ObjectDecorator&lt;*,*&gt;">
+    <DisplayString>{{ {object} }}</DisplayString>
+    <Expand>
+      <ExpandedItem>object,na</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::ObjInstance&lt;*&gt;">
+    <DisplayString>{{ &lt;{refCount}&gt; }}</DisplayString>
+  </Type>
+  <Type Name="daq::ObjectPtr&lt;*&gt;">
+    <DisplayString Condition="object == nullptr">empty</DisplayString>
+    <DisplayString>{object,na}</DisplayString>
+    <StringView>object</StringView>
+    <Expand>
+      <Item Name="[borrowed]">borrowed</Item>
+      <ExpandedItem>object,na</ExpandedItem>      
+    </Expand>
+  </Type>
+  <Type Name="daq::EventArgsImplTemplate&lt;*&gt;">
+    <DisplayString>{{ {eventName}, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="eventId">eventId</Item>
+      <Item Name="eventName">eventName</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::ConstexprString&lt;*&gt;">
+    <DisplayString>{{{string._Elems,[$T1]} size={$T1} }}</DisplayString>
+    <StringView>string._Elems,s8</StringView>
+    <Expand>
+      <ExpandedItem>string</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::VersionInfoImpl">
+    <DisplayString>VersionInfo {{ v{major}.{minor}.{patch}, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="major">major,d</Item>
+      <Item Name="minor">minor,d</Item>
+      <Item Name="patch">patch,d</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::IteratorBaseImpl&lt;*,*&gt;">
+    <DisplayString>{{ Iterator, &lt;{refCount}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="[container]">coreContainer</Item>
+      <Item Name="current">*it</Item>
+      <Item Name="end">*end</Item>
+      <Item Name="started">started</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::NativeIterator&lt;*&gt;">
+    <DisplayString>{iterator}</DisplayString>
+    <Expand>
+      <ExpandedItem>iterator</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::RefCount">
+    <DisplayString>{{ strong={strong} weak={weak} }}</DisplayString>
+    <Expand>
+      <Item Name="strong">strong</Item>
+      <Item Name="weak">weak</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::StructTypeImpl">
+    <DisplayString>{{ StructType {typeName} }}</DisplayString>
+    <Expand>
+      <Item Name="names">names</Item>
+      <Item Name="defaultValues">defaultValues</Item>
+      <Item Name="types">types</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::SimpleTypeImpl">
+    <DisplayString Condition="coreType == daq::CoreType::ctBool">{{ SimpleType: Boolean }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctInt">{{ SimpleType: Integer }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctFloat">{{ SimpleType: Float }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctString">{{ SimpleType: String }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctList">{{ SimpleType: List }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctDict">{{ SimpleType: Dict }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctRatio">{{ SimpleType: Ratio }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctProc">{{ SimpleType: Procedure }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctObject">{{ SimpleType: Object }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctBinaryData">{{ SimpleType: BinaryData }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctFunc">{{ SimpleType: Function }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctComplexNumber">{{ SimpleType: ComplexNumber }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctStruct">{{ SimpleType: Structure }}</DisplayString>
+    <DisplayString Condition="coreType == daq::CoreType::ctUndefined">{{ SimpleType: Undefined }}</DisplayString>
+    <Expand>
+      <ExpandedItem>(daq::GenericTypeImpl&lt;daq::ISimpleType&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::GenericTypeImpl&lt;*&gt;">
+    <DisplayString>{{ {typeName} {coreType} }}</DisplayString>
+  </Type>
 </AutoVisualizer>

--- a/core/opendaq/device/src/CMakeLists.txt
+++ b/core/opendaq/device/src/CMakeLists.txt
@@ -88,6 +88,7 @@ opendaq_add_library(${BASE_NAME} STATIC
     ${SRC_PrivateHeaders}
     ${SRC_PublicHeaders}
     ${ConfigHeaderSource}
+    device.natvis
 )
 
 opendaq_target_link_libraries(${BASE_NAME}

--- a/core/opendaq/device/src/device.natvis
+++ b/core/opendaq/device/src/device.natvis
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="daq::GenericDevice&lt;*,*&gt;">
+    <DisplayString>{{ Device, &lt;{(*refCount).strong},{(*refCount).weak}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">*refCount</Item>
+      <Item Name="deviceInfo">deviceInfo</Item>
+      <Item Name="devices">devices</Item>
+      <Item Name="ioFolder">ioFolder</Item>
+      <Item Name="streamingOptions">streamingOptions,view(simple)</Item>
+      <ExpandedItem>(daq::SignalContainerImpl&lt;$T1,daq::IDeviceDomain,daq::IDevicePrivate,$T2&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::GenericDevice&lt;*&gt;">
+    <DisplayString>{{ Device, &lt;{(*refCount).strong},{(*refCount).weak}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">*refCount</Item>
+      <Item Name="deviceInfo">deviceInfo</Item>
+      <Item Name="devices">devices</Item>
+      <Item Name="ioFolder">ioFolder</Item>
+      <Item Name="streamingOptions">streamingOptions,view(simple)</Item>
+      <ExpandedItem>(daq::SignalContainerImpl&lt;$T1,daq::IDeviceDomain,daq::IDevicePrivate&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::GenericSignalContainerImpl&lt;*,daq::IDeviceDomain,daq::IDevicePrivate,*&gt;">
+    <Expand>
+      <Item Name="signals">signals</Item>
+      <Item Name="functionBlocks">functionBlocks</Item>
+      <Item Name="components">components,view(simple)</Item>
+      <Item Name="defaultComponents">defaultComponents,view(simple)</Item>
+      <ExpandedItem>(daq::ComponentImpl&lt;$T1,daq::IDeviceDomain,daq::IDevicePrivate,$T2&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::GenericSignalContainerImpl&lt;*,daq::IDeviceDomain,daq::IDevicePrivate&gt;">
+    <Expand>
+      <Item Name="signals">signals</Item>
+      <Item Name="functionBlocks">functionBlocks</Item>
+      <Item Name="components">components,view(simple)</Item>
+      <Item Name="defaultComponents">defaultComponents,view(simple)</Item>
+      <ExpandedItem>(daq::ComponentImpl&lt;$T1,daq::IDeviceDomain,daq::IDevicePrivate&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/core/opendaq/modulemanager/src/module_manager.natvis
+++ b/core/opendaq/modulemanager/src/module_manager.natvis
@@ -7,7 +7,6 @@
       <Item Name="name">name</Item>
       <Item Name="version">version</Item>
       <Item Name="context">context</Item>
-      <Item Name="manager">manager</Item>
     </Expand>
   </Type>
   <Type Name="daq::ContextImpl">
@@ -16,12 +15,21 @@
       <Item Name="[refCount]">refCount</Item>
       <Item Name="logger">logger</Item>
       <Item Name="scheduler">scheduler</Item>
+      <Item Name="moduleManager">moduleManager</Item>
+      <Item Name="typeManager">typeManager</Item>
     </Expand>
   </Type>
   <Type Name="daq::ModuleManagerImpl">
-    <DisplayString>{{ ModuleManager, &lt;{refCount}&gt; }}</DisplayString>
+    <DisplayString>{{ ModuleManager, &lt;{refCount->strong}, {refCount->weak}&gt; }}</DisplayString>
     <Expand>
       <ExpandedItem>libraries</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::ModuleLibrary">
+    <DisplayString>{{ ModuleLibrary, {module} }}</DisplayString>
+    <Expand>
+      <Item Name="handle">handle</Item>
+      <Item Name="module">module</Item>
     </Expand>
   </Type>
 </AutoVisualizer>

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -84,6 +84,7 @@ ErrCode ModuleManagerImpl::loadModules(IContext* context)
     logger = contextPtr.getLogger();
     if (!logger.assigned())
         return makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Logger must not be null");
+
     loggerComponent = this->logger.getOrAddComponent("ModuleManager");
     
     return daqTry([&](){

--- a/core/opendaq/opendaq/src/CMakeLists.txt
+++ b/core/opendaq/opendaq/src/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(${LIB_NAME} SHARED ${SRC_Cpp}
                                ${SRC_PrivateHeaders}
                                ${SRC_PublicHeaders}
                                ${ConfigHeaderSource}
+                               opendaq.natvis
 )
 
 add_library(${SDK_TARGET_NAMESPACE}::${BASE_NAME} ALIAS ${LIB_NAME})

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -133,6 +133,8 @@ ErrCode InstanceImpl::addServer(IString* serverTypeId, IPropertyObject* serverCo
     OPENDAQ_PARAM_NOT_NULL(serverTypeId);
     OPENDAQ_PARAM_NOT_NULL(server);
 
+    auto typeId = toStdString(serverTypeId);
+
     for (const auto module : moduleManager.getModules())
     {
         DictPtr<IString, IServerType> serverTypes;
@@ -148,13 +150,11 @@ ErrCode InstanceImpl::addServer(IString* serverTypeId, IPropertyObject* serverCo
         if (!serverTypes.assigned())
             continue;
 
-        auto typeId = toStdString(serverTypeId);
-
         for (const auto& [id, serverType] : serverTypes)
         {
             if (id == typeId)
             {
-                // Use root device instead of BluberryInstance(this) to prevent cycling reference.
+                // Use root device instead of Instance(this) to prevent cycling reference.
                 auto createdServer = module.createServer(typeId, rootDevice, serverConfig);
 
                 std::scoped_lock lock(configSync);

--- a/core/opendaq/opendaq/src/opendaq.natvis
+++ b/core/opendaq/opendaq/src/opendaq.natvis
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="daq::FolderImpl&lt;*&gt;">
+    <DisplayString>{{ Folder {localId} ({items.m_ht.m_values._Mypair._Myval2._Mysize}) &lt;{refCount->strong},{refCount->weak}&gt; }}</DisplayString>
+    <Expand>
+      <Item Name="name">name</Item>
+      <Item Name="itemId">itemId</Item>
+      <ExpandedItem>(daq::ComponentImpl&lt;$T1&gt;*)this,nd</ExpandedItem>
+      <ExpandedItem>items.m_ht.m_values,view(simple)</ExpandedItem>
+      <!--<Item Name="raw">this,!</Item>-->
+    </Expand>
+  </Type>
+  <Type Name="daq::ChannelImpl&lt;*&gt;">
+    <DisplayString>{{ Channel {localId} }}</DisplayString>
+    <Expand>
+      <ExpandedItem>(daq::FunctionBlockImpl&lt;daq::IChannel,$T1&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>    
+  <Type Name="daq::ComponentImpl&lt;*,*,*&gt;">
+    <DisplayString>{{ Component {localId} }}</DisplayString>
+    <Expand>
+      <Item Name="active">active</Item>
+      <Item Name="isRemoved">isComponentRemoved</Item>
+      <Item Name="localId">localId</Item>
+      <Item Name="globalId">globalId</Item>
+      <Item Name="tags">tags</Item>
+      <Item Name="parent">parent</Item>
+      <ExpandedItem>(daq::GenericPropertyObjectImpl&lt;$T1,daq::IRemovable,$T2,$T3&gt;*)this,nd</ExpandedItem>
+      <Item Name="[object]">this,!</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::ComponentImpl&lt;*,*&gt;">
+    <DisplayString>{{ Component {localId} }}</DisplayString>
+    <Expand>
+      <Item Name="active">active</Item>
+      <Item Name="isRemoved">isComponentRemoved</Item>
+      <Item Name="localId">localId</Item>
+      <Item Name="globalId">globalId</Item>
+      <Item Name="tags">tags</Item>
+      <Item Name="parent">parent</Item>
+      <ExpandedItem>(daq::GenericPropertyObjectImpl&lt;$T1,daq::IRemovable,$T2&gt;*)this,nd</ExpandedItem>
+      <Item Name="[object]">this,!</Item>
+    </Expand>
+  </Type>
+  <Type Name="daq::ComponentImpl&lt;*&gt;">
+    <DisplayString>{{ Component {localId} }}</DisplayString>
+    <Expand>
+      <Item Name="active">active</Item>
+      <Item Name="isRemoved">isComponentRemoved</Item>
+      <Item Name="localId">localId</Item>
+      <Item Name="globalId">globalId</Item>
+      <Item Name="tags">tags</Item>
+      <Item Name="parent">parent</Item>
+      <ExpandedItem>(daq::GenericPropertyObjectImpl&lt;$T1,daq::IRemovable&gt;*)this,nd</ExpandedItem>
+      <Item Name="[object]">this,!</Item>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/core/opendaq/opendaq/src/opendaq.natvis
+++ b/core/opendaq/opendaq/src/opendaq.natvis
@@ -15,7 +15,31 @@
     <Expand>
       <ExpandedItem>(daq::FunctionBlockImpl&lt;daq::IChannel,$T1&gt;*)this,nd</ExpandedItem>
     </Expand>
-  </Type>    
+  </Type>
+  <Type Name="daq::GenericSignalContainerImpl&lt;*&gt;">
+    <Expand>
+      <Item Name="signals">signals</Item>
+      <Item Name="functionBlocks">functionBlocks</Item>
+      <Item Name="components">components</Item>
+      <ExpandedItem>(daq::ComponentImpl&lt;*&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::GenericSignalContainerImpl&lt;*,*&gt;">
+    <Expand>
+      <Item Name="components">components</Item>
+      <Item Name="signals">signals</Item>
+      <Item Name="functionBlocks">functionBlocks</Item>
+      <ExpandedItem>(daq::ComponentImpl&lt;$T1,$T2&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="daq::GenericSignalContainerImpl&lt;*,*,*&gt;">
+    <Expand>
+      <Item Name="signals">signals</Item>
+      <Item Name="functionBlocks">functionBlocks</Item>
+      <Item Name="components">components</Item>
+      <ExpandedItem>(daq::ComponentImpl&lt;$T1,$T2,$T3&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
   <Type Name="daq::ComponentImpl&lt;*,*,*&gt;">
     <DisplayString>{{ Component {localId} }}</DisplayString>
     <Expand>

--- a/core/opendaq/reader/include/opendaq/reader_factory.h
+++ b/core/opendaq/reader/include/opendaq/reader_factory.h
@@ -307,6 +307,18 @@ MultiReaderPtr MultiReader(ListPtr<ISignal> signals, ReadMode mode, ReadTimeoutT
     );
 }
 
+template <typename TDomainType = ClockTick>
+MultiReaderPtr MultiReaderRaw(ListPtr<ISignal> signals, ReadTimeoutType timeoutType = ReadTimeoutType::All)
+{
+    return MultiReader(
+        signals,
+        SampleType::Undefined,
+        SampleTypeFromType<TDomainType>::SampleType,
+        ReadMode::RawValue,
+        timeoutType
+    );
+}
+
 template <typename TValueType = double, typename TDomainType = ClockTick>
 MultiReaderPtr MultiReaderFromExisting(MultiReaderPtr invalidatedReader)
 {

--- a/core/opendaq/reader/include/opendaq/reader_impl.h
+++ b/core/opendaq/reader/include/opendaq/reader_impl.h
@@ -447,7 +447,7 @@ protected:
     {
         switch (readMode)
         {
-            case ReadMode::Raw:
+            case ReadMode::Unscaled:
                 return packet.getRawData();
             case ReadMode::Scaled:
                 return packet.getData();

--- a/core/opendaq/reader/include/opendaq/sample_reader.h
+++ b/core/opendaq/reader/include/opendaq/sample_reader.h
@@ -28,8 +28,9 @@ BEGIN_NAMESPACE_OPENDAQ
 
 enum class ReadMode
 {
-    Raw,
-    Scaled
+    Unscaled,
+    Scaled,
+    RawValue
 };
 
 /*#

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -542,7 +542,6 @@ ErrCode MultiReaderImpl::readPackets()
 #if (OPENDAQ_LOG_LEVEL <= OPENDAQ_LOG_LEVEL_TRACE)
             auto start = std::chrono::steady_clock::now();
 #endif
-
             readSamples(toRead);
 
 #if (OPENDAQ_LOG_LEVEL <= OPENDAQ_LOG_LEVEL_TRACE)

--- a/core/opendaq/reader/src/reader.natvis
+++ b/core/opendaq/reader/src/reader.natvis
@@ -62,7 +62,7 @@
     </Expand>
   </Type>
   <Type Name="daq::TypedReader&lt;*&gt;">
-    <DisplayString>{{ TypedReader, read: {"$T1"}, data: {dataSampleType} }}</DisplayString>
+    <DisplayString>{{ TypedReader, read: {"$T1",sb}, data: {dataSampleType} }}</DisplayString>
   </Type>
   <Type Name="daq::UndefinedReader">
     <DisplayString>{{ UndefinedReader }}</DisplayString>

--- a/core/opendaq/reader/src/signal_reader.cpp
+++ b/core/opendaq/reader/src/signal_reader.cpp
@@ -13,7 +13,7 @@ SignalReader::SignalReader(const InputPortConfigPtr& port,
                            ReadMode mode,
                            const LoggerComponentPtr& logger)
     : loggerComponent(logger)
-    , valueReader(createReaderForType(valueReadType, nullptr))
+    , valueReader(createReaderForType(mode == ReadMode::RawValue ? SampleType::Undefined : valueReadType, nullptr))
     , domainReader(createReaderForType(domainReadType, nullptr))
     , port(port)
     , connection(port.getConnection())
@@ -28,7 +28,8 @@ SignalReader::SignalReader(const SignalReader& old,
                            SampleType valueReadType,
                            SampleType domainReadType)
     : loggerComponent(old.loggerComponent)
-    , valueReader(createReaderForType(valueReadType, old.valueReader->getTransformFunction()))
+    , valueReader(createReaderForType(old.readMode == ReadMode::RawValue ? SampleType::Undefined : valueReadType,
+                                      old.valueReader->getTransformFunction()))
     , domainReader(createReaderForType(domainReadType, old.domainReader->getTransformFunction()))
     , port(old.port)
     , connection(port.getConnection())
@@ -48,7 +49,7 @@ SignalReader::SignalReader(const SignalInfo& old,
                            SampleType valueReadType,
                            SampleType domainReadType)
     : loggerComponent(old.loggerComponent)
-    , valueReader(createReaderForType(valueReadType, old.valueTransformFunction))
+    , valueReader(createReaderForType(old.readMode == ReadMode::RawValue ? SampleType::Undefined : valueReadType, old.valueTransformFunction))
     , domainReader(createReaderForType(domainReadType, old.domainTransformFunction))
     , port(old.port)
     , connection(port.getConnection())
@@ -134,6 +135,13 @@ void SignalReader::handleDescriptorChanged(const EventPacketPtr& eventPacket)
     auto params = eventPacket.getParameters();
     DataDescriptorPtr newValueDescriptor = params[event_packet_param::DATA_DESCRIPTOR];
     DataDescriptorPtr newDomainDescriptor = params[event_packet_param::DOMAIN_DATA_DESCRIPTOR];
+
+    if (readMode == ReadMode::RawValue &&
+        newValueDescriptor.assigned() &&
+        valueReader->getReadType() == SampleType::Undefined)
+    {
+        valueReader = createReaderForType(newValueDescriptor.getSampleType(), valueReader->getTransformFunction());
+    }
     
     invalid = !valueReader->handleDescriptorChanged(newValueDescriptor);
     auto validDomain = domainReader->handleDescriptorChanged(newDomainDescriptor);
@@ -371,7 +379,8 @@ void* SignalReader::getValuePacketData(const DataPacketPtr& packet) const
 {
     switch (readMode)
     {
-        case ReadMode::Raw:
+        case ReadMode::RawValue:
+        case ReadMode::Unscaled:
             return packet.getRawData();
         case ReadMode::Scaled:
             return packet.getData();

--- a/core/opendaq/server/src/CMakeLists.txt
+++ b/core/opendaq/server/src/CMakeLists.txt
@@ -49,6 +49,7 @@ opendaq_add_library(${BASE_NAME} STATIC
     ${SRC_PrivateHeaders}
     ${SRC_PublicHeaders}
     ${ConfigHeaderSource}
+    server.natvis
 )
 
 opendaq_target_link_libraries(${BASE_NAME}

--- a/core/opendaq/server/src/server.natvis
+++ b/core/opendaq/server/src/server.natvis
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="daq::ServerImpl">
+    <DisplayString>Server, &lt;{refCount}&gt;</DisplayString>
+    <Expand>
+      <Item Name="[refCount]">refCount</Item>
+      <Item Name="serverConfig">serverConfig</Item>
+      <Item Name="rootDevice">rootDevice</Item>
+      <Item Name="context">context</Item>
+      <Item Name="moduleManager">moduleManager</Item>
+    </Expand>
+	</Type>
+</AutoVisualizer>

--- a/core/opendaq/signal/src/signal.natvis
+++ b/core/opendaq/signal/src/signal.natvis
@@ -24,7 +24,7 @@
       <Item Name="name">name</Item>
       <Item Name="active">active</Item>
       <Item Name="public">isPublic</Item>
-      <Item Name="descriptor">signalDescriptor</Item>
+      <Item Name="descriptor">dataDescriptor</Item>
       <Item Name="domain">domainSignal</Item>
       <Item Name="connections">connections</Item>
       <Item Name="relatedSignals">relatedSignals</Item>
@@ -63,7 +63,7 @@
       <Item Name="descriptor">descriptor</Item>
       <Item Name="sampleCount">sampleCount</Item>
       <Item Name="offset" Condition="offset.object != nullptr">offset</Item>
-      <Item Name="offset" Condition="offset.object == nullptr">empty</Item>
+      <Item Name="offset" Condition="offset.object == nullptr">"empty",sb</Item>
       <Item Name="sampleMemSize">sampleMemSize</Item>
       <Item Name="data">data</Item>
       <Item Name="scaledData">scaledData</Item>
@@ -74,11 +74,9 @@
     </Expand>
   </Type>
   <Type Name="daq::DataDescriptorImpl">
-    <DisplayString Condition="frozen == true">{{ DataDescriptor: {name} [Frozen] &lt;{refCount}&gt; }}</DisplayString>
-    <DisplayString Condition="frozen == false">{{ DataDescriptor: {name} &lt;{refCount}&gt; }}</DisplayString>
+    <DisplayString>{{ DataDescriptor: {name} &lt;{refCount}&gt; }}</DisplayString>
     <Expand>
       <Item Name="[refCount]">refCount</Item>
-      <Item Name="[frozen]">frozen</Item>
       <Item Name="name">name</Item>
       <Item Name="dimensions">dimensions</Item>
       <Item Name="sampleType">sampleType</Item>
@@ -93,11 +91,9 @@
     </Expand>
   </Type>
   <Type Name="daq::DataRuleImpl">
-    <DisplayString Condition="frozen == true">{{ DataRule: {ruleType} [Frozen] &lt;{refCount}&gt; }}</DisplayString>
-    <DisplayString Condition="frozen == false">{{ DataDescriptor: {ruleType} &lt;{refCount}&gt; }}</DisplayString>
+    <DisplayString>{{ DataDescriptor: {ruleType} &lt;{refCount}&gt; }}</DisplayString>
     <Expand>
       <Item Name="[refCount]">refCount</Item>
-      <Item Name="[frozen]">frozen</Item>
       <Item Name="type">ruleType</Item>
       <Item Name="params">params</Item>
     </Expand>
@@ -143,17 +139,6 @@
       <Item Name="inputType">inputDataType</Item>
       <Item Name="outputType">outputDataType</Item>
       <Item Name="params">params</Item>
-    </Expand>
-  </Type>
-  <Type Name="daq::UnitImpl">
-    <DisplayString Condition="frozen == true">{{ Unit: {name} / {symbol} [Frozen] }}</DisplayString>
-    <DisplayString Condition="frozen == false">{{ Unit: {name} / {symbol} }}</DisplayString>
-    <Expand>
-      <Item Name="[refCount]">refCount</Item>
-      <Item Name="[frozen]">frozen</Item>
-      <Item Name="symbol">symbol</Item>
-      <Item Name="name">name,sb</Item>
-      <Item Name="quantity">quantity</Item>
     </Expand>
   </Type>
 </AutoVisualizer>

--- a/core/opendaq/streaming/src/CMakeLists.txt
+++ b/core/opendaq/streaming/src/CMakeLists.txt
@@ -64,6 +64,7 @@ opendaq_add_library(${BASE_NAME} STATIC
     ${SRC_PrivateHeaders}
     ${SRC_PublicHeaders}
     ${ConfigHeaderSource}
+    streaming.natvis
 )
 
 opendaq_target_link_libraries(${BASE_NAME}

--- a/core/opendaq/streaming/src/streaming.natvis
+++ b/core/opendaq/streaming/src/streaming.natvis
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="daq::StreamingInfoConfigImpl">
+    <DisplayString>{StreamingInfo}</DisplayString>
+    <Expand>
+      <ExpandedItem>(daq::GenericPropertyObjectImpl&lt;daq::IStreamingInfoConfig&gt;*)this,nd</ExpandedItem>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/examples/cpp/quick_start/quick_start_full.cpp
+++ b/examples/cpp/quick_start/quick_start_full.cpp
@@ -1,9 +1,9 @@
+#include <opendaq/opendaq.h>
 #include <chrono>
 #include <iostream>
 #include <thread>
-#include <opendaq/opendaq.h>
 
-int main(int /*argc*/, const char* /*argv*/[])
+int quickStartFull(int /*argc*/, const char* /*argv*/ [])
 {
     // Create a new Instance that we will use for all the interactions with the SDK
     daq::InstancePtr instance = daq::Instance(MODULE_PATH);
@@ -130,5 +130,171 @@ int main(int /*argc*/, const char* /*argv*/[])
 
     std::cout << "Press \"enter\" to exit the application..." << std::endl;
     std::cin.get();
+    return 0;
+}
+
+int streamReaderTest(int /*argc*/, const char* /*argv*/ [])
+{
+    // Create a new Instance that we will use for all the interactions with the SDK
+    daq::InstancePtr instance = daq::Instance(MODULE_PATH);
+
+    // Find and connect to a device hosting an OPC UA TMS server
+    const auto availableDevices = instance.getAvailableDevices();
+    daq::DevicePtr device;
+    for (const auto& deviceInfo : availableDevices)
+    {
+        if (deviceInfo.getConnectionString().toView().find("daq.opcua://") != std::string::npos)
+        {
+            device = instance.addDevice(deviceInfo.getConnectionString());
+            break;
+        }
+    }
+
+    // Exit if no device is found
+    if (!device.assigned())
+    {
+        std::cerr << "No relevant device found!" << std::endl;
+        return 0;
+    }
+
+    // Output the name of the added device
+    std::cout << device.getInfo().getName() << std::endl;
+
+    // Output 10 samples using reader
+    using namespace std::chrono_literals;
+    auto signals = device.getSignalsRecursive();
+
+    // Get the first channel and its signal
+    daq::ChannelPtr channel = device.getChannels()[0];
+    daq::SignalPtr signal = channel.getSignals()[0];
+
+    daq::StreamReaderPtr reader = daq::StreamReader<double, int64_t>(signal);
+
+    const std::size_t BUFF_SIZE = 10000;
+
+    double values[BUFF_SIZE]{};
+    std::size_t counts[10000]{};
+
+    auto now = std::chrono::system_clock::now();
+    auto sec10 = now + 1min;
+
+    while (now < sec10)
+    {
+        std::size_t readCount = BUFF_SIZE;
+        reader.read(&values, &readCount);
+
+        counts[readCount]++;
+
+        std::this_thread::sleep_for(20ms);
+        now = std::chrono::system_clock::now();
+    }
+
+    for (int i = 0; i < std::size(counts); ++i)
+    {
+        if (counts[i] != 0)
+        {
+            std::cout << i << ": " << counts[i] << std::endl;
+        }
+    }
+
+    std::cout << "Press \"enter\" to exit the application..." << std::endl;
+    std::cin.get();
+    return 0;
+}
+
+int multiReaderTest(int /*argc*/, const char* /*argv*/ [])
+{
+    // Create a new Instance that we will use for all the interactions with the SDK
+    daq::InstancePtr instance = daq::Instance(MODULE_PATH);
+
+    // Find and connect to a device hosting an OPC UA TMS server
+    const auto availableDevices = instance.getAvailableDevices();
+    daq::DevicePtr device;
+    for (const auto& deviceInfo : availableDevices)
+    {
+        if (deviceInfo.getConnectionString().toView().find("daq.opcua://") != std::string::npos)
+        {
+            device = instance.addDevice(deviceInfo.getConnectionString());
+            break;
+        }
+    }
+
+    // Exit if no device is found
+    if (!device.assigned())
+    {
+        std::cerr << "No relevant device found!" << std::endl;
+        return 0;
+    }
+
+    // Output the name of the added device
+    std::cout << device.getInfo().getName() << std::endl;
+
+    // Output 10 samples using reader
+    using namespace std::chrono_literals;
+    auto signals = device.getSignalsRecursive();
+
+    for (std::size_t i = signals.getCount(); i != 0; --i)
+    {
+        if (!signals[i - 1].getDomainSignal().assigned())
+        {
+            signals.removeAt(i - 1);
+        }
+    }
+
+    auto reader = daq::MultiReader<double, int64_t>(signals);
+    auto av = reader.getAvailableCount();
+
+    const std::size_t BUFF_SIZE = 10000;
+    const std::size_t NUM_SIGNALS = 2;
+
+
+
+    std::array<double[BUFF_SIZE], NUM_SIGNALS> values{};
+    std::array<daq::ClockTick[BUFF_SIZE], NUM_SIGNALS> domain{};
+
+    void* valuesPerSignal[NUM_SIGNALS]{values[0], values[1]};
+    void* domainPerSignal[NUM_SIGNALS]{domain[0], domain[1]};
+
+    std::size_t counts[10000]{};
+    do
+    {
+        av = reader.getAvailableCount();
+        std::this_thread::sleep_for(20ms);
+    }
+    while(av == 0);
+
+    auto now = std::chrono::system_clock::now();
+    auto sec10 = now + 30min;
+
+    while (now < sec10)
+    {
+        std::size_t readCount = BUFF_SIZE;
+        reader.read(&valuesPerSignal, &readCount);
+
+        counts[readCount]++;
+
+        std::this_thread::sleep_for(20ms);
+        now = std::chrono::system_clock::now();
+    }
+
+    for (int i = 0; i < std::size(counts); ++i)
+    {
+        if (counts[i] != 0)
+        {
+            std::cout << i << ": " << counts[i] << std::endl;
+        }
+    }
+
+    std::cout << "Press \"enter\" to exit the application..." << std::endl;
+    std::cin.get();
+    return 0;
+}
+
+int main(int argc, const char* argv[])
+{
+    quickStartFull(argc, argv);
+    //streamReaderTest(argc, argv);
+    //multiReaderTest(argc, argv);
+
     return 0;
 }

--- a/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
+++ b/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
@@ -30,7 +30,7 @@ class NativeStreamingServerImpl : public daq::Server
 {
 public:
     explicit NativeStreamingServerImpl(daq::DevicePtr rootDevice, PropertyObjectPtr config, const ContextPtr& context);
-    ~NativeStreamingServerImpl();
+    ~NativeStreamingServerImpl() override;
     static PropertyObjectPtr createDefaultConfig();
     static ServerTypePtr createType();
 

--- a/modules/native_streaming_server_module/src/CMakeLists.txt
+++ b/modules/native_streaming_server_module/src/CMakeLists.txt
@@ -30,6 +30,7 @@ source_group("module" FILES ${MODULE_HEADERS_DIR}/native_streaming_server_module
 
 add_library(${LIB_NAME} SHARED ${SRC_Include}
                                ${SRC_Srcs}
+                               native_streaming_server.natvis
 )
 
 add_library(${SDK_TARGET_NAMESPACE}::${LIB_NAME} ALIAS ${LIB_NAME})

--- a/modules/native_streaming_server_module/src/native_streaming_server.natvis
+++ b/modules/native_streaming_server_module/src/native_streaming_server.natvis
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="daq::modules::native_streaming_server_module::NativeStreamingServerImpl">
+    <DisplayString>{{ NativeStreamingServer, &lt;{refCount}&gt;}}</DisplayString>
+        <Expand>
+          <ExpandedItem>(daq::ServerImpl*)this,nd</ExpandedItem>
+          <Item Name="readThreadActive">readThreadActive</Item>
+          <Item Name="readThreadSleepTime">readThreadSleepTime</Item>
+        </Expand>
+	</Type>
+</AutoVisualizer>

--- a/modules/opcua_server_module/src/CMakeLists.txt
+++ b/modules/opcua_server_module/src/CMakeLists.txt
@@ -25,6 +25,7 @@ source_group("module" FILES ${MODULE_HEADERS_DIR}/opcua_server_module_impl.h
 
 add_library(${LIB_NAME} SHARED ${SRC_Include}
                                ${SRC_Srcs}
+                               opcua_server.natvis
 )
 
 add_library(${SDK_TARGET_NAMESPACE}::${LIB_NAME} ALIAS ${LIB_NAME})

--- a/modules/opcua_server_module/src/opcua_server.natvis
+++ b/modules/opcua_server_module/src/opcua_server.natvis
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="daq::modules::opcua_server_module::OpcUaServerImpl">
+    <DisplayString>OpcUaServerImpl, &lt;{refCount}&gt;</DisplayString>
+      <Expand>
+        <ExpandedItem>(daq::ServerImpl*)this,nd</ExpandedItem>
+          <Item Name="server">server</Item>
+          <Item Name="config">config</Item>
+          <Item Name="context">context</Item>
+      </Expand>
+  </Type>
+</AutoVisualizer>

--- a/shared/libraries/discovery/src/daq_discovery_client.cpp
+++ b/shared/libraries/discovery/src/daq_discovery_client.cpp
@@ -53,7 +53,8 @@ void DiscoveryClient::discoverMdnsDevices()
     {
         try
         {
-            discoveredDevices.pushBack(createDeviceInfo(device));
+            if (auto deviceInfo = createDeviceInfo(device); deviceInfo.assigned())
+                discoveredDevices.pushBack(deviceInfo);
         }
         catch (...)
         {
@@ -99,8 +100,8 @@ DeviceInfoPtr DiscoveryClient::createDeviceInfo(MdnsDiscoveredDevice discoveredD
     auto exceptionMessage = "Failed to parse discovery data. Not a openDAQ device.";
 
     if (discoveredDevice.ipv4Address.empty())
-        throw DaqException(OPENDAQ_ERR_INVALIDPARAMETER, exceptionMessage);
-    
+        return nullptr;
+
     std::unordered_set<std::string> requiredCapsCopy = requiredCaps;
     auto caps = discoveredDevice.getPropertyOrDefault("caps");
     std::stringstream ss(caps);


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
Add the option for MultiReader to not do any conversion or scaling per signal and just return whatever is in the packet buffer.
This effectively ignores the reader `readType` and it falls on the user to provide a buffer of proper type and length and react properly on any value type changes.

This PR also has some NatVis and general fixes attached.