### PR TITLE
[TBBAS-959] Fix: Container properties require explicit conversion before usage

### DIFF
--- a/bindings/python/core_types/src/py_converter.cpp
+++ b/bindings/python/core_types/src/py_converter.cpp
@@ -78,8 +78,16 @@ py::object baseObjectToPyObject(const daq::ObjectPtr<daq::IBaseObject>& baseObje
             py::str p(static_cast<std::string>(baseObject));
             return p;
         }
-        // case daq::ctList:
-        // case daq::ctDict:
+        case daq::ctList:
+        {
+            InterfaceWrapper<daq::IList> wrappedInterface(baseObject.asPtr<daq::IList>().addRefAndReturn());
+            return py::cast(wrappedInterface);
+        }
+        case daq::ctDict:
+        {
+            InterfaceWrapper<daq::IDict> wrappedInterface(baseObject.asPtr<daq::IDict>().addRefAndReturn());
+            return py::cast(wrappedInterface);
+        }
         case daq::ctRatio:
         {
             const auto ratio = baseObject.asPtr<daq::IRatio>();

--- a/bindings/python/tests/test_property_system.py
+++ b/bindings/python/tests/test_property_system.py
@@ -106,9 +106,6 @@ class TestPropertySystem(opendaq_test.TestCase):
             'child.child.property1'), 10)
 
     def test_container_props(self):
-        # TODO: remove when fixed
-        self.expect_memory_leak = True
-
         property_object = opendaq.PropertyObject()
 
         list = opendaq.List()
@@ -124,13 +121,10 @@ class TestPropertySystem(opendaq_test.TestCase):
         property_object.add_property(opendaq.DictProperty(
             opendaq.String('dict'), dict, opendaq.Boolean(True)))
 
-        l = opendaq.IList.convert_from(
-            property_object.get_property_value('list'))
-        d = opendaq.IDict.convert_from(
-            property_object.get_property_value('dict'))
-
-        self.assertEqual(l[0], 'Banana')
-        self.assertEqual(d['Apple'], 2)
+        self.assertEqual(
+            property_object.get_property_value('list')[0], 'Banana')
+        self.assertEqual(
+            property_object.get_property_value('dict')['Apple'], 2)
 
     def test_reference_props(self):
         property_object = opendaq.PropertyObject()
@@ -176,7 +170,7 @@ class TestPropertySystem(opendaq_test.TestCase):
 
         float_property_builder = opendaq.FloatPropertyBuilder(opendaq.String(
             'property1'), opendaq.Float(10.0))
-        float_property_builder.visible =  opendaq.Boolean(True)
+        float_property_builder.visible = opendaq.Boolean(True)
 
         # FIXME: not accepting types
         # float_property_builder.min_value = opendaq.Float(0.0)
@@ -361,7 +355,8 @@ class TestPropertySystem(opendaq_test.TestCase):
     # TODO: events not supported yet
 
     def test_class(self):
-        property_class_builder = opendaq.PropertyObjectClassBuilder(opendaq.String('Class'))
+        property_class_builder = opendaq.PropertyObjectClassBuilder(
+            opendaq.String('Class'))
         property_class_builder.add_property(opendaq.IntProperty(opendaq.String(
             'property1'), opendaq.Integer(1), opendaq.Boolean(True)))
 
@@ -377,7 +372,8 @@ class TestPropertySystem(opendaq_test.TestCase):
     def test_class_manager(self):
         type_manager = opendaq.TypeManager()
 
-        property_class_builder = opendaq.PropertyObjectClassBuilder(opendaq.String('Class'))
+        property_class_builder = opendaq.PropertyObjectClassBuilder(
+            opendaq.String('Class'))
         property_class_builder.add_property(opendaq.IntProperty(opendaq.String(
             'property1'), opendaq.Integer(1), opendaq.Boolean(True)))
         list = opendaq.List()


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

Fix the bug causing impossibility to use container properties without explicit conversion, for example
`property_object.get_property_value('list')[0]`
