### PR TITLE
Move IoFolder implementation to header

### DIFF
--- a/core/opendaq/device/include/opendaq/io_folder_impl.h
+++ b/core/opendaq/device/include/opendaq/io_folder_impl.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <opendaq/folder_impl.h>
 #include <opendaq/io_folder_config.h>
+#include <opendaq/channel.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -29,17 +30,39 @@ public:
                  const ComponentPtr& parent,
                  const StringPtr& localId,
                  const StringPtr& className = nullptr,
-                 ComponentStandardProps propsMode = ComponentStandardProps::Add);
+                 ComponentStandardProps propsMode = ComponentStandardProps::Add)
+        : Super(context, parent, localId, className, propsMode)
+    {
+    }
 
     // ISerializable
-    ErrCode INTERFACE_FUNC getSerializeId(ConstCharPtr* id) const override;
+    ErrCode INTERFACE_FUNC getSerializeId(ConstCharPtr* id) const override
+    {
+        OPENDAQ_PARAM_NOT_NULL(id);
 
-    static ConstCharPtr SerializeId();
-    static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IBaseObject** obj);
+        *id = SerializeId();
+
+        return OPENDAQ_SUCCESS;
+    }
+
+    static ConstCharPtr SerializeId()
+    {
+        return "IoFolder";
+    }
+
+    static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IBaseObject** obj)
+    {
+        return OPENDAQ_ERR_NOTIMPLEMENTED;
+    }
+
 protected:
-    bool addItemInternal(const ComponentPtr& component) override;
+    bool addItemInternal(const ComponentPtr& component) override
+    {
+        if (!component.supportsInterface<IIoFolderConfig>() && !component.supportsInterface<IChannel>())
+            throw InvalidParameterException("Type of item not allowed in the folder");
 
+        return Super::addItemInternal(component);
+    }
 };
-
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/src/io_folder_impl.cpp
+++ b/core/opendaq/device/src/io_folder_impl.cpp
@@ -1,43 +1,6 @@
 #include <opendaq/io_folder_impl.h>
-#include <opendaq/channel.h>
 
 BEGIN_NAMESPACE_OPENDAQ
-
-IoFolderImpl::IoFolderImpl(const ContextPtr& context,
-                           const ComponentPtr& parent,
-                           const StringPtr& localId,
-                           const StringPtr& className,
-                           const ComponentStandardProps propsMode)
-    : Super(context, parent, localId, className, propsMode)
-{
-}
-
-ErrCode INTERFACE_FUNC IoFolderImpl::getSerializeId(ConstCharPtr* id) const
-{
-    OPENDAQ_PARAM_NOT_NULL(id);
-
-    *id = SerializeId();
-
-    return OPENDAQ_SUCCESS;
-}
-
-ConstCharPtr IoFolderImpl::SerializeId()
-{
-    return "IoFolder";
-}
-
-ErrCode IoFolderImpl::Deserialize(ISerializedObject* serialized, IBaseObject* context, IBaseObject** obj)
-{
-    return OPENDAQ_ERR_NOTIMPLEMENTED;
-}
-
-bool IoFolderImpl::addItemInternal(const ComponentPtr& component)
-{
-    if (!component.supportsInterface<IIoFolderConfig>() && !component.supportsInterface<IChannel>())
-        throw InvalidParameterException("Type of item not allowed in the folder");
-
-    return Super::addItemInternal(component);
-}
 
 OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, IoFolder, IFolderConfig,

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -4,6 +4,7 @@
 #include <opendaq/context_factory.h>
 #include <opendaq/folder_factory.h>
 #include <opendaq/io_folder_factory.h>
+#include <opendaq/io_folder_impl.h>
 #include <opendaq/gmock/function_block.h>
 #include <gtest/gtest.h>
 #include <opendaq/device_private.h>
@@ -42,6 +43,11 @@ TEST_F(DeviceTest, IOFolder)
 {
     auto ioFolder = daq::IoFolder(daq::NullContext(), nullptr, "fld");
     ASSERT_TRUE(ioFolder.supportsInterface<daq::IIoFolderConfig>());
+}
+
+TEST_F(DeviceTest, IOFolderCreateCustom)
+{
+    ASSERT_NO_THROW((daq::createWithImplementation<daq::IIoFolderConfig, daq::IoFolderImpl>(daq::NullContext(), nullptr, "fld")));
 }
 
 TEST_F(DeviceTest, IOFolderSubItems)


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

IoFolder implementation is now header-only. This enables us to create new classes out of it.
