### PR TITLE
<TBBAS-1210> Enable support of shared domain signals in websocket streaming client

### DIFF
--- a/external/streaming_protocol/CMakeLists.txt
+++ b/external/streaming_protocol/CMakeLists.txt
@@ -6,8 +6,8 @@ endif()
 
 opendaq_dependency(
     NAME                streaming_protocol
-    REQUIRED_VERSION    0.10.11
+    REQUIRED_VERSION    0.10.12
     GIT_REPOSITORY      https://github.com/openDAQ/streaming-protocol-lt.git
-    GIT_REF             v0.10.11
+    GIT_REF             v0.10.12
     EXPECT_TARGET       daq::streaming_protocol
 )

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/input_signal.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/input_signal.h
@@ -42,6 +42,9 @@ public:
     void setTableId(std::string id);
     std::string getTableId() const;
 
+    void setIsDomainSignal(bool value);
+    bool getIsDomainSignal() const;
+
 protected:
     DataDescriptorPtr currentDataDescriptor;
     DataDescriptorPtr currentDomainDataDescriptor;
@@ -49,6 +52,7 @@ protected:
     std::string name;
     std::string description;
     std::string tableId;
+    bool isDomainSignal;
 
     mutable std::mutex descriptorsSync;
 };

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/signal_descriptor_converter.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/signal_descriptor_converter.h
@@ -40,12 +40,13 @@ public:
      */
     static void ToStreamedSignal(const daq::SignalPtr& signal, daq::streaming_protocol::BaseSignalPtr stream, const SignalProps& sigProps);
 
+    static void EncodeInterpretationObject(const DataDescriptorPtr& dataDescriptor, nlohmann::json& extra);
+
 private:
     static daq::DataRulePtr GetRule(const daq::streaming_protocol::SubscribedSignal& subscribedSignal);
     static void SetTimeRule(const daq::DataRulePtr& rule, daq::streaming_protocol::BaseSignalPtr signal);
     static daq::SampleType Convert(daq::streaming_protocol::SampleType dataType);
     static daq::streaming_protocol::SampleType Convert(daq::SampleType sampleType);
-    static void EncodeInterpretationObject(const DataDescriptorPtr& dataDescriptor, nlohmann::json& extra);
     static void DecodeInterpretationObject(const nlohmann::json& extra, DataDescriptorBuilderPtr& dataDescriptor);
     static nlohmann::json DictToJson(const DictPtr<IString, IBaseObject>& dict);
     static DictPtr<IString, IBaseObject> JsonToDict(const nlohmann::json& json);

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
@@ -89,7 +89,7 @@ protected:
     void setDomainDescriptor(const std::string& signalId,
                              const InputSignalPtr& inputSignal,
                              const DataDescriptorPtr& domainDescriptor);
-    std::pair<std::string, InputSignalPtr> findSignalByTableId(const std::string& tableId);
+    std::vector<std::pair<std::string, InputSignalPtr>> findDataSignalsByTableId(const std::string& tableId);
 
     LoggerPtr logger;
     LoggerComponentPtr loggerComponent;

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_server.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_server.h
@@ -54,13 +54,13 @@ public:
     void onAccept(const OnAcceptCallback& callback);
     void onSubscribe(const OnSubscribeCallback& callback);
     void onUnsubscribe(const OnUnsubscribeCallback& callback);
-    void unicastPacket(const daq::streaming_protocol::StreamWriterPtr& client, const std::string& signalId, const PacketPtr& packet);
+    void unicastPacket(const std::string& streamId, const std::string& signalId, const PacketPtr& packet);
     void broadcastPacket(const std::string& signalId, const PacketPtr &packet);
     void sendPacketToSubscribers(const std::string& signalId, const PacketPtr& packet);
 
 protected:
     using SignalMap = std::unordered_map<std::string, OutputSignalPtr>;
