### PR TITLE
Use Scheduler in Trigger function block implementation with a temporary workaround

### DIFF
--- a/modules/ref_fb_module/src/trigger_fb_impl.cpp
+++ b/modules/ref_fb_module/src/trigger_fb_impl.cpp
@@ -202,7 +202,7 @@ void TriggerFbImpl::processDataPacket(const DataPacketPtr& packet)
 void TriggerFbImpl::createInputPorts()
 {
     // TODO SameThread vs Scheduler
-    inputPort = createAndAddInputPort("input", PacketReadyNotification::SameThread);
+    inputPort = createAndAddInputPort("input", PacketReadyNotification::Scheduler);
 }
 
 void TriggerFbImpl::createSignals()

--- a/modules/ref_fb_module/tests/test_fb_trigger.cpp
+++ b/modules/ref_fb_module/tests/test_fb_trigger.cpp
@@ -48,6 +48,9 @@ public:
         createFunctionBlock();
         sendPacketsAndChangeThreshold();
         receivePacketsAndCheck();
+
+        // TODO Temporay fix so PacketReadyNotification::Scheduler works
+        context.getScheduler().stop();
     }
 
 private:


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Description:
Use PacketReadyNotification::Scheduler instead of PacketReadyNotification::SameThread but also stop the Scheduler as a temporary fix in Trigger function block implementation.