### PR TITLE
Apply properties on update end in order

### DIFF
--- a/core/coreobjects/tests/amplifier_test.cpp
+++ b/core/coreobjects/tests/amplifier_test.cpp
@@ -753,3 +753,26 @@ TEST_F(STGAmplifierTest, GetRefPropSelectionValuesAfterChange)
     ampl.setPropertyValue("Measurement", 1);
     ASSERT_EQ(rangeProp.getSelectionValues(), bridgeRangeValues);
 }
+
+TEST_F(STGAmplifierTest, TestBeginEndUpdateOrder)
+{
+    auto ampl = PropertyObject(objManager, "StgAmp");
+
+    ampl.beginUpdate();
+    ampl.setPropertyValue("Measurement", 3);
+    ampl.setPropertyValue("InputType", 3);
+    ampl.setPropertyValue("Measurement", 2);
+    ampl.setPropertyValue("Range", 2);
+    ampl.setPropertyValue("Measurement", 1);
+    ampl.setPropertyValue("Range", 1);
+    ampl.setPropertyValue("Range", 1);
+    ampl.setPropertyValue("Range", 1);
+    ampl.setPropertyValue("Measurement", 0);
+    ampl.setPropertyValue("InputType", 0);
+    ampl.endUpdate();
+
+    ASSERT_EQ(ampl.getPropertyValue("TemperatureInputType"), 3);
+    ASSERT_EQ(ampl.getPropertyValue("ResistanceRange"), 2);
+    ASSERT_EQ(ampl.getPropertyValue("BridgeRange"), 1);
+    ASSERT_EQ(ampl.getPropertyValue("VoltageInputType"), 0);
+}


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

Setting property while an object was being updated performed all validation/coercion/binding operations and stored the evaluated value in a list of values to be written on `endUpdate`. This did not take into account that a value change can impact future write operations done during the update.

This bugfix moves the validation/coercion/binding to the `endUpdate` call where the instead of simply storing the new value into the local value map, `setPropertyValue` is called.
