### PR TITLE
Add option to multi reader to start reading on the full unit of the domain

### DIFF
--- a/core/opendaq/reader/include/opendaq/multi_reader.h
+++ b/core/opendaq/reader/include/opendaq/multi_reader.h
@@ -144,6 +144,15 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
 )
 
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, MultiReaderEx, IMultiReader,
+    IList*, signals,
+    SampleType, valueReadType,
+    SampleType, domainReadType,
+    ReadMode, mode,
+    ReadTimeoutType, timeoutType,
+    bool, startOnFullUnitOfDomain)
+
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, MultiReaderFromExisting, IMultiReader,
     IMultiReader*, invalidatedReader,
     SampleType, valueReadType,

--- a/core/opendaq/reader/include/opendaq/multi_reader_impl.h
+++ b/core/opendaq/reader/include/opendaq/multi_reader_impl.h
@@ -28,7 +28,8 @@ public:
                     SampleType valueReadType,
                     SampleType domainReadType,
                     ReadMode mode,
-                    ReadTimeoutType timeoutType);
+                    ReadTimeoutType timeoutType,
+                    bool startOnFullUnitOfDomain = false);
 
     MultiReaderImpl(MultiReaderImpl* old,
                     SampleType valueReadType,
@@ -119,6 +120,8 @@ private:
     std::vector<SignalReader> signals;
 
     LoggerComponentPtr loggerComponent;
+
+    bool startOnFullUnitOfDomain;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/include/opendaq/multi_typed_reader.h
+++ b/core/opendaq/reader/include/opendaq/multi_typed_reader.h
@@ -66,6 +66,8 @@ public:
 
     virtual void getValue(void* start) const noexcept = 0;
 
+    virtual void roundUpOnUnitOfDomain() = 0;
+
 #if !defined(NDEBUG)
     virtual void print(std::ostream& os) const = 0;
     virtual std::string asTime() const = 0;
@@ -134,6 +136,18 @@ public:
         }
     }
 
+    void roundUpOnUnitOfDomain() override
+    {
+        const auto den = info.resolution.getDenominator() * info.multiplier.getNumerator();
+        const auto num = info.resolution.getNumerator() * info.multiplier.getDenominator();
+
+        if (den % num != 0)
+            throw NotSupportedException("Resolution must be aligned on full unit of domain");
+
+        value = (((value * num + den - 1) / den) * den) / num;
+    }
+
+
 #if !defined(NDEBUG)
     void print(std::ostream& os) const override
     {
@@ -198,6 +212,12 @@ public:
         throw NotSupportedException();
     }
 
+    void roundUpOnUnitOfDomain() override
+    {
+        throw NotSupportedException();
+    };
+
+
 #if !defined(NDEBUG)
     void print(std::ostream& os) const override
     {
@@ -235,6 +255,11 @@ public:
     {
         throw NotSupportedException();
     }
+
+    void roundUpOnUnitOfDomain() override
+    {
+        throw NotSupportedException();
+    };
 
 #if !defined(NDEBUG)
     void print(std::ostream& os) const override
@@ -285,6 +310,12 @@ public:
     {
         return value;
     }
+
+    void roundUpOnUnitOfDomain() override
+    {
+        throw NotSupportedException();
+    };
+
 
 #if !defined(NDEBUG)
     virtual void print(std::ostream& os) const override

--- a/core/opendaq/reader/include/opendaq/reader_factory.h
+++ b/core/opendaq/reader/include/opendaq/reader_factory.h
@@ -278,6 +278,16 @@ inline MultiReaderPtr MultiReader(const ListPtr<ISignal>& signals,
     return MultiReader_Create(signals, valueReadType, domainReadType, mode, timeoutType);
 }
 
+inline MultiReaderPtr MultiReaderEx(const ListPtr<ISignal>& signals,
+                                    SampleType valueReadType,
+                                    SampleType domainReadType,
+                                    ReadMode mode = ReadMode::Scaled,
+                                    ReadTimeoutType timeoutType = ReadTimeoutType::All,
+                                    bool startOnFullUnitOfDomain = false)
+{
+    return MultiReaderEx_Create(signals, valueReadType, domainReadType, mode, timeoutType, startOnFullUnitOfDomain);
+}
+
 inline MultiReaderPtr MultiReaderFromExisting(const MultiReaderPtr& invalidatedReader, SampleType valueReadType, SampleType domainReadType)
 {
     return MultiReaderFromExisting_Create(invalidatedReader, valueReadType, domainReadType);
@@ -293,6 +303,13 @@ MultiReaderPtr MultiReader(ListPtr<ISignal> signals, ReadTimeoutType timeoutType
         ReadMode::Scaled,
         timeoutType
     );
+}
+
+template <typename TValueType = double, typename TDomainType = ClockTick>
+MultiReaderPtr MultiReaderEx(ListPtr<ISignal> signals, ReadTimeoutType timeoutType = ReadTimeoutType::All, bool startOnFullUnitOfDomain = false)
+{
+    return MultiReaderEx(
+        signals, SampleTypeFromType<TValueType>::SampleType, SampleTypeFromType<TDomainType>::SampleType, ReadMode::Scaled, timeoutType, startOnFullUnitOfDomain);
 }
 
 template <typename TValueType = double, typename TDomainType = ClockTick>


### PR DESCRIPTION
At some point, there will be too many factories and their parameters. We should rework the multi-reader either to accept a single object that consists of many parameters, i.e., IMultiReaderCreateParams, or even better to make a builder pattern of multi-reader construction.