### PR TITLE
Freeze and clone nested object-type property default values

### DIFF
--- a/bindings/python/opendaq/generated/component/py_component.cpp
+++ b/bindings/python/opendaq/generated/component/py_component.cpp
@@ -124,7 +124,7 @@ void defineIComponent(pybind11::module_ m, PyDaqIntf<daq::IComponent, daq::IProp
             const auto objectPtr = daq::ComponentPtr::Borrow(object);
             objectPtr.setVisible(visible);
         },
-        "Gets `visible` metadata state of the component");
+        "Gets `visible` metadata state of the component / Sets `visible` attribute state of the component");
     cls.def_property_readonly("locked_attributes",
         [](daq::IComponent *object)
         {
@@ -132,7 +132,7 @@ void defineIComponent(pybind11::module_ m, PyDaqIntf<daq::IComponent, daq::IProp
             return objectPtr.getLockedAttributes().detach();
         },
         py::return_value_policy::take_ownership,
-        "");
+        "Gets a list of the component's locked attributes. The locked attributes cannot be modified via their respective setters.");
     /*
     cls.def_property_readonly("on_component_core_event",
         [](daq::IComponent *object)
@@ -141,6 +141,6 @@ void defineIComponent(pybind11::module_ m, PyDaqIntf<daq::IComponent, daq::IProp
             return objectPtr.getOnComponentCoreEvent().detach();
         },
         py::return_value_policy::take_ownership,
-        "");
+        "Gets the Core Event object that triggers whenever a change to this component happens within the openDAQ core structure.");
     */
 }

--- a/bindings/python/opendaq/generated/component/py_component_private.cpp
+++ b/bindings/python/opendaq/generated/component/py_component_private.cpp
@@ -35,7 +35,7 @@ PyDaqIntf<daq::IComponentPrivate, daq::IBaseObject> declareIComponentPrivate(pyb
 
 void defineIComponentPrivate(pybind11::module_ m, PyDaqIntf<daq::IComponentPrivate, daq::IBaseObject> cls)
 {
-    cls.doc() = "";
+    cls.doc() = "Provides access to private methods of the component.";
 
     cls.def("lock_attributes",
         [](daq::IComponentPrivate *object, daq::IList* attributes)
@@ -44,14 +44,14 @@ void defineIComponentPrivate(pybind11::module_ m, PyDaqIntf<daq::IComponentPriva
             objectPtr.lockAttributes(attributes);
         },
         py::arg("attributes"),
-        "");
+        "Locks the attributes contained in the provided list.");
     cls.def("lock_all_attributes",
         [](daq::IComponentPrivate *object)
         {
             const auto objectPtr = daq::ComponentPrivatePtr::Borrow(object);
             objectPtr.lockAllAttributes();
         },
-        "");
+        "Locks all attributes of the component.");
     cls.def("unlock_attributes",
         [](daq::IComponentPrivate *object, daq::IList* attributes)
         {
@@ -59,14 +59,14 @@ void defineIComponentPrivate(pybind11::module_ m, PyDaqIntf<daq::IComponentPriva
             objectPtr.unlockAttributes(attributes);
         },
         py::arg("attributes"),
-        "");
+        "Unlocks the attributes contained in the provided list.");
     cls.def("unlock_all_attributes",
         [](daq::IComponentPrivate *object)
         {
             const auto objectPtr = daq::ComponentPrivatePtr::Borrow(object);
             objectPtr.unlockAllAttributes();
         },
-        "");
+        "Unlocks all attributes of the component.");
     cls.def("trigger_component_core_event",
         [](daq::IComponentPrivate *object, daq::ICoreEventArgs* args)
         {
@@ -74,5 +74,5 @@ void defineIComponentPrivate(pybind11::module_ m, PyDaqIntf<daq::IComponentPriva
             objectPtr.triggerComponentCoreEvent(args);
         },
         py::arg("args"),
-        "");
+        "Triggers the component-specific core event with the provided arguments.");
 }

--- a/bindings/python/opendaq/generated/component/py_search_filter.cpp
+++ b/bindings/python/opendaq/generated/component/py_search_filter.cpp
@@ -35,7 +35,7 @@ PyDaqIntf<daq::ISearchFilter, daq::IBaseObject> declareISearchFilter(pybind11::m
 
 void defineISearchFilter(pybind11::module_ m, PyDaqIntf<daq::ISearchFilter, daq::IBaseObject> cls)
 {
-    cls.doc() = "";
+    cls.doc() = "Search filter that can be passed as an optional parameter to openDAQ tree traversal functions to filter out unwanted results. Allows for recursive searches.";
 
     m.def("VisibleSearchFilter", &daq::VisibleSearchFilter_Create);
     m.def("RequiredTagsSearchFilter", &daq::RequiredTagsSearchFilter_Create);
@@ -55,7 +55,7 @@ void defineISearchFilter(pybind11::module_ m, PyDaqIntf<daq::ISearchFilter, daq:
             return objectPtr.acceptsComponent(component);
         },
         py::arg("component"),
-        "");
+        "Defines whether or not the component should be included in the search results");
     cls.def("visit_children",
         [](daq::ISearchFilter *object, daq::IComponent* component)
         {
@@ -63,5 +63,5 @@ void defineISearchFilter(pybind11::module_ m, PyDaqIntf<daq::ISearchFilter, daq:
             return objectPtr.visitChildren(component);
         },
         py::arg("component"),
-        "");
+        "Defines whether or not the children of said component should be traversed during a recursive search.");
 }

--- a/bindings/python/opendaq/generated/context/py_context.cpp
+++ b/bindings/python/opendaq/generated/context/py_context.cpp
@@ -79,6 +79,6 @@ void defineIContext(pybind11::module_ m, PyDaqIntf<daq::IContext, daq::IBaseObje
             return objectPtr.getOnCoreEvent().detach();
         },
         py::return_value_policy::take_ownership,
-        "Gets the Core Event object that triggers whenever a change happens within the SDK core structure.");
+        "Gets the Core Event object that triggers whenever a change happens within the openDAQ core structure.");
     */
 }

--- a/bindings/python/tests/test_property_system.py
+++ b/bindings/python/tests/test_property_system.py
@@ -21,7 +21,7 @@ class TestPropertySystem(opendaq_test.TestCase):
 
         property_object.set_property_value('property1', 'value')
         property_object.set_property_value('property2', 3)
-
+             
         self.assertEqual(
             property_object.get_property_value('property1'), 'value')
         self.assertEqual(property_object.get_property_value('property2'), 3)
@@ -94,14 +94,14 @@ class TestPropertySystem(opendaq_test.TestCase):
         property_object = opendaq.PropertyObject()
         child1 = opendaq.PropertyObject()
         child2 = opendaq.PropertyObject()
-
-        property_object.add_property(
-            opendaq.ObjectProperty(opendaq.String('child'), child1))
-        child1.add_property(opendaq.ObjectProperty(
-            opendaq.String('child'), child2))
+        
         child2.add_property(opendaq.IntProperty(opendaq.String(
             'property1'), opendaq.Integer(10), opendaq.Boolean(True)))
-
+        child1.add_property(opendaq.ObjectProperty(
+            opendaq.String('child'), child2))
+        property_object.add_property(
+            opendaq.ObjectProperty(opendaq.String('child'), child1))
+        
         self.assertEqual(property_object.get_property_value(
             'child.child.property1'), 10)
 
@@ -315,16 +315,15 @@ class TestPropertySystem(opendaq_test.TestCase):
 
     def test_nested_objects(self):
         property_object = opendaq.PropertyObject()
-
         child1 = opendaq.PropertyObject()
-        property_object.add_property(
-            opendaq.ObjectProperty(opendaq.String('child'), child1))
-
         child2 = opendaq.PropertyObject()
+        
         child2.add_property(opendaq.StringProperty(opendaq.String(
             'property'), opendaq.String('value'), opendaq.Boolean(True)))
         child1.add_property(opendaq.ObjectProperty(
             opendaq.String('child'), child2))
