### PR TITLE
Fixed deployment cleanup filter for AWS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,10 +137,8 @@ jobs:
           aws s3 ls "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --human-readable
           Write-Output "# S3 remove '*-$("${{ matrix.cmake_generator_platform }}".Replace("x64", "win64"))_*.exe'"
           aws s3 rm "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --exclude '*' --include "*-$("${{ matrix.cmake_generator_platform }}".Replace("x64", "win64"))_*.exe"
-          aws s3 ls "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --human-readable
           Write-Output "# S3 copy from '${{ env.package_path }}'"
           aws s3 cp . "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive
-          aws s3 ls "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --human-readable
 
       - name: Upload Wheels to S3
         if: github.ref == 'refs/heads/main' && matrix.cmake_generator_platform != 'Win32'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,8 +133,14 @@ jobs:
       - name: Upload package to S3
         working-directory: ${{ env.package_path }}
         run: |
-          aws s3 rm "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --exclude '*' --include '*.exe'
+          Write-Output "# S3 listing"
+          aws s3 ls "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --human-readable
+          Write-Output "# S3 remove '*-$("${{ matrix.cmake_generator_platform }}".Replace("x64", "win64"))_*.exe'"
+          aws s3 rm "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --exclude '*' --include "*-$("${{ matrix.cmake_generator_platform }}".Replace("x64", "win64"))_*.exe"
+          aws s3 ls "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --human-readable
+          Write-Output "# S3 copy from '${{ env.package_path }}'"
           aws s3 cp . "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive
+          aws s3 ls "s3://${{ env.s3bucket }}/${{ env.s3path }}/" --recursive --human-readable
 
       - name: Upload Wheels to S3
         if: github.ref == 'refs/heads/main' && matrix.cmake_generator_platform != 'Win32'


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
When `deploy.yml` is run, two jobs for Windows are running. One for x64 and one for Win32.
Before the generated package is written to AWS S3, the old one should be deleted there.
Until now, that cleanup was deleting all packages.
This fix distinguishes between x64 and Win32 build to remove only the platform dependent file from S3.

The mechanism can be checked in branch [ci/deploy-rm-filter-test](https://github.com/openDAQ/openDAQ/tree/ci/deploy-rm-filter-test), upload section of the action run ("filter test for deploy on AWS").