### PR TITLE
Add core event triggers for Property Object

### DIFF
--- a/changelog/changelog_2.0.0-3.0.0.txt
+++ b/changelog/changelog_2.0.0-3.0.0.txt
@@ -1,3 +1,19 @@
+13.12.2023
+Description:
+  - Add Core event to Context object that triggers on core changes
+  - Add automatic triggers for Property Object changes
+     - Add/Remove property, Value changed, Update ended
+	 
++ [interface] ICoreEventArgs : public IEventArgs
++ [function] ICoreEventArgs::getParameters(IDict** parameters)
++ [factory] CoreEventArgsPtr CoreEventArgs(Int id, const DictPtr<IString, IBaseObject>& parameters)
++ [factory] CoreEventArgsPtr CoreEventArgsPropertyValueChanged(const StringPtr& propName, const BaseObjectPtr& value)
++ [factory] CoreEventArgsPtr CoreEventArgsUpdateEnd(const DictPtr<IString, IBaseObject>& updatedProperties)
++ [factory] CoreEventArgsPtr CoreEventArgsPropertyAdded(const PropertyPtr& prop)
++ [factory] CoreEventArgsPtr CoreEventArgsPropertyRemoved(const StringPtr& propName)
+
++ [function] IContext::getOnCoreEvent(IEvent** event)
+
 7.12.2023
 
 Description:

--- a/core/coreobjects/include/coreobjects/core_event_args.h
+++ b/core/coreobjects/include/coreobjects/core_event_args.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/coretypes.h>
+#include <coretypes/event_args.h>
+#include <coreobjects/core_event_args_ids.h>
+#include <coreobjects/property.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+/*!
+ * @ingroup opendaq_utility
+ * @addtogroup opendaq_core_events Core Event Args
+ * @{
+ */
+    
+
+/*#
+ * [interfaceSmartPtr(IEventArgs, EventArgsPtr, "<coretypes/event_args_ptr.h>")]
+ */
+
+/*!
+ * @brief Arguments object that defines a Core event type, and provides a set of parameters specific to a given
+ * event type.
+ *
+ * Core events are triggered whenever a change in the openDAQ core structure happens. This includes changes to property values,
+ * addition/removal of child components, connecting signals to input ports and others. The event type can be identified
+ * via the event ID available within the CoreEventArgs object. Each event type has a set of predetermined parameters
+ * available in the `parameters` field of the arguments. These can be used by any openDAQ server, or other listener to
+ * react to changes within the core structure.
+ *
+ * The Core Event object can be obtained from the Context object created by the Instance that is available to any component
+ * within the openDAQ tree structure.
+ *
+ * @subsection opendaq_core_events_types Core event types
+ *
+ * This section provides a list of core event types, when they are triggered, as well as their parameter content.
+ *
+ * @subsubsection opendaq_core_event_types_value_changed Property value changed
+ *
+ * Event triggered whenever a value of a component's property is changed. It triggers after the PropertyObject's and Property's
+ * `onValueWriteEvent`, providing the value of the property after said events are finished processing.
+ *
+ * The Property value changed core event does not trigger when updating a component via `update`, and when `beginUpdate` has been called.
+ *
+ * The parameters dictionary contains:
+ *  - The name of the property as a string under the key "Name"
+ *  - The new value of the property under the key "Value"
+ *
+ * The ID of the event is 0, and the event name is "PropertyValueChanged".
+ *
+ * @subsubsection opendaq_core_event_types_update_end Update end
+ *
+ * Event triggered whenever a component finishes updating - at the end of the `update` call, or when `endUpdate` is called.
+ *
+ * The parameters dictionary contains:
+ *  - The dictionary of updated properties under the key "UpdatedProperties". The dictionary has the string names
+ *  of properties as key, and base object values as values.
+ *
+ * The ID of the event is 10, and the event name is "UpdateEnd".
+ *
+ * @subsubsection opendaq_core_event_types_property_added_removed Property added/removed
+ *
+ * The Property added and Property removed events are triggered whenever a property is added/removed from a component.
+ *
+ * The "added" event contains the following parameters:
+ *  - The added property as a Property object under the key "Property"
+ *
+ * The "removed" event contains the following parameters:
+ *  - The name of the property as a string under the key "Name"
+ *  
+ * The ID of the Property added event is 20, and the event name is "PropertyAdded".
+ * The ID of the Property removed event is 30, and the event name is "PropertyRemoved".
+ */
+DECLARE_OPENDAQ_INTERFACE(ICoreEventArgs, IEventArgs)
+{
+    // [templateType(parameters, IString, IBaseObject)]
+    /*!
+     * @brief Gets the parameters of the core event.
+     * @param[out] parameters The parameters of the core event.
+     */
+    virtual ErrCode INTERFACE_FUNC getParameters(IDict** parameters) = 0;
+};
+
+/*!@}*/
+
+/*!
+ * @ingroup opendaq_core_events
+ * @addtogroup opendaq_core_events_factories Factories
+ * @{
+ */
+
+/*!
+ * @brief Creates Core event args with a given ID and custom parameters.
+ * @param eventId The ID of the event. If the ID is not equal to one of the pre-defined IDs, the event name will be "Unknown".
+ * @param parameters The parameters of the event.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY(
+    LIBRARY_FACTORY, CoreEventArgs,
+    Int, eventId,
+    IDict*, parameters
+)
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a property value of a component is changed.
+ * @param propName The name of the property of which value was changed.
+ * @param value The new value of the property.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, CoreEventArgsPropertyValueChanged, ICoreEventArgs,
+    IString*, propName,
+    IBaseObject*, value
+)
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a component is finished updating.
+ * @param updatedProperties The dictionary of updated properties. Contains the name (string) of a property
+ * as key, and the new value (base object) as the dictionary value.
+ *
+ * A component finished updating when `endUpdate` is called, or at the end of the `update` call.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, CoreEventArgsUpdateEnd, ICoreEventArgs,
+    IDict*, updatedProperties
+)
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a property is added to a component.
+ * @param prop The property that was added.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, CoreEventArgsPropertyAdded, ICoreEventArgs,
+    IProperty*, prop
+)
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a property is removed from a component.
+ * @param propName The name of the property that was removed.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, CoreEventArgsPropertyRemoved, ICoreEventArgs,
+    IString*, propName
+)
+
+/*!@}*/
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/core_event_args_factory.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_factory.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coreobjects/core_event_args_ptr.h>
+#include <coretypes/dictobject_factory.h>
+#include <coreobjects/property_ptr.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+/*!
+ * @ingroup opendaq_core_events
+ * @addtogroup opendaq_core_events_factories Factories
+ * @{
+ */
+
+/*!
+ * @brief Creates Core event args with a given ID and custom parameters.
+ * @param id The ID of the event. If the ID is not equal to one of the pre-defined IDs, the event name will be "Unknown".
+ * @param parameters The parameters of the event.
+ */
+inline CoreEventArgsPtr CoreEventArgs(Int id, const DictPtr<IString, IBaseObject>& parameters)
+{
+    CoreEventArgsPtr obj(CoreEventArgs_Create(id, parameters));
+    return obj;
+}
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a property value of a component is changed.
+ * @param propName The name of the property of which value was changed.
+ * @param value The new value of the property.
+ */
+inline CoreEventArgsPtr CoreEventArgsPropertyValueChanged(const StringPtr& propName, const BaseObjectPtr& value)
+{
+    CoreEventArgsPtr obj(CoreEventArgsPropertyValueChanged_Create(propName, value));
+    return obj;
+}
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a component is finished updating.
+ * @param updatedProperties The dictionary of updated properties. Contains the name (string) of a property
+ * as key, and the new value (base object) as the dictionary value.
+ *
+ * A component finished updating when `endUpdate` is called, or at the end of the `update` call.
+ */
+inline CoreEventArgsPtr CoreEventArgsUpdateEnd(const DictPtr<IString, IBaseObject>& updatedProperties)
+{
+    CoreEventArgsPtr obj(CoreEventArgsUpdateEnd_Create(updatedProperties));
+    return obj;
+}
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a property is added to a component.
+ * @param prop The property that was added.
+ */
+inline CoreEventArgsPtr CoreEventArgsPropertyAdded(const PropertyPtr& prop)
+{
+    CoreEventArgsPtr obj(CoreEventArgsPropertyAdded_Create(prop));
+    return obj;
+}
+
+/*!
+ * @brief Creates Core event args that are passed as argument when a property is removed from a component.
+ * @param propName The name of the property that was removed.
+ */
+inline CoreEventArgsPtr CoreEventArgsPropertyRemoved(const StringPtr& propName)
+{
+    CoreEventArgsPtr obj(CoreEventArgsPropertyRemoved_Create(propName));
+    return obj;
+}
+
+/*!@}*/
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/core_event_args_ids.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_ids.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/common.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+/*!
+ * @ingroup opendaq_utility
+ * @addtogroup opendaq_core_events Core Event IDs
+ * @{
+ */
+
+namespace core_event_ids
+{
+    constexpr Int PropertyValueChanged = 0;
+    constexpr Int UpdateEnd = 10;
+    constexpr Int PropertyAdded = 20;
+    constexpr Int PropertyRemoved = 30;
+}
+
+/*!@}*/
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/core_event_args_impl.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_impl.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/common.h>
+#include <coreobjects/core_event_args.h>
+#include <coretypes/event_args_impl.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+class CoreEventArgsImpl : public EventArgsBase<ICoreEventArgs>
+{
+public:
+    explicit CoreEventArgsImpl (Int id, const DictPtr<IString, IBaseObject>& parameters);
+
+    ErrCode INTERFACE_FUNC getParameters(IDict** parameters) override;
+private:
+    DictPtr<IString, IBaseObject> parameters;
+    bool validateParameters() const;
+};
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/src/CMakeLists.txt
+++ b/core/coreobjects/src/CMakeLists.txt
@@ -36,6 +36,7 @@ rtgen(SRC_Validator validator.h)
 rtgen(SRC_Unit unit.h)
 rtgen(SRC_UnitBuilder unit_builder.h)
 rtgen(SRC_ComponentType component_type.h)
+rtgen(SRC_CoreEventArgs core_event_args.h)
 
 get_target_property(CORE_CONTAINERS_SRCS core_containers INTERFACE_SOURCES)
 
@@ -136,6 +137,13 @@ source_group("component_type" FILES ${SDK_HEADERS_DIR}/component_type.h
                                     ${SDK_HEADERS_DIR}/component_type_impl.h
 )
 
+source_group("core_event_args" FILES ${SDK_HEADERS_DIR}/core_event_args.h
+                                     ${SDK_HEADERS_DIR}/core_event_args_factory.h
+                                     ${SDK_HEADERS_DIR}/core_event_args_impl.h
+                                     ${SDK_HEADERS_DIR}/core_event_args_ids.h
+                                     core_event_args_impl.cpp
+)
+
 set(SRC_Cpp version.cpp
             eval_value_impl.cpp
             eval_value_lexer.cpp
@@ -157,6 +165,7 @@ set(SRC_Cpp version.cpp
             util.cpp
             unit_impl.cpp
             unit_builder_impl.cpp
+			core_event_args_impl.cpp
 )
 
 set(SRC_PublicHeaders coreobjects.h
@@ -188,6 +197,8 @@ set(SRC_PublicHeaders coreobjects.h
                       errors.h
                       unit_factory.h
                       component_type.h
+                      core_event_args_factory.h 
+                      core_event_args_ids.h 
 )
 
 set(SRC_PrivateHeaders eval_value_impl.h
@@ -209,6 +220,7 @@ set(SRC_PrivateHeaders eval_value_impl.h
                        property_object_class_builder_impl.h
                        property_object_internal.h
                        component_type_impl.h
+					   core_event_args_impl.h
 )
 
 prepend_include(${TARGET_FOLDER_NAME} SRC_PrivateHeaders)
@@ -235,6 +247,7 @@ list(APPEND SRC_PublicHeaders  ${ConfigHeader}
                                ${SRC_Unit}
                                ${SRC_UnitBuilder}
                                ${SRC_ComponentType}
+                               ${SRC_CoreEventArgs}
                                coreobjects.natvis
 )
 

--- a/core/coreobjects/src/core_event_args_impl.cpp
+++ b/core/coreobjects/src/core_event_args_impl.cpp
@@ -1,0 +1,95 @@
+#include <coreobjects/core_event_args_impl.h>
+#include <coreobjects/property_ptr.h>
+#include <coretypes/validation.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+static std::string getCoreEventName(const Int id)
+{
+    switch(id)
+    {
+        case core_event_ids::PropertyValueChanged:
+            return "PropertyValueChanged";
+        case core_event_ids::UpdateEnd:
+            return "UpdateEnd";
+        case core_event_ids::PropertyAdded:
+            return "PropertyAdded";
+        case core_event_ids::PropertyRemoved:
+            return "PropertyRemoved";
+        default:
+            break;
+    }
+
+    return "Unknown";
+}
+
+CoreEventArgsImpl::CoreEventArgsImpl(Int id, const DictPtr<IString, IBaseObject>& parameters)
+    : EventArgsImplTemplate<ICoreEventArgs>(id, getCoreEventName(id))
+    , parameters(parameters)
+{
+    if (!validateParameters())
+        throw InvalidParameterException{"Core event parameters for event type \"{}\" are invalid", this->eventName};
+}
+
+ErrCode CoreEventArgsImpl::getParameters(IDict** parameters)
+{
+    OPENDAQ_PARAM_NOT_NULL(parameters);
+
+    *parameters = this->parameters.addRefAndReturn();
+    return OPENDAQ_SUCCESS;
+}
+
+bool CoreEventArgsImpl::validateParameters() const
+{
+    switch(eventId)
+    {
+        case core_event_ids::PropertyValueChanged:
+            return parameters.hasKey("Name") && parameters.hasKey("Value") && parameters.getCount() == 2;
+        case core_event_ids::UpdateEnd:
+            return parameters.hasKey("UpdatedProperties") && parameters.get("UpdatedProperties").asPtrOrNull<IDict>().assigned() && parameters.getCount() == 1;
+        case core_event_ids::PropertyAdded:
+            return parameters.hasKey("Property") && parameters.getCount() == 1;
+        case core_event_ids::PropertyRemoved:
+            return parameters.hasKey("Name") && parameters.getCount() == 1;
+        default:
+            break;
+    }
+
+    return true;
+}
+
+OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, CoreEventArgs, Int, eventId, IDict*, parameters)
+
+#if !defined(BUILDING_STATIC_LIBRARY)
+
+extern "C"
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyValueChanged(ICoreEventArgs** objTmp, IString* propName, IBaseObject* value)
+{
+    const auto dict = Dict<IString, IBaseObject>({{"Name", propName}, {"Value", value}});
+    return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::PropertyValueChanged,dict);
+}
+
+extern "C"
+ErrCode PUBLIC_EXPORT createCoreEventArgsUpdateEnd(ICoreEventArgs** objTmp, IDict* updatedProperties)
+{
+    const auto dict = Dict<IString, IBaseObject>({{"UpdatedProperties", updatedProperties}});
+    return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::UpdateEnd,dict);
+}
+
+extern "C"
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyAdded(ICoreEventArgs** objTmp, IProperty* prop)
+{
+    const auto dict = Dict<IString, IBaseObject>({{"Property", prop}});
+    return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::PropertyAdded,dict);
+}
+
+extern "C"
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyRemoved(ICoreEventArgs** objTmp, IString* propName)
+{
+    const auto dict = Dict<IString, IBaseObject>({{"Name", propName}});
+    return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::PropertyRemoved,dict);
+}
+
+#endif
+
+END_NAMESPACE_OPENDAQ

