### PR TITLE
Fix first call of TmsClientDevice::GetTickSinceOrigin

### DIFF
--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_device_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_device_impl.h
@@ -68,7 +68,7 @@ private:
 
     bool timeDomainFetched = false;
     RatioPtr resolution;
-    SizeT ticksSinceOrigin;
+    SizeT ticksSinceOrigin{};
     StringPtr origin;
     UnitPtr domainUnit;
     LoggerPtr logger;

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_device_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_device_impl.cpp
@@ -205,6 +205,9 @@ void TmsClientDeviceImpl::fetchTimeDomain()
                           ConvertToDaqCoreString(deviceDomain->unit.quantity));
     else
         domainUnit = Unit("");
+
+    ticksSinceOrigin = deviceDomain->ticksSinceOrigin;
+
     timeDomainFetched = true;
 }
 

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
@@ -218,6 +218,22 @@ TEST_F(TmsDeviceTest, DeviceInfo)
     ASSERT_EQ(clientDeviceInfo.getPropertyValue("custom_int"), 1);
 }
 
+TEST_F(TmsDeviceTest, DeviceGetTicksSinceOrigin)
+{
+    auto ctx = NullContext();
+    DevicePtr serverDevice = createDevice();
+
+    auto serverTmsDevice = TmsServerDevice(serverDevice, this->getServer(), ctx, serverContext);
+    auto nodeId = serverTmsDevice.registerOpcUaNode();
+
+    auto clientDevice = TmsClientRootDevice(ctx, nullptr, "dev", clientContext, nodeId, nullptr);
+    auto clientSubDevices = clientDevice.getDevices();
+    auto clientSubDevice = clientSubDevices[1];
+
+    auto ticksSinceOrigin = clientSubDevice.asPtr<IDeviceDomain>(true).getTicksSinceOrigin();
+    ASSERT_EQ(ticksSinceOrigin, 789);
+}
+
 TEST_F(TmsDeviceTest, DeviceDomain)
 {
     auto ctx = NullContext();


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

Fix for TmsClientDevice::GetTicksSinceOrigin if the domain is not fetched yet.