+        property_object.add_property(
+            opendaq.ObjectProperty(opendaq.String('child'), child1))
 
         property_object.set_property_value('child.child.property', 'val')
         self.assertEqual(property_object.get_property_value(

--- a/changelog/changelog_2.0.0-3.0.0.txt
+++ b/changelog/changelog_2.0.0-3.0.0.txt
@@ -16,6 +16,24 @@ Description:
 +  [interface] IComponentDeserializeContext: public IBaseObject
 +  [interface] IDeserializeComponent: public IBaseObject
 
+16.01.2024
+Nested object-type property enhancement
+  - Object-type property default values are now frozen when added to Property objects 
+  - Said default values are cloned as local values that can be modified by users
+  - Property object core events now contain the path to the property if the property is contained within a nested property object
+
++ [function] IPropertyObjectInternal::clone(IPropertyObject** cloned)
++ [function] IPropertyObjectInternal::setPath(IString* path)
+-m [factory] CoreEventArgsPtr CoreEventArgsPropertyValueChanged(const PropertyObjectPtr& propOwner, const StringPtr& propName, const BaseObjectPtr& value)
++m [factory] CoreEventArgsPtr CoreEventArgsPropertyValueChanged(const PropertyObjectPtr& propOwner, const StringPtr& propName, const BaseObjectPtr& value, const StringPtr& path)
+-m [factory] CoreEventArgsPtr CoreEventArgsPropertyObjectUpdateEnd(const PropertyObjectPtr& propOwner, const DictPtr<IString, IBaseObject>& updatedProperties)
++m [factory] CoreEventArgsPtr CoreEventArgsPropertyObjectUpdateEnd(const PropertyObjectPtr& propOwner, const DictPtr<IString, IBaseObject>& updatedProperties, const StringPtr& path)
+-m [factory] CoreEventArgsPtr CoreEventArgsPropertyAdded(const PropertyObjectPtr& propOwner, const PropertyPtr& prop)
++m [factory] CoreEventArgsPtr CoreEventArgsPropertyAdded(const PropertyObjectPtr& propOwner, const PropertyPtr& prop, const StringPtr& path)
+-m [factory] CoreEventArgsPtr CoreEventArgsPropertyRemoved(const PropertyObjectPtr& propOwner, const StringPtr& propName)
++m [factory] CoreEventArgsPtr CoreEventArgsPropertyRemoved(const PropertyObjectPtr& propOwner, const StringPtr& propName, const StringPtr& path)
+
+
 12.01.2024
 Description:
 Search filters, visible flag, component attributes

--- a/core/coreobjects/include/coreobjects/core_event_args.h
+++ b/core/coreobjects/include/coreobjects/core_event_args.h
@@ -69,6 +69,12 @@ BEGIN_NAMESPACE_OPENDAQ
  *  - The Property object owner of the property under the key "Owner"
  *  - The name of the property as a string under the key "Name"
  *  - The new value of the property under the key "Value"
+ *  - The relative path to the property owner from the sender component under the key "Path".
+ *
+ * The "Path" parameter is used for object-type properties where it represents the path to the property through child Property objects.
+ * Eg. the path to the "MyInt" property of child object-type property named "Child1" on a component would be "Child1". In the case of
+ * deeper nesting of object-type properties (if "Child1" had another object-type property named "Child2") the path would be as follows:
+ * "Child1.Child2.MyInt".
  *
  * The ID of the event is 0, and the event name is "PropertyValueChanged".
  *
@@ -83,6 +89,12 @@ BEGIN_NAMESPACE_OPENDAQ
  *  - The Property object owner of the property under the key "Owner"
  *  - The dictionary of updated properties under the key "UpdatedProperties". The dictionary has the string names
  *  of properties as key, and base object values as values.
+ *  - The relative path to the property owner from the sender component under the key "Path".
+ *
+ * The "Path" parameter is used for object-type properties where it represents the path to the property through child Property objects.
+ * Eg. the path to the "MyInt" property of child object-type property named "Child1" on a component would be "Child1". In the case of
+ * deeper nesting of object-type properties (if "Child1" had another object-type property named "Child2") the path would be as follows:
+ * "Child1.Child2.MyInt".
  *
  * The ID of the event is 10, and the event name is "PropertyObjectUpdateEnd".
  *
@@ -96,11 +108,18 @@ BEGIN_NAMESPACE_OPENDAQ
  * The "added" event contains the following parameters:
  *  - The Property object owner of the property under the key "Owner"
  *  - The added property as a Property object under the key "Property"
+ *  - The relative path to the property owner from the sender component under the key "Path".
  *
  * The "removed" event contains the following parameters:
  *  - The Property object owner of the property under the key "Owner"
  *  - The name of the property as a string under the key "Name"
+ *  - The relative path to the property owner from the sender component under the key "Path".
  *  
+ * The "Path" parameter is used for object-type properties where it represents the path to the property through child Property objects.
+ * Eg. the path to the "MyInt" property of child object-type property named "Child1" on a component would be "Child1". In the case of
+ * deeper nesting of object-type properties (if "Child1" had another object-type property named "Child2") the path would be as follows:
+ * "Child1.Child2.MyInt".
+ *
  * The ID of the Property added event is 20, and the event name is "PropertyAdded".
  * The ID of the Property removed event is 30, and the event name is "PropertyRemoved".
  *
@@ -219,6 +238,8 @@ OPENDAQ_DECLARE_CLASS_FACTORY(
  * @param propOwner The property object that owns the changed property.
  * @param propName The name of the property of which value was changed.
  * @param value The new value of the property.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id and property name.
  *
  * The ID of the event is 0, and the event name is "PropertyValueChanged".
  */
@@ -226,7 +247,8 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, CoreEventArgsPropertyValueChanged, ICoreEventArgs,
     IPropertyObject*, propOwner,
     IString*, propName,
-    IBaseObject*, value
+    IBaseObject*, value,
+    IString*, path
 )
 
 /*!
@@ -234,6 +256,8 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
  * @param propOwner The property object that was updated.
  * @param updatedProperties The dictionary of updated properties. Contains the name (string) of a property
  * as key, and the new value (base object) as the dictionary value.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id.
  *
  * A property object finished updating when `endUpdate` is called, or at the end of the `update` call.
  * The ID of the event is 10, and the event name is "PropertyObjectUpdateEnd".
@@ -241,33 +265,40 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, CoreEventArgsPropertyObjectUpdateEnd, ICoreEventArgs,
     IPropertyObject*, propOwner,
-    IDict*, updatedProperties
+    IDict*, updatedProperties,
+    IString*, path
 )
 
 /*!
  * @brief Creates Core event args that are passed as argument when a property is added to a component.
  * @param propOwner The property object that owns the added property.
  * @param prop The property that was added.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id and property name.
  *
  * The ID of the event is 20, and the event name is "PropertyAdded".
  */
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, CoreEventArgsPropertyAdded, ICoreEventArgs,
     IPropertyObject*, propOwner,
-    IProperty*, prop
+    IProperty*, prop,
+    IString*, path
 )
 
 /*!
  * @brief Creates Core event args that are passed as argument when a property is removed from a component.
  * @param propOwner The property object that owned the removed property.
  * @param propName The name of the property that was removed.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id and property name.
  *
  * The ID of the event is 30, and the event name is "PropertyRemoved".
  */
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, CoreEventArgsPropertyRemoved, ICoreEventArgs,
     IPropertyObject*, propOwner,
-    IString*, propName
+    IString*, propName,
+    IString*, path
 )
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/core_event_args_factory.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_factory.h
@@ -43,10 +43,12 @@ inline CoreEventArgsPtr CoreEventArgs(Int id, const DictPtr<IString, IBaseObject
  * @param propOwner The property object that owns the changed property.
  * @param propName The name of the property of which value was changed.
  * @param value The new value of the property.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id and property name.
  */
-inline CoreEventArgsPtr CoreEventArgsPropertyValueChanged(const PropertyObjectPtr& propOwner, const StringPtr& propName, const BaseObjectPtr& value)
+inline CoreEventArgsPtr CoreEventArgsPropertyValueChanged(const PropertyObjectPtr& propOwner, const StringPtr& propName, const BaseObjectPtr& value, const StringPtr& path)
 {
-    CoreEventArgsPtr obj(CoreEventArgsPropertyValueChanged_Create(propOwner, propName, value));
+    CoreEventArgsPtr obj(CoreEventArgsPropertyValueChanged_Create(propOwner, propName, value, path));
     return obj;
 }
 
@@ -55,12 +57,14 @@ inline CoreEventArgsPtr CoreEventArgsPropertyValueChanged(const PropertyObjectPt
  * @param propOwner The property object that was updated.
  * @param updatedProperties The dictionary of updated properties. Contains the name (string) of a property
  * as key, and the new value (base object) as the dictionary value.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id.
  *
  * A component finished updating when `endUpdate` is called, or at the end of the `update` call.
  */
-inline CoreEventArgsPtr CoreEventArgsPropertyObjectUpdateEnd(const PropertyObjectPtr& propOwner, const DictPtr<IString, IBaseObject>& updatedProperties)
+inline CoreEventArgsPtr CoreEventArgsPropertyObjectUpdateEnd(const PropertyObjectPtr& propOwner, const DictPtr<IString, IBaseObject>& updatedProperties, const StringPtr& path)
 {
-    CoreEventArgsPtr obj(CoreEventArgsPropertyObjectUpdateEnd_Create(propOwner, updatedProperties));
+    CoreEventArgsPtr obj(CoreEventArgsPropertyObjectUpdateEnd_Create(propOwner, updatedProperties, path));
     return obj;
 }
 
@@ -68,10 +72,12 @@ inline CoreEventArgsPtr CoreEventArgsPropertyObjectUpdateEnd(const PropertyObjec
  * @brief Creates Core event args that are passed as argument when a property is added to a component.
  * @param propOwner The property object that owns the added property.
  * @param prop The property that was added.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id and property name.
  */
-inline CoreEventArgsPtr CoreEventArgsPropertyAdded(const PropertyObjectPtr& propOwner, const PropertyPtr& prop)
+inline CoreEventArgsPtr CoreEventArgsPropertyAdded(const PropertyObjectPtr& propOwner, const PropertyPtr& prop, const StringPtr& path)
 {
-    CoreEventArgsPtr obj(CoreEventArgsPropertyAdded_Create(propOwner, prop));
+    CoreEventArgsPtr obj(CoreEventArgsPropertyAdded_Create(propOwner, prop, path));
     return obj;
 }
 
@@ -79,10 +85,12 @@ inline CoreEventArgsPtr CoreEventArgsPropertyAdded(const PropertyObjectPtr& prop
  * @brief Creates Core event args that are passed as argument when a property is removed from a component.
  * @param propOwner The property object that owned the removed property.
  * @param propName The name of the property that was removed.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ * Does not include the Component id and property name.
  */
-inline CoreEventArgsPtr CoreEventArgsPropertyRemoved(const PropertyObjectPtr& propOwner, const StringPtr& propName)
+inline CoreEventArgsPtr CoreEventArgsPropertyRemoved(const PropertyObjectPtr& propOwner, const StringPtr& propName, const StringPtr& path)
 {
-    CoreEventArgsPtr obj(CoreEventArgsPropertyRemoved_Create(propOwner, propName));
+    CoreEventArgsPtr obj(CoreEventArgsPropertyRemoved_Create(propOwner, propName, path));
     return obj;
 }
 

--- a/core/coreobjects/include/coreobjects/property.h
+++ b/core/coreobjects/include/coreobjects/property.h
@@ -186,11 +186,17 @@ struct IPropertyBuilder;
  * Object type properties can only have their Name, Description and Default value configured,
  * where the Default value is mandatory.
  *
- * Object Properties behave slightly differently in that their Default Values do
- * not get frozen when the Property is added to a Property Object (they do get frozen when
- * added to a Property Object Class, or if the Object Property is Read-only).
- * As such, Properties of the Default Value Property Object can be modified even after being
- * added to a Property Object.
+ * Object properties, as all other Property types get frozen once added to a Property
+ * Object. The notable exception is that locally, the object (default value) is cloned and cached. 
+ * When the Property value of the Object-type Property is read, the cloned object is returned instead 
+ * of the default value. This cloned object is not frozen, allowing for the any Properties of 
+ * the child Property Object to be modified. The same behaviour is applied when a Property Object 
+ * is created from a Property Object Class - all Object-type properties of the class are cloned.
+ *
+ * Notably, by default, all Object properties are read-only. Read-only object-type properties
+ * cannot be wholly replaced, but the child property values of the object can still be modified.
+ * The "Clear property value" method will work on object-type properties, even if the object
+ * is read-only.
  *
  * @subsection objects_property_containers Container-type properties
  *

--- a/core/coreobjects/include/coreobjects/property_builder_impl.h
+++ b/core/coreobjects/include/coreobjects/property_builder_impl.h
@@ -111,6 +111,7 @@ public:
         : PropertyBuilderImpl(name, BaseObjectPtr(defaultValue))
     {
         this->valueType = ctObject;
+        this->readOnly = true;
         if (defaultValue == nullptr)
             this->defaultValue = PropertyObject().detach();
     }

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -202,6 +202,7 @@ public:
         : PropertyImpl(name, BaseObjectPtr(defaultValue), true)
     {
         this->valueType = ctObject;
+        this->readOnly = true;
         if (defaultValue == nullptr)
             this->defaultValue = PropertyObject().detach();
 
@@ -786,15 +787,7 @@ public:
 
         if (defaultValue.assigned())
         {
-            Bool shouldFreeze = true;
-            if (valueType == ctObject)
-            {
-                const ErrCode err = getReadOnly(&shouldFreeze);
-                if (OPENDAQ_FAILED(err))
-                    return err;
-            }
-
-            if (const auto freezable = defaultValue.asPtrOrNull<IFreezable>(); shouldFreeze && freezable.assigned())
+            if (const auto freezable = defaultValue.asPtrOrNull<IFreezable>(); freezable.assigned())
             {
                 const ErrCode err = freezable->freeze();
                 if (OPENDAQ_FAILED(err))

--- a/core/coreobjects/include/coreobjects/property_object.h
+++ b/core/coreobjects/include/coreobjects/property_object.h
@@ -172,6 +172,10 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObject, IBaseObject)
      * When a Property value is set, the value is written in the internal dictionary of Property values.
      * This function will remove said value from the dictionary. If the tries to obtain the Property value of
      * a property that does not have a set Property value, then the default value is returned.
+     *
+     * Importantly, clearing the value of an Object-type property will release the reference of the current
+     * Property object value of the property. It will then create a new clone of the Default value and set it
+     * as the value of the property.
      */
     virtual ErrCode INTERFACE_FUNC clearPropertyValue(IString* propertyName) = 0;
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -63,8 +63,7 @@ class GenericPropertyObjectImpl : public ImplementationOfWeak<PropObjInterface,
 {
 public:
     explicit GenericPropertyObjectImpl();
-    explicit GenericPropertyObjectImpl(const TypeManagerPtr& manager, const StringPtr& className);
-    explicit GenericPropertyObjectImpl(const TypeManagerPtr& manager, const StringPtr& className, const ProcedurePtr& triggerCoreEvent);
+    explicit GenericPropertyObjectImpl(const TypeManagerPtr& manager, const StringPtr& className, const ProcedurePtr& triggerCoreEvent = nullptr);
 
     virtual ErrCode INTERFACE_FUNC getClassName(IString** className) override;
 
@@ -96,7 +95,9 @@ public:
     virtual ErrCode INTERFACE_FUNC enableCoreEventTrigger() override;
     virtual ErrCode INTERFACE_FUNC disableCoreEventTrigger() override;
     ErrCode INTERFACE_FUNC getCoreEventTrigger(IProcedure** trigger) override;
-    ErrCode INTERFACE_FUNC setCoreEventTrigger(IProcedure* trigger)override;
+    ErrCode INTERFACE_FUNC setCoreEventTrigger(IProcedure* trigger) override;
+    ErrCode INTERFACE_FUNC clone(IPropertyObject** clonedPropertyObject) override;
+    ErrCode INTERFACE_FUNC setPath(IString* path) override;
 
     // IUpdatable
     virtual ErrCode INTERFACE_FUNC update(ISerializedObject* obj) override;
@@ -124,6 +125,17 @@ public:
     // IPropertyObjectProtected
     virtual ErrCode INTERFACE_FUNC setProtectedPropertyValue(IString* propertyName, IBaseObject* value) override;
     virtual ErrCode INTERFACE_FUNC clearProtectedPropertyValue(IString* propertyName) override;
+    
+    using PropertyValueEventEmitter = EventEmitter<PropertyObjectPtr, PropertyValueEventArgsPtr>;
+    using EndUpdateEventEmitter = EventEmitter<PropertyObjectPtr, EndUpdateEventArgsPtr>;
+
+    void configureClonedMembers(const std::unordered_map<StringPtr, PropertyValueEventEmitter>& valueWriteEvents,
+                                const std::unordered_map<StringPtr, PropertyValueEventEmitter>& valueReadEvents,
+                                const EndUpdateEventEmitter& endUpdateEvent,
+                                const ProcedurePtr& triggerCoreEvent,
+                                const PropertyOrderedMap& localProperties,
+                                const std::unordered_map<StringPtr, BaseObjectPtr, StringHash, StringEqualTo>& propValues,
+                                const std::vector<StringPtr>& customOrder);
 
 protected:
     struct UpdatingAction
@@ -141,6 +153,7 @@ protected:
     int updateCount;
     UpdatingActions updatingPropsAndValues;
     bool coreEventMuted;
+    WeakRefPtr<ITypeManager> manager;
 
     void internalDispose(bool) override;
     ErrCode setPropertyValueInternal(IString* name, IBaseObject* value, bool triggerEvent, bool protectedAccess, bool isUpdating);
@@ -188,8 +201,6 @@ protected:
     PropertyPtr getUnboundPropertyOrNull(const StringPtr& name) const;
 
 private:
-    using PropertyValueEventEmitter = EventEmitter<PropertyObjectPtr, PropertyValueEventArgsPtr>;
-    using EndUpdateEventEmitter = EventEmitter<PropertyObjectPtr, EndUpdateEventArgsPtr>;
 
     StringPtr className;
     PropertyObjectClassPtr objectClass;
@@ -197,9 +208,11 @@ private:
     std::unordered_map<StringPtr, PropertyValueEventEmitter> valueReadEvents;
     EndUpdateEventEmitter endUpdateEvent;
     ProcedurePtr triggerCoreEvent;
+    StringPtr path;
 
     PropertyOrderedMap localProperties;
     std::unordered_map<StringPtr, BaseObjectPtr, StringHash, StringEqualTo> propValues;
+
 
     // Gets the property, as well as its value. Gets the referenced property, if the property is a refProp
     ErrCode getPropertyAndValueInternal(const StringPtr& name, BaseObjectPtr& value, PropertyPtr& property, bool triggerEvent = true);
@@ -247,6 +260,8 @@ private:
 
     PropertyPtr checkForRefPropAndGetBoundProp(PropertyPtr& prop, bool* isReferenced = nullptr) const;
 
+    void cloneAndSetChildPropertyObject(const PropertyPtr& prop);
+
     // Checks whether the property is a reference property that references an already referenced property
     bool hasDuplicateReferences(const PropertyPtr& prop);
 
@@ -271,17 +286,20 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
     , coreEventMuted(true)
     , className(nullptr)
     , objectClass(nullptr)
+    , path("")
 {
     this->internalAddRef();
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
 }
 
-
 template <typename PropObjInterface, typename... Interfaces>
 GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjectImpl(const TypeManagerPtr& manager,
-                                                                                      const StringPtr& className)
+                                                                                      const StringPtr& className,
+                                                                                      const ProcedurePtr& triggerCoreEvent)
     : GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjectImpl()
 {
+    this->triggerCoreEvent = triggerCoreEvent;
+
     if (className.assigned() && className != "")
     {
         this->className = className;
@@ -298,16 +316,13 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
             throw InvalidTypeException{"Type with name {} is not a property object class", className};
 
         objectClass = objClass;
-    }
-}
 
-template <typename PropObjInterface, typename... Interfaces>
-GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjectImpl(const TypeManagerPtr& manager,
-                                                                                      const StringPtr& className,
-                                                                                      const ProcedurePtr& triggerCoreEvent)
-    : GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjectImpl(manager, className)
-{
-    this->triggerCoreEvent = triggerCoreEvent;
+        for (const auto& prop : objectClass.getProperties(true))
+            cloneAndSetChildPropertyObject(prop);
+    }
+
+    if (manager.assigned())
+        this->manager = manager;
 }
 
 template <class PropObjInterface, class... Interfaces>
@@ -738,7 +753,9 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
         {
             if (prop.getReadOnly())
             {
-                return OPENDAQ_ERR_ACCESSDENIED;
+                CoreType coreType = prop.getCoreType();
+                if (!(coreType == ctObject && isChildProp))
+                    return OPENDAQ_ERR_ACCESSDENIED;
             }
         }
 
@@ -786,6 +803,18 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             validatePropertyWrite(prop, valuePtr);
             coerceMinMax(prop, valuePtr);
 
+            if (prop.getValueType() == ctObject)
+            {
+                const auto objInternal = valuePtr.asPtrOrNull<IPropertyObjectInternal>();
+                if (objInternal.assigned() && !coreEventMuted)
+                {
+                    const auto childPath = path != "" ? path + "." + propName : propName;
+                    objInternal.setPath(childPath);
+                    objInternal.setCoreEventTrigger(triggerCoreEvent);
+                    objInternal.enableCoreEventTrigger();
+                }
+            }
+
             if (isUpdating)
             {
                 updatingPropsAndValues.insert_or_assign(prop, UpdatingAction{true, valuePtr});
@@ -800,18 +829,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
                 {
                     const auto newVal = callPropertyValueWrite(prop, valuePtr, PropertyEventType::Update, false);
                     if (!coreEventMuted && triggerCoreEvent.assigned())
-                        triggerCoreEvent(CoreEventArgsPropertyValueChanged(objPtr, propName, newVal));
-                }
-            }
-
-            if (prop.getValueType() == ctObject)
-            {
-                const auto obj = valuePtr.asPtrOrNull<IPropertyObjectInternal>();
-                if (obj.assigned())
-                {
-                    obj.setCoreEventTrigger(triggerCoreEvent);
-                    if (!coreEventMuted)
-                        obj.enableCoreEventTrigger();
+                        triggerCoreEvent(CoreEventArgsPropertyValueChanged(objPtr, propName, newVal, path));
                 }
             }
         }
@@ -968,6 +986,30 @@ PropertyPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkFor
     if (isReferenced)
         *isReferenced = false;
     return boundProp;
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::cloneAndSetChildPropertyObject(const PropertyPtr& prop)
+{
+    const auto propPtrInternal = prop.asPtr<IPropertyInternal>();
+    if (propPtrInternal.assigned() && propPtrInternal.getValueTypeUnresolved() == ctObject && prop.getDefaultValue().assigned())
+    {
+        const auto propName = prop.getName();
+        const auto defaultValueObjInternal = prop.getDefaultValue().asPtrOrNull<IPropertyObjectInternal>();
+        if (!defaultValueObjInternal.assigned())
+            return;
+        const auto cloned = defaultValueObjInternal.clone();
+        setPropertyValueInternal(propName, cloned, false, true, false);
+
+        if (!coreEventMuted)
+        {
+            const auto childPath = path != "" ? path + "." + propName : propName;
+            const auto clonedInternal = cloned.asPtr<IPropertyObjectInternal>();
+            clonedInternal.setPath(childPath);
+            clonedInternal.setCoreEventTrigger(triggerCoreEvent);
+            clonedInternal.enableCoreEventTrigger();
+        }
+    }
 }
 
 template <typename PropObjInterface, typename ... Interfaces>
@@ -1261,6 +1303,25 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearProtect
     return clearPropertyValueInternal(propertyName, true, updateCount > 0);
 }
 
+template <typename PropObjInterface, typename... Interfaces>
+void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::configureClonedMembers(
+    const std::unordered_map<StringPtr, PropertyValueEventEmitter>& valueWriteEvents,
+    const std::unordered_map<StringPtr, PropertyValueEventEmitter>& valueReadEvents,
+    const EndUpdateEventEmitter& endUpdateEvent,
+    const ProcedurePtr& triggerCoreEvent,
+    const PropertyOrderedMap& localProperties,
+    const std::unordered_map<StringPtr, BaseObjectPtr, StringHash, StringEqualTo>& propValues,
+    const std::vector<StringPtr>& customOrder)
+{
+    this->valueWriteEvents = valueWriteEvents;
+    this->valueReadEvents = valueReadEvents;
+    this->endUpdateEvent = endUpdateEvent;
+    this->triggerCoreEvent = triggerCoreEvent;
+    this->localProperties = localProperties;
+    this->propValues = propValues;
+    this->customOrder = customOrder;
+}
+
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropertyValue(IString* propertyName)
 {
@@ -1300,7 +1361,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
 
         if (!protectedAccess)
         {
-            if (prop.getReadOnly())
+            if (prop.getReadOnly() && prop.getValueType() != ctObject)
             {
                 return OPENDAQ_ERR_ACCESSDENIED;
             }
@@ -1340,9 +1401,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
             else
             {
                 propValues.erase(it);
+                cloneAndSetChildPropertyObject(prop);
+
                 const auto val = callPropertyValueWrite(prop, nullptr, PropertyEventType::Clear, false);
                 if (!coreEventMuted && triggerCoreEvent.assigned())
-                    triggerCoreEvent(CoreEventArgsPropertyValueChanged(objPtr, propName, val));
+                    triggerCoreEvent(CoreEventArgsPropertyValueChanged(objPtr, propName, val, path));
             }
         }
     }
@@ -1398,21 +1461,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::addProperty(
         const auto res = localProperties.insert(std::make_pair(propName, propPtr));
         if (!res.second)
             return this->makeErrorInfo(OPENDAQ_ERR_ALREADYEXISTS, fmt::format(R"(Property with name {} already exists.)", propName));
+        
+        cloneAndSetChildPropertyObject(propPtr);
 
         if (!coreEventMuted && triggerCoreEvent.assigned())
-            triggerCoreEvent(CoreEventArgsPropertyAdded(objPtr, propPtr));
-
-        const auto propPtrInternal = propPtr.asPtr<IPropertyInternal>();
-        if (propPtrInternal.getValueTypeUnresolved() == ctObject && propPtr.getDefaultValue().assigned())
-        {
-            const auto defaultValueObjInternal = propPtr.getDefaultValue().asPtrOrNull<IPropertyObjectInternal>();
-            if (defaultValueObjInternal.assigned())
-            {
-                defaultValueObjInternal.setCoreEventTrigger(triggerCoreEvent);
-                if (!coreEventMuted)
-                    defaultValueObjInternal.enableCoreEventTrigger();
-            }
-        }
+            triggerCoreEvent(CoreEventArgsPropertyAdded(objPtr, propPtr, path));
 
         return OPENDAQ_SUCCESS;
     });
@@ -1444,7 +1497,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::removeProper
     }
 
     if(!coreEventMuted && triggerCoreEvent.assigned())
-        triggerCoreEvent(CoreEventArgsPropertyRemoved(objPtr, propertyName));
+        triggerCoreEvent(CoreEventArgsPropertyRemoved(objPtr, propertyName, path));
 
     return OPENDAQ_SUCCESS;
 }
