### PR TITLE
Skip writing Property object values if they do not constitute a value change

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object.h
+++ b/core/coreobjects/include/coreobjects/property_object.h
@@ -83,6 +83,7 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObject, IBaseObject)
      * @retval OPENDAQ_ERR_VALIDATE_FAILED if the Validator fails to validate the `value`.
      * @retval OPENDAQ_ERR_COERCION_FAILED if the Coercer fails to coerce the `value`.
      * @retval OPENDAQ_ERR_FROZEN if the Property object is frozen.
+     * @retval OPENDAQ_ERR_IGNORED if the `value` is the same as the default, or the previously written value.
      *
      * Stores the provided `value` into an internal dictionary of property name and value pairs. This property value can
      * later be retrieved through the corresponding getter method when invoked with the same `propertyName`. The provided

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -187,7 +187,7 @@ private:
     PropertyNameInfo getPropertyNameInfo(const StringPtr& name) const;
 
     // Adds the value to the local list of values (`propValues`)
-    void writeLocalValue(const StringPtr& name, const BaseObjectPtr& value);
+    bool writeLocalValue(const StringPtr& name, const BaseObjectPtr& value);
 
     // Checks if the value is a container type, or base `IPropertyObject`. Only such values can be set in `setProperty`
     ErrCode checkContainerType(const PropertyPtr& prop, const BaseObjectPtr& value);
@@ -772,7 +772,9 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             }
             else
             {
-                writeLocalValue(propName, valuePtr);
+                if (!writeLocalValue(propName, valuePtr))
+                    return OPENDAQ_IGNORED;
+
                 setOwnerToPropertyValue(valuePtr);
                 if (triggerEvent)
                 {
@@ -831,17 +833,33 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkPropert
 }
 
 template <class PropObjInterface, class... Interfaces>
-void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::writeLocalValue(const StringPtr& name, const BaseObjectPtr& value)
+bool GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::writeLocalValue(const StringPtr& name, const BaseObjectPtr& value)
 {
     auto it = propValues.find(name);
     if (it != propValues.end())
     {
+        if (it->second == value)
+            return false;
         it->second = value;
     }
     else
     {
-        propValues.emplace(name, value);
+        bool shouldWrite = true;
+        try
+        {
+            shouldWrite = objPtr.getProperty(name).getDefaultValue() != value;
+        }
+        catch(...)
+        {
+        }
+
+        if (shouldWrite)
+            propValues.emplace(name, value);
+        else
+            return false;
     }
+
+    return true;
 }
 
 template <class PropObjInterface, class... Interfaces>
@@ -1612,11 +1630,16 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::beginUpdate(
 template <typename PropObjInterface, typename... Interfaces>
 void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::applyUpdate()
 {
+    auto ignoredProps = List<IProperty>();
     for (auto& item : updatingPropsAndValues)
     {
         if (item.second.setValue)
         {
-            writeLocalValue(item.first.getName(), item.second.value);
+            if (!writeLocalValue(item.first.getName(), item.second.value))
+            {
+                ignoredProps.pushBack(item.first);
+                continue;
+            }
             setOwnerToPropertyValue(item.second.value);
         }
         else
@@ -1629,6 +1652,9 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::applyUpdate()
         else
             callPropertyValueWrite(item.first, nullptr, PropertyEventType::Clear, true);
     }
+
+    for (const auto& prop : ignoredProps)
+        updatingPropsAndValues.erase(prop);
 
     updatingValuesWrite(updatingPropsAndValues);
     updatingPropsAndValues.clear();

--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -105,7 +105,7 @@ TEST_F(CoreEventTest, PropertyChangedNested)
     };
 
     obj1.setPropertyValue("string", "bar");
-    obj2.setPropertyValue("string", "foo");
+    obj2.setPropertyValue("string", "bar");
 
     ASSERT_EQ(callCount, 2);
 }

--- a/shared/libraries/opcuatms/opcuatms_server/tests/test_tms_property_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/tests/test_tms_property_object.cpp
@@ -96,7 +96,7 @@ TEST_F(TmsPropertyObjectTest, OnPropertyValueChangeEvent)
             waitForChangeEvent.set_value();
         });
 
-    propertyObject.setPropertyValue("IntProp", 1);
+    propertyObject.setPropertyValue("IntProp", 2);
 
     auto future = waitForChangeEvent.get_future();
     ASSERT_NE(future.wait_for(2s), std::future_status::timeout);


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

When calling `setPropertyValue`, the value should not be written, nor should a "write" event be triggered if the value is equal to the previously written one, or the default (if no local value is present)