--- a/core/coretypes/include/coretypes/event_args_impl.h
+++ b/core/coretypes/include/coretypes/event_args_impl.h
@@ -41,7 +41,7 @@ public:
     virtual ErrCode INTERFACE_FUNC getEventId(Int* id) override;
     virtual ErrCode INTERFACE_FUNC getEventName(IString** name) override;
 
-private:
+protected:
     Int eventId;
     StringPtr eventName;
 };

--- a/core/opendaq/component/tests/CMakeLists.txt
+++ b/core/opendaq/component/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MODULE_NAME component)
 set(TEST_SOURCES
     test_component.cpp
     test_folder.cpp
+    test_core_event.cpp
 )
 
 opendaq_prepare_test_runner(TEST_APP FOR ${MODULE_NAME}

--- a/core/opendaq/component/tests/test_component.cpp
+++ b/core/opendaq/component/tests/test_component.cpp
@@ -85,7 +85,7 @@ TEST_F(ComponentTest, StandardProperties)
 {
     const auto name = "foo";
     const auto desc = "bar";
-    const auto component = Component(nullptr, nullptr, "temp");
+    const auto component = Component(NullContext(), nullptr, "temp");
 
     component.setName(name);
     component.setDescription(desc);
@@ -98,7 +98,7 @@ TEST_F(ComponentTest, SerializeAndUpdate)
 {
     const auto name = "foo";
     const auto desc = "bar";
-    const auto component = Component(nullptr, nullptr, "temp");
+    const auto component = Component(NullContext(), nullptr, "temp");
 
     component.setName(name);
     component.setDescription(desc);
@@ -107,7 +107,7 @@ TEST_F(ComponentTest, SerializeAndUpdate)
     component.serialize(serializer);
     const auto str1 = serializer.getOutput();
 
-    const auto newComponent = Component(nullptr, nullptr, "temp");
+    const auto newComponent = Component(NullContext(), nullptr, "temp");
     const auto deserializer = JsonDeserializer();
     const auto updatable = newComponent.asPtr<IUpdatable>();
 

--- a/core/opendaq/component/tests/test_core_event.cpp
+++ b/core/opendaq/component/tests/test_core_event.cpp
@@ -1,0 +1,213 @@
+#include <opendaq/component_factory.h>
+#include <opendaq/context_factory.h>
+#include <coreobjects/property_factory.h>
+#include <gtest/gtest.h>
+
+using namespace daq;
+
+using CoreEventTest = testing::Test;
+
+TEST_F(CoreEventTest, PropertyChanged)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+    component.addProperty(StringProperty("string", "foo"));
+    int callCount = 0;
+
+    context.getOnCoreEvent() += [&](const ComponentPtr& comp, const CoreEventArgsPtr& args)
+    {
+        ASSERT_EQ(args.getEventId(), core_event_ids::PropertyValueChanged);
+        ASSERT_EQ(args.getEventName(), "PropertyValueChanged");
+        ASSERT_EQ(comp, component);
+        ASSERT_TRUE(args.getParameters().hasKey("Name"));
+        ASSERT_TRUE(args.getParameters().hasKey("Value"));
+
+        callCount++;
+    };
+
+    component.setPropertyValue("string", "bar");
+    component.setPropertyValue("string", "foo");
+    component.clearPropertyValue("string");
+
+    ASSERT_EQ(callCount, 3);
+}
+
+TEST_F(CoreEventTest, PropertyChangedWithInternalEvent)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+    component.addProperty(StringProperty("string", "foo"));
+
+    int callCount = 0;
+    component.getOnPropertyValueWrite("string") +=
+        [&](const PropertyObjectPtr& obj, const PropertyValueEventArgsPtr& args)
+        {
+            args.setValue("override_" + std::to_string(callCount));
+        };
+
+    context.getOnCoreEvent() +=
+        [&](const ComponentPtr& comp, const CoreEventArgsPtr& args)
+        {
+            ASSERT_EQ(args.getEventId(), core_event_ids::PropertyValueChanged);
+            ASSERT_EQ(args.getEventName(), "PropertyValueChanged");
+            ASSERT_EQ(comp, component);
+            ASSERT_TRUE(args.getParameters().hasKey("Name"));
+            ASSERT_TRUE(args.getParameters().hasKey("Value"));
+            ASSERT_EQ(args.getParameters().get("Value"), "override_" + std::to_string(callCount));
+
+            callCount++;
+        };
+
+    component.setPropertyValue("string", "bar");
+    component.setPropertyValue("string", "foo");
+    component.clearPropertyValue("string");
+
+    ASSERT_EQ(callCount, 3);
+}
+
+TEST_F(CoreEventTest, EndUpdateEventSerilizer)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+    component.addProperty(StringProperty("string", "foo"));
+    component.addProperty(IntProperty("int", 0));
+    component.addProperty(FloatProperty("float", 1.123));
+    
+    component.setPropertyValue("string", "bar");
+    component.setPropertyValue("int", 1);
+
+    const auto serializer = JsonSerializer();
+    component.serialize(serializer);
+    const auto out = serializer.getOutput();
+    
+    component.clearPropertyValue("string");
+    component.clearPropertyValue("int");
+
+    int propChangeCount = 0;
+    int updateCount = 0;
+    int otherCount = 0;
+
+    context.getOnCoreEvent() +=
+        [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+        {
+            DictPtr<IString, IBaseObject> updated;
+            switch (args.getEventId())
+            {
+                case core_event_ids::PropertyValueChanged:
+                    propChangeCount++;
+                    break;
+                case core_event_ids::UpdateEnd:
+                    updateCount++;
+                    updated = args.getParameters().get("UpdatedProperties");
+                    ASSERT_EQ(updated.getCount(), 2);
+                    ASSERT_EQ(args.getEventName(), "UpdateEnd");
+                    break;
+                default:
+                    otherCount++;
+                    break;
+            }            
+        };
+
+    const auto deserializer = JsonDeserializer();
+    deserializer.update(component, serializer.getOutput());
+
+    ASSERT_EQ(propChangeCount, 0);
+    ASSERT_EQ(updateCount, 1);
+    ASSERT_EQ(otherCount, 0);
+}
+
+TEST_F(CoreEventTest, EndUpdateEventBeginEnd)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+    component.addProperty(StringProperty("string", "foo"));
+    component.addProperty(IntProperty("int", 0));
+    component.addProperty(FloatProperty("float", 1.123));
+
+    int propChangeCount = 0;
+    int updateCount = 0;
+    int otherCount = 0;
+
+    context.getOnCoreEvent() +=
+        [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+        {
+            DictPtr<IString, IBaseObject> updated;
+            switch (args.getEventId())
+            {
+                case core_event_ids::PropertyValueChanged:
+                    propChangeCount++;
+                    break;
+                case core_event_ids::UpdateEnd:
+                    updateCount++;
+                    updated = args.getParameters().get("UpdatedProperties");
+                    ASSERT_EQ(updated.getCount(), 2);
+                    ASSERT_EQ(args.getEventName(), "UpdateEnd");
+                    break;
+                default:
+                    otherCount++;
+                    break;
+            }            
+        };
+
+    component.beginUpdate();
+    component.setPropertyValue("string", "bar");
+    component.setPropertyValue("int", 1);
+    component.endUpdate();
+    
+    component.beginUpdate();
+    component.clearPropertyValue("string");
+    component.clearPropertyValue("int");
+    component.endUpdate();
+
+    ASSERT_EQ(propChangeCount, 0);
+    ASSERT_EQ(updateCount, 2);
+    ASSERT_EQ(otherCount, 0);
+}
+
+TEST_F(CoreEventTest, PropertyAddedEvent)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+
+    int addCount = 0;
+
+    context.getOnCoreEvent() +=
+        [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+        {
+            ASSERT_EQ(args.getEventId(), core_event_ids::PropertyAdded);
+            ASSERT_EQ(args.getEventName(), "PropertyAdded");
+            ASSERT_TRUE(args.getParameters().hasKey("Property"));
+            addCount++;
+        };
+
+    component.addProperty(StringProperty("string1", "foo"));
+    component.addProperty(StringProperty("string2", "bar"));
+    component.addProperty(FloatProperty("float", 1.123));
+    ASSERT_EQ(addCount, 3);
+}
+
+TEST_F(CoreEventTest, PropertyRemovedEvent)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+    
+    component.addProperty(StringProperty("string1", "foo"));
+    component.addProperty(StringProperty("string2", "bar"));
+    component.addProperty(FloatProperty("float", 1.123));
+
+    int removeCount = 0;
+
+    context.getOnCoreEvent() +=
+        [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+        {
+            ASSERT_EQ(args.getEventId(), core_event_ids::PropertyRemoved);
+            ASSERT_EQ(args.getEventName(), "PropertyRemoved");
+            ASSERT_TRUE(args.getParameters().hasKey("Name"));
+            removeCount++;
+        };
+
+    component.removeProperty("string1");
+    component.removeProperty("string2");
+    component.removeProperty("float");
+    ASSERT_EQ(removeCount, 3);
+}

--- a/core/opendaq/context/include/opendaq/context.h
+++ b/core/opendaq/context/include/opendaq/context.h
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <coretypes/type_manager.h>
+#include <coretypes/event.h>
 #include <opendaq/logger.h>
 
 BEGIN_NAMESPACE_OPENDAQ
@@ -42,6 +43,9 @@ struct IModuleManager;
 
 /*#
  * [interfaceLibrary(ITypeManager, "coretypes")]
+ * [interfaceLibrary(ICoreEventArgs, "coreobjects")]
+ * [interfaceSmartPtr(IComponent, ComponentPtr, "<opendaq/context_ptr.fwd_declare.h>")]
+ * [includeHeader("<coretypes/event_wrapper.h>")]
  */
 DECLARE_OPENDAQ_INTERFACE(IContext, IBaseObject)
 {
@@ -65,6 +69,19 @@ DECLARE_OPENDAQ_INTERFACE(IContext, IBaseObject)
      * @param[out] manager The type manager.
      */
     virtual ErrCode INTERFACE_FUNC getTypeManager(ITypeManager** manager) = 0;
+
+    // [templateType(event, IComponent, ICoreEventArgs)]
+    /*!
+     * @brief Gets the Core Event object that triggers whenever a change happens within the SDK core structure.
+     * @param[out] event The Core Event object. The event triggers with a Component reference and a CoreEventArgs object as arguments.
+     *
+     * The Core Event is triggered on various changes to the SDK Components. This includes changes to property values,
+     * addition/removal of child components, connecting signals to input ports and others. The event type can be identified
+     * via the event ID available within the CoreEventArgs object. Each event type has a set of predetermined parameters
+     * available in the `parameters` field of the arguments. These can be used by any openDAQ server, or other listener to
+     * react to changes within the core structure.
+     */
+    virtual ErrCode INTERFACE_FUNC getOnCoreEvent(IEvent** event) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/context/include/opendaq/context_ptr.fwd_declare.h
+++ b/core/opendaq/context/include/opendaq/context_ptr.fwd_declare.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <opendaq/component.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+template <typename InterfaceType>
+class GenericComponentPtr;
+
+using ComponentPtr = daq::GenericComponentPtr<IComponent>;
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/context/src/CMakeLists.txt
+++ b/core/opendaq/context/src/CMakeLists.txt
@@ -11,15 +11,16 @@ set(RTGEN_OUTPUT_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR})
 rtgen(SRC_Context context.h)
 
 source_group("context" FILES ${SDK_HEADERS_DIR}/context.h
+                             ${SDK_HEADERS_DIR}/context_ptr.fwd_declare.h
 )
 
 set(SRC_Cpp empty.cpp
 )
 
-set(SRC_PublicHeaders
+set(SRC_PublicHeaders context_ptr.fwd_declare.h 
 )
 
-set(SRC_PrivateHeaders
+set(SRC_PrivateHeaders 
 )
 
 prepend_include(${MAIN_TARGET} SRC_PrivateHeaders)
@@ -35,8 +36,8 @@ list(APPEND SRC_PrivateHeaders ${SRC_Context_PrivateHeaders}
 )
 
 add_library(${LIB_NAME} ${OPENDAQ_COMPONENT_TYPE} ${SRC_Cpp}
-                                                    ${SRC_PrivateHeaders}
-                                                    ${SRC_PublicHeaders}
+                                                  ${SRC_PrivateHeaders}
+                                                  ${SRC_PublicHeaders}
 )
 
 add_library(${SDK_TARGET_NAMESPACE}::${BASE_NAME} ALIAS ${LIB_NAME})

--- a/core/opendaq/modulemanager/include/opendaq/context_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/context_impl.h
@@ -36,6 +36,7 @@ public:
     ErrCode INTERFACE_FUNC getLogger(ILogger** logger) override;
     ErrCode INTERFACE_FUNC getModuleManager(IBaseObject** manager) override;
     ErrCode INTERFACE_FUNC getTypeManager(ITypeManager** manager) override;
+    ErrCode INTERFACE_FUNC getOnCoreEvent(IEvent** event) override;
     ErrCode INTERFACE_FUNC moveModuleManager(IModuleManager** manager) override;
 
 private:
@@ -44,6 +45,7 @@ private:
     WeakRefPtr<IModuleManager> moduleManagerWeakRef;
     ModuleManagerPtr moduleManager;
     TypeManagerPtr typeManager;
+    EventEmitter<ComponentPtr, CoreEventArgsPtr> coreEvent;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/modulemanager/src/context_impl.cpp
+++ b/core/opendaq/modulemanager/src/context_impl.cpp
@@ -74,6 +74,14 @@ ErrCode ContextImpl::getTypeManager(ITypeManager** manager)
     return OPENDAQ_SUCCESS;
 }
 
+ErrCode ContextImpl::getOnCoreEvent(IEvent** event)
+{
+    OPENDAQ_PARAM_NOT_NULL(event);
+
+    *event = coreEvent.addRefAndReturn();
+    return OPENDAQ_SUCCESS;
+}
+
 ErrCode ContextImpl::moveModuleManager(IModuleManager** manager)
 {
     OPENDAQ_PARAM_NOT_NULL(manager);

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/context.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/context.h
@@ -34,12 +34,14 @@ struct MockContext : daq::ImplementationOf<daq::IContext, daq::IContextInternal>
     MOCK_METHOD(daq::ErrCode, getLogger, (daq::ILogger** logger), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, getModuleManager, (daq::IBaseObject** manager), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, getTypeManager, (daq::ITypeManager** manager), (override MOCK_CALL));
+    MOCK_METHOD(daq::ErrCode, getOnCoreEvent, (daq::IEvent** event), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, moveModuleManager, (daq::IModuleManager** manager), (override MOCK_CALL));
 
     daq::SchedulerPtr scheduler;
     daq::LoggerPtr logger;
     daq::TypeManagerPtr typeManager;
     daq::BaseObjectPtr moduleManager;
+    daq::EventEmitter<daq::ComponentPtr, daq::CoreEventArgsPtr> coreEvent;
 
     MockContext()
     {
@@ -64,6 +66,12 @@ struct MockContext : daq::ImplementationOf<daq::IContext, daq::IContextInternal>
         EXPECT_CALL(*this, getModuleManager)
             .Times(AnyNumber())
             .WillRepeatedly(DoAll(Invoke([&](daq::IBaseObject** moduleManagerOut) { *moduleManagerOut = moduleManager.addRefAndReturn(); }),
+                                  Return(OPENDAQ_SUCCESS)));
+
+        
+        EXPECT_CALL(*this, getOnCoreEvent)
+            .Times(AnyNumber())
+            .WillRepeatedly(DoAll(Invoke([&](daq::IEvent** event) { *event = coreEvent.addRefAndReturn(); }),
                                   Return(OPENDAQ_SUCCESS)));
     }
 };


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

Initial PR for the SDK core support for events that trigger when the core is changed. This PR includes the global event attached to the context, as well as the event triggers for property object changes.