@@ -1664,7 +1717,10 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::applyUpdate()
         }
         else
         {
-            propValues.erase(item.first.getName());
+            const auto prop = item.first;
+            propValues.erase(prop.getName());
+
+            cloneAndSetChildPropertyObject(prop);
         }
 
         if (item.second.setValue)
@@ -1783,24 +1839,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::enableCoreEv
         {
             const auto objInternal = item.second.template asPtrOrNull<IPropertyObjectInternal>();
             if (objInternal.assigned())
-                objInternal.enableCoreEventTrigger();
-        }
-    }
-
-    for (const auto& item : localProperties)
-    {
-        if (item.second.assigned())
-        {
-            const auto  propInternal = item.second.template asPtrOrNull<IPropertyInternal>();
-            if (propInternal.getValueTypeUnresolved() == ctObject)
             {
-                const auto defaultVal = item.second.getDefaultValue();
-                if (defaultVal.assigned())
-                {
-                    const auto objInternal = defaultVal.template asPtrOrNull<IPropertyObjectInternal>();
-                    if (objInternal.assigned())
-                        objInternal.enableCoreEventTrigger();
-                }
+                const auto childPath = path != "" ? path + "." + item.first : item.first;
+                objInternal.setPath(childPath);
+                objInternal.setCoreEventTrigger(triggerCoreEvent);
+                objInternal.enableCoreEventTrigger();
             }
         }
     }
