### PR TITLE
Inline static destructors are called multiple times (VS 2017 compiler bug)

### DIFF
--- a/core/opendaq/functionblock/src/CMakeLists.txt
+++ b/core/opendaq/functionblock/src/CMakeLists.txt
@@ -82,6 +82,10 @@ opendaq_add_library(${BASE_NAME} STATIC
     ${ConfigHeaderSource}
 )
 
+if (MSVC)
+    opendaq_target_compile_options(${BASE_NAME} PRIVATE /bigobj)
+endif()
+
 opendaq_target_link_libraries(${BASE_NAME}
     PUBLIC
         daq::coreobjects

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -337,7 +337,7 @@ TEST_F(MultiReaderTest, SignalStartDomainFrom0SkipSamples)
 
     SizeT skip = 100;
     multi.skipSamples(&skip);
-    ASSERT_EQ(skip, 100);
+    ASSERT_EQ(skip, 100u);
 
     available = multi.getAvailableCount();
     ASSERT_EQ(available, 346u);
@@ -367,7 +367,7 @@ TEST_F(MultiReaderTest, SignalStartDomainFrom0SkipSamples)
 
     skip = 1000;
     multi.skipSamples(&skip);
-    ASSERT_EQ(skip, 341);
+    ASSERT_EQ(skip, 341u);
 
     available = multi.getAvailableCount();
     ASSERT_EQ(available, 0u);


### PR DESCRIPTION
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] Pull request title reflects its content
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# Description:

On the following link, you can find more info about this issue: [Inline static destructors are called multiple times, once for each cpp including it](https://developercommunity.visualstudio.com/t/inline-static-destructors-are-called-multiple-time/1157794)

I used the suggested workaround.