-    using ClientMap = std::unordered_map<daq::streaming_protocol::StreamWriterPtr, SignalMap>;
+    using ClientMap = std::unordered_map<std::string, std::pair<daq::streaming_protocol::StreamWriterPtr, SignalMap>>;
 
     void onAcceptInternal(const daq::stream::StreamPtr& stream);
     void writeProtocolInfo(const daq::streaming_protocol::StreamWriterPtr& writer);

--- a/shared/libraries/websocket_streaming/src/input_signal.cpp
+++ b/shared/libraries/websocket_streaming/src/input_signal.cpp
@@ -11,6 +11,7 @@ using namespace daq;
 using namespace daq::streaming_protocol;
 
 InputSignal::InputSignal()
+    : isDomainSignal(false)
 {
 }
 
@@ -74,6 +75,16 @@ void InputSignal::setTableId(std::string id)
 std::string InputSignal::getTableId() const
 {
     return tableId;
+}
+
+void InputSignal::setIsDomainSignal(bool value)
+{
+    isDomainSignal = value;
+}
+
+bool InputSignal::getIsDomainSignal() const
+{
+    return isDomainSignal;
 }
 
 END_NAMESPACE_OPENDAQ_WEBSOCKET_STREAMING

--- a/shared/libraries/websocket_streaming/tests/CMakeLists.txt
+++ b/shared/libraries/websocket_streaming/tests/CMakeLists.txt
@@ -3,6 +3,8 @@ set(TEST_APP test_${MODULE_NAME})
 
 add_executable(${TEST_APP}
     streaming_test_helpers.h
+    mock_streaming_server.h
+    mock_streaming_server.cpp
     test_signal_descriptor_converter.cpp
     test_streaming.cpp
     test_websocket_client_device.cpp

--- a/shared/libraries/websocket_streaming/tests/mock_streaming_server.cpp
+++ b/shared/libraries/websocket_streaming/tests/mock_streaming_server.cpp
@@ -1,0 +1,362 @@
+#include <nlohmann/json.hpp>
+
+#include <streaming_protocol/Defines.h>
+#include <streaming_protocol/Logging.hpp>
+#include <streaming_protocol/jsonrpc_defines.hpp>
+
+#include "mock_streaming_server.h"
+#include <opendaq/event_packet_ids.h>
+#include <opendaq/event_packet_params.h>
+#include <opendaq/custom_log.h>
+
+#include <streaming_protocol/Unit.hpp>
+#include <websocket_streaming/signal_descriptor_converter.h>
+
+namespace streaming_test_helpers
+{
+
+using namespace daq;
+using namespace daq::streaming_protocol;
+using namespace daq::stream;
+
+MockStreamingServer::MockStreamingServer(const ContextPtr& context)
+    : work(ioContext.get_executor())
+    , logger(context.getLogger())
+{
+    loggerComponent = this->logger.getOrAddComponent("MockStreamingServer");
+    logCallback = [this](spdlog::source_loc location, spdlog::level::level_enum level, const char* msg) {
+        this->loggerComponent.logMessage(SourceLocation{location.filename, location.line, location.funcname}, msg, static_cast<LogLevel>(level));
+    };
+}
+
+MockStreamingServer::~MockStreamingServer()
+{
+    stop();
+    logger.removeComponent("MockStreamingServer");
+}
+
+void MockStreamingServer::start(uint16_t port, uint16_t controlPort)
+{
+    this->port = port;
+
+    ioContext.restart();
+
+    auto acceptFunc = [this](StreamPtr stream) { this->onAcceptInternal(stream); };
+
+    this->server = std::make_unique<daq::stream::WebsocketServer>(ioContext, acceptFunc, port);
+    this->server->start();
+
+    auto controlCommandCb = [this](const std::string& streamId,
+                                   const std::string& command,
+                                   const daq::streaming_protocol::SignalIds& signalIds,
+                                   std::string& errorMessage)
+    {
+        return onControlCommand(streamId, command, signalIds, errorMessage);
+    };
+    this->controlServer =
+        std::make_unique<daq::streaming_protocol::ControlServer>(ioContext,
+                                                                 controlPort,
+                                                                 controlCommandCb,
+                                                                 logCallback);
+    this->controlServer->start();
+
+    this->serverThread = std::thread([this]() { this->ioContext.run(); });
+}
+
+void MockStreamingServer::stop()
+{
+    ioContext.stop();
+
+    if (!serverThread.joinable())
+        return;
+
+    this->server->stop();
+    serverThread.join();
+    this->server.reset();
+}
+
+void MockStreamingServer::onAccept(const OnAcceptCallback& callback)
+{
+    onAcceptCallback = callback;
+}
+
+void MockStreamingServer::onAcceptInternal(const daq::stream::StreamPtr& stream)
+{
+    auto writer = std::make_shared<StreamWriter>(stream);
+    writeProtocolInfo(writer);
+    writeInit(writer);
+
+    auto signals = List<ISignal>();
+    if (onAcceptCallback)
+        signals = onAcceptCallback();
+
+    auto outputSignals = std::unordered_map<std::string, std::pair<SizeT, SignalPtr>>();
+    SizeT signalNumber = 0;
+    for (const auto& signal : signals)
+    {
+        bool isDomainSignal = !signal.getDomainSignal().assigned();
+        auto descriptor = signal.getDescriptor();
+
+        if (!descriptor.assigned() ||
+            !isDomainSignal && descriptor.getSampleType() != daq::SampleType::Float64 ||
+            !isDomainSignal && descriptor.getRule().getType() != daq::DataRuleType::Explicit ||
+            isDomainSignal && descriptor.getSampleType() != daq::SampleType::UInt64 ||
+            isDomainSignal && descriptor.getRule().getType() != daq::DataRuleType::Linear)
+        {
+            LOG_E("Unsupported type of signal {}; data signal should be explicit float64, "
+                  "domain signal linear unsigned64", signal.getGlobalId());
+            throw GeneralErrorException("Unsupported type of signal");
+        }
+        outputSignals.insert({signal.getGlobalId().toStdString(), {++signalNumber, signal}});
+    }
+
+    LOG_I("New client connected. Stream Id: {}", writer->id());
+    clients.insert({writer, outputSignals});
+
+    writeSignalsAvailable(writer, signals);
+}
+
+int MockStreamingServer::onControlCommand(const std::string& streamId,
+                                          const std::string& command,
+                                          const daq::streaming_protocol::SignalIds& signalIds,
+                                          std::string& errorMessage)
+{
+    if (signalIds.empty())
+    {
+        LOG_W("Signal list is empty, reject command", streamId);
+        errorMessage = "Signal list is empty";
+        return -1;
+    }
+
+    auto clientIter = std::find_if(std::begin(clients),
+                                   std::end(clients),
+                                   [&streamId](const auto& pair)
+                                   {
+                                       return pair.first->id() == streamId;
+                                   });
+
+    if (clientIter == std::end(clients))
+    {
+        LOG_W("Unknown streamId: {}, reject command", streamId);
+        errorMessage = "Unknown streamId:  '" + streamId + "'";
+        return -1;
+    }
+
+    auto writer = clientIter->first;
+    auto signalMap = clientIter->second;
+
+    if (command == "subscribe")
+    {
+        subscribeSignals(signalIds, signalMap, writer);
+    }
+    else if (command == "unsubscribe")
+    {
+        unsubscribeSignals(signalIds, signalMap, writer);
+    }
+    else
+    {
+        LOG_W("Unknown control command: {}", command);
+        errorMessage = "Unknown command: " + command;
+        return -1;
+    }
+
+    size_t unknownSignalsCount = 0;
+    std::string message = "Command '" + command + "' failed for unknown signals:\n";
+    for (const auto& signalId : signalIds)
+    {
+        if (auto signalMapIter = signalMap.find(signalId); signalMapIter == signalMap.end())
+        {
+            unknownSignalsCount++;
+            message.append(signalId + "\n");
+        }
+    }
+    if (unknownSignalsCount > 0)
+    {
+        LOG_W("{}", message);
+        errorMessage = message;
+        return -1;
+    }
+
+    return 0;
+}
+
+void MockStreamingServer::subscribeSignals(const daq::streaming_protocol::SignalIds& signalIds,
+                                           const SignalMap& signalMap,
+                                           const daq::streaming_protocol::StreamWriterPtr& writer)
+{
+    for (const auto& signalId : signalIds)
+    {
+        if (auto signalMapIter = signalMap.find(signalId); signalMapIter != signalMap.end())
+        {
+            auto signalNumber = signalMapIter->second.first;
+            auto signalPtr = signalMapIter->second.second;
+
+            if (!signalPtr.hasProperty("tableId"))
+                throw GeneralErrorException("Unknown table id of signal");
+
+            std::string tableId = signalPtr.getPropertyValue("tableId").asPtr<IString>().toStdString();
+
+            if (!signalPtr.getDomainSignal().assigned())
+            {
+                // considered as domain signal
+                writeSignalSubscribe(signalId, signalNumber, writer);
+                writeTimeSignalMeta(tableId, signalNumber, signalPtr, writer);
+            }
+            else
+            {
+                // considered as data signal
+                writeSignalSubscribe(signalId, signalNumber, writer);
+                writeDataSignalMeta(tableId, signalNumber, signalPtr, writer);
+
+                auto domainSignal = signalPtr.getDomainSignal();
+                std::string domainSignalId = domainSignal.getGlobalId().toStdString();
+                if (auto domainSignalMapIter = signalMap.find(domainSignalId);
+                    domainSignalMapIter == signalMap.end())
+                {
+                    throw GeneralErrorException("Domain signal should be registered as available");
+                }
+            }
+        }
+    }
+}
+
+void MockStreamingServer::unsubscribeSignals(const daq::streaming_protocol::SignalIds& signalIds,
+                                             const SignalMap& signalMap,
+                                             const daq::streaming_protocol::StreamWriterPtr& writer)
+{
+    for (const auto& signalId : signalIds)
+    {
+        if (auto signalMapIter = signalMap.find(signalId); signalMapIter != signalMap.end())
+        {
+            auto signalNumber = signalMapIter->second.first;
+            auto signalPtr = signalMapIter->second.second;
+
+            writeSignalUnsubscribe(signalId, signalNumber, writer);
+        }
+    }
+}
+
+void MockStreamingServer::writeProtocolInfo(const daq::streaming_protocol::StreamWriterPtr& writer)
+{
+    nlohmann::json msg;
+    msg[METHOD] = META_METHOD_APIVERSION;
+    msg[PARAMS][VERSION] = OPENDAQ_LT_STREAM_VERSION;
+    writer->writeMetaInformation(0, msg);
+}
+
+void MockStreamingServer::writeSignalsAvailable(const daq::streaming_protocol::StreamWriterPtr& writer,
+                                                const ListPtr<ISignal>& signals)
+{
+    std::vector<std::string> signalIds;
+
+    for (const auto& signal : signals)
+        signalIds.push_back(signal.getGlobalId());
+
+    nlohmann::json msg;
+    msg[METHOD] = META_METHOD_AVAILABLE;
+    msg[PARAMS][META_SIGNALIDS] = signalIds;
+    writer->writeMetaInformation(0, msg);
+}
+
+void MockStreamingServer::writeInit(const streaming_protocol::StreamWriterPtr& writer)
+{
+    nlohmann::json initMeta;
+    initMeta[METHOD] = META_METHOD_INIT;
+    initMeta[PARAMS][META_STREAMID] = writer->id();
+
+    nlohmann::json jsonRpcHttp;
+    jsonRpcHttp["httpMethod"] = "POST";
+    jsonRpcHttp["httpPath"] = "/";
+    jsonRpcHttp["httpVersion"] = "1.1";
+    jsonRpcHttp["port"] = std::to_string(controlServer->getPort());
+
+    nlohmann::json commandInterfaces;
+    commandInterfaces["jsonrpc-http"] = jsonRpcHttp;
+
+    initMeta[PARAMS][COMMANDINTERFACES] = commandInterfaces;
+    writer->writeMetaInformation(0, initMeta);
+}
+
+void MockStreamingServer::writeSignalSubscribe(const std::string& signalId,
+                                               SizeT signalNumber,
+                                               const streaming_protocol::StreamWriterPtr& writer)
+{
+    nlohmann::json subscribeData;
+    subscribeData[METHOD] = META_METHOD_SUBSCRIBE;
+    subscribeData[PARAMS][META_SIGNALID] = signalId;
+    int result = writer->writeMetaInformation(signalNumber, subscribeData);
+    if (result < 0)
+        throw GeneralErrorException("Write Subscribe Meta Information failure");
+}
+
+void MockStreamingServer::writeDataSignalMeta(const std::string& tableId,
+                                              SizeT signalNumber,
+                                              const SignalPtr& signal,
+                                              const streaming_protocol::StreamWriterPtr& writer)
+{
+    nlohmann::json dataSignal;
+    dataSignal[METHOD] = META_METHOD_SIGNAL;
+    dataSignal[PARAMS][META_TABLEID] = tableId;
+
+    dataSignal[PARAMS][META_DEFINITION][META_NAME] = signal.getName();
+    dataSignal[PARAMS][META_DEFINITION][META_DATATYPE] = DATA_TYPE_REAL64;
+    dataSignal[PARAMS][META_DEFINITION][META_RULE] = META_RULETYPE_EXPLICIT;
+
+    nlohmann::json interpretationObject;
+    websocket_streaming::SignalDescriptorConverter::EncodeInterpretationObject(
+        signal.getDescriptor(), interpretationObject);
+    dataSignal[PARAMS][META_INTERPRETATION] = interpretationObject;
+
+    int result = writer->writeMetaInformation(signalNumber, dataSignal);
+    if (result < 0)
+        throw GeneralErrorException("Write Data Signal Meta Information failure");
+}
+
+void MockStreamingServer::writeTimeSignalMeta(const std::string& tableId,
+                                              SizeT signalNumber,
+                                              const SignalPtr& signal,
+                                              const streaming_protocol::StreamWriterPtr& writer)
+{
+    auto descriptor = signal.getDescriptor();
+    auto resolution = descriptor.getTickResolution();
+
+    nlohmann::json timeSignal;
+    timeSignal[METHOD] = META_METHOD_SIGNAL;
+    timeSignal[PARAMS][META_TABLEID] = tableId;
+    timeSignal[PARAMS][META_DEFINITION][META_NAME] = signal.getName();
+    timeSignal[PARAMS][META_DEFINITION][META_RULE] = META_RULETYPE_LINEAR;
+
+    timeSignal[PARAMS][META_DEFINITION][META_RULETYPE_LINEAR][META_DELTA] =
+        (uint64_t)descriptor.getRule().getParameters().get("delta");
+    timeSignal[PARAMS][META_DEFINITION][META_DATATYPE] = DATA_TYPE_UINT64;
+
+    timeSignal[PARAMS][META_DEFINITION][META_UNIT][META_UNIT_ID] = daq::streaming_protocol::Unit::UNIT_ID_SECONDS;
+    timeSignal[PARAMS][META_DEFINITION][META_UNIT][META_DISPLAY_NAME] = "s";
+    timeSignal[PARAMS][META_DEFINITION][META_UNIT][META_QUANTITY] = META_TIME;
+    timeSignal[PARAMS][META_DEFINITION][META_ABSOLUTE_REFERENCE] = UNIX_EPOCH;
+    timeSignal[PARAMS][META_DEFINITION][META_RESOLUTION][META_NUMERATOR] = 1;
+    timeSignal[PARAMS][META_DEFINITION][META_RESOLUTION][META_DENOMINATOR] =
+        resolution.getDenominator() / resolution.getNumerator();
+
+    nlohmann::json interpretationObject;
+    websocket_streaming::SignalDescriptorConverter::EncodeInterpretationObject(
+        descriptor, interpretationObject);
+    timeSignal[PARAMS][META_INTERPRETATION] = interpretationObject;
+
+    int result = writer->writeMetaInformation(signalNumber, timeSignal);
+    if (result < 0)
+        throw GeneralErrorException("Write Time Signal Meta Information failure");
+}
+
+void MockStreamingServer::writeSignalUnsubscribe(const std::string& signalId,
+                                             SizeT signalNumber,
+                                             const streaming_protocol::StreamWriterPtr& writer)
+{
+    nlohmann::json unsubscribe;
+    unsubscribe[METHOD] = META_METHOD_UNSUBSCRIBE;
+    int result = writer->writeMetaInformation(signalNumber, unsubscribe);
+    if (result < 0)
+        throw GeneralErrorException("Write Unsubscribe Meta Information failure");
+}
+
+}

--- a/shared/libraries/websocket_streaming/tests/mock_streaming_server.cpp
+++ b/shared/libraries/websocket_streaming/tests/mock_streaming_server.cpp
@@ -111,7 +111,7 @@ void MockStreamingServer::onAcceptInternal(const daq::stream::StreamPtr& stream)
     }
 
     LOG_I("New client connected. Stream Id: {}", writer->id());