@@ -1857,6 +1900,40 @@ template <typename PropObjInterface, typename ... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setCoreEventTrigger(IProcedure* trigger)
 {
     this->triggerCoreEvent = trigger;
+    return OPENDAQ_SUCCESS;
+}
+
+template <typename PropObjInterface, typename... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clone(IPropertyObject** clonedPropertyObject)
+{
+    OPENDAQ_PARAM_NOT_NULL(clonedPropertyObject);
+
+    const auto managerRef = manager.assigned() ? manager.getRef() : nullptr; 
+    PropertyObjectPtr obj = createWithImplementation<IPropertyObject, PropertyObjectImpl>(managerRef, this->className);
+
+    auto implPtr = static_cast<PropertyObjectImpl*>(obj.getObject());
+    implPtr->configureClonedMembers(valueWriteEvents,
+                                    valueReadEvents,
+                                    endUpdateEvent,
+                                    triggerCoreEvent,
+                                    localProperties,
+                                    propValues,
+                                    customOrder);
+
+    *clonedPropertyObject = obj.detach();
+    return OPENDAQ_SUCCESS;
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPath(IString* path)
+{
+    OPENDAQ_PARAM_NOT_NULL(path);
+
+    if (this->path == "")
+        this->path = path;
+    else
+        return OPENDAQ_IGNORED;
+
     return OPENDAQ_SUCCESS;
 }
 
@@ -2283,7 +2360,7 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::updatingValuesW
     }
 
     if(!coreEventMuted && triggerCoreEvent.assigned())
-        triggerCoreEvent(CoreEventArgsPropertyObjectUpdateEnd(objPtr, dict));
+        triggerCoreEvent(CoreEventArgsPropertyObjectUpdateEnd(objPtr, dict, path));
 }
 
 template <class PropObjInterface, class... Interfaces>

--- a/core/coreobjects/include/coreobjects/property_object_internal.h
+++ b/core/coreobjects/include/coreobjects/property_object_internal.h
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <coreobjects/property.h>
+#include <coreobjects/property_object.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -33,6 +34,8 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObjectInternal, IBaseObject)
     virtual ErrCode INTERFACE_FUNC disableCoreEventTrigger() = 0;
     virtual ErrCode INTERFACE_FUNC getCoreEventTrigger(IProcedure** trigger) = 0;
     virtual ErrCode INTERFACE_FUNC setCoreEventTrigger(IProcedure* trigger) = 0;
+    virtual ErrCode INTERFACE_FUNC clone(IPropertyObject** cloned) = 0;
+    virtual ErrCode INTERFACE_FUNC setPath(IString* path) = 0;
 };
 
 /*!@}*/

--- a/core/coreobjects/src/core_event_args_impl.cpp
+++ b/core/coreobjects/src/core_event_args_impl.cpp
@@ -8,30 +8,30 @@ OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, CoreEventArgs, Int, eventId, IDict
 #if !defined(BUILDING_STATIC_LIBRARY)
 
 extern "C"
-ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyValueChanged(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IString* propName, IBaseObject* value)
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyValueChanged(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IString* propName, IBaseObject* value, IString* path)
 {
-    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner}, {"Name", propName}, {"Value", value}});
+    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner}, {"Name", propName}, {"Value", value}, {"Path", path}});
     return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::PropertyValueChanged,dict);
 }
 
 extern "C"
-ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyObjectUpdateEnd(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IDict* updatedProperties)
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyObjectUpdateEnd(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IDict* updatedProperties, IString* path)
 {
-    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner},{"UpdatedProperties", updatedProperties}});
+    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner},{"UpdatedProperties", updatedProperties}, {"Path", path}});
     return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::PropertyObjectUpdateEnd,dict);
 }
 
 extern "C"
-ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyAdded(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IProperty* prop)
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyAdded(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IProperty* prop, IString* path)
 {
-    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner}, {"Property", prop}});
+    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner}, {"Property", prop}, {"Path", path}});
     return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::PropertyAdded,dict);
 }
 
 extern "C"
-ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyRemoved(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IString* propName)
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyRemoved(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IString* propName, IString* path)
 {
-    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner}, {"Name", propName}});
+    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner}, {"Name", propName}, {"Path", path}});
     return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, Int, IDict*>(objTmp, core_event_ids::PropertyRemoved,dict);
 }
 

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -15,6 +15,7 @@
 #include <coreobjects/eval_value_factory.h>
 #include <coreobjects/callable_info_factory.h>
 #include <coreobjects/argument_info_factory.h>
+#include <coreobjects/property_object_internal_ptr.h>
 
 using namespace daq;
 
@@ -87,6 +88,20 @@ protected:
                                                .setParentName("BaseClass")
                                                .build();
         objManager.addType(specificClass);
+
+        const auto defaultObj1 = PropertyObject();
+        defaultObj1.addProperty(StringProperty("MyString", "foo"));
+        PropertyObjectClassPtr objectClass = PropertyObjectClassBuilder(objManager, "ObjectClass")
+                                                    .addProperty(ObjectProperty("Child", defaultObj1))
+                                                    .build();
+         objManager.addType(objectClass);
+
+        const auto defaultObj2 = PropertyObject();
+        defaultObj2.addProperty(ObjectProperty("Child", defaultObj1));
+        PropertyObjectClassPtr nestedObjectClass = PropertyObjectClassBuilder(objManager, "NestedObjectClass")
+                                                    .addProperty(ObjectProperty("Child", PropertyObject(objManager, "ObjectClass")))
+                                                    .build();
+        objManager.addType(nestedObjectClass);
     }
 
     void TearDown() override
