### PR TITLE
Reuse existing device info transfered via native protocol

### DIFF
--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -83,9 +83,6 @@ public:
                               const StringPtr& localId);
     ~NativeDeviceImpl() override;
 
-    // IDevice
-    ErrCode INTERFACE_FUNC getInfo(IDeviceInfo** info) override;
-
     // INativeDevicePrivate
     void INTERFACE_FUNC attachDeviceHelper(std::unique_ptr<NativeDeviceHelper> deviceHelper) override;
     void INTERFACE_FUNC setConnectionString(const StringPtr& connectionString) override;
@@ -94,8 +91,8 @@ public:
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 
 private:
-    DeviceInfoConfigPtr deviceInfo;
     std::unique_ptr<NativeDeviceHelper> deviceHelper;
+    bool deviceInfoSet;
 };
 
 END_NAMESPACE_OPENDAQ_NATIVE_STREAMING_CLIENT_MODULE

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -120,9 +120,14 @@ TEST_F(NativeDeviceModulesTest, DeviceInfo)
     auto client = CreateClientInstance();
 
     auto info = client.getDevices()[0].getInfo();
+    auto subDeviceInfo = client.getDevices()[0].getDevices()[0].getInfo();
 
     ASSERT_TRUE(info.assigned());
     ASSERT_EQ(info.getConnectionString(), "daq.nd://127.0.0.1");
+    ASSERT_EQ(subDeviceInfo.getName(), "Device 0");
+    ASSERT_EQ(subDeviceInfo.getConnectionString(), "daqref://device0");
+    ASSERT_EQ(subDeviceInfo.getModel(), "Reference Device");
+    ASSERT_EQ(subDeviceInfo.getSerialNumber(), "dev_ser_0");
 }
 
 TEST_F(NativeDeviceModulesTest, ChannelProps)


### PR DESCRIPTION
Device info is now a field in common DeviceImpl and is deserialized in native configuration protocol. Connection string is overriden.