-    clients.insert({writer, outputSignals});
+    clients.insert({writer->id(), {writer, outputSignals}});
 
     writeSignalsAvailable(writer, signals);
 }
@@ -128,13 +128,7 @@ int MockStreamingServer::onControlCommand(const std::string& streamId,
         return -1;
     }
 
-    auto clientIter = std::find_if(std::begin(clients),
-                                   std::end(clients),
-                                   [&streamId](const auto& pair)
-                                   {
-                                       return pair.first->id() == streamId;
-                                   });
-
+    auto clientIter = clients.find(streamId);
     if (clientIter == std::end(clients))
     {
         LOG_W("Unknown streamId: {}, reject command", streamId);
@@ -142,8 +136,8 @@ int MockStreamingServer::onControlCommand(const std::string& streamId,
         return -1;
     }
 
-    auto writer = clientIter->first;
-    auto signalMap = clientIter->second;
+    auto writer = clientIter->second.first;
+    auto signalMap = clientIter->second.second;
 
     if (command == "subscribe")
     {

--- a/shared/libraries/websocket_streaming/tests/mock_streaming_server.h
+++ b/shared/libraries/websocket_streaming/tests/mock_streaming_server.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "websocket_streaming/websocket_streaming.h"
+#include "stream/WebsocketServer.hpp"
+#include "websocket_streaming/output_signal.h"
+#include "streaming_protocol/StreamWriter.h"
+#include "streaming_protocol/ControlServer.hpp"
+#include "streaming_protocol/Logging.hpp"
+#include <thread>
+#include <boost/asio/io_context.hpp>
+#include <functional>
+
+#include <opendaq/data_packet_ptr.h>
+#include <opendaq/event_packet_ptr.h>
+
+#include <opendaq/context_ptr.h>
+#include <opendaq/logger_ptr.h>
+#include <opendaq/logger_component_ptr.h>
+
+namespace streaming_test_helpers
+{
+
+/// This alternative implementation of the Streaming Server is designed for testing purposes.
+/// It is intended to bypass the `daq::streaming_protocol::BaseSignal` library interface,
+/// preventing the generation of artificial time signals and enabling the sharing of the same
+/// domain signal among multiple data signals.
+///
+/// Limitations and requirements:
+/// - It does not implement the transfer of signal data; only the publication of
+///   signal meta-information is supported.
+/// - To simplify the implementation, it exclusively handles data signals
+///   with explicit rule and a data type of float64, along with domain signals
+///   having a linear rule and unsigned64 type.
+/// - The domain signal must be published as available.
+/// - The `tableId` for the signal is set using the StringProperty named "tableId,"
+///   and it is expected that all published signals have this property.
+
+class MockStreamingServer;
+using MockStreamingServerPtr = std::shared_ptr<MockStreamingServer>;
+
+class MockStreamingServer
+{
+public:
+    using OnAcceptCallback = std::function<daq::ListPtr<daq::ISignal>()>;
+
+    MockStreamingServer(const daq::ContextPtr& context);
+    ~MockStreamingServer();
+
+    void start(uint16_t port = daq::streaming_protocol::WEBSOCKET_LISTENING_PORT,
+               uint16_t controlPort = daq::streaming_protocol::HTTP_CONTROL_PORT);
+    void stop();
+    void onAccept(const OnAcceptCallback& callback);
+
+protected:
+    using SignalMap = std::unordered_map<std::string, std::pair<daq::SizeT, daq::SignalPtr>>;
+    using ClientMap = std::unordered_map<daq::streaming_protocol::StreamWriterPtr, SignalMap>;
+
+    void onAcceptInternal(const daq::stream::StreamPtr& stream);
+    void writeProtocolInfo(const daq::streaming_protocol::StreamWriterPtr& writer);
+    void writeSignalsAvailable(const daq::streaming_protocol::StreamWriterPtr& writer,
+                               const daq::ListPtr<daq::ISignal>& signals);
+    void writeInit(const daq::streaming_protocol::StreamWriterPtr& writer);
+
+    void writeSignalSubscribe(const std::string& signalId,
+                              daq::SizeT signalNumber,
+                              const daq::streaming_protocol::StreamWriterPtr& writer);
+    void writeSignalUnsubscribe(const std::string& signalId,
+                                daq::SizeT signalNumber,
+                                const daq::streaming_protocol::StreamWriterPtr& writer);
+
+    void writeDataSignalMeta(const std::string& tableId,
+                             daq::SizeT signalNumber,
+                             const daq::SignalPtr& signal,
+                             const daq::streaming_protocol::StreamWriterPtr& writer);
+    void writeTimeSignalMeta(const std::string& tableId,
+                             daq::SizeT signalNumber,
+                             const daq::SignalPtr& signal,
+                             const daq::streaming_protocol::StreamWriterPtr& writer);
+
+    int onControlCommand(const std::string& streamId,
+                         const std::string& command,
+                         const daq::streaming_protocol::SignalIds& signalIds,
+                         std::string& errorMessage);
+    void subscribeSignals(const daq::streaming_protocol::SignalIds& signalIds,
+                          const SignalMap& signalMap,
+                          const daq::streaming_protocol::StreamWriterPtr& writer);
+    void unsubscribeSignals(const daq::streaming_protocol::SignalIds& signalIds,
+                            const SignalMap& signalMap,
+                            const daq::streaming_protocol::StreamWriterPtr& writer);
+
+    void writeTime(daq::SizeT signalNumber,
+                   uint64_t timeTicks,
+                   const daq::streaming_protocol::StreamWriterPtr& writer);
+
+    uint16_t port;
+    boost::asio::io_context ioContext;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work;
+    daq::stream::WebsocketServerUniquePtr server;
+    std::unique_ptr<daq::streaming_protocol::ControlServer> controlServer;
+    std::thread serverThread;
+    ClientMap clients;
+    OnAcceptCallback onAcceptCallback;
+
+    daq::LoggerPtr logger;
+    daq::LoggerComponentPtr loggerComponent;
+    daq::streaming_protocol::LogCallback logCallback;
+};
+
+}

--- a/shared/libraries/websocket_streaming/tests/mock_streaming_server.h
+++ b/shared/libraries/websocket_streaming/tests/mock_streaming_server.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     using SignalMap = std::unordered_map<std::string, std::pair<daq::SizeT, daq::SignalPtr>>;
-    using ClientMap = std::unordered_map<daq::streaming_protocol::StreamWriterPtr, SignalMap>;
+    using ClientMap = std::unordered_map<std::string, std::pair<daq::streaming_protocol::StreamWriterPtr, SignalMap>>;
 
     void onAcceptInternal(const daq::stream::StreamPtr& stream);
     void writeProtocolInfo(const daq::streaming_protocol::StreamWriterPtr& writer);

--- a/shared/libraries/websocket_streaming/tests/streaming_test_helpers.h
+++ b/shared/libraries/websocket_streaming/tests/streaming_test_helpers.h
@@ -50,7 +50,8 @@ namespace streaming_test_helpers
         return instance;
     }
 
-    inline daq::SignalPtr createTimeSignal(const daq::ContextPtr& ctx)
+    inline daq::SignalPtr createTimeSignal(const daq::ContextPtr& ctx,
+                                           const daq::StringPtr& tableId = "TestTable")
     {
         const size_t nanosecondsInSecond = 1000000000;
         auto delta = nanosecondsInSecond / 1000;
@@ -64,7 +65,9 @@ namespace streaming_test_helpers
                               .setName("Time")
                               .build();
 
-        return SignalWithDescriptor(ctx, descriptor, nullptr, descriptor.getName());
+        auto signal = SignalWithDescriptor(ctx, descriptor, nullptr, descriptor.getName());
+        signal.addProperty(daq::StringProperty("tableId", tableId));
+        return signal;
     }
 
     inline daq::SignalPtr createTestSignal(const daq::ContextPtr& ctx)
@@ -110,6 +113,35 @@ namespace streaming_test_helpers
                               .build();
 
         auto signal = SignalWithDescriptor(ctx, descriptor, nullptr, descriptor.getName());
+        return signal;
+    }
+
+    inline daq::SignalPtr createTestSignalWithDomain(const daq::ContextPtr& ctx,
+                                                     const daq::StringPtr& name,
+                                                     const daq::SignalPtr& domainSignal,
+                                                     const daq::StringPtr& tableId = "TestTable")
+    {
+        auto meta = daq::Dict<daq::IString, daq::IString>();
+        meta["color"] = "green";
+        meta["used"] = "0";
+
+        auto descriptor = daq::DataDescriptorBuilder()
+                              .setSampleType(daq::SampleType::Float64)
+                              .setUnit(daq::Unit("V", 1, "voltage", "quantity"))
+                              .setValueRange(daq::Range(0, 10))
+                              .setRule(daq::ExplicitDataRule())
+                              .setPostScaling(daq::LinearScaling(1.0, 0.0, daq::SampleType::Int16, daq::ScaledSampleType::Float64))
+                              .setName(name)
+                              .setMetadata(meta)
+                              .build();
+
+        auto timeSignal = createTimeSignal(ctx);
+        auto signal = SignalWithDescriptor(ctx, descriptor, nullptr, descriptor.getName());
+        signal.setDomainSignal(domainSignal);
+        signal.setName(name);
+        signal.setDescription("TestDescription");
+        signal.addProperty(daq::StringProperty("tableId", tableId));
+
         return signal;
     }
 }


### PR DESCRIPTION
# Description:

* Allow multiple data signals to have same `tableId`
* Add client handling of domain signals listed as available
* Add `MockStreamingServer` implementation used in tests to bypass the creation of artificial time signals within the streaming-lt library
* Expand the WebSocket pseudo device test suite with the relevant tests

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