@@ -223,7 +238,7 @@ TEST_F(PropertyObjectTest, GetValueTypeReferenceProperty)
 
 TEST_F(PropertyObjectTest, SerializeJsonSimple)
 {
-    const std::string expectedJson = R"({"__type":"PropertyObject","className":"Test","propValues":{"Referenced":12}})";
+    const std::string expectedJson = R"({"__type":"PropertyObject","className":"Test","propValues":{"AtomicObject":{"__type":"PropertyObject"},"Referenced":12}})";
 
     PropertyObjectPtr propObj = PropertyObject(objManager, "Test");
     propObj.setPropertyValue("IntProperty", "12");
@@ -247,7 +262,7 @@ TEST_F(PropertyObjectTest, SerializeJsonSimple)
 
 TEST_F(PropertyObjectTest, SerializeJsonSimpleWithLocalProperty)
 {
-    const std::string expectedJson = R"({"__type":"PropertyObject","className":"Test","propValues":{"Referenced":12},"properties":[{"__type":"Property","name":"LocalProp","valueType":3,"defaultValue":"-","readOnly":false,"visible":true}]})";
+    const std::string expectedJson = R"({"__type":"PropertyObject","className":"Test","propValues":{"AtomicObject":{"__type":"PropertyObject"},"Referenced":12},"properties":[{"__type":"Property","name":"LocalProp","valueType":3,"defaultValue":"-","readOnly":false,"visible":true}]})";
 
     PropertyObjectPtr propObj = PropertyObject(objManager, "Test");
     propObj.addProperty(StringPropertyBuilder("LocalProp", "-").build());
@@ -272,7 +287,7 @@ TEST_F(PropertyObjectTest, SerializeJsonSimpleWithLocalProperty)
 
 TEST_F(PropertyObjectTest, DeserializeJsonSimple)
 {
-    const std::string json = R"({"__type":"PropertyObject","className":"Test","propValues":{"Referenced":12}})";
+    const std::string json = R"({"__type":"PropertyObject","className":"Test","propValues":{"AtomicObject":{"__type":"PropertyObject"},"Referenced":12}})";
 
     auto deserializer = JsonDeserializer();
 
@@ -289,7 +304,7 @@ TEST_F(PropertyObjectTest, DeserializeJsonSimple)
 TEST_F(PropertyObjectTest, DeserializeJsonSimpleWithLocalProperty)
 {
     const std::string json =
-        R"({"__type":"PropertyObject","className":"Test","propValues":{"Referenced":12},"properties":[{"__type":"Property","name":"LocalProp","valueType":3,"defaultValue":"-","readOnly":false,"visible":true}]})";
+        R"({"__type":"PropertyObject","className":"Test","propValues":{"AtomicObject":{"__type":"PropertyObject"},"Referenced":12},"properties":[{"__type":"Property","name":"LocalProp","valueType":3,"defaultValue":"-","readOnly":false,"visible":true}]})";
 
     const auto deserializer = JsonDeserializer();
 
@@ -683,31 +698,35 @@ TEST_F(PropertyObjectTest, ChildPropSet)
     const auto childProp = ObjectProperty("Child", childObj);
     propObj.addProperty(childProp);
 
-    propObj.setPropertyValue("Child", childObj);
     propObj.setPropertyValue("Child.IntProperty", 1);
+    const PropertyObjectPtr childObjCloned = propObj.getPropertyValue("Child");
 
-    ASSERT_EQ(childObj.getPropertyValue("IntProperty"), 1);
+    ASSERT_EQ(childObjCloned.getPropertyValue("IntProperty"), 1);
 }
 
 TEST_F(PropertyObjectTest, NestedChildPropSet)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj1 = PropertyObject(objManager, "Test");
-    auto childObj2 = PropertyObject(objManager, "Test");
-    auto childObj3 = PropertyObject(objManager, "Test");
+    auto defaultObj1 = PropertyObject(objManager, "Test");
+    auto defaultObj2 = PropertyObject(objManager, "Test");
+    auto defaultObj3 = PropertyObject(objManager, "Test");
 
-    const auto childProp1 = ObjectProperty("Child", childObj1);
+    const auto childProp3 = ObjectProperty("Child", defaultObj3);
+    defaultObj2.addProperty(childProp3);
+    
+    const auto childProp2 = ObjectProperty("Child", defaultObj2);
+    defaultObj1.addProperty(childProp2);
+
+    const auto childProp1 = ObjectProperty("Child", defaultObj1);
     propObj.addProperty(childProp1);
-
-    const auto childProp2 = ObjectProperty("Child", childObj2);
-    childObj1.addProperty(childProp2);
-
-    const auto childProp3 = ObjectProperty("Child", childObj3);
-    childObj2.addProperty(childProp3);
 
     propObj.setPropertyValue("Child.IntProperty", 1);
     propObj.setPropertyValue("Child.Child.IntProperty", 2);
     propObj.setPropertyValue("Child.Child.Child.IntProperty", 3);
+
+    const PropertyObjectPtr childObj1 = propObj.getPropertyValue("Child");
+    const PropertyObjectPtr childObj2 = childObj1.getPropertyValue("Child");
+    const PropertyObjectPtr childObj3 = childObj2.getPropertyValue("Child");
 
     ASSERT_EQ(childObj1.getPropertyValue("IntProperty"), 1);
     ASSERT_EQ(childObj2.getPropertyValue("IntProperty"), 2);
@@ -719,11 +738,11 @@ TEST_F(PropertyObjectTest, ChildPropGet)
     auto propObj = PropertyObject(objManager, "Test");
     auto childObj = PropertyObject(objManager, "Test");
 
-    const auto childProp = ObjectProperty("Child", childObj);
-    propObj.addProperty(childProp);
-
-    propObj.setPropertyValue("Child", childObj);
     childObj.setPropertyValue("IntProperty", 2);
+    const auto childProp = ObjectProperty("Child", childObj);
+
+    propObj.addProperty(childProp);
+    propObj.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("Child", childObj);
 
     ASSERT_EQ(propObj.getPropertyValue("Child.IntProperty"), 2);
 }
@@ -731,14 +750,13 @@ TEST_F(PropertyObjectTest, ChildPropGet)
 TEST_F(PropertyObjectTest, ChildPropClear)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj = PropertyObject(objManager, "Test");
+    auto defaultObj = PropertyObject(objManager, "Test");
 
-    const auto childProp = ObjectProperty("Child", childObj);
+    defaultObj.setPropertyValue("IntProperty", 2);
+    const auto childProp = ObjectProperty("Child", defaultObj);
     propObj.addProperty(childProp);
-
-    propObj.setPropertyValue("Child", childObj);
-    childObj.setPropertyValue("IntProperty", 2);
-
+    
+    const PropertyObjectPtr childObj = propObj.getPropertyValue("Child");
     ASSERT_NO_THROW(propObj.clearPropertyValue("Child.IntProperty"));
     ASSERT_EQ(childObj.getPropertyValue("IntProperty"), 10);
 }
@@ -750,18 +768,18 @@ TEST_F(PropertyObjectTest, NestedChildPropGet)
     auto childObj2 = PropertyObject(objManager, "Test");
     auto childObj3 = PropertyObject(objManager, "Test");
 
-    const auto childProp1 = ObjectProperty("Child", childObj1);
-    propObj.addProperty(childProp1);
-
-    const auto childProp2 = ObjectProperty("Child", childObj2);
-    childObj1.addProperty(childProp2);
+    childObj1.setPropertyValue("IntProperty", 1);
+    childObj2.setPropertyValue("IntProperty", 2);
+    childObj3.setPropertyValue("IntProperty", 3);
 
     const auto childProp3 = ObjectProperty("Child", childObj3);
     childObj2.addProperty(childProp3);
 
-    childObj1.setPropertyValue("IntProperty", 1);
-    childObj2.setPropertyValue("IntProperty", 2);
-    childObj3.setPropertyValue("IntProperty", 3);
+    const auto childProp2 = ObjectProperty("Child", childObj2);
+    childObj1.addProperty(childProp2);
+
+    const auto childProp1 = ObjectProperty("Child", childObj1);
+    propObj.addProperty(childProp1);
 
     ASSERT_EQ(propObj.getPropertyValue("Child.IntProperty"), 1);
     ASSERT_EQ(propObj.getPropertyValue("Child.Child.IntProperty"), 2);
@@ -771,26 +789,30 @@ TEST_F(PropertyObjectTest, NestedChildPropGet)
 TEST_F(PropertyObjectTest, NestedChildPropClear)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj1 = PropertyObject(objManager, "Test");
-    auto childObj2 = PropertyObject(objManager, "Test");
-    auto childObj3 = PropertyObject(objManager, "Test");
+    auto defaultObj1 = PropertyObject(objManager, "Test");
+    auto defaultObj2 = PropertyObject(objManager, "Test");
+    auto defaultObj3 = PropertyObject(objManager, "Test");
 
-    const auto childProp1 = ObjectProperty("Child", childObj1);
+    defaultObj1.setPropertyValue("IntProperty", 1);
+    defaultObj2.setPropertyValue("IntProperty", 2);
+    defaultObj3.setPropertyValue("IntProperty", 3);
+
+    const auto childProp3 = ObjectProperty("Child", defaultObj3);
+    defaultObj2.addProperty(childProp3);
+
+    const auto childProp2 = ObjectProperty("Child", defaultObj2);
+    defaultObj1.addProperty(childProp2);
+
+    const auto childProp1 = ObjectProperty("Child", defaultObj1);
     propObj.addProperty(childProp1);
-
-    const auto childProp2 = ObjectProperty("Child", childObj2);
-    childObj1.addProperty(childProp2);
-
-    const auto childProp3 = ObjectProperty("Child", childObj3);
-    childObj2.addProperty(childProp3);
-
-    childObj1.setPropertyValue("IntProperty", 1);
-    childObj2.setPropertyValue("IntProperty", 2);
-    childObj3.setPropertyValue("IntProperty", 3);
 
     ASSERT_NO_THROW(propObj.clearPropertyValue("Child.IntProperty"));
     ASSERT_NO_THROW(propObj.clearPropertyValue("Child.Child.IntProperty"));
     ASSERT_NO_THROW(propObj.clearPropertyValue("Child.Child.Child.IntProperty"));
+    
+    const PropertyObjectPtr childObj1 = propObj.getPropertyValue("Child");
+    const PropertyObjectPtr childObj2 = childObj1.getPropertyValue("Child");
+    const PropertyObjectPtr childObj3 = childObj2.getPropertyValue("Child");
 
     ASSERT_EQ(childObj1.getPropertyValue("IntProperty"), 10);
     ASSERT_EQ(childObj2.getPropertyValue("IntProperty"), 10);
@@ -800,36 +822,39 @@ TEST_F(PropertyObjectTest, NestedChildPropClear)
 TEST_F(PropertyObjectTest, ChildPropSetViaRefProp)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj = PropertyObject(objManager, "Test");
+    auto defaultObj = PropertyObject(objManager, "Test");
 
-    const auto childProp = ObjectProperty("Child", childObj);
+    const auto childProp = ObjectProperty("Child", defaultObj);
     propObj.addProperty(childProp);
-
-    propObj.setPropertyValue("Child", childObj);
     propObj.setPropertyValue("Kind.IntProperty", 1);
-
+    
+    const PropertyObjectPtr childObj = propObj.getPropertyValue("Child");
     ASSERT_EQ(childObj.getPropertyValue("IntProperty"), 1);
 }
 
 TEST_F(PropertyObjectTest, NestedChildPropSetViaRefProp)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj1 = PropertyObject(objManager, "Test");
-    auto childObj2 = PropertyObject(objManager, "Test");
-    auto childObj3 = PropertyObject(objManager, "Test");
+    auto defaultObj1 = PropertyObject(objManager, "Test");
+    auto defaultObj2 = PropertyObject(objManager, "Test");
+    auto defaultObj3 = PropertyObject(objManager, "Test");
+    
+    const auto childProp3 = ObjectProperty("Child", defaultObj3);
+    defaultObj2.addProperty(childProp3);
 
-    const auto childProp1 = ObjectProperty("Child", childObj1);
+    const auto childProp2 = ObjectProperty("Child", defaultObj2);
+    defaultObj1.addProperty(childProp2);
+
+    const auto childProp1 = ObjectProperty("Child", defaultObj1);
     propObj.addProperty(childProp1);
-
-    const auto childProp2 = ObjectProperty("Child", childObj2);
-    childObj1.addProperty(childProp2);
-
-    const auto childProp3 = ObjectProperty("Child", childObj3);
-    childObj2.addProperty(childProp3);
 
     propObj.setPropertyValue("Kind.IntProperty", 1);
     propObj.setPropertyValue("Kind.Kind.IntProperty", 2);
     propObj.setPropertyValue("Kind.Kind.Kind.IntProperty", 3);
+    
+    const PropertyObjectPtr childObj1 = propObj.getPropertyValue("Child");
+    const PropertyObjectPtr childObj2 = childObj1.getPropertyValue("Child");
+    const PropertyObjectPtr childObj3 = childObj2.getPropertyValue("Child");
 
     ASSERT_EQ(childObj1.getPropertyValue("IntProperty"), 1);
     ASSERT_EQ(childObj2.getPropertyValue("IntProperty"), 2);
@@ -839,28 +864,26 @@ TEST_F(PropertyObjectTest, NestedChildPropSetViaRefProp)
 TEST_F(PropertyObjectTest, ChildPropGetViaRefProp)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj = PropertyObject(objManager, "Test");
-
-    const auto childProp = ObjectProperty("Child", childObj);
+    auto defaultObj = PropertyObject(objManager, "Test");
+    
+    defaultObj.setPropertyValue("IntProperty", 2);
+    const auto childProp = ObjectProperty("Child", defaultObj);
     propObj.addProperty(childProp);
-
-    propObj.setPropertyValue("Child", childObj);
-    childObj.setPropertyValue("IntProperty", 2);
-
+    
+    const PropertyObjectPtr childObj = propObj.getPropertyValue("Child");
     ASSERT_EQ(propObj.getPropertyValue("Kind.IntProperty"), 2);
 }
 
 TEST_F(PropertyObjectTest, ChildPropClearViaRefProp)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj = PropertyObject(objManager, "Test");
-
-    const auto childProp = ObjectProperty("Child", childObj);
+    auto defaultObj = PropertyObject(objManager, "Test");
+    
+    defaultObj.setPropertyValue("IntProperty", 1);
+    const auto childProp = ObjectProperty("Child", defaultObj);
     propObj.addProperty(childProp);
 
-    propObj.setPropertyValue("Child", childObj);
-    childObj.setPropertyValue("IntProperty", 1);
-
+    const PropertyObjectPtr childObj = propObj.getPropertyValue("Child");
     ASSERT_NO_THROW(propObj.clearPropertyValue("Kind.IntProperty"));
     ASSERT_EQ(childObj.getPropertyValue("IntProperty"), 10);
 }
@@ -868,22 +891,26 @@ TEST_F(PropertyObjectTest, ChildPropClearViaRefProp)
 TEST_F(PropertyObjectTest, NestedChildPropGetViaRefProp)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj1 = PropertyObject(objManager, "Test");
-    auto childObj2 = PropertyObject(objManager, "Test");
-    auto childObj3 = PropertyObject(objManager, "Test");
+    auto defaultObj1 = PropertyObject(objManager, "Test");
+    auto defaultObj2 = PropertyObject(objManager, "Test");
+    auto defaultObj3 = PropertyObject(objManager, "Test");
+    
+    defaultObj1.setPropertyValue("IntProperty", 1);
+    defaultObj2.setPropertyValue("IntProperty", 2);
+    defaultObj3.setPropertyValue("IntProperty", 3);
+    
+    const auto childProp3 = ObjectProperty("Child", defaultObj3);
+    defaultObj2.addProperty(childProp3);
 
