### PR TITLE
[TBBAS-1219] Python: Get rid of camel case notation in code and docs

### DIFF
--- a/bindings/python/core_types/src/py_list.cpp
+++ b/bindings/python/core_types/src/py_list.cpp
@@ -95,25 +95,25 @@ void defineIList(pybind11::module_ m, PyDaqIntf<daq::IList> cls)
             return pythonIterator;
         });
 
-    cls.def("pushBack",  // this should be .append()
+    cls.def("push_back",  // this should be .append()
         [](daq::IList* list, const py::object& pyObject)
         {
             auto listPtr = daq::ListPtr<daq::IBaseObject>::Borrow(list);
             listPtr.pushBack(pyObjectToBaseObject(pyObject));
         });
-    cls.def("pushFront",
+    cls.def("push_front",
         [](daq::IList* list, const py::object& pyObject)
         {
             auto listPtr = daq::ListPtr<daq::IBaseObject>::Borrow(list);
             listPtr.pushFront(pyObjectToBaseObject(pyObject));
         });
-    cls.def("popFront",
+    cls.def("pop_front",
         [](daq::IList* list)
         {
             auto listPtr = daq::ListPtr<daq::IBaseObject>::Borrow(list);
             return baseObjectToPyObject(listPtr.popFront(), listPtr.getElementInterfaceId());
         });
-    cls.def("popBack",
+    cls.def("pop_back",
         [](daq::IList* list)
         {
             auto listPtr = daq::ListPtr<daq::IBaseObject>::Borrow(list);

--- a/bindings/python/tests/test_core_type_string.py
+++ b/bindings/python/tests/test_core_type_string.py
@@ -40,7 +40,7 @@ class TestString(opendaq_test.TestCase):
     def test_can_cast_from(self):
         self.assertTrue(daq.IBaseObject.can_cast_from(daq.String('test')))
 
-    def test_intConversion(self):
+    def test_int_conversion(self):
         self.assertEqual(int(daq.String('10')), 10)
 
     '''

--- a/bindings/python/tests/test_core_types.py
+++ b/bindings/python/tests/test_core_types.py
@@ -27,12 +27,12 @@ class TestBaseObject(opendaq_test.TestCase):
         self.assertTrue(daq.IBaseObject.can_cast_from(daq.BaseObject()))
 
     '''
-    def test_toString(self):
+    def test_to_string(self):
         s = str(daq.BaseObject())
         self.assertEqual(s, "daq::IBaseObject")
     '''
 
-    def test_toInt(self):
+    def test_to_int(self):
         with self.assertRaisesRegex(RuntimeError, 'Invalid cast'):
             int(daq.BaseObject())
 
@@ -85,7 +85,7 @@ class TestNumObjectWrapper:
             self.customAssertEqual(hash(self.createObject(0)), 0)
             self.customAssertEqual(hash(self.createObject(1230)), 1230)
 
-        def test_intConversion(self):
+        def test_int_conversion(self):
             self.customAssertEqual(int(self.createObject(12)), 12)
 
         '''
@@ -155,55 +155,55 @@ class TestList(opendaq_test.TestCase):
             int(list)
     '''
 
-    def test_getCount(self):
+    def test_get_count(self):
         self.assertEqual(len(daq.List()), 0)
 
-    def test_pushAndPop(self):
+    def test_push_and_pop(self):
         list = daq.List()
         val = daq.Integer(2)
-        list.pushBack(val)
+        list.push_back(val)
         self.assertEqual(len(list), 1)
-        val1 = list.popBack()
+        val1 = list.pop_back()
         self.assertEqual(val, val1)
         self.assertEqual(len(list), 0)
 
-    def test_pushPythonObject(self):
+    def test_push_python_object(self):
         list = daq.List()
-        list.pushBack(1)
+        list.push_back(1)
         self.assertEqual(len(list), 1)
-        value = list.popBack()
+        value = list.pop_back()
         self.assertIsInstance(value, int)
         self.assertEqual(value, 1)
 
-    def test_pushBack(self):
+    def test_push_back(self):
         list = daq.List()
-        list.pushBack(3)
-        list.pushBack(4)
+        list.push_back(3)
+        list.push_back(4)
         self.assertEqual(len(list), 2)
         self.assertEqual(list[1], 4)
 
-    def test_pushFront(self):
+    def test_push_front(self):
         list = daq.List()
-        list.pushFront(3)
-        list.pushFront(4)
+        list.push_front(3)
+        list.push_front(4)
         self.assertEqual(len(list), 2)
         self.assertEqual(list[1], 3)
 
-    def test_popBack(self):
+    def test_pop_back(self):
         list = daq.List()
-        list.pushBack(3)
-        list.pushBack(4)
-        self.assertEqual(list.popBack(), 4)
+        list.push_back(3)
+        list.push_back(4)
+        self.assertEqual(list.pop_back(), 4)
         self.assertEqual(len(list), 1)
 
-    def test_popFront(self):
+    def test_pop_front(self):
         list = daq.List()
-        list.pushBack(3)
-        list.pushBack(4)
-        self.assertEqual(list.popFront(), 3)
+        list.push_back(3)
+        list.push_back(4)
+        self.assertEqual(list.pop_front(), 3)
         self.assertEqual(len(list), 1)
 
-    def test_getItemAtSlice(self):
+    def test_get_item_at_slice(self):
         list = daq.List()
 
         n = 20
@@ -215,14 +215,14 @@ class TestList(opendaq_test.TestCase):
         for i in range(n//k):
             self.assertEqual(slice[i], k*i)
 
-    def test_getItemAt(self):
+    def test_get_item_at(self):
         list = daq.List()
 
-        list.pushBack(3)
-        list.pushBack(False)
-        list.pushBack(1.0)
-        list.pushBack(daq.BaseObject())
-        list.pushBack("Test")
+        list.push_back(3)
+        list.push_back(False)
+        list.push_back(1.0)
+        list.push_back(daq.BaseObject())
+        list.push_back("Test")
 
         value = list[0]
         self.assertEqual(value, 3)
@@ -246,17 +246,17 @@ class TestList(opendaq_test.TestCase):
     def test_get_last_item(self):
         list = daq.List()
 
-        list.pushBack(3)
-        list.pushBack(2)
-        list.pushBack(1)
+        list.push_back(3)
+        list.push_back(2)
+        list.push_back(1)
         self.assertEqual(list[-1], 1)
 
 class TestIterable(opendaq_test.TestCase):
     def test_from_iterable(self):
         l = daq.List()
-        l.pushBack(1)
-        l.pushBack(2)
-        l.pushBack(3)
+        l.push_back(1)
+        l.push_back(2)
+        l.push_back(3)
         iterable = daq.IIterable.cast_from(l)
 
         i = 1
@@ -266,9 +266,9 @@ class TestIterable(opendaq_test.TestCase):
 
     def test_from_list(self):
         l = daq.List()
-        l.pushBack(1)
-        l.pushBack(2)
-        l.pushBack(3)
+        l.push_back(1)
+        l.push_back(2)
+        l.push_back(3)
 
         i = 1
         for item in l:
@@ -288,10 +288,10 @@ class TestDict(opendaq_test.TestCase):
     def test_core_type(self):
         self.assertEqual(daq.Dict().core_type, daq.CoreType.ctDict)
 
-    def test_getCount(self):
+    def test_get_count(self):
         self.assertEqual(len(daq.Dict()), 0)
 
-    def test_insertGetAndRemove(self):
+    def test_insert_get_and_remove(self):
         dict = daq.Dict()
         dict[2] = "Test"
         dict["A"] = 3
@@ -368,69 +368,69 @@ class TestLeaks(opendaq_test.TestCase):
 
         a = l[0]
         a = l[0]
-        
+
 class TestProcedure(opendaq_test.TestCase):
-    
+
     def test_no_params(self):
-        
+
         value = 10
         def set_value():
             nonlocal value
             value = 20
         proc = daq.Procedure(set_value)
         proc()
-        
+
         self.assertEqual(value, 20)
 
     def test_one_param(self):
-        
+
         value = 10
         def set_value(v):
             nonlocal value
             value += v
         proc = daq.Procedure(set_value)
         proc(10)
-        
+
         self.assertEqual(value, 20)
 
     def test_two_params(self):
-        
+
         value = 10
         def set_value(v1, v2):
             nonlocal value
             value += v1 + v2
         proc = daq.Procedure(set_value)
         proc(8, 2)
-        
+
         self.assertEqual(value, 20)
 
 class TestFunction(opendaq_test.TestCase):
-    
+
     def test_no_params(self):
-        
+
         def set_value():
             return 10
         func = daq.Function(set_value)
         value = func()
-        
+
         self.assertEqual(value, 10)
 
     def test_one_param(self):
-        
+
         def set_value(v):
             return v
         func = daq.Function(set_value)
         value = func(10)
-        
+
         self.assertEqual(value, 10)
 
     def test_two_param(self):
-        
+
         def set_value(v1, v2):
             return v1 - v2
         func = daq.Function(set_value)
         value = func(20, 10)
-        
+
         self.assertEqual(value, 10)
 
 if __name__ == '__main__':

--- a/bindings/python/tests/test_property_system.py
+++ b/bindings/python/tests/test_property_system.py
@@ -21,7 +21,7 @@ class TestPropertySystem(opendaq_test.TestCase):
 
         property_object.set_property_value('property1', 'value')
         property_object.set_property_value('property2', 3)
-             
+
         self.assertEqual(
             property_object.get_property_value('property1'), 'value')
         self.assertEqual(property_object.get_property_value('property2'), 3)
@@ -44,9 +44,9 @@ class TestPropertySystem(opendaq_test.TestCase):
             'property2'), opendaq.Float(10.0))
         float_property_builder.visible = opendaq.Boolean(True)
         suggested_values = opendaq.List()
-        suggested_values.pushBack(1.0)
-        suggested_values.pushBack(2.0)
-        suggested_values.pushBack(3.0)
+        suggested_values.push_back(1.0)
+        suggested_values.push_back(2.0)
+        suggested_values.push_back(3.0)
         float_property_builder.suggested_values = suggested_values
         property_object.add_property(float_property_builder.build())
 
@@ -61,9 +61,9 @@ class TestPropertySystem(opendaq_test.TestCase):
         property_object = opendaq.PropertyObject()
 
         list = opendaq.List()
-        list.pushBack('value1')
-        list.pushBack('value2')
-        list.pushBack('value3')
+        list.push_back('value1')
+        list.push_back('value2')
+        list.push_back('value3')
 
         selection_property = opendaq.SelectionProperty(opendaq.String(
             'property1'), list, opendaq.Integer(1), opendaq.Boolean(True))
@@ -94,14 +94,14 @@ class TestPropertySystem(opendaq_test.TestCase):
         property_object = opendaq.PropertyObject()
         child1 = opendaq.PropertyObject()
         child2 = opendaq.PropertyObject()
-        
+
         child2.add_property(opendaq.IntProperty(opendaq.String(
             'property1'), opendaq.Integer(10), opendaq.Boolean(True)))
         child1.add_property(opendaq.ObjectProperty(
             opendaq.String('child'), child2))
         property_object.add_property(
             opendaq.ObjectProperty(opendaq.String('child'), child1))
-        
+
         self.assertEqual(property_object.get_property_value(
             'child.child.property1'), 10)
 
@@ -109,9 +109,9 @@ class TestPropertySystem(opendaq_test.TestCase):
         property_object = opendaq.PropertyObject()
 
         list = opendaq.List()
-        list.pushBack('Banana')
-        list.pushBack('Apple')
-        list.pushBack('Kiwi')
+        list.push_back('Banana')
+        list.push_back('Apple')
+        list.push_back('Kiwi')
         property_object.add_property(opendaq.ListProperty(
             opendaq.String('list'), list, opendaq.Boolean(True)))
 
@@ -183,8 +183,8 @@ class TestPropertySystem(opendaq_test.TestCase):
 
         simulated_channel = opendaq.PropertyObject()
         waveform_list = opendaq.List()
-        waveform_list.pushBack('Sine')
-        waveform_list.pushBack('Counter')
+        waveform_list.push_back('Sine')
+        waveform_list.push_back('Counter')
         simulated_channel.add_property(opendaq.SelectionProperty(opendaq.String(
             'waveform'), waveform_list, opendaq.Integer(0), opendaq.Boolean(True)))
         simulated_channel.add_property(opendaq.ReferenceProperty(opendaq.String('settings'), opendaq.EvalValue(
@@ -198,10 +198,10 @@ class TestPropertySystem(opendaq_test.TestCase):
         frequency_property_builder.unit = opendaq.Unit(1, opendaq.String(
             'Hz'), opendaq.String(''), opendaq.String(''))
         suggested_values = opendaq.List()
-        suggested_values.pushBack(0.1)
-        suggested_values.pushBack(10.0)
-        suggested_values.pushBack(100.0)
-        suggested_values.pushBack(1000.0)
+        suggested_values.push_back(0.1)
+        suggested_values.push_back(10.0)
+        suggested_values.push_back(100.0)
+        suggested_values.push_back(1000.0)
         frequency_property_builder.suggested_values = suggested_values
         simulated_channel.add_property(frequency_property_builder.build())
 
@@ -209,8 +209,8 @@ class TestPropertySystem(opendaq_test.TestCase):
 
         sine_settings = opendaq.PropertyObject()
         unit_list = opendaq.List()
-        unit_list.pushBack('V')
-        unit_list.pushBack('mV')
+        unit_list.push_back('V')
+        unit_list.push_back('mV')
         sine_settings.add_property(opendaq.SelectionProperty(opendaq.String(
             'amplitude_unit'), unit_list, opendaq.Integer(0), opendaq.Boolean(True)))
 
@@ -240,8 +240,8 @@ class TestPropertySystem(opendaq_test.TestCase):
         counter_settings.add_property(opendaq.IntProperty(opendaq.String(
             'increment'), opendaq.Integer(1), opendaq.Boolean(True)))
         mode_list = opendaq.List()
-        mode_list.pushBack('Infinite')
-        mode_list.pushBack('Loop')
+        mode_list.push_back('Infinite')
+        mode_list.push_back('Loop')
         counter_settings.add_property(opendaq.SelectionProperty(opendaq.String(
             'mode'), mode_list, opendaq.Integer(0), opendaq.Boolean(True)))
 
@@ -317,7 +317,7 @@ class TestPropertySystem(opendaq_test.TestCase):
         property_object = opendaq.PropertyObject()
         child1 = opendaq.PropertyObject()
         child2 = opendaq.PropertyObject()
-        
+
         child2.add_property(opendaq.StringProperty(opendaq.String(
             'property'), opendaq.String('value'), opendaq.Boolean(True)))
         child1.add_property(opendaq.ObjectProperty(
@@ -332,8 +332,8 @@ class TestPropertySystem(opendaq_test.TestCase):
     def test_selection_property_read(self):
         property_object = opendaq.PropertyObject()
         list = opendaq.List()
-        list.pushBack('value1')
-        list.pushBack('value2')
+        list.push_back('value1')
+        list.push_back('value2')
         property_object.add_property(opendaq.SelectionProperty(opendaq.String(
             'property'), list, opendaq.Integer(1), opendaq.Boolean(True)))
 
@@ -343,30 +343,30 @@ class TestPropertySystem(opendaq_test.TestCase):
     def test_list_property_read(self):
         property_object = opendaq.PropertyObject()
         list = opendaq.List()
-        list.pushBack('value1')
-        list.pushBack('value2')
+        list.push_back('value1')
+        list.push_back('value2')
         property_object.add_property(opendaq.ListProperty(
             opendaq.String('property'), list, opendaq.Boolean(True)))
 
         self.assertEqual(property_object.get_property_value(
             'property[0]'), 'value1')
-        
+
     def test_list_property_set(self):
         property_object = opendaq.PropertyObject()
         list = opendaq.List()
-        list.pushBack('value1')
-        list.pushBack('value2')
+        list.push_back('value1')
+        list.push_back('value2')
         property_object.add_property(opendaq.ListProperty(
             opendaq.String('List'), list, opendaq.Boolean(True)))
 
         list = property_object.get_property_value("List")
-        list.pushBack('value3')
+        list.push_back('value3')
         property_object.set_property_value('List', list)
         print(property_object.get_property_value('List'))
-        
+
         self.assertEqual(property_object.get_property_value(
             'List[2]'), 'value3')
-     
+
     def test_dict_property_set(self):
         property_object = opendaq.PropertyObject()
         dict = opendaq.Dict()
@@ -381,7 +381,7 @@ class TestPropertySystem(opendaq_test.TestCase):
 
         # Prints "Pear", "Strawberry", and "Blueberry"
         print(property_object.get_property_value('Dict'))
-        
+
     # TODO: events not supported yet
 
     def test_class(self):
@@ -391,8 +391,8 @@ class TestPropertySystem(opendaq_test.TestCase):
             'property1'), opendaq.Integer(1), opendaq.Boolean(True)))
 
         list = opendaq.List()
-        list.pushBack('value1')
-        list.pushBack('value2')
+        list.push_back('value1')
+        list.push_back('value2')
 
         property_class_builder.add_property(opendaq.SelectionProperty(opendaq.String(
             'property2'), list, opendaq.Integer(1), opendaq.Boolean(True)))
@@ -407,8 +407,8 @@ class TestPropertySystem(opendaq_test.TestCase):
         property_class_builder.add_property(opendaq.IntProperty(opendaq.String(
             'property1'), opendaq.Integer(1), opendaq.Boolean(True)))
         list = opendaq.List()
-        list.pushBack('value1')
-        list.pushBack('value2')
+        list.push_back('value1')
+        list.push_back('value2')
         property_class_builder.add_property(opendaq.SelectionProperty(opendaq.String(
             'property2'), list, opendaq.Integer(1), opendaq.Boolean(True)))
         property_class = property_class_builder.build()

--- a/docs/Antora/modules/background_info/pages/components.adoc
+++ b/docs/Antora/modules/background_info/pages/components.adoc
@@ -130,7 +130,7 @@ Python::
 +
 [source,python]
 ----
-def findSignals(device: opendaq.IDevice):
+def find_signals(device: opendaq.IDevice):
     search_filter = opendaq.RecursiveSearchFilter(opendaq.AnySearchFilter())
     for signal in device.get_signals(search_filter):
         print(signal.global_id)

--- a/docs/Antora/modules/background_info/pages/device.adoc
+++ b/docs/Antora/modules/background_info/pages/device.adoc
@@ -84,7 +84,7 @@ Python::
 [source,python]
 ----
 def access_device_components(device: opendaq.IDevice):
-    functionBlocks = device.function_blocks
+    function_blocks = device.function_blocks
     signals = device.signals
     sub_devices = device.devices
     io_folder = device.inputs_outputs_folder
@@ -192,7 +192,7 @@ def device_info(device: opendaq.IDevice):
     # Gets the Device information and prints its serial number
     info = device.info
     print(info.serial_number)
-# Prints the name of the first available device
+    # Prints the name of the first available device
     available_device_info = device.available_devices.values[0]
     print(available_device_info.name)
 ----
@@ -240,8 +240,8 @@ Python::
 ----
 def instance_and_root():
     instance = opendaq.Instance()
-    
-# The below two lines are equivalent.
+
+    # The below two lines are equivalent.
     available_devices1 = instance.available_devices
     available_devices2 = instance.root_device.available_devices
 ----

--- a/docs/Antora/modules/background_info/pages/function_blocks.adoc
+++ b/docs/Antora/modules/background_info/pages/function_blocks.adoc
@@ -42,7 +42,7 @@ Python::
 [source,python]
 ----
 input_port.connect(signal)
-// signal is now connected to the inputPort
+# signal is now connected to the inputPort
 signal1 = input_port.signal
 assert signal1 == signal
 ----
@@ -81,7 +81,7 @@ Python::
 +
 [source,python]
 ----
-fb = instance.addFunctionBlock("fft_fb")
+fb = instance.add_function_block("fft_fb")
 # Function Block appears under FunctionBlocks of the instance
 fbs = instance.function_blocks
 fb1 = fbs[-1]

--- a/docs/Antora/modules/background_info/pages/modules.adoc
+++ b/docs/Antora/modules/background_info/pages/modules.adoc
@@ -68,13 +68,13 @@ Python::
 def loading_modules(context: opendaq.IContext):
     # Loads modules from the executable directory
     manager1 = opendaq.ModuleManager(opendaq.String(''), context)
-# Loads modules from the current working directory
+    # Loads modules from the current working directory
     manager2 = opendaq.ModuleManager(opendaq.String('.'), context)
-# Loads modules from a path relative to the current directory
+    # Loads modules from a path relative to the current directory
     manager3 = opendaq.ModuleManager(opendaq.String('./dir1/dir2'), context)
-# Loads modules from an absolute path
+    # Loads modules from an absolute path
     manager4 = opendaq.ModuleManager(opendaq.String('/dir1/dir2'), context)
-# Does not load any modules
+    # Does not load any modules
     manager5 = opendaq.ModuleManager(opendaq.String('[[none]]'), context)
 ----
 ====
@@ -99,9 +99,9 @@ Python::
 [source,python]
 ----
 def instance():
-# if the path is not specified, the executable directory is used for the module path
+    # if the path is not specified, the executable directory is used for the module path
     instance1 = opendaq.Instance()
-# Uses the  current working directory as the module path
+    # Uses the  current working directory as the module path
     instance2 = opendaq.Instance(opendaq.String('.'))
 ----
 ====

--- a/docs/Antora/modules/background_info/pages/property_system.adoc
+++ b/docs/Antora/modules/background_info/pages/property_system.adoc
@@ -51,14 +51,14 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj = opendaq.PropertyObject()
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'MyString'), opendaq.String('foo'), opendaq.Boolean(True)))
-propObj.add_property(opendaq.IntProperty(opendaq.String(
+prop_obj.add_property(opendaq.IntProperty(opendaq.String(
     'MyInteger'), opendaq.Integer(0), opendaq.Boolean(True)))
 
-propObj.set_property_value('MyString', opendaq.String('bar'))
-print(propObj.get_property_value('MyString'))
+prop_obj.set_property_value('MyString', opendaq.String('bar'))
+print(prop_obj.get_property_value('MyString'))
 ----
 ====
 
@@ -107,11 +107,11 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj = opendaq.PropertyObject()
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'MyString'), opendaq.String('foo'), opendaq.Boolean(True)))
-propObj.set_property_value('MyString', opendaq.String('bar'))
-print(propObj.get_property_value('MyString'))
+prop_obj.set_property_value('MyString', opendaq.String('bar'))
+print(prop_obj.get_property_value('MyString'))
 ----
 ====
 
@@ -250,28 +250,28 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-intProp = opendaq.IntPropertyBuilder(opendaq.String('Integer'), opendaq.Integer(10))
+prop_obj = opendaq.PropertyObject()
+int_prop = opendaq.IntPropertyBuilder(opendaq.String('Integer'), opendaq.Integer(10))
 # Unsupported in the current version
-# intProp.min_value = 0
-# intProp.max_value = 15
-propObj.add_property(intProp.build())
+# int_prop.min_value = 0
+# int_prop.max_value = 15
+prop_obj.add_property(int_prop.build())
 
-floatProp = opendaq.FloatPropertyBuilder(opendaq.String('Float'), opendaq.Float(3.21))
+float_prop = opendaq.FloatPropertyBuilder(opendaq.String('Float'), opendaq.Float(3.21))
 
 suggested_values = opendaq.List()
-suggested_values.pushBack(opendaq.Float(1.23))
-suggested_values.pushBack(opendaq.Float(3.21))
-suggested_values.pushBack(opendaq.Float(5.67))
-floatProp.suggested_values = suggested_values
+suggested_values.push_back(opendaq.Float(1.23))
+suggested_values.push_back(opendaq.Float(3.21))
+suggested_values.push_back(opendaq.Float(5.67))
+float_prop.suggested_values = suggested_values
 
-propObj.add_property(floatProp.build())
+prop_obj.add_property(float_prop.build())
 # "Integer" is set to 15 due to the max value
-propObj.set_property_value('Integer', opendaq.Integer(20))
-print(propObj.get_property_value('Integer'))
+prop_obj.set_property_value('Integer', opendaq.Integer(20))
+print(prop_obj.get_property_value('Integer'))
 # "Float" is set to 2.34 in despite the suggested values not containing the value 2.34
-propObj.set_property_value('Float', opendaq.Float(2.34))
-print(propObj.get_property_value('Float'))
+prop_obj.set_property_value('Float', opendaq.Float(2.34))
+print(prop_obj.get_property_value('Float'))
 ----
 ====
 
@@ -326,31 +326,31 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
+prop_obj = opendaq.PropertyObject()
 
 list = opendaq.List()
-list.pushBack(opendaq.String('Apple'))
-list.pushBack(opendaq.String('Banana'))
-list.pushBack(opendaq.String('Kiwi'))
+list.push_back(opendaq.String('Apple'))
+list.push_back(opendaq.String('Banana'))
+list.push_back(opendaq.String('Kiwi'))
 
-propObj.add_property(opendaq.SelectionProperty(opendaq.String(
+prop_obj.add_property(opendaq.SelectionProperty(opendaq.String(
     'ListSelection'), list, opendaq.Integer(1), opendaq.Boolean(True)))
 dict = opendaq.Dict()
 dict[0] = opendaq.String('foo')
 dict[10] = opendaq.String('bar')
-propObj.add_property(opendaq.SparseSelectionProperty(opendaq.String(
+prop_obj.add_property(opendaq.SparseSelectionProperty(opendaq.String(
     'DictSelection'), dict, opendaq.Integer(10), opendaq.Boolean(True)))
 
 # Prints "1"
-print(propObj.get_property_value('ListSelection'))
+print(prop_obj.get_property_value('ListSelection'))
 # Prints "Banana"
-print(propObj.get_property_selection_value('ListSelection'))
-propObj.set_property_value('ListSelection', opendaq.Integer(2))
+print(prop_obj.get_property_selection_value('ListSelection'))
+prop_obj.set_property_value('ListSelection', opendaq.Integer(2))
 
 # Prints "bar"
-print(propObj.get_property_selection_value('DictSelection'))
+print(prop_obj.get_property_selection_value('DictSelection'))
 # Selects "foo"
-propObj.set_property_value('DictSelection', opendaq.Integer(0))
+prop_obj.set_property_value('DictSelection', opendaq.Integer(0))
 ----
 ====
 
@@ -408,7 +408,7 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
+prop_obj = opendaq.PropertyObject()
 child1 = opendaq.PropertyObject()
 child2 = opendaq.PropertyObject()
 
@@ -419,11 +419,11 @@ child2.add_property(opendaq.StringProperty(opendaq.String(
     'String'), opendaq.String('foo'), opendaq.Boolean(True)))
 child1.add_property(opendaq.ObjectProperty(
     opendaq.String('Child'), child2))
-propObj.add_property(opendaq.ObjectProperty(
+prop_obj.add_property(opendaq.ObjectProperty(
     opendaq.String('Child'), child1))
 
 # Prints out the value of the "String" Property of child2
-print(propObj.get_property_value('Child.Child.String'))
+print(prop_obj.get_property_value('Child.Child.String'))
 ----
 ====
 
@@ -470,29 +470,28 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
+prop_obj = opendaq.PropertyObject()
 
 list = opendaq.List()
-list.pushBack(opendaq.String('Banana'))
-list.pushBack(opendaq.String('Apple'))
-list.pushBack(opendaq.String('Kiwi'))
-propObj.add_property(opendaq.ListProperty(
+list.push_back(opendaq.String('Banana'))
+list.push_back(opendaq.String('Apple'))
+list.push_back(opendaq.String('Kiwi'))
+prop_obj.add_property(opendaq.ListProperty(
     opendaq.String('List'), list, opendaq.Boolean(True)))
 
 dict = opendaq.Dict()
 dict[0] = opendaq.String('foo')
 dict[10] = opendaq.String('bar')
-propObj.add_property(opendaq.DictProperty(
+prop_obj.add_property(opendaq.DictProperty(
     opendaq.String('Dict'), dict, opendaq.Boolean(True)))
 
-# Unsupported in the current version
-# print(propObj.get_property_value('List')[0])
-# print(propObj.get_property_value('Dict')[10])
+print(prop_obj.get_property_value('List')[0])
+print(prop_obj.get_property_value('Dict')[10])
 
 list1 = opendaq.List()
-list1.pushBack(opendaq.String('Pear'))
-list1.pushBack(opendaq.String('Strawberry'))
-propObj.set_property_value('List', list1)
+list1.push_back(opendaq.String('Pear'))
+list1.push_back(opendaq.String('Strawberry'))
+prop_obj.set_property_value('List', list1)
 ----
 ====
 
@@ -545,24 +544,24 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-propObj.add_property(opendaq.IntProperty(opendaq.String(
+prop_obj = opendaq.PropertyObject()
+prop_obj.add_property(opendaq.IntProperty(opendaq.String(
     'Integer'), opendaq.Integer(0), opendaq.Boolean(True)))
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'Prop1'), opendaq.String('foo'), opendaq.Boolean(True)))
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'Prop2'), opendaq.String('bar'), opendaq.Boolean(True)))
 
-propObj.add_property(opendaq.ReferenceProperty(opendaq.String(
+prop_obj.add_property(opendaq.ReferenceProperty(opendaq.String(
     'RefProp'), opendaq.EvalValue(opendaq.String('switch($Integer, 0, %Prop1, 1, %Prop2)'))))
 
 # Prints "foo"
-print(propObj.get_property_value('RefProp'))
+print(prop_obj.get_property_value('RefProp'))
 
-propObj.set_property_value('Integer', opendaq.Integer(1))
+prop_obj.set_property_value('Integer', opendaq.Integer(1))
 
 # Prints "bar"
-print(propObj.get_property_value('RefProp'))
+print(prop_obj.get_property_value('RefProp'))
 ----
 ====
 
@@ -638,12 +637,12 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj = opendaq.PropertyObject()
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'String'), opendaq.String('foo'), opendaq.Boolean(True)))
-propObj.add_property(opendaq.RatioProperty(opendaq.String(
+prop_obj.add_property(opendaq.RatioProperty(opendaq.String(
     'Ratio'), opendaq.Ratio(1, 10), opendaq.Boolean(True)))
-propObj.add_property(opendaq.BoolProperty(opendaq.String(
+prop_obj.add_property(opendaq.BoolProperty(opendaq.String(
     'Bool'), opendaq.Boolean(True), opendaq.Boolean(True)))
 ----
 ====
@@ -678,13 +677,13 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-floatProp = opendaq.FloatPropertyBuilder(opendaq.String('MyFloat'), opendaq.Float(1.123))
+prop_obj = opendaq.PropertyObject()
+float_prop = opendaq.FloatPropertyBuilder(opendaq.String('MyFloat'), opendaq.Float(1.123))
 # Unsupported in the current version
-# floatProp.min_value = 0.0
-# floatProp.max_value = 10.0
+# float_prop.min_value = 0.0
+# float_prop.max_value = 10.0
 
-propObj.add_property(floatProp.build())
+propObj.add_property(float_prop.build())
 ----
 ====
 
@@ -788,23 +787,23 @@ Python::
 +
 [source,python]
 ----
-simulatedChannel = opendaq.PropertyObject()
+simulated_channel = opendaq.PropertyObject()
 list = opendaq.List()
-list.pushBack(opendaq.String('Sine'))
-list.pushBack(opendaq.String('Counter'))
-simulatedChannel.add_property(opendaq.SelectionProperty(opendaq.String(
+list.push_back(opendaq.String('Sine'))
+list.push_back(opendaq.String('Counter'))
+simulated_channel.add_property(opendaq.SelectionProperty(opendaq.String(
     'Waveform'), list, opendaq.Integer(0), opendaq.Boolean(True)))
-simulatedChannel.add_property(opendaq.ReferenceProperty(opendaq.String(
+simulated_channel.add_property(opendaq.ReferenceProperty(opendaq.String(
     'Settings'), opendaq.EvalValue(opendaq.String('if($Waveform == 0, %SineSettings, %CounterSettings)'))))
-    
+
 ...
 
-simulatedChannel.add_property(opendaq.ObjectProperty(
+simulated_channel.add_property(opendaq.ObjectProperty(
     opendaq.String('SineSettings'), sineSettings))
 
 ...
 
-simulatedChannel.add_property(opendaq.ObjectProperty(
+simulated_channel.add_property(opendaq.ObjectProperty(
     opendaq.String('CounterSettings'), counterSettings))
 ----
 ====
@@ -864,13 +863,13 @@ Python::
 
 # The ScalingFactor Property is shown if EnableScaling is true.
 # Unsupported in the current version
-scalingFactor.visible = opendaq.EvalValue(opendaq.String('$EnableScaling'))
+scaling_factor.visible = opendaq.EvalValue(opendaq.String('$EnableScaling'))
 
 ...
 
 # The LoopThreshold Property is shown if the "Mode" Property is set to 1.
 # Unsupported in the current version
-loopThreshold.visible = opendaq.EvalValue(opendaq.String('$Mode == 1'))
+loop_threshold.visible = opendaq.EvalValue(opendaq.String('$Mode == 1'))
 ----
 ====
 
@@ -899,15 +898,15 @@ Python::
 [source,python]
 ----
 list = opendaq.List()
-list.pushBack(opendaq.String('V'))
-list.pushBack(opendaq.String('mV'))
-sineSettings.add_property(opendaq.SelectionProperty(opendaq.String(
+list.push_back(opendaq.String('V'))
+list.push_back(opendaq.String('mV'))
+sine_settings.add_property(opendaq.SelectionProperty(opendaq.String(
     'AmplitudeUnit'), list, opendaq.Integer(0), opendaq.Boolean(True)))
 
 ...
 
 # Unsupported in the current version
-amplitudeProp.unit = opendaq.EvalValue(opendaq.String('Unit(%AmplitudeUnit:SelectedValue)'))
+amplitude_prop.unit = opendaq.EvalValue(opendaq.String('Unit(%AmplitudeUnit:SelectedValue)'))
 ----
 ====
 
@@ -956,19 +955,19 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-coercedProp = opendaq.IntPropertyBuilder(opendaq.String('CoercedProp'), opendaq.Integer(5))
-coercedProp.coercer = opendaq.Coercer(opendaq.String('if(Value < 10, Value, 10)'))
-propObj.add_property(coercedProp.build())
+prop_obj = opendaq.PropertyObject()
+coerced_prop = opendaq.IntPropertyBuilder(opendaq.String('CoercedProp'), opendaq.Integer(5))
+coerced_prop.coercer = opendaq.Coercer(opendaq.String('if(Value < 10, Value, 10)'))
+prop_obj.add_property(coerced_prop.build())
 
-validatedProp = opendaq.IntPropertyBuilder(opendaq.String('ValidatedProp'), opendaq.Integer(5))
-validatedProp.validator = opendaq.Validator(opendaq.String('Value < 10'))
-propObj.add_property(validatedProp.build())
+validated_prop = opendaq.IntPropertyBuilder(opendaq.String('ValidatedProp'), opendaq.Integer(5))
+validated_prop.validator = opendaq.Validator(opendaq.String('Value < 10'))
+prop_obj.add_property(validated_prop.build())
 
 # Sets the value to 10
-propObj.set_property_value('CoercedProp', opendaq.Integer(15))
+prop_obj.set_property_value('CoercedProp', opendaq.Integer(15))
 # Throws a validation error
-propObj.set_property_value('ValidatedProp', opendaq.Integer(15))
+prop_obj.set_property_value('ValidatedProp', opendaq.Integer(15))
 ----
 ====
 
@@ -1010,12 +1009,12 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj = opendaq.PropertyObject()
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'foo'), opendaq.String('bar'), opendaq.Boolean(True)))
-propObj.remove_property('foo')
+prop_obj.remove_property('foo')
 
-fooProp = propObj.get_property('foo') # Throws runtime error
+foo_prop = prop_obj.get_property('foo') # Throws runtime error
 ----
 ====
 
@@ -1060,18 +1059,18 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj = opendaq.PropertyObject()
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'String'), opendaq.String('foo'), opendaq.Boolean(True)))
-propObj.add_property(opendaq.IntProperty(opendaq.String(
+prop_obj.add_property(opendaq.IntProperty(opendaq.String(
     'Int'), opendaq.Integer(10), opendaq.Boolean(False)))
-propObj.add_property(opendaq.FloatProperty(opendaq.String(
+prop_obj.add_property(opendaq.FloatProperty(opendaq.String(
     'Float'), opendaq.Float(15.0), opendaq.Boolean(True)))
-propObj.add_property(opendaq.ReferenceProperty(opendaq.String(
+prop_obj.add_property(opendaq.ReferenceProperty(opendaq.String(
     'FloatRef'), opendaq.EvalValue(opendaq.String('%Float'))))
 
-allProps = propObj.all_properties
-visibleProps = propObj.visible_properties
+all_props = prop_obj.all_properties
+visible_props = prop_obj.visible_properties
 # Properties orderings are not supported in the current version
 ----
 ====
@@ -1100,16 +1099,16 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
-propObj.add_property(opendaq.StringProperty(opendaq.String(
+prop_obj = opendaq.PropertyObject()
+prop_obj.add_property(opendaq.StringProperty(opendaq.String(
     'String'), opendaq.String('foo'), opendaq.Boolean(True)))
 
 # Prints "foo"
-print(propObj.get_property_value('String'))
-propObj.set_property_value('String', opendaq.String('bar'))
+print(prop_obj.get_property_value('String'))
+prop_obj.set_property_value('String', opendaq.String('bar'))
 
 # Prints "bar"
-print(propObj.get_property_value('String'))
+print(prop_obj.get_property_value('String'))
 ----
 ====
 
@@ -1141,7 +1140,7 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
+prop_obj = opendaq.PropertyObject()
 child1 = opendaq.PropertyObject()
 child2 = opendaq.PropertyObject()
 
@@ -1149,14 +1148,14 @@ child2.add_property(opendaq.StringProperty(opendaq.String(
     'String'), opendaq.String('foo'), opendaq.Boolean(True)))
 child1.add_property(opendaq.ObjectProperty(
     opendaq.String('Child'), child2))
-propObj.add_property(opendaq.ObjectProperty(
+prop_obj.add_property(opendaq.ObjectProperty(
     opendaq.String('Child'), child1))
 
-propObj.set_property_value(
+prop_obj.set_property_value(
     'Child.Child.String', opendaq.String('bar'))
 
 # Prints "bar"
-print(propObj.get_property_value('Child.Child.String'))
+print(prop_obj.get_property_value('Child.Child.String'))
 ----
 ====
 
@@ -1185,15 +1184,15 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
+prop_obj = opendaq.PropertyObject()
 list = opendaq.List()
-list.pushBack(opendaq.String('Banana'))
-list.pushBack(opendaq.String('Kiwi'))
-propObj.add_property(opendaq.SelectionProperty(opendaq.String(
+list.push_back(opendaq.String('Banana'))
+list.push_back(opendaq.String('Kiwi'))
+prop_obj.add_property(opendaq.SelectionProperty(opendaq.String(
     'Selection'), list, opendaq.Integer(1), opendaq.Boolean(True)))
 
 # Prints "Kiwi"
-print(propObj.get_property_selection_value('Selection'))
+print(prop_obj.get_property_selection_value('Selection'))
 ----
 ====
 
@@ -1224,15 +1223,15 @@ Python::
 +
 [source,python]
 ----
-propObj = opendaq.PropertyObject()
+prop_obj = opendaq.PropertyObject()
 list = opendaq.List()
-list.pushBack(opendaq.String('Banana'))
-list.pushBack(opendaq.String('Kiwi'))
-propObj.add_property(opendaq.ListProperty(
+list.push_back(opendaq.String('Banana'))
+list.push_back(opendaq.String('Kiwi'))
+prop_obj.add_property(opendaq.ListProperty(
     opendaq.String('List'), list, opendaq.Boolean(True)))
 
 # Prints "Banana"
-print(propObj.get_property_value('List[0]'))
+print(prop_obj.get_property_value('List[0]'))
 
 ----
 ====
@@ -1258,12 +1257,12 @@ Python::
 +
 [source,python]
 ----
-list = propObj.get_property_value("List")
-list.pushBack('Blueberry')
-propObj.set_property_value('List', list)
+list = prop_obj.get_property_value("List")
+list.push_back('Blueberry')
+prop_obj.set_property_value('List', list)
 
 # Prints "Pear", "Strawberry", and "Blueberry"
-print(propObj.get_property_value('List'))
+print(prop_obj.get_property_value('List'))
 ----
 ====
 
@@ -1297,11 +1296,11 @@ dict[2] = 'Kiwi'
 property_object.add_property(opendaq.DictProperty(
     opendaq.String('Dict'), dict, opendaq.Boolean(True)))
 
-dict = propObj.get_property_value("Dict")
+dict = property_object.get_property_value("Dict")
 dict[3] = 'Blueberry'
 
 # The "Dict" property now contains {1 : "Banana"}, {2 : "Kiwi"}, {3 : "Blueberry"}
-propObj.set_property_value('Dict', dict)
+property_object.set_property_value('Dict', dict)
 ----
 ====
 
@@ -1388,9 +1387,9 @@ prop_class = opendaq.PropertyObjectClassBuilder(opendaq.String('MyClass'))
 prop_class.add_property(opendaq.IntProperty(opendaq.String(
     'Integer'), opendaq.Integer(10), opendaq.Boolean(True)))
 list = opendaq.List()
-list.pushBack(opendaq.String('Banana'))
-list.pushBack(opendaq.String('Apple'))
-list.pushBack(opendaq.String('Kiwi'))
+list.push_back(opendaq.String('Banana'))
+list.push_back(opendaq.String('Apple'))
+list.push_back(opendaq.String('Kiwi'))
 prop_class.add_property(opendaq.SelectionProperty(opendaq.String('Selection'), list, opendaq.Integer(1), opendaq.Boolean(True)))
 ----
 ====
@@ -1433,17 +1432,17 @@ manager = opendaq.TypeManager()
 prop_class = opendaq.PropertyObjectClassBuilder(opendaq.String('MyClass'))
 prop_class.add_property(opendaq.IntProperty(opendaq.String('Integer'), opendaq.Integer(10), opendaq.Boolean(True)))
 list = opendaq.List()
-list.pushBack(opendaq.String('Banana'))
-list.pushBack(opendaq.String('Apple'))
-list.pushBack(opendaq.String('Kiwi'))
+list.push_back(opendaq.String('Banana'))
+list.push_back(opendaq.String('Apple'))
+list.push_back(opendaq.String('Kiwi'))
 prop_class.add_property(opendaq.SelectionProperty(opendaq.String('Selection'), list, opendaq.Integer(1), opendaq.Boolean(True)))
 
 manager.add_class(prop_class.build())
 
-propObj = opendaq.PropertyObjectWithClassAndManager(manager, opendaq.String('MyClass'))
+prop_obj = opendaq.PropertyObjectWithClassAndManager(manager, opendaq.String('MyClass'))
 
 # Prints "Apple"
-print(propObj.get_property_selection_value('Selection'))
+print(prop_obj.get_property_selection_value('Selection'))
 ----
 ====
 
@@ -1492,13 +1491,13 @@ prop_class2.add_property(opendaq.StringProperty(opendaq.String('OwnProp'), opend
 prop_class2.parent_name = 'InheritedClass'
 manager.add_class(prop_class2.build())
 
-propObj = opendaq.PropertyObjectWithClassAndManager(manager, opendaq.String('MyClass'))
+prop_obj = opendaq.PropertyObjectWithClassAndManager(manager, opendaq.String('MyClass'))
 
 # Prints "foo"
-print(propObj.get_property_value('InheritedProp'))
+print(prop_obj.get_property_value('InheritedProp'))
 
 # Prints "bar"
-print(propObj.get_property_value('OwnProp'))
+print(prop_obj.get_property_value('OwnProp'))
 ----
 ====
 

--- a/docs/Antora/modules/howto_guides/pages/howto_configure_function_block.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_configure_function_block.adoc
@@ -66,8 +66,8 @@ Python::
 +
 [source,python]
 ----
-currentBlockSize = function_block.get_property_value('BlockSize')
-print(f'Current block size is {currentBlockSize}')
+current_block_size = function_block.get_property_value('BlockSize')
+print(f'Current block size is {current_block_size}')
 function_block.set_property_value('BlockSize', 100)
 ---- 
 ====
@@ -186,8 +186,8 @@ for prop in function_block.visible_properties:
     print(prop.name)
 
 # print current block size
-currentBlockSize = function_block.get_property_value('BlockSize')
-print(f'Current block size is {currentBlockSize}')
+current_block_size = function_block.get_property_value('BlockSize')
+print(f'Current block size is {current_block_size}')
 
 # configure the properties of the function block
 function_block.set_property_value('BlockSize', 100)

--- a/docs/Antora/modules/howto_guides/pages/howto_save_load_configuration.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_save_load_configuration.adoc
@@ -39,10 +39,10 @@ Python::
 [source,python]
 ----
 # save configuration to string
-json_str = instance.save_configuration();
+json_str = instance.save_configuration()
 
 # write configuration string to file
-config_file = open("config.json", "w")       
+config_file = open("config.json", "w")
 config_file.write(json_str)
 config_file.close()
 ----
@@ -102,11 +102,11 @@ Python::
 ----
 # read configuration from file
 config_file = open("config.json", "r")
-json_str = config_file.read();
+json_str = config_file.read()
 config_file.close()
 
 # load configuration from string
-instance.load_configuration(json_str);
+instance.load_configuration(json_str)
 ----
 ====
 

--- a/examples/python/gui_demo.py
+++ b/examples/python/gui_demo.py
@@ -23,9 +23,9 @@ yes_no = {
 }
 
 class DeviceInfoLocal:
-    def __init__(self, connString):
-        self.name = connString
-        self.connection_string = connString
+    def __init__(self, conn_string):
+        self.name = conn_string
+        self.connection_string = conn_string
         self.serial_number = 'no-serial-number'
 
 def show_modal(window):


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

- Fix naming of functions and variables according Python's conventions
- Other minor fixes