### PR TITLE
<TBBAS-1168> Optimize device enumeration/discovery duration

### DIFF
--- a/shared/libraries/discovery/include/daq_discovery/daq_discovery_client.h
+++ b/shared/libraries/discovery/include/daq_discovery/daq_discovery_client.h
@@ -26,7 +26,7 @@ class DiscoveryClient
 public:
     DiscoveryClient(std::function<std::string(MdnsDiscoveredDevice)> connectionStringFormatCb, std::unordered_set<std::string> requiredCaps = {});
     
-    void initMdnsClient(const std::string& serviceName, std::chrono::milliseconds discoveryDuration = 1000ms);
+    void initMdnsClient(const std::string& serviceName, std::chrono::milliseconds discoveryDuration = 500ms);
     virtual ListPtr<IDeviceInfo> discoverDevices();
 
 protected:


### PR DESCRIPTION
# Description:

* 'getAvailableDevices' per-module calls are executed in parallel on separate threads
* set the mDNS query response wait timeout to be determined by a custom duration value (1s default) rather than a fixed 2-second timeout.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