-    const auto childProp1 = ObjectProperty("Child", childObj1);
+    const auto childProp2 = ObjectProperty("Child", defaultObj2);
+    defaultObj1.addProperty(childProp2);
+
+    const auto childProp1 = ObjectProperty("Child", defaultObj1);
     propObj.addProperty(childProp1);
 
-    const auto childProp2 = ObjectProperty("Child", childObj2);
-    childObj1.addProperty(childProp2);
-
-    const auto childProp3 = ObjectProperty("Child", childObj3);
-    childObj2.addProperty(childProp3);
-
-    childObj1.setPropertyValue("IntProperty", 1);
-    childObj2.setPropertyValue("IntProperty", 2);
-    childObj3.setPropertyValue("IntProperty", 3);
+    const PropertyObjectPtr childObj1 = propObj.getPropertyValue("Child");
+    const PropertyObjectPtr childObj2 = childObj1.getPropertyValue("Child");
+    const PropertyObjectPtr childObj3 = childObj2.getPropertyValue("Child");
     
     ASSERT_EQ(propObj.getPropertyValue("Kind.IntProperty"), 1);
     ASSERT_EQ(propObj.getPropertyValue("Kind.Kind.IntProperty"), 2);
@@ -893,27 +920,31 @@ TEST_F(PropertyObjectTest, NestedChildPropGetViaRefProp)
 TEST_F(PropertyObjectTest, NestedChildPropClearViaRefProp)
 {
     auto propObj = PropertyObject(objManager, "Test");
-    auto childObj1 = PropertyObject(objManager, "Test");
-    auto childObj2 = PropertyObject(objManager, "Test");
-    auto childObj3 = PropertyObject(objManager, "Test");
+    auto defaultObj1 = PropertyObject(objManager, "Test");
+    auto defaultObj2 = PropertyObject(objManager, "Test");
+    auto defaultObj3 = PropertyObject(objManager, "Test");
+    
 
-    const auto childProp1 = ObjectProperty("Child", childObj1);
+    defaultObj1.setPropertyValue("IntProperty", 1);
+    defaultObj2.setPropertyValue("IntProperty", 2);
+    defaultObj3.setPropertyValue("IntProperty", 3);
+
+    const auto childProp3 = ObjectProperty("Child", defaultObj3);
+    defaultObj2.addProperty(childProp3);
+
+    const auto childProp2 = ObjectProperty("Child", defaultObj2);
+    defaultObj1.addProperty(childProp2);
+
+    const auto childProp1 = ObjectProperty("Child", defaultObj1);
     propObj.addProperty(childProp1);
-
-    const auto childProp2 = ObjectProperty("Child", childObj2);
-    childObj1.addProperty(childProp2);
-
-    const auto childProp3 = ObjectProperty("Child", childObj3);
-    childObj2.addProperty(childProp3);
-
-    childObj1.setPropertyValue("IntProperty", 1);
-    childObj2.setPropertyValue("IntProperty", 2);
-    childObj3.setPropertyValue("IntProperty", 3);
 
     ASSERT_NO_THROW(propObj.clearPropertyValue("Kind.IntProperty"));
     ASSERT_NO_THROW(propObj.clearPropertyValue("Kind.Kind.IntProperty"));
     ASSERT_NO_THROW(propObj.clearPropertyValue("Kind.Kind.Kind.IntProperty"));
-
+    
+    const PropertyObjectPtr childObj1 = propObj.getPropertyValue("Child");
+    const PropertyObjectPtr childObj2 = childObj1.getPropertyValue("Child");
+    const PropertyObjectPtr childObj3 = childObj2.getPropertyValue("Child");
     ASSERT_EQ(childObj1.getPropertyValue("IntProperty"), 10);
     ASSERT_EQ(childObj2.getPropertyValue("IntProperty"), 10);
     ASSERT_EQ(childObj3.getPropertyValue("IntProperty"), 10);
@@ -1117,12 +1148,10 @@ TEST_F(PropertyObjectTest, ChildPropGetArray)
 {
     auto propObj = PropertyObject(objManager, "Test");
     auto childObj = PropertyObject(objManager, "Test");
-
+    
+    childObj.setPropertyValue("ListProperty", List<Int>(1, 4));
     const auto childProp = ObjectProperty("Child", childObj);
     propObj.addProperty(childProp);
-
-    propObj.setPropertyValue("Child", childObj);
-    childObj.setPropertyValue("ListProperty", List<Int>(1, 4));
 
     ASSERT_EQ(propObj.getPropertyValue("Child.ListProperty[1]"), 4);
 }
@@ -1707,4 +1736,201 @@ TEST_F(PropertyObjectTest, BeginEndUpdate)
     ASSERT_EQ(propObj.getPropertyValue("Prop1"), "Value1_1");
     ASSERT_EQ(propObj.getPropertyValue("Prop2"), "Value2");
     ASSERT_EQ(propObj.getPropertyValue("Prop3"), "-");
+}
+
+TEST_F(PropertyObjectTest, Clone)
+{
+    auto propObj = PropertyObject();
+
+    auto propObj1 = PropertyObject();
+    propObj1.addProperty(StringProperty("foo", "bar"));
+
+    auto propObj2 = PropertyObject();
+    propObj2.addProperty(StringProperty("foo", "bar"));
+    
+    propObj1.addProperty(ObjectProperty("child", propObj2));
+    propObj.addProperty(ObjectProperty("child", propObj1));
+
+    PropertyObjectPtr clonedObj1 = propObj.getPropertyValue("child");
+    PropertyObjectPtr clonedObj2 = clonedObj1.getPropertyValue("child");
+
+    ASSERT_NO_THROW(propObj.asPtr<IPropertyObjectInternal>().clone());
+
+    propObj.setPropertyValue("child.child.foo", "test");
+    ASSERT_EQ(propObj2.getPropertyValue("foo"), "bar");
+    ASSERT_EQ(clonedObj2.getPropertyValue("foo"), "test");
+}
+
+TEST_F(PropertyObjectTest, NestedObjectsFrozen)
+{
+    const auto propObj = PropertyObject();
+    const auto propObj1 = PropertyObject();
+    propObj.addProperty(ObjectProperty("Child", propObj1));
+    ASSERT_TRUE(propObj1.isFrozen());
+}
+
+TEST_F(PropertyObjectTest, ClonedObjectSet)
+{
+    const auto propObj = PropertyObject();
+    const auto propObj1 = PropertyObject();
+    propObj1.addProperty(IntProperty("MyInt", 10));
+    propObj.addProperty(ObjectProperty("Child", propObj1));
+
+    const PropertyObjectPtr cloned = propObj.getPropertyValue("Child");
+    propObj.setPropertyValue("Child.MyInt", 15);
+    ASSERT_EQ(cloned.getPropertyValue("MyInt"), 15);
+}
+
+TEST_F(PropertyObjectTest, ClonedObjectsClear)
+{
+    const auto propObj = PropertyObject();
+    const auto propObj1 = PropertyObject();
+    propObj1.addProperty(IntProperty("MyInt", 10));
+    propObj.addProperty(ObjectProperty("Child", propObj1));
+
+    const auto cloned = propObj.getPropertyValue("Child");
+    propObj.setPropertyValue("Child.MyInt", 15);
+    propObj.clearPropertyValue("Child");
+    ASSERT_NE(cloned, propObj.getPropertyValue("Child"));
+    ASSERT_EQ(propObj.getPropertyValue("Child.MyInt"), 10);
+}
+
+TEST_F(PropertyObjectTest, BeginEndUpdateCloned)
+{
+    const auto propObj = PropertyObject();
+    const auto propObj1 = PropertyObject();
+    propObj1.addProperty(IntProperty("MyInt", 10));
+    propObj1.addProperty(StringProperty("MyString", "foo"));
+    propObj.addProperty(ObjectProperty("Child", propObj1));
+
+    const auto oldChild = propObj.getPropertyValue("Child");
+
+    propObj.beginUpdate();
+
+    const auto newChild = PropertyObject();
+    newChild.addProperty(IntProperty("NewInt", 15));
+    propObj.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("Child", newChild);
+    ASSERT_EQ(propObj.getPropertyValue("Child"), oldChild);
+
+    propObj.endUpdate();
+
+    ASSERT_EQ(propObj.getPropertyValue("Child"), newChild);
+}
+
+TEST_F(PropertyObjectTest, BeginEndUpdateClonedClear)
+{
+    const auto propObj = PropertyObject();
+    const auto propObj1 = PropertyObject();
+    propObj1.addProperty(IntProperty("MyInt", 10));
+    propObj1.addProperty(StringProperty("MyString", "foo"));
+    propObj.addProperty(ObjectProperty("Child", propObj1));
+
+    const auto oldChild = propObj.getPropertyValue("Child");
+    const auto newChild = PropertyObject();
+    newChild.addProperty(IntProperty("NewInt", 15));
+    propObj.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("Child", newChild);
+
+    propObj.beginUpdate();
+
+    propObj.clearPropertyValue("Child");
+    ASSERT_EQ(propObj.getPropertyValue("Child"), newChild);
+
+    propObj.endUpdate();
+
+    ASSERT_NE(propObj.getPropertyValue("Child"), newChild);
+    ASSERT_NE(propObj.getPropertyValue("Child"), oldChild);
+    ASSERT_EQ(propObj.getPropertyValue("Child.MyString"), "foo");
+}
+
+TEST_F(PropertyObjectTest, BeginEndUpdateClonedClassObject)
+{
+    const auto propObj = PropertyObject(objManager, "NestedObjectClass");
+    const auto oldChild = propObj.getPropertyValue("Child");
+
+    propObj.beginUpdate();
+
+    const auto newChild = PropertyObject();
+    newChild.addProperty(IntProperty("NewInt", 15));
+    propObj.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("Child", newChild);
+
+    ASSERT_EQ(propObj.getPropertyValue("Child"), oldChild);
+
+    propObj.endUpdate();
+    ASSERT_EQ(propObj.getPropertyValue("Child"), newChild);
+
+    
+    propObj.beginUpdate();
+
+    propObj.clearPropertyValue("Child");
+    ASSERT_EQ(propObj.getPropertyValue("Child"), newChild);
+
+    propObj.endUpdate();
+
+    ASSERT_NE(propObj.getPropertyValue("Child"), newChild);
+    ASSERT_NE(propObj.getPropertyValue("Child"), oldChild);
+    ASSERT_EQ(propObj.getPropertyValue("Child.Child.MyString"), "foo");
+}
+
+TEST_F(PropertyObjectTest, ClonedClassObjects)
+{
+    const auto propObj = PropertyObject(objManager, "NestedObjectClass");
+    const PropertyObjectClassPtr classObj = objManager.getType("NestedObjectClass");
+    ASSERT_NE(propObj.getPropertyValue("Child"), classObj.getProperty("Child").getDefaultValue());
+    ASSERT_TRUE(classObj.getProperty("Child").getDefaultValue().isFrozen());
+    ASSERT_FALSE(propObj.getPropertyValue("Child").isFrozen());
+}
+
+// TODO: Enable once nested object property deserialization works without classes
+TEST_F(PropertyObjectTest, DISABLED_ClonedObjectsSerialize)
+{
+    const std::string expectedJson = R"({"__type":"PropertyObject","propValues":{"Child1":{"__type":"PropertyObject","propValues":{"Child2":{"__type":"PropertyObject"}}}}})";
+
+    const PropertyObjectPtr propObj1 = PropertyObject();
+    const PropertyObjectPtr propObj2 = PropertyObject();
+    const PropertyObjectPtr propObj3 = PropertyObject();
+    propObj3.addProperty(IntProperty("MyInt", 10));
+    propObj2.addProperty(ObjectProperty("Child2", propObj3));
+    propObj1.addProperty(ObjectProperty("Child1", propObj2));
+
+    const auto serializer1 = JsonSerializer();
+    propObj1.serialize(serializer1);
+
+    const std::string json = serializer1.getOutput().toStdString();
+
+    ASSERT_EQ(json, expectedJson);
+
+    const auto deserializer = JsonDeserializer();
+
+    const PropertyObjectPtr ptr = deserializer.deserialize(String(json.data()), objManager);
+
+    const auto serializer2 = JsonSerializer();
+    ptr.serialize(serializer2);
+
+    const std::string deserializedJson = serializer2.getOutput().toStdString();
+
+    ASSERT_EQ(json, deserializedJson);
+}
+
+TEST_F(PropertyObjectTest, ClonedClassObjectsSerialize)
+{
+    const std::string expectedJson = R"({"__type":"PropertyObject","className":"NestedObjectClass","propValues":{"Child":{"__type":"PropertyObject","className":"ObjectClass","propValues":{"Child":{"__type":"PropertyObject","properties":[{"__type":"Property","name":"MyString","valueType":3,"defaultValue":"foo","readOnly":false,"visible":true}]}}}}})";
+
+    const auto propObj = PropertyObject(objManager, "NestedObjectClass");
+    const auto serializer1 = JsonSerializer();
+    propObj.serialize(serializer1);
+
+    const std::string json = serializer1.getOutput().toStdString();
+
+    ASSERT_EQ(json, expectedJson);
+
+    const auto deserializer = JsonDeserializer();
+
+    const PropertyObjectPtr ptr = deserializer.deserialize(String(json.data()), objManager);
+
+    const auto serializer2 = JsonSerializer();
+    ptr.serialize(serializer2);
+
+    const std::string deserializedJson = serializer2.getOutput().toStdString();
+
+    ASSERT_EQ(json, deserializedJson);
 }

