### PR TITLE
fix OPENDAQ_ENABLE_NATIVE_STREAMING: always create RTGen output dir if it doesn't exist

### DIFF
--- a/cmake/RTGen.cmake
+++ b/cmake/RTGen.cmake
@@ -94,9 +94,11 @@ function(_rtgen_interface FILENAME OUTFILES_VAR)
             # If generating bindings set the output directory to "bindings/{LANG}"
             # Create the directory if it doesn't exist yet
             set(RTGEN_OUTPUT_DIR "${CURR_BINDINGS_DIR}/${LANG}")
-            if (NOT EXISTS RTGEN_OUTPUT_DIR)
-                opendaq_create_dir(${RTGEN_OUTPUT_DIR})
-            endif()
+        endif()
+
+        # Create the directory if it doesn't exist yet
+        if (NOT EXISTS RTGEN_OUTPUT_DIR)
+            opendaq_create_dir(${RTGEN_OUTPUT_DIR})
         endif()
 
         if (RTGEN_NAMESPACE)


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] Pull request title reflects its content
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [N/A] Any dependent changes have been merged and published in downstream modules

# Description:

This PR fixes a bug that appears when compiling with `-DOPENDAQ_ENABLE_NATIVE_STREAMING=ON`:

    [ 98%] Generating bindings for: config_client_object.h
    Warning: Error occurred while generating the output file: Failed to copy the generated file to the output directory.
    make[2]: *** [shared/libraries/config_protocol/src/CMakeFiles/opendaq_config_protocol.dir/build.make:80: shared/libraries/config_protocol/include/config_protocol/config_client_object_ptr.h] Error 4
    make[1]: *** [CMakeFiles/Makefile2:6479: shared/libraries/config_protocol/src/CMakeFiles/opendaq_config_protocol.dir/all] Error 2
    make: *** [Makefile:166: all] Error 2

The root cause is that `RTGen.exe` expects the output directory to exist, but the `rtgen()` CMake function only created the directory if `${LANG}` is _not_ `cpp` (for reasons I don't understand). WIth this PR the output directory is always created. Feel free to amend this PR if this is better fixed in another way.