### PR TITLE
Deadlock in daqPrintTrackedObjects if we have a tracked struct

### DIFF
--- a/core/coretypes/include/coretypes/struct_impl.h
+++ b/core/coretypes/include/coretypes/struct_impl.h
@@ -376,13 +376,17 @@ ErrCode GenericStructImpl<StructInterface, Interfaces...>::toString(CharPtr* str
 
     std::ostringstream strStream;
     bool first = true;
-    for (const auto& field: fields)
+    auto fieldNames = structType.getFieldNames();
+    for (daq::SizeT i = 0; i < fieldNames.getCount(); i++)
     {
+        const StringPtr& fieldName = fieldNames[i];
+        const BaseObjectPtr& fieldValue = fields[fieldName];
+
         if (!first)
             strStream << "; ";
 
         first = false;
-        strStream << field.first.toStdString() << "=" << (field.second.assigned() ? static_cast<std::string>(field.second) : "null");
+        strStream << fieldName.toStdString() << "=" << (fieldValue.assigned() ? static_cast<std::string>(fieldValue) : "null");
     }
 
     const auto len = strStream.str().size() + 1;

--- a/core/coretypes/tests/test_struct.cpp
+++ b/core/coretypes/tests/test_struct.cpp
@@ -384,3 +384,16 @@ TEST_F(StructObjectTest, NestedStructBuilder)
 
     ASSERT_EQ(nestedStruct, builtStruct);
 }
+
+TEST_F(StructObjectTest, PrintTrackedObjectWithoutDeadlock)
+{
+    if (!daqIsTrackingObjects())
+        GTEST_SKIP() << "The test has no meaning if object tracking is disabled";
+
+    const auto manager = TypeManager();
+
+    const auto structMembers = Dict<IString, IBaseObject>({{"string", "bar"}, {"integer", 10}});
+    const auto simpleStruct = Struct("foo", structMembers, manager);
+
+    daqPrintTrackedObjects();  // Struct::ToString should not create any new objects (deadlock)
+}

--- a/shared/libraries/testutils/src/memcheck_listener.cpp
+++ b/shared/libraries/testutils/src/memcheck_listener.cpp
@@ -36,7 +36,7 @@ void MemCheckListener::OnTestStart(const testing::TestInfo& info)
 
 void MemCheckListener::OnTestEnd(const testing::TestInfo& info)
 {
-    if (!info.result()->Failed())
+    if (info.result()->Passed())
     {
 #ifndef NDEBUG
     #ifdef _MSC_VER


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# Checklist:

- [X] Pull request title reflects its content
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# Description:

daqPrintTrackedObjects calls toString on every object. If struct creates an iterator in toString, we get a deadlock between daqPrintTrackedObjects and daqTrackObject. 

My solution assumes that StructType::getFieldNames() doesn't create a new list.

Another solution would be to change the implementation of tracking objects. We agree with @JakaMohorkoDS that changing ToString is good enough for now. It is generally hard to avoid creating new objects when working with dictionaries.  