--- a/core/opendaq/component/include/opendaq/component_private.h
+++ b/core/opendaq/component/include/opendaq/component_private.h
@@ -34,7 +34,7 @@ DECLARE_OPENDAQ_INTERFACE(IComponentPrivate, IBaseObject)
 {
     // [templateType(attributes, IString)]
     /*!
-     * @brief Adds the attributes contained in the list to the set of locked components.
+     * @brief Locks the attributes contained in the provided list.
      * @param attributes The list of attributes that should be locked. Is not case sensitive.
      */
     virtual ErrCode INTERFACE_FUNC lockAttributes(IList* attributes) = 0;
@@ -46,7 +46,7 @@ DECLARE_OPENDAQ_INTERFACE(IComponentPrivate, IBaseObject)
 
     // [templateType(attributes, IString)]
     /*!
-     * @brief Removes the attributes contained in the list from the set of locked components.
+     * @brief Unlocks the attributes contained in the provided list.
      * @param attributes The list of attributes that should be unlocked. Is not case sensitive.
      */
     virtual ErrCode INTERFACE_FUNC unlockAttributes(IList* attributes) = 0;

--- a/core/opendaq/functionblock/tests/test_fb_wrapper.cpp
+++ b/core/opendaq/functionblock/tests/test_fb_wrapper.cpp
@@ -101,9 +101,7 @@ protected:
         auto propObj = daq::PropertyObject();
         propObj->addProperty(daq::BoolProperty("boolprop", daq::True));
 
-        fb->addProperty(daq::ObjectProperty("objprop", daq::PropertyObject()));
-
-        fb->setPropertyValue("objprop", propObj);
+        fb->addProperty(daq::ObjectProperty("objprop", propObj));
     }
 
     daq::MockFunctionBlock::Strict fb;

--- a/core/opendaq/opendaq/src/CMakeLists.txt
+++ b/core/opendaq/opendaq/src/CMakeLists.txt
@@ -137,7 +137,7 @@ set_source_files_properties(${ConfigHeader} PROPERTIES GENERATED TRUE)
 source_group("Generated\\Header Files" FILES ${ConfigHeader})
 
 if (MSVC)
-    target_compile_options(${LIB_NAME} PRIVATE /wd4100)
+    target_compile_options(${LIB_NAME} PRIVATE /wd4100 /bigobj)
 endif()
 
 opendaq_set_output_lib_name(${LIB_NAME} ${PROJECT_VERSION_MAJOR})

--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -12,6 +12,7 @@
 #include <opendaq/input_port_factory.h>
 #include <opendaq/signal_factory.h>
 #include <coreobjects/property_object_factory.h>
+#include <coreobjects/property_object_protected_ptr.h>
 
 using namespace daq;
 
@@ -75,15 +76,17 @@ TEST_F(CoreEventTest, PropertyChangedNested)
 {
     const auto context = NullContext();
     const auto component = Component(context, nullptr, "comp");
-    const auto obj1 = PropertyObject();
+
+    const auto defaultObj = PropertyObject();
     const auto obj2 = PropertyObject();
-    component.addProperty(ObjectProperty("obj1", obj1));
+    defaultObj.addProperty(StringProperty("string", "foo"));
+    obj2.addProperty(StringProperty("string", "foo"));
+
+    component.addProperty(ObjectProperty("obj1", defaultObj));
+    const PropertyObjectPtr obj1 = component.getPropertyValue("obj1");
 
     component.addProperty(ObjectProperty("obj2"));
-    component.setPropertyValue("obj2", obj2);
-
-    obj1.addProperty(StringProperty("string", "foo"));
-    obj2.addProperty(StringProperty("string", "foo"));
+    component.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("obj2", obj2);
 
     int callCount = 0;
 
@@ -97,9 +100,14 @@ TEST_F(CoreEventTest, PropertyChangedNested)
         ASSERT_TRUE(args.getParameters().hasKey("Value"));
 
         if (callCount == 0)
+        {
             ASSERT_EQ(obj1, args.getParameters().get("Owner"));
+        }
         else
+        {
             ASSERT_EQ(obj2, args.getParameters().get("Owner"));
+            ASSERT_EQ("obj2", args.getParameters().get("Path"));
+        }
 
         callCount++;
     };
@@ -110,20 +118,87 @@ TEST_F(CoreEventTest, PropertyChangedNested)
     ASSERT_EQ(callCount, 2);
 }
 
