### PR TITLE
Eval value parser simplification

### DIFF
--- a/core/coreobjects/include/coreobjects/eval_value_parser.h
+++ b/core/coreobjects/include/coreobjects/eval_value_parser.h
@@ -49,18 +49,8 @@ class EvalValueParser
         Right,
     };
 
-    typedef std::unique_ptr<daq::BaseNode>(EvalValueParser::*InfixParselet)(EvalValueToken /*token*/, std::unique_ptr<daq::BaseNode> /*left*/, Associativity /*associativity*/, int /*parseletPrecedence*/);
-    typedef std::unique_ptr<daq::BaseNode>(EvalValueParser::*PrefixParselet)(EvalValueToken /*token*/, int /*parseletPrecedence*/);
-
-    struct PrefixParseletWithPrecedence
+    struct ParseletDetails
     {
-        PrefixParselet parse;
-        int precedence;
-    };
-
-    struct InfixParseletWithPrecedence
-    {
-        InfixParselet parse;
         int precedence;
         Associativity associativity;
     };
@@ -109,8 +99,8 @@ private:
     std::unique_ptr<daq::BaseNode> valref();
     std::unique_ptr<daq::BaseNode> propref();
 
-    void registerInfix(EvalValueToken::Type tokenType, InfixParselet parselet, int precedence, Associativity associativity = Associativity::Left);
-    void registerPrefix(EvalValueToken::Type tokenType, PrefixParselet parselet, int precedence = OperatorPrecedence::Prefix);
+    void registerInfix(EvalValueToken::Type tokenType, int precedence, Associativity associativity = Associativity::Left);
+    void registerPrefix(EvalValueToken::Type tokenType, int precedence = OperatorPrecedence::Prefix);
 
     int nextTokenPrecedence() const;
     bool isAt(EvalValueToken::Type tokenType) const;
@@ -121,8 +111,8 @@ private:
     EvalValueToken advance();
     EvalValueToken peek() const;
 
-    std::unordered_map<EvalValueToken::Type, PrefixParseletWithPrecedence> prefixParselets;
-    std::unordered_map<EvalValueToken::Type, InfixParseletWithPrecedence> infixParselets;
+    std::unordered_map<EvalValueToken::Type, ParseletDetails> prefixParselets;
+    std::unordered_map<EvalValueToken::Type, ParseletDetails> infixParselets;
 
     std::vector<EvalValueToken> tokens;
     std::unordered_set<std::string> propertyReferences;

--- a/core/coreobjects/src/eval_value_parser.cpp
+++ b/core/coreobjects/src/eval_value_parser.cpp
@@ -242,8 +242,9 @@ std::unique_ptr<daq::BaseNode> EvalValueParser::prefix(const EvalValueToken& tok
                 node->onResolveReference = params->onResolveReference;
                 return node;
             }
+        default:
+            throw daq::ParseFailedException("syntax error");
     }
-    throw daq::ParseFailedException("syntax error");
 }
 
 std::unique_ptr<daq::BaseNode> EvalValueParser::valref()

--- a/core/coreobjects/tests/test_evalvalue.cpp
+++ b/core/coreobjects/tests/test_evalvalue.cpp
@@ -103,6 +103,9 @@ TEST_F(EvalValueTest, TestPrecedence)
 
     r = EvalValue("1 * 2 + 3");
     ASSERT_EQ(r, 5LL);
+
+    Bool b = EvalValue("1 * 2 == 3 + -1");
+    ASSERT_EQ(b, True);
 }
 
 TEST_F(EvalValueTest, TestAssociativity)
@@ -472,6 +475,10 @@ TEST_F(EvalValueTest, UnaryMinus)
     a = EvalValue("-3 + -2");
 
     ASSERT_EQ(a, -5);
+
+    a = EvalValue("--3---4");
+
+    ASSERT_EQ(a, -1);
 }
 
 TEST_F(EvalValueTest, UnaryMinusFloat)

--- a/core/coreobjects/tests/test_evalvalue.cpp
+++ b/core/coreobjects/tests/test_evalvalue.cpp
@@ -112,6 +112,9 @@ TEST_F(EvalValueTest, TestAssociativity)
 
     r = EvalValue("16 / 4 / 2");
     ASSERT_EQ(r, 2LL);
+
+    Bool b = EvalValue("3 == -3 == False");
+    ASSERT_EQ(b, True);
 }
 
 TEST_F(EvalValueTest, IntResultConversion)

--- a/core/coreobjects/tests/test_evalvalue.cpp
+++ b/core/coreobjects/tests/test_evalvalue.cpp
@@ -105,6 +105,15 @@ TEST_F(EvalValueTest, TestPrecedence)
     ASSERT_EQ(r, 5LL);
 }
 
+TEST_F(EvalValueTest, TestAssociativity)
+{
+    Int r = EvalValue("6 - 3 - 1");
+    ASSERT_EQ(r, 2LL);
+
+    r = EvalValue("16 / 4 / 2");
+    ASSERT_EQ(r, 2LL);
+}
+
 TEST_F(EvalValueTest, IntResultConversion)
 {
     Float r1 = EvalValue("1 + 1");
@@ -456,6 +465,10 @@ TEST_F(EvalValueTest, UnaryMinus)
     int a = EvalValue("-1");
 
     ASSERT_EQ(a, -1);
+
+    a = EvalValue("-3 + -2");
+
+    ASSERT_EQ(a, -5);
 }
 
 TEST_F(EvalValueTest, UnaryMinusFloat)


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

# Checklist:

- [ ] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

This replaces the majority of recursive descend parsing with
Pratt parser, simplifying much of the code. The EvalValue
consists of only expressions, so we don't need most of the
recursive descent stuff.