### PR TITLE
Enable streaming-lt pseudo device connection using TCP sockets

### DIFF
--- a/examples/python/gui_demo.py
+++ b/examples/python/gui_demo.py
@@ -23,9 +23,9 @@ yes_no = {
 }
 
 class DeviceInfoLocal:
-    def __init__(self, ip):
-        self.name = ip
-        self.connection_string = 'daq.opcua://{}'.format(ip)
+    def __init__(self, connString):
+        self.name = connString
+        self.connection_string = connString
         self.serial_number = 'no-serial-number'
 
 def show_modal(window):
@@ -83,10 +83,9 @@ class App(tk.Tk):
         self.ui_scaling_factor = int(args.scale)
         self.include_reference_devices = bool(args.demo)
         try:
-            ipaddress.ip_address(args.ip)
-            self.ip = args.ip
+            self.connection_string = args.connection_string
         except ValueError:
-            self.ip = None
+            self.connection_string = None
 
         self.title('openDAQ demo')
         self.geometry('{}x{}'.format(1400*self.ui_scaling_factor, 1000*self.ui_scaling_factor))
@@ -150,7 +149,7 @@ class App(tk.Tk):
 
         self.all_devices = {}
 #        self.scan_devices()
-        if self.ip != None:
+        if self.connection_string != None:
             self.add_first_available_device() # also calls self.update_tree_widget()
         self.update_tree_widget()
 
@@ -164,8 +163,8 @@ class App(tk.Tk):
             if not conn in self.all_devices:
                 self.all_devices[conn] = {'device_info': device_info, 'enabled': False, 'device': None}
 
-        if self.ip != None:
-            add_device(DeviceInfoLocal(self.ip))
+        if self.connection_string != None:
+            add_device(DeviceInfoLocal(self.connection_string))
         for device_info in self.instance.available_devices:
             add_device(device_info)
 
@@ -836,7 +835,7 @@ class App(tk.Tk):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Display openDAQ device configuration and plot values')
     parser.add_argument('--scale', help='UI scaling factor', type=int, default=1.0)
-    parser.add_argument('--ip', help='IP address', type=str, default='')
+    parser.add_argument('--connection_string', help='Connection string', type=str, default='')
     parser.add_argument('--demo', help='Include internal demo/reference devices', action='store_true')
 
     app = App(parser.parse_args())

--- a/modules/tests/test_opendaq_device_modules/CMakeLists.txt
+++ b/modules/tests/test_opendaq_device_modules/CMakeLists.txt
@@ -13,7 +13,10 @@ if (OPENDAQ_ENABLE_NATIVE_STREAMING)
 endif()
 
 if (OPENDAQ_ENABLE_NATIVE_STREAMING OR OPENDAQ_ENABLE_WEBSOCKET_STREAMING)
-    list(APPEND TEST_SOURCES test_streaming.cpp test_subdevices.cpp)
+    list(APPEND TEST_SOURCES test_subdevices.cpp)
+    if (NOT APPLE)
+        list(APPEND TEST_SOURCES test_streaming.cpp)
+    endif()
 endif()
 
 add_executable(${TEST_APP} ${TEST_SOURCES}

--- a/modules/tests/test_ws_siggen_integration/CMakeLists.txt
+++ b/modules/tests/test_ws_siggen_integration/CMakeLists.txt
@@ -13,17 +13,21 @@ target_link_libraries(${TEST_APP} PRIVATE daq::test_utils
 
 add_dependencies(${TEST_APP} daq::ws_stream_cl_module
                              siggen2websocket
+                             siggen2socket
 )
 
 find_program(BASH_PROGRAM bash)
 if(BASH_PROGRAM)
     message(STATUS "Bash found - add siggen test")
     set(TEST_SCRIPT "\
-        $<TARGET_FILE:siggen2websocket> 7413 ${CMAKE_CURRENT_SOURCE_DIR}/siggen_config.json 1>/tmp/siggen_output 2>/tmp/siggen_output 0</dev/null & \
+        $<TARGET_FILE:siggen2websocket> 7413 ${CMAKE_CURRENT_SOURCE_DIR}/siggen_config.json 1>/tmp/siggen2websocket_output 2>/tmp/siggen2websocket_output 0</dev/null & \
+        $<TARGET_FILE:siggen2socket> 7411 ${CMAKE_CURRENT_SOURCE_DIR}/siggen_config.json 1>/tmp/siggen2socket_output 2>/tmp/siggen2socket_output 0</dev/null & \
         $<TARGET_FILE:${TEST_APP}>; \
         EXIT_CODE=$?; \
         killall siggen2websocket; \
-        echo \"\nsiggen2websocket output:\n\n$(</tmp/siggen_output)\"; \
+        killall siggen2socket; \
+        echo \"\nsiggen2websocket output:\n\n$(</tmp/siggen2websocket_output)\"; \
+        echo \"\nsiggen2socket output:\n\n$(</tmp/siggen2socket_output)\"; \
         exit $EXIT_CODE"
     )
     add_test(NAME ${TEST_APP}

--- a/modules/websocket_streaming_client_module/include/websocket_streaming_client_module/websocket_streaming_client_module_impl.h
+++ b/modules/websocket_streaming_client_module/include/websocket_streaming_client_module/websocket_streaming_client_module_impl.h
@@ -37,7 +37,8 @@ public:
 
 private:
     static StringPtr tryCreateWebsocketConnectionString(const StreamingInfoPtr& config);
-    static DeviceTypePtr createDeviceType();
+    static DeviceTypePtr createWebsocketDeviceType();
+    static DeviceTypePtr createTcpsocketDeviceType();
 
     std::mutex sync;
     size_t deviceIndex;

--- a/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
+++ b/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
@@ -9,7 +9,9 @@
 BEGIN_NAMESPACE_OPENDAQ_WEBSOCKET_STREAMING_CLIENT_MODULE
 
 static const char* WebsocketDeviceTypeId = "daq.ws";
+static const char* TcpsocketDeviceTypeId = "daq.tcp";
 static const char* WebsocketDevicePrefix = "daq.ws://";
+static const char* TcpsocketDevicePrefix = "daq.tcp://";
 static const char* WebsocketStreamingPrefix = "daq.wss://";
 static const char* WebsocketStreamingID = "daq.wss";
 
@@ -38,7 +40,7 @@ ListPtr<IDeviceInfo> WebsocketStreamingClientModule::onGetAvailableDevices()
     auto availableDevices = discoveryClient.discoverDevices();
     for (auto device : availableDevices)
     {
-        device.asPtr<IDeviceInfoConfig>().setDeviceType(createDeviceType());
+        device.asPtr<IDeviceInfoConfig>().setDeviceType(createWebsocketDeviceType());
     }
     return availableDevices;
 }
@@ -47,8 +49,11 @@ DictPtr<IString, IDeviceType> WebsocketStreamingClientModule::onGetAvailableDevi
 {
     auto result = Dict<IString, IDeviceType>();
 
-    auto deviceType = createDeviceType();
-    result.set(deviceType.getId(), deviceType);
+    auto websocketDeviceType = createWebsocketDeviceType();
+    auto tcpsocketDeviceType = createTcpsocketDeviceType();
+
+    result.set(websocketDeviceType.getId(), websocketDeviceType);
+    result.set(tcpsocketDeviceType.getId(), tcpsocketDeviceType);
 
     return result;
 }
@@ -79,6 +84,8 @@ bool WebsocketStreamingClientModule::onAcceptsConnectionParameters(const StringP
 {
     std::string connStr = connectionString;
     auto found = connStr.find(WebsocketDevicePrefix);
+    if (found != 0)
+        found = connStr.find(TcpsocketDevicePrefix);
     return (found == 0);
 }
 
@@ -138,10 +145,17 @@ StringPtr WebsocketStreamingClientModule::tryCreateWebsocketConnectionString(con
     return connectionString;
 }
 
-DeviceTypePtr WebsocketStreamingClientModule::createDeviceType()
+DeviceTypePtr WebsocketStreamingClientModule::createWebsocketDeviceType()
 {
     return DeviceType(WebsocketDeviceTypeId,
                       "Websocket enabled device",
+                      "Pseudo device, provides only signals of the remote device as flat list");
+}
+
+DeviceTypePtr WebsocketStreamingClientModule::createTcpsocketDeviceType()
+{
+    return DeviceType(TcpsocketDeviceTypeId,
+                      "Tcpsocket enabled device",
                       "Pseudo device, provides only signals of the remote device as flat list");
 }
 

--- a/modules/websocket_streaming_client_module/tests/test_websocket_streaming_client_module.cpp
+++ b/modules/websocket_streaming_client_module/tests/test_websocket_streaming_client_module.cpp
@@ -234,9 +234,11 @@ TEST_F(WebsocketStreamingClientModuleTest, GetAvailableComponentTypes)
 
     DictPtr<IString, IDeviceType> deviceTypes;
     ASSERT_NO_THROW(deviceTypes = module.getAvailableDeviceTypes());
-    ASSERT_EQ(deviceTypes.getCount(), 1u);
+    ASSERT_EQ(deviceTypes.getCount(), 2u);
     ASSERT_TRUE(deviceTypes.hasKey("daq.ws"));
     ASSERT_EQ(deviceTypes.get("daq.ws").getId(), "daq.ws");
+    ASSERT_TRUE(deviceTypes.hasKey("daq.tcp"));
+    ASSERT_EQ(deviceTypes.get("daq.tcp").getId(), "daq.tcp");
 
     DictPtr<IString, IServerType> serverTypes;
     ASSERT_NO_THROW(serverTypes = module.getAvailableServerTypes());

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
@@ -50,8 +50,8 @@ public:
         std::function<void(const StringPtr& signalId, const DataDescriptorPtr& domainDescriptor)>;
     using OnAvailableSignalsCallback = std::function<void(const std::vector<std::string>& signalIds)>;
 
-    StreamingClient(const ContextPtr& context, const std::string& connectionString);
-    StreamingClient(const ContextPtr& context, const std::string& host, uint16_t port, const std::string& target = "/");
+    StreamingClient(const ContextPtr& context, const std::string& connectionString, bool useRawTcpConnection = false);
+    StreamingClient(const ContextPtr& context, const std::string& host, uint16_t port, const std::string& target, bool useRawTcpConnection = false);
     ~StreamingClient();
 
     bool connect();
@@ -112,6 +112,7 @@ protected:
     std::chrono::milliseconds connectTimeout{1000};
     std::unordered_map<std::string, std::pair<std::promise<void>, std::future<void>>> signalInitializedStatus;
     std::unordered_map<std::string, DataDescriptorPtr> cachedDomainDescriptors;
+    bool useRawTcpConnection;
 };
 
 END_NAMESPACE_OPENDAQ_WEBSOCKET_STREAMING

--- a/shared/libraries/websocket_streaming/src/websocket_client_device_impl.cpp
+++ b/shared/libraries/websocket_streaming/src/websocket_client_device_impl.cpp
@@ -48,7 +48,8 @@ void WebsocketClientDeviceImpl::activateStreaming()
 /// connects to streaming server and waits till the list of available signals received
 void WebsocketClientDeviceImpl::createWebsocketStreaming()
 {
-    auto streamingClient = std::make_shared<StreamingClient>(context, connectionString);
+    bool useRawTcpConnection = connectionString.toStdString().find("daq.tcp://") == 0;
+    auto streamingClient = std::make_shared<StreamingClient>(context, connectionString, useRawTcpConnection);
 
     auto signalInitCallback = [this](const StringPtr& signalId, const SubscribedSignalInfo& sInfo)
     {

--- a/shared/libraries/websocket_streaming/src/websocket_streaming_impl.cpp
+++ b/shared/libraries/websocket_streaming/src/websocket_streaming_impl.cpp
@@ -22,7 +22,7 @@ WebsocketStreamingImpl::WebsocketStreamingImpl(StreamingClientPtr streamingClien
 {
     prepareStreamingClient();
     if (!this->streamingClient->connect())
-        throw NotFoundException("Failed to connect to websocket server url: {}", connectionString);
+        throw NotFoundException("Failed to connect to streaming server url: {}", connectionString);
 }
 
 void WebsocketStreamingImpl::onSetActive(bool active)

--- a/shared/libraries/websocket_streaming/tests/test_streaming.cpp
+++ b/shared/libraries/websocket_streaming/tests/test_streaming.cpp
@@ -14,6 +14,7 @@ class StreamingTest : public testing::Test
 {
 public:
     const uint16_t StreamingPort = daq::streaming_protocol::WEBSOCKET_LISTENING_PORT;
+    const std::string StreamingTarget = "/";
     SignalPtr testDoubleSignal;
     ContextPtr context;
 
@@ -42,7 +43,7 @@ TEST_F(StreamingTest, Connect)
     auto server = std::make_shared<StreamingServer>(context);
     server->start(StreamingPort);
 
-    auto client = StreamingClient(context, "127.0.0.1", StreamingPort);
+    auto client = StreamingClient(context, "127.0.0.1", StreamingPort, StreamingTarget);
 
     ASSERT_FALSE(client.isConnected());
     client.connect();
@@ -58,7 +59,7 @@ TEST_F(StreamingTest, ConnectTimeout)
     auto server = std::make_shared<StreamingServer>(context);
     server->start(StreamingPort);
 
-    auto client = StreamingClient(context, "127.0.0.1", 7000);
+    auto client = StreamingClient(context, "127.0.0.1", 7000, StreamingTarget);
 
     client.connect();
     ASSERT_FALSE(client.isConnected());
@@ -69,7 +70,7 @@ TEST_F(StreamingTest, ConnectTwice)
     auto server = std::make_shared<StreamingServer>(context);
     server->start(StreamingPort);
 
-    auto client = StreamingClient(context, "127.0.0.1", StreamingPort);
+    auto client = StreamingClient(context, "127.0.0.1", StreamingPort, StreamingTarget);
 
     ASSERT_TRUE(client.connect());
     client.disconnect();
@@ -113,7 +114,7 @@ TEST_F(StreamingTest, SimpePacket)
     server->start(StreamingPort);
 
     std::vector<PacketPtr> receivedPackets;
-    auto client = StreamingClient(context, "127.0.0.1", StreamingPort);
+    auto client = StreamingClient(context, "127.0.0.1", StreamingPort, StreamingTarget);
 
     auto onPacket = [&receivedPackets](const StringPtr& signalId, const PacketPtr& packet)
     {


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
* pseudo device can be alternatively connected using raw tcp sockets by prefix `daq.tcp://`
* enable gui_app to connect any type (not only opcua) of device by user defiined connection string: 
`python gui_demo.py --connection_string daq.tcp://127.0.0.1:7411`