### PR TITLE
Added .NET Bindings generation flag to cmake preset "package"

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -115,6 +115,7 @@
                 "OPENDAQ_ENABLE_TESTS": false,
                 "OPENDAQ_ALWAYS_FETCH_BOOST": false,
                 "OPENDAQ_GENERATE_PYTHON_BINDINGS": false,
+                "OPENDAQ_GENERATE_CSHARP_BINDINGS": false,
                 "DAQMODULES_REF_DEVICE_MODULE": true,
                 "DAQMODULES_REF_FB_MODULE": true,
                 "DAQMODULES_AUDIO_DEVICE_MODULE": false,
@@ -132,6 +133,7 @@
             "cacheVariables": {
                 "OPENDAQ_ENABLE_TESTS": false,
                 "OPENDAQ_GENERATE_PYTHON_BINDINGS": true,
+                "OPENDAQ_GENERATE_CSHARP_BINDINGS": true,
                 "DAQMODULES_REF_DEVICE_MODULE": true,
                 "DAQMODULES_REF_FB_MODULE": true,
                 "DAQMODULES_AUDIO_DEVICE_MODULE": true,


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

Just missed to add `"OPENDAQ_GENERATE_CSHARP_BINDINGS": true,` to the "package" preset so that the .NET Bindings will be generated in `deploy.yml`.