### PR TITLE
Bugfix: Float Type not supported in Structures

### DIFF
--- a/shared/libraries/opcua/opcuashared/include/opcuashared/opcuavariant.h
+++ b/shared/libraries/opcua/opcuashared/include/opcuashared/opcuavariant.h
@@ -161,6 +161,7 @@ public:
     std::string toString() const;
     int64_t toInteger() const;
     double toDouble() const;
+    float toFloat() const;
     bool toBool() const;
     OpcUaNodeId toNodeId() const;
 

--- a/shared/libraries/opcua/opcuashared/src/opcuavariant.cpp
+++ b/shared/libraries/opcua/opcuashared/src/opcuavariant.cpp
@@ -195,6 +195,11 @@ double OpcUaVariant::toDouble() const
     return readScalar<UA_Double>();
 }
 
+float OpcUaVariant::toFloat() const
+{
+    return readScalar<UA_Float>();
+}
+
 bool OpcUaVariant::toBool() const
 {
     return readScalar<UA_Boolean>();

--- a/shared/libraries/opcuatms/opcuatms/src/converters/core_types_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/converters/core_types_converter.cpp
@@ -263,7 +263,9 @@ OpcUaObject<UA_Float> StructConverter<IFloat, UA_Float>::ToTmsType(const FloatPt
 template <>
 FloatPtr VariantConverter<IFloat>::ToDaqObject(const OpcUaVariant& variant, const ContextPtr& /*context*/)
 {
-    return variant.toDouble();
+    if (variant.isType<UA_Double>())
+        return variant.toDouble();
+    return variant.toFloat();
 }
 
 template <>

--- a/shared/libraries/opcuatms/opcuatms/src/converters/core_types_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/converters/core_types_converter.cpp
@@ -263,9 +263,9 @@ OpcUaObject<UA_Float> StructConverter<IFloat, UA_Float>::ToTmsType(const FloatPt
 template <>
 FloatPtr VariantConverter<IFloat>::ToDaqObject(const OpcUaVariant& variant, const ContextPtr& /*context*/)
 {
-    if (variant.isType<UA_Double>())
-        return variant.toDouble();
-    return variant.toFloat();
+    if (variant.isType<UA_Float>())
+        return variant.toFloat();
+    return variant.toDouble();
 }
 
 template <>

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
@@ -41,22 +41,26 @@ protected:
     void SetUp() override
     {
         TmsObjectIntegrationTest::SetUp();
-
-         // create class with name "STGAmplifier"
-        auto stgAmplClass =
-            PropertyObjectClassBuilder("StgAmp")
-                .addProperty(SelectionProperty(
-                    "Measurement", List<IString>("Voltage", "Bridge", "Resistance", "Temperature", "Current", "Potentiometer"), 0))
-                
-                .build();
-
         objManager = TypeManager();
-        objManager.addType(stgAmplClass);
+
+        // create class with name "FusionAmp"
+        auto fusionAmpClass =
+            PropertyObjectClassBuilder("FusionAmp")
+                .addProperty(SelectionProperty(
+                    "Measurement", List<IString>("Voltage", "FullBridge", "HalfBridge", "QuarterBridge"), 0))
+                .addProperty(StructProperty(
+                    "AdjustmentPoint", Struct("AdjustmentPointScalingStructure", Dict<IString, IBaseObject>({{"Index", 1}, {"Factor", 2.1}, {"Offset", 3.0}}), objManager))
+                )
+                .addProperty(StructProperty(
+                    "Scaler", Struct("GainScalingStructure", Dict<IString, IBaseObject>({{"Factor", 2.1}, {"Offset", 3.0}}), objManager))
+                )
+                .build();
+        objManager.addType(fusionAmpClass);
     }
 
     void TearDown() override
     {
-        objManager.removeType("StgAmp");
+        objManager.removeType("FusionAmp");
     }
 
     RegisteredPropertyObject registerPropertyObject(const PropertyObjectPtr& prop)
@@ -85,6 +89,33 @@ TEST_F(TmsFusionDevice, SampleRateTest)
 
     ASSERT_TRUE(clientSignal.getPublic());
     ASSERT_NO_THROW(clientSignal.getPropertyValue("SampleRate"));
+}
+
+TEST_F(TmsFusionDevice, StructTest)
+{
+    const auto obj = PropertyObject(objManager, "FusionAmp");
+    auto [serverObj, fusionAmp] = registerPropertyObject(obj);
+ 
+    // Test struct with int and float values
+    const auto adjustmentPoint =  StructBuilder(fusionAmp.getPropertyValue("AdjustmentPoint"));                
+    adjustmentPoint.set("Index", 10);
+    adjustmentPoint.set("Factor", 3.1);
+    fusionAmp.setPropertyValue("AdjustmentPoint", adjustmentPoint.build());
+    
+    const auto adjustmentPointManipulated =  StructBuilder(fusionAmp.getPropertyValue("AdjustmentPoint"));                
+    ASSERT_EQ(adjustmentPointManipulated.get("Index"), 10);
+    ASSERT_FLOAT_EQ(adjustmentPointManipulated.get("Factor"), 3.1);
+
+    // Test strusct with double values
+    const auto scaler =  StructBuilder(fusionAmp.getPropertyValue("Scaler"));                
+    scaler.set("Factor", 3.62);
+    scaler.set("Offset", 3.1);
+    fusionAmp.setPropertyValue("Scaler", scaler.build());
+    
+    const auto scalerManipulated =  StructBuilder(fusionAmp.getPropertyValue("Scaler"));                
+    ASSERT_DOUBLE_EQ(scalerManipulated.get("Factor"), 3.62);
+    ASSERT_DOUBLE_EQ(scalerManipulated.get("Offset"), 3.1);
+
 }
 
 TEST_F(TmsFusionDevice, DISABLED_SimulatorTest)

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
@@ -104,7 +104,7 @@ TEST_F(TmsFusionDevice, StructTest)
     
     const auto adjustmentPointManipulated =  StructBuilder(fusionAmp.getPropertyValue("AdjustmentPoint"));                
     ASSERT_EQ(adjustmentPointManipulated.get("Index"), 10);
-    ASSERT_FLOAT_EQ(adjustmentPointManipulated.get("Factor"), 3.1);
+    ASSERT_FLOAT_EQ(adjustmentPointManipulated.get("Factor"), (float) 3.1);
 
     // Test strusct with double values
     const auto scaler =  StructBuilder(fusionAmp.getPropertyValue("Scaler"));                
@@ -113,8 +113,8 @@ TEST_F(TmsFusionDevice, StructTest)
     fusionAmp.setPropertyValue("Scaler", scaler.build());
     
     const auto scalerManipulated =  StructBuilder(fusionAmp.getPropertyValue("Scaler"));                
-    ASSERT_DOUBLE_EQ(scalerManipulated.get("Factor"), 3.62);
-    ASSERT_DOUBLE_EQ(scalerManipulated.get("Offset"), 3.1);
+    ASSERT_DOUBLE_EQ(scalerManipulated.get("Factor"), (double) 3.62);
+    ASSERT_DOUBLE_EQ(scalerManipulated.get("Offset"), (double) 3.1);
 
 }
 


### PR DESCRIPTION
Structs and so opc ua variants can have also variables with the opc ua type float. These need to be mapped in the correct way.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:
