### PR TITLE
install missing public core headers

### DIFF
--- a/core/opendaq/component/src/CMakeLists.txt
+++ b/core/opendaq/component/src/CMakeLists.txt
@@ -70,10 +70,12 @@ set(SRC_PublicHeaders
     folder_impl.h
     deserialize_component.h
     component_factory.h
+    component_keys.h
 	component_deserialize_context_factory.h
     component_deserialize_context_impl.h	
     search_filter_factory.h
     tags_factory.h
+    tags_impl.h
 )
 
 set(SRC_PrivateHeaders
@@ -100,6 +102,7 @@ list(APPEND SRC_PublicHeaders ${SRC_Component_PublicHeaders}
                               ${SRC_IoFolder_PublicHeaders}
                               ${SRC_Removable_PublicHeaders}
                               ${SRC_ComponentDeserializeContext_PublicHeaders}
+                              ${SRC_DeserializeComponent_PublicHeaders}
                               ${SRC_SearchFilter_PublicHeaders}
                               ${SRC_RecursiveSearch_PublicHeaders}
                               ${SRC_ComponentPrivate_PublicHeaders}


### PR DESCRIPTION
It seems that core headers tags_impl.h and component_keys.h, as well as RTGen'd deserialize_component headers, have either recently been added, or have recently been included from other public headers in the SDK. Consequently they now seem to be required. However, they are not installed (they're missing from SRC_PublicHeaders in core/opendaq/component/src/CMakeLists.txt).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] Pull request title reflects its content
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

See top.