+TEST_F(CoreEventTest, MultipleLevelNestedObjectPath)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+
+    const auto defaultObj = PropertyObject();
+    const auto defaultObj1 = PropertyObject();
+    const auto defaultObj2 = PropertyObject();
+    defaultObj2.addProperty(IntProperty("IntVal", 5));
+    
+    defaultObj1.addProperty(ObjectProperty("obj3", defaultObj2));
+    defaultObj.addProperty(ObjectProperty("obj2", defaultObj1));
+    component.addProperty(ObjectProperty("obj1", defaultObj));
+
+    int callCount = 0;
+    component.asPtrOrNull<IPropertyObjectInternal>().enableCoreEventTrigger();
+    context.getOnCoreEvent() += [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+    {
+        ASSERT_EQ("obj1.obj2.obj3", args.getParameters().get("Path"));
+        callCount++;
+    };
+
+    const PropertyObjectPtr obj = component.getPropertyValue("obj1.obj2.obj3");
+    component.setPropertyValue("obj1.obj2.obj3.IntVal", 10);
+    obj.addProperty(StringProperty("test", "test"));
+    obj.removeProperty("test");
+    obj.beginUpdate();
+    obj.endUpdate();
+
+    ASSERT_EQ(callCount, 4);
+}
+
+TEST_F(CoreEventTest, NestedAddAfterCoreEventEnable)
+{
+    const auto context = NullContext();
+    const auto component = Component(context, nullptr, "comp");
+
+    const auto defaultObj = PropertyObject();
+    const auto defaultObj1 = PropertyObject();
+    const auto defaultObj2 = PropertyObject();
+
+    defaultObj2.addProperty(IntProperty("IntVal", 5));
+    defaultObj1.addProperty(ObjectProperty("obj3", defaultObj2));
+
+    component.asPtrOrNull<IPropertyObjectInternal>().enableCoreEventTrigger();
+
+    defaultObj.addProperty(ObjectProperty("obj2", defaultObj1));
+    component.addProperty(ObjectProperty("obj1", defaultObj));
+
+    int callCount = 0;
+    context.getOnCoreEvent() += [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+    {
+        ASSERT_EQ("obj1.obj2.obj3", args.getParameters().get("Path"));
+        callCount++;
+    };
+
+    const PropertyObjectPtr obj = component.getPropertyValue("obj1.obj2.obj3");
+    component.setPropertyValue("obj1.obj2.obj3.IntVal", 10);
+    obj.addProperty(StringProperty("test", "test"));
+    obj.removeProperty("test");
+    obj.beginUpdate();
+    obj.endUpdate();
+
+    ASSERT_EQ(callCount, 4);
+}
+
 TEST_F(CoreEventTest, NestedObjDisableTrigger)
 {
     const auto context = NullContext();
     const auto component = Component(context, nullptr, "comp");
 
-    const auto obj1 = PropertyObject();
+    const auto defaultObj = PropertyObject();
     const auto obj2 = PropertyObject();
-    component.addProperty(ObjectProperty("obj1", obj1));
+    defaultObj.addProperty(StringProperty("string", "foo"));
+    obj2.addProperty(StringProperty("string", "foo"));
+
+    component.addProperty(ObjectProperty("obj1", defaultObj));
+    const PropertyObjectPtr obj1 = component.getPropertyValue("obj1");
 
     component.addProperty(ObjectProperty("obj2"));
-    component.setPropertyValue("obj2", obj2);
-
-    obj1.addProperty(StringProperty("string", "foo"));
-    obj2.addProperty(StringProperty("string", "foo"));
+    component.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("obj2", obj2);
 
     int callCount = 0;
 
@@ -293,12 +368,15 @@ TEST_F(CoreEventTest, PropertyAddedNested)
 {
     const auto context = NullContext();
     const auto component = Component(context, nullptr, "comp");
-    const auto obj1 = PropertyObject();
+
+    const auto defaultObj = PropertyObject();
     const auto obj2 = PropertyObject();
-    component.addProperty(ObjectProperty("obj1", obj1));
+
+    component.addProperty(ObjectProperty("obj1", defaultObj));
+    const PropertyObjectPtr obj1 = component.getPropertyValue("obj1");
 
     component.addProperty(ObjectProperty("obj2"));
-    component.setPropertyValue("obj2", obj2);
+    component.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("obj2", obj2);
 
     int addCount = 0;
     
@@ -356,15 +434,17 @@ TEST_F(CoreEventTest, PropertyRemovedNested)
 {
     const auto context = NullContext();
     const auto component = Component(context, nullptr, "comp");
-    const auto obj1 = PropertyObject();
+
+    const auto defaultObj = PropertyObject();
     const auto obj2 = PropertyObject();
-    component.addProperty(ObjectProperty("obj1", obj1));
+    defaultObj.addProperty(StringProperty("string", "foo"));
+    obj2.addProperty(StringProperty("string", "foo"));
+
+    component.addProperty(ObjectProperty("obj1", defaultObj));
+    const PropertyObjectPtr obj1 = component.getPropertyValue("obj1");
 
     component.addProperty(ObjectProperty("obj2"));
-    component.setPropertyValue("obj2", obj2);
-
-    obj1.addProperty(StringProperty("string", "foo"));
-    obj2.addProperty(StringProperty("string", "foo"));
+    component.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("obj2", obj2);
 
     int removeCount = 0;
     

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -324,7 +324,7 @@ TEST_F(InstanceTest, InstanceBuilderSetGet)
                                 .setSchedulerWorkerNum(1)
                                 .setScheduler(scheduler)
                                 .setDefaultRootDeviceLocalId("DefaultRootDeviceLocalId")
-                                .setRootDevice("daqref://device0")
+                                .setRootDevice("test")
                                 .setDefaultRootDeviceInfo(defaultRootDeviceInfo);
     
     ASSERT_EQ(instanceBuilder.getLogger(), logger);
@@ -343,7 +343,7 @@ TEST_F(InstanceTest, InstanceBuilderSetGet)
     ASSERT_EQ(instanceBuilder.getSchedulerWorkerNum(), 1);
     ASSERT_EQ(instanceBuilder.getScheduler(), scheduler);
     ASSERT_EQ(instanceBuilder.getDefaultRootDeviceLocalId(), "DefaultRootDeviceLocalId");
-    ASSERT_EQ(instanceBuilder.getRootDevice(), "daqref://device0");
+    ASSERT_EQ(instanceBuilder.getRootDevice(), "test");
     ASSERT_EQ(instanceBuilder.getDefaultRootDeviceInfo(), defaultRootDeviceInfo);
 }
 
@@ -377,11 +377,10 @@ TEST_F(InstanceTest, InstanceCreateFactory)
 TEST_F(InstanceTest, InstanceBuilderGetDefault)
 {
     const auto instanceBuilder = InstanceBuilder()
-                                .setGlobalLogLevel(LogLevel::Debug)
-                                .setComponentLogLevel("Instance", LogLevel::Error)
-                                .addLoggerSink(StdOutLoggerSink())
-                                .setSchedulerWorkerNum(1)
-                                .setRootDevice("daqref://device0");
+                                     .setGlobalLogLevel(LogLevel::Debug)
+                                     .setComponentLogLevel("Instance", LogLevel::Error)
+                                     .addLoggerSink(StdOutLoggerSink())
+                                     .setSchedulerWorkerNum(1);
 
     ASSERT_EQ(instanceBuilder.getLogger().assigned(), false);
     ASSERT_EQ(instanceBuilder.getScheduler().assigned(), false);
@@ -402,11 +401,16 @@ TEST_F(InstanceTest, InstanceBuilderGetDefault)
     ASSERT_EQ(scheduler.isMultiThreaded(), false);
 
     // check moduleManager
-    auto moduleManager = instance.getContext().getModuleManager();
+    ModuleManagerPtr moduleManager = instance.getContext().getModuleManager();
     ASSERT_EQ(moduleManager.assigned(), true);
 
+    // We cannot add modules in the instance builder as the context is not yet created
+    const ModulePtr deviceModule(MockDeviceModule_Create(instance.getContext()));
+    moduleManager.addModule(deviceModule);
+
+    instance.setRootDevice("mock_phys_device");
     ASSERT_TRUE(instance.getRootDevice().assigned());
-    ASSERT_FALSE(instance.getRootDevice().getName() == "DefaultRootDeviceLocalId");   
+    ASSERT_EQ(instance.getRootDevice().getName(), "mockdev");
 }
 
 END_NAMESPACE_OPENDAQ

--- a/docs/Antora/modules/background_info/pages/property_system.adoc
+++ b/docs/Antora/modules/background_info/pages/property_system.adoc
@@ -371,11 +371,17 @@ WARNING: The Selection Property getter cannot use the "dot" notation at this mom
 Object type Properties can only have their Name, Description, Visible, Read-only and Default
 value configured, where the Default value is mandatory.
 
-IMPORTANT: Object Properties behave slightly differently than other Property types in that
-their Default Values do not get frozen when the Property is added to a Property Object 
-(they do get frozen when added to a <<#object_class, Property Object Class>>, or if the 
-Object Property is Read-only). As such, Properties of the Default Value Property Object 
-can be modified even after being added to a Property Object.
+IMPORTANT: Object properties, as all other Property types get frozen once added to a Property
+Object. The notable exception is that locally, the object (default value) is cloned and cached. 
+When the Property value of the Object-type Property is read, the cloned object is returned instead 
+of the default value. This cloned object is not frozen, allowing for the any Properties of 
+the child Property Object to be modified. The same behaviour is applied when a Property Object 
+is created from a Property Object Class - all Object-type properties of the class are cloned.
+
+Notably, by default, all Object properties are read-only. Read-only object-type properties
+cannot be wholly replaced, but the child property values of the object can still be modified.
+The "Clear property value" method will work on object-type properties, even if the object
+is read-only.
 
 .Object Properties example
 
@@ -389,9 +395,11 @@ auto propObj = PropertyObject();
 auto child1 = PropertyObject();
 auto child2 = PropertyObject();
 
-propObj.addProperty(ObjectProperty("Child", child1));
-child1.addProperty(ObjectProperty("Child", child2));
+// The order below is important, as "child1" and "child2" are frozen once 
+// used as default property values.
 child2.addProperty(StringProperty("String", "foo"));
+child1.addProperty(ObjectProperty("Child", child2));
+propObj.addProperty(ObjectProperty("Child", child1));
 
 // Prints out the value of the "String" Property of child2
 std::cout << propObj.getPropertyValue("Child.Child.String") << std::endl;
@@ -404,12 +412,15 @@ propObj = opendaq.PropertyObject()
 child1 = opendaq.PropertyObject()
 child2 = opendaq.PropertyObject()
 
-propObj.add_property(opendaq.ObjectProperty(
-    opendaq.String('Child'), child1))
-child1.add_property(opendaq.ObjectProperty(
-    opendaq.String('Child'), child2))
+# The order below is important, as "child1" and "child2" are frozen once 
+# used as default property values.
+
 child2.add_property(opendaq.StringProperty(opendaq.String(
     'String'), opendaq.String('foo'), opendaq.Boolean(True)))
+child1.add_property(opendaq.ObjectProperty(
+    opendaq.String('Child'), child2))
+propObj.add_property(opendaq.ObjectProperty(
+    opendaq.String('Child'), child1))
 
 # Prints out the value of the "String" Property of child2
 print(propObj.get_property_value('Child.Child.String'))
@@ -1114,13 +1125,12 @@ Cpp::
 [source,cpp]
 ----
 auto propObj = PropertyObject();
-
 auto child1 = PropertyObject();
-propObj.addProperty(ObjectProperty("Child", child1));
-
 auto child2 = PropertyObject();
+
 child2.addProperty(StringProperty("String", "foo"));
 child1.addProperty(ObjectProperty("Child", child2));
+propObj.addProperty(ObjectProperty("Child", child1));
 
 propObj.setPropertyValue("Child.Child.String", "bar");
 
@@ -1132,16 +1142,15 @@ Python::
 [source,python]
 ----
 propObj = opendaq.PropertyObject()
-
 child1 = opendaq.PropertyObject()
-propObj.add_property(opendaq.ObjectProperty(
-    opendaq.String('Child'), child1))
-
 child2 = opendaq.PropertyObject()
+
 child2.add_property(opendaq.StringProperty(opendaq.String(
     'String'), opendaq.String('foo'), opendaq.Boolean(True)))
 child1.add_property(opendaq.ObjectProperty(
     opendaq.String('Child'), child2))
+propObj.add_property(opendaq.ObjectProperty(
+    opendaq.String('Child'), child1))
 
 propObj.set_property_value(
     'Child.Child.String', opendaq.String('bar'))

--- a/docs/tests/test_property_system.cpp
+++ b/docs/tests/test_property_system.cpp
@@ -69,10 +69,10 @@ TEST_F(PropertySystemTest, ObjectProps)
     auto propObj = PropertyObject();
     auto child1 = PropertyObject();
     auto child2 = PropertyObject();
-
-    propObj.addProperty(ObjectProperty("Child", child1));
-    child1.addProperty(ObjectProperty("Child", child2));
+    
     child2.addProperty(StringProperty("String", "foo"));
+    child1.addProperty(ObjectProperty("Child", child2));
+    propObj.addProperty(ObjectProperty("Child", child1));
 
     // Prints out the value of the "String" property of child2
     ASSERT_EQ(propObj.getPropertyValue("Child.Child.String"), "foo");
@@ -249,13 +249,14 @@ TEST_F(PropertySystemTest, ReadWritePropValues)
 TEST_F(PropertySystemTest, NestedObjects)
 {
     auto propObj = PropertyObject();
-
-    auto child1 = PropertyObject();
-    propObj.addProperty(ObjectProperty("Child", child1));
-
+    
     auto child2 = PropertyObject();
     child2.addProperty(StringProperty("String", "foo"));
+
+    auto child1 = PropertyObject();
     child1.addProperty(ObjectProperty("Child", child2));
+
+    propObj.addProperty(ObjectProperty("Child", child1));
 
     propObj.setPropertyValue("Child.Child.String", "bar");
     ASSERT_EQ(propObj.getPropertyValue("Child.Child.String"), "bar");

--- a/modules/ref_device_module/src/CMakeLists.txt
+++ b/modules/ref_device_module/src/CMakeLists.txt
@@ -34,6 +34,10 @@ add_library(${LIB_NAME} SHARED ${SRC_Include}
 
 add_library(${SDK_TARGET_NAMESPACE}::${LIB_NAME} ALIAS ${LIB_NAME})
 
+if (MSVC)
+    target_compile_options(${LIB_NAME} PRIVATE /bigobj)
+endif()
+
 target_link_libraries(${LIB_NAME} PUBLIC daq::opendaq
 )
 

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_property_object_advanced.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_property_object_advanced.cpp
@@ -490,8 +490,9 @@ TEST_F(TmsPropertyObjectAdvancedTest, ObjectGetSet)
     testObj.addProperty(IntProperty("test", 0));
 
     ASSERT_ANY_THROW(clientObj.setPropertyValue("Object", testObj));
-    ASSERT_ANY_THROW(clientChildObj.setPropertyValue("ObjNumber", 1));
+    ASSERT_NO_THROW(clientChildObj.setPropertyValue("ObjNumber", 1));
 
+    ASSERT_EQ(clientChildObj.getPropertyValue("ObjNumber"), 1);
     PropertyObjectPtr serverNonClassObj = obj.getPropertyValue("NonClassObj");
     PropertyObjectPtr clientNonClassObj = clientObj.getPropertyValue("NonClassObj");
     ASSERT_EQ(serverNonClassObj.getPropertyValue("test"), clientNonClassObj.getPropertyValue("test"));
@@ -641,10 +642,12 @@ TEST_F(TmsPropertyObjectAdvancedTest, ObjectPropWithMetadata)
     auto [serverObj, clientObj] = registerPropertyObject(obj);
 
     PropertyObjectPtr clientObjWithMetadata = clientObj.getPropertyValue("ObjectWithMetadata");
-    ASSERT_ANY_THROW(clientObjWithMetadata.setPropertyValue("foo", "notbar"));
+    ASSERT_NO_THROW(clientObjWithMetadata.setPropertyValue("foo", "notbar"));
+    ASSERT_EQ(clientObjWithMetadata.getPropertyValue("foo"), "notbar");
 
     PropertyObjectPtr clientLocalObjWithMetadata = clientObj.getPropertyValue("LocalObjectWithMetadata");
-    ASSERT_ANY_THROW(clientLocalObjWithMetadata.setPropertyValue("foo", "notbar"));
+    ASSERT_NO_THROW(clientLocalObjWithMetadata.setPropertyValue("foo", "notbar"));
+    ASSERT_EQ(clientLocalObjWithMetadata.getPropertyValue("foo"), "notbar");
 
     PropertyPtr clientObjectWithMetadataProp = clientObj.getProperty("ObjectWithMetadata");
     PropertyPtr serverObjectWithMetadataProp = obj.getProperty("ObjectWithMetadata");


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

Object-type properties as of now behaved differently than any other property type. They were not frozen on add to property objects, but were frozen when added to property object classes. This was made more consistent by always freezing them, but also creating a local clone of the object that is returned to users on `getPropertyValue`. That clone can be edited.

Additionally, Property object core events now contain the path to the property if the property is contained within a nested property object.