### PR TITLE
Swap EvalValue precedence for logic and equality operators

### DIFF
--- a/core/coreobjects/include/coreobjects/eval_value_parser.h
+++ b/core/coreobjects/include/coreobjects/eval_value_parser.h
@@ -36,8 +36,8 @@ class EvalValueParser
     enum OperatorPrecedence
     {
         MinPrecedence = 0,
-        Equality,
         Logic,
+        Equality,
         Term,
         Factor,
         Prefix,
@@ -59,8 +59,8 @@ public:
     EvalValueParser(const std::vector<EvalValueToken>& aTokens, ParseParams* aParams);
 
     // [precedences]
-    //   equality: "==" | "!=" | "<" | "<=" | ">" | ">="
     //   logic:    "||" | "&&"
+    //   equality: "==" | "!=" | "<" | "<=" | ">" | ">="
     //   term:     "+" | "-"
     //   factor:   "*" | "/"
     //   prefix:   "!" | "-" (unary)
@@ -68,7 +68,7 @@ public:
     // [grammar]
     // parse      : expression
     // expression : infix
-    // infix      : prefix ( ( "==" | "!=" | "<" | "<=" | ">" | ">="  |  "||" | "&&"  |  "+" | "-"  |  "*" | "/" ) prefix )*
+    // infix      : prefix ( ("||" | "&&" | "==" | "!=" | "<" | "<=" | ">" | ">=" | "+" | "-" | "*" | "/" ) prefix )*
     // prefix     : FLOATVALUE
     //            | INTVALUE
     //            | BOOLVALUE

--- a/core/coreobjects/tests/test_evalvalue.cpp
+++ b/core/coreobjects/tests/test_evalvalue.cpp
@@ -118,6 +118,18 @@ TEST_F(EvalValueTest, TestAssociativity)
 
     Bool b = EvalValue("3 == -3 == False");
     ASSERT_EQ(b, True);
+    
+    b = EvalValue("1 > 0 && 2 > 1");
+    ASSERT_EQ(b, True);
+
+    b = EvalValue("1 > 2 && 2 > 1");
+    ASSERT_EQ(b, False);
+
+    b = EvalValue("1 > 2 || 2 > 1");
+    ASSERT_EQ(b, True);
+
+    b = EvalValue("1 > 2 || 2 > 3");
+    ASSERT_EQ(b, False);
 }
 
 TEST_F(EvalValueTest, IntResultConversion)


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
Now that I had a chance to play with EvalValue a bit more in real-life examples, I think
it makes a lot more sense for logical or & and operators to have precedence lower than
(in)equality checking. This allows for more "natural" (i.e. c-like) expressions: 
`$value == 1 || $value > 3` with this patch parses as `($value == 1) || ($value > 3)` 
instead of `$value == (1 || $value) > 3` as it would before.