### PR TITLE
Other/various fixes

### DIFF
--- a/core/coreobjects/tests/test_property_object_class.cpp
+++ b/core/coreobjects/tests/test_property_object_class.cpp
@@ -175,3 +175,41 @@ TEST_F(PropertyObjectClassTest, PropertyObjectClassCreateFactory)
     ASSERT_EQ(propertyObjectClass.getParentName(), "PropertyObjectClassParent");
     ASSERT_EQ(propertyObjectClass.getProperties(false), List<IProperty>(properties["Test"]));
 }
+
+TEST_F(PropertyObjectClassTest, Deserialize)
+{
+    auto serializer = JsonSerializer();
+    propObjClass.serialize(serializer);
+    const auto str = serializer.getOutput();
+
+    const auto deserializer = JsonDeserializer();
+    const PropertyObjectClassPtr newPropObjClass = deserializer.deserialize(str);
+
+    serializer.reset();
+    newPropObjClass.serialize(serializer);
+    const auto newStr = serializer.getOutput();
+
+    ASSERT_EQ(str, newStr);
+}
+
+TEST_F(PropertyObjectClassTest, DeserializeWithParent)
+{
+    const auto childPropObjClassBuilder = PropertyObjectClassBuilder("ChildPropertyObject")
+                                              .setParentName("PropertyObject")
+                                              .addProperty(StringPropertyBuilder("ChildProp", "").build());
+
+    const auto childPropObjClass = childPropObjClassBuilder.build();
+
+    auto serializer = JsonSerializer();
+    childPropObjClass.serialize(serializer);
+    const auto str = serializer.getOutput();
+
+    const auto deserializer = JsonDeserializer();
+    const PropertyObjectClassPtr newPropObjClass = deserializer.deserialize(str);
+
+    serializer.reset();
+    newPropObjClass.serialize(serializer);
+    const auto newStr = serializer.getOutput();
+
+    ASSERT_EQ(str, newStr);
+}

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1186,7 +1186,7 @@ void GenericDevice<TInterface, Interfaces...>::deserializeCustomObjectValues(con
     this->template deserializeDefaultFolder<IComponent>(serializedObject, context, factoryCallback, ioFolder, "IO");
     this->template deserializeDefaultFolder<IDevice>(serializedObject, context, factoryCallback, devices, "Dev");
 
-    const std::set<std::string> ignoredKeys{"__type", "deviceInfo", "deviceDomain", "deviceUnit", "deviceResolution"};
+    const std::set<std::string> ignoredKeys{"__type", "deviceInfo", "deviceDomain", "deviceUnit", "deviceResolution", "properties", "propValues"};
 
     const auto keys = serializedObject.getKeys();
     for (const auto& key : serializedObject.getKeys())

--- a/core/opendaq/functionblock/tests/test_function_block.cpp
+++ b/core/opendaq/functionblock/tests/test_function_block.cpp
@@ -6,6 +6,7 @@
 #include <opendaq/component_deserialize_context_factory.h>
 #include <opendaq/input_port_config_ptr.h>
 #include <opendaq/tags_private_ptr.h>
+#include <coreobjects/property_object_class_factory.h>
 
 using FunctionBlockTest = testing::Test;
 
@@ -79,15 +80,15 @@ TEST_F(FunctionBlockTest, HasItem)
 class MockFbImpl final : public daq::FunctionBlock
 {
 public:
-    MockFbImpl(const daq::ContextPtr& ctx, const daq::ComponentPtr& parent, const daq::StringPtr& localId, bool nested)
-        : daq::FunctionBlock(daq::FunctionBlockType("test_uid", "test_name", "test_description"), ctx, parent, localId)
+    MockFbImpl(const daq::ContextPtr& ctx, const daq::ComponentPtr& parent, const daq::StringPtr& localId, const daq::StringPtr& className, bool nested)
+        : daq::FunctionBlock(daq::FunctionBlockType("test_uid", "test_name", "test_description"), ctx, parent, localId, className)
     {
         createAndAddSignal("sig1");
         createAndAddInputPort("ip1", daq::PacketReadyNotification::None);
         if (!nested)
         {
             const auto nestedFb =
-                daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl>(ctx, this->functionBlocks, "nestedFb", true);
+                daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl>(ctx, this->functionBlocks, "nestedFb", className, true);
             addNestedFunctionBlock(nestedFb);
         }
     }
@@ -95,7 +96,7 @@ public:
 
 TEST_F(FunctionBlockTest, SerializeAndDeserialize)
 {
-    const auto fb = daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl>(daq::NullContext(), nullptr, "fb", false);
+    const auto fb = daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl>(daq::NullContext(), nullptr, "fb", nullptr, false);
     fb.setName("fb_name");
     fb.setDescription("fb_desc");
     fb.getTags().asPtr<daq::ITagsPrivate>().add("fld_tag");
@@ -125,10 +126,49 @@ TEST_F(FunctionBlockTest, SerializeAndDeserialize)
     ASSERT_EQ(str1, str2);
 }
 
+TEST_F(FunctionBlockTest, SerializeAndDeserializeWithClassName)
+{
+    const auto ctx = daq::NullContext();
+
+    const auto fbClass =
+        daq::PropertyObjectClassBuilder("FBClass").addProperty(daq::StringPropertyBuilder("StringProp", "-").build()).build();
+
+    ctx.getTypeManager().addType(fbClass);
+
+    const auto fb = daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl>(ctx, nullptr, "fb", "FBClass", false);
+    fb.setName("fb_name");
+    fb.setDescription("fb_desc");
+    fb.getTags().asPtr<daq::ITagsPrivate>().add("fld_tag");
+    fb.setPropertyValue("StringProp", "Value");
+
+    const auto serializer = daq::JsonSerializer(daq::True);
+    fb.serialize(serializer);
+    const auto str1 = serializer.getOutput();
+
+    const auto deserializer = daq::JsonDeserializer();
+
+    const auto deserializeContext = daq::ComponentDeserializeContext(ctx, nullptr, nullptr, "fb");
+
+    const daq::FunctionBlockPtr newFb = deserializer.deserialize(str1, deserializeContext, nullptr);
+
+    ASSERT_EQ(newFb.getName(), fb.getName());
+    ASSERT_EQ(newFb.getDescription(), fb.getDescription());
+    ASSERT_EQ(newFb.getTags(), fb.getTags());
+
+    ASSERT_EQ(newFb.getSignals().getElementInterfaceId(), daq::ISignal::Id);
+    ASSERT_EQ(newFb.getInputPorts().getElementInterfaceId(), daq::IInputPort::Id);
+    ASSERT_EQ(newFb.getFunctionBlocks().getElementInterfaceId(), daq::IFunctionBlock::Id);
+
+    const auto serializer2 = daq::JsonSerializer(daq::True);
+    newFb.serialize(serializer2);
+    const auto str2 = serializer2.getOutput();
+
+    ASSERT_EQ(str1, str2);
+}
 
 TEST_F(FunctionBlockTest, BeginUpdateEndUpdate)
 {
-    const auto fb = daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl>(daq::NullContext(), nullptr, "fb", false);
+    const auto fb = daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl>(daq::NullContext(), nullptr, "fb", nullptr, false);
     fb.addProperty(daq::StringPropertyBuilder("FbProp", "-").build());
 
     const auto sig = fb.getSignals()[0];

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_channel_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_channel_impl.h
@@ -42,7 +42,7 @@ inline ConfigClientChannelImpl::ConfigClientChannelImpl(const ConfigProtocolClie
                                                         const ContextPtr& ctx,
                                                         const ComponentPtr& parent,
                                                         const StringPtr& localId)
-    : Super(configProtocolClientComm, remoteGlobalId, type, ctx, parent, localId)
+    : Super(configProtocolClientComm, remoteGlobalId, type, ctx, parent, localId, nullptr)
 {
 }
 

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -98,7 +98,7 @@ ErrCode ConfigClientComponentBaseImpl<Impl>::getName(IString** name)
 template <class Impl>
 ErrCode ConfigClientComponentBaseImpl<Impl>::setName(IString* name)
 {
-    return OPENDAQ_ERR_INVALID_OPERATION;
+    return daqTry([this, &name] { this->clientComm->setAttributeValue(this->remoteGlobalId, "Name", name); });
 }
 
 template <class Impl>
@@ -110,7 +110,7 @@ ErrCode ConfigClientComponentBaseImpl<Impl>::getDescription(IString** descriptio
 template <class Impl>
 ErrCode ConfigClientComponentBaseImpl<Impl>::setDescription(IString* description)
 {
-    return OPENDAQ_ERR_INVALID_OPERATION;
+    return daqTry([this, &description] { this->clientComm->setAttributeValue(this->remoteGlobalId, "Description", description); });
 }
 
 template <class Impl>

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_function_block_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_function_block_impl.h
@@ -37,7 +37,8 @@ public:
                                       const FunctionBlockTypePtr& functionBlockType,
                                       const ContextPtr& ctx,
                                       const ComponentPtr& parent,
-                                      const StringPtr& localId);
+                                      const StringPtr& localId,
+                                      const StringPtr& className);
 
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 };
@@ -49,8 +50,9 @@ ConfigClientBaseFunctionBlockImpl<Impl>::ConfigClientBaseFunctionBlockImpl(
     const FunctionBlockTypePtr& type,
     const ContextPtr& ctx,
     const ComponentPtr& parent,
-    const StringPtr& localId)
-    : ConfigClientComponentBaseImpl<Impl>(configProtocolClientComm, remoteGlobalId, type, ctx, parent, localId)
+    const StringPtr& localId,
+    const StringPtr& className)
+    : ConfigClientComponentBaseImpl<Impl>(configProtocolClientComm, remoteGlobalId, type, ctx, parent, localId, className)
 {
 }
 
@@ -85,7 +87,8 @@ ErrCode ConfigClientBaseFunctionBlockImpl<Impl>::Deserialize(ISerializedObject* 
                                 fbType,
                                 deserializeContext.getContext(),
                                 deserializeContext.getParent(),
-                                deserializeContext.getLocalId());
+                                deserializeContext.getLocalId(),
+                                className);
                        })
                        .detach();
         });

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -51,6 +51,7 @@ public:
     BaseObjectPtr getPropertyValue(const std::string& globalId, const std::string& propertyName);
     void clearPropertyValue(const std::string& globalId, const std::string& propertyName);
     BaseObjectPtr callProperty(const std::string& globalId, const std::string& propertyName, const BaseObjectPtr& params);
+    void setAttributeValue(const std::string& globalId, const std::string& attributeName, const BaseObjectPtr& attributeValue);
 
     bool getConnected() const;
     ContextPtr getDaqContext();

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -211,9 +211,10 @@ DevicePtr ConfigProtocolClient<TRootDeviceImpl>::connect(const ComponentPtr& par
         const auto type = typeManager.getType(typeName);
         if (localTypeManager.hasType(type.getName()))
         {
-            const auto localType = localTypeManager.getType(type.getName());
+            // TODO: implement type comparison/equalTo for property object classes
+/*            const auto localType = localTypeManager.getType(type.getName());
             if (localType != type)
-                throw InvalidValueException("Remote type different than local");
+                throw InvalidValueException("Remote type different than local");*/
             continue;
         }
 

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
@@ -31,6 +31,7 @@ public:
     static BaseObjectPtr callProperty(const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr beginUpdate(const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr endUpdate(const ComponentPtr& component, const ParamsDictPtr& params);
+    static BaseObjectPtr setAttributeValue(const ComponentPtr& component, const ParamsDictPtr& params);
 };
 
 inline BaseObjectPtr ConfigServerComponent::getPropertyValue(const ComponentPtr& component, const ParamsDictPtr& params)
@@ -107,6 +108,21 @@ inline BaseObjectPtr ConfigServerComponent::beginUpdate(const ComponentPtr& comp
 inline BaseObjectPtr ConfigServerComponent::endUpdate(const ComponentPtr& component, const ParamsDictPtr& params)
 {
     component.endUpdate();
+    return nullptr;
+}
+
+inline BaseObjectPtr ConfigServerComponent::setAttributeValue(const ComponentPtr& component, const ParamsDictPtr& params)
+{
+    const auto attributeName = static_cast<std::string>(params["AttributeName"]);
+    const auto attributeValue = static_cast<std::string>(params["AttributeValue"]);
+
+    if (attributeName == "Name")
+        component.setName(attributeValue);
+    else if (attributeName == "Description")
+        component.setDescription(attributeValue);
+    else
+        throw InvalidParameterException("Attribute not available or not supported via native config protocol");
+
     return nullptr;
 }
 

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -103,6 +103,21 @@ BaseObjectPtr ConfigProtocolClientComm::callProperty(const std::string& globalId
     return result;
 }
 
+void ConfigProtocolClientComm::setAttributeValue(const std::string& globalId,
+    const std::string& attributeName,
+    const BaseObjectPtr& attributeValue)
+{
+    auto dict = Dict<IString, IBaseObject>();
+    dict.set("ComponentGlobalId", String(globalId));
+    dict.set("AttributeName", String(attributeName));
+    dict.set("AttributeValue", String(attributeValue));
+    auto setAttributeValueRpcRequestPacketBuffer = createRpcRequestPacketBuffer(generateId(), "SetAttributeValue", dict);
+    const auto setAttributeValueRpcReplyPacketBuffer = sendRequestCallback(setAttributeValueRpcRequestPacketBuffer);
+
+    // ReSharper disable once CppExpressionWithoutSideEffects
+    parseRpcReplyPacketBuffer(setAttributeValueRpcReplyPacketBuffer);
+}
+
 BaseObjectPtr ConfigProtocolClientComm::createRpcRequest(const StringPtr& name, const ParamsDictPtr& params) const
 {
     auto obj = Dict<IString, IBaseObject>();

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -134,6 +134,7 @@ void ConfigProtocolServer::buildRpcDispatchStructure()
     addHandler<ComponentPtr>("CallProperty", &ConfigServerComponent::callProperty);
     addHandler<ComponentPtr>("BeginUpdate", &ConfigServerComponent::beginUpdate);
     addHandler<ComponentPtr>("EndUpdate", &ConfigServerComponent::endUpdate);
+    addHandler<ComponentPtr>("SetAttributeValue", &ConfigServerComponent::setAttributeValue);
 
     addHandler<DevicePtr>("GetInfo", &ConfigServerDevice::getInfo);
     addHandler<DevicePtr>("GetAvailableFunctionBlockTypes", &ConfigServerDevice::getAvailableFunctionBlockTypes);

--- a/shared/libraries/config_protocol/tests/test_config_client_server.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_client_server.cpp
@@ -363,3 +363,28 @@ TEST_F(ConfigProtocolTest, BeginEndUpdate)
     client->getClientComm()->sendComponentCommand("//root", "EndUpdate");
     ASSERT_EQ(device->getPropertyValue("PropName"), "val");
 }
+
+TEST_F(ConfigProtocolTest, SetNameAndDescriptionAttribute)
+{
+    StringPtr deviceName;
+    StringPtr deviceDescription;
+
+    EXPECT_CALL(device.mock(), setName(_)).WillOnce([&](IString* name)
+    {
+        deviceName = name;
+        return OPENDAQ_SUCCESS;
+    });
+
+    EXPECT_CALL(device.mock(), setDescription(_))
+        .WillOnce(
+            [&](IString* description)
+            {
+                deviceDescription = description;
+                return OPENDAQ_SUCCESS;
+            });
+
+    client->getClientComm()->setAttributeValue("//root", "Name", "devName");
+    ASSERT_EQ(deviceName, "devName");
+    client->getClientComm()->setAttributeValue("//root", "Description", "devDescription");
+    ASSERT_EQ(deviceDescription, "devDescription");
+}

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -401,3 +401,25 @@ TEST_F(ConfigProtocolIntegrationTest, BeginEndUpdateRecursive)
     ASSERT_EQ(clientDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");
     ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");
 }
+
+TEST_F(ConfigProtocolIntegrationTest, SetSignalNameAndDescriptionFromClient)
+{
+    const auto serverSignal = serverDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts()[0].getSignal();
+    const auto clientSignal = clientDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts()[0].getSignal();
+
+    clientSignal.setName("SigName");
+
+    ASSERT_EQ(clientSignal.getName(), "SigName");
+    ASSERT_EQ(serverSignal.getName(), "SigName");
+}
+
+TEST_F(ConfigProtocolIntegrationTest, SetSignalNameAndDescriptionFromServer)
+{
+    const auto serverSignal = serverDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts()[0].getSignal();
+    const auto clientSignal = clientDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts()[0].getSignal();
+
+    serverSignal.setName("SigName");
+
+    ASSERT_EQ(clientSignal.getName(), "SigName");
+    ASSERT_EQ(serverSignal.getName(), "SigName");
+}


### PR DESCRIPTION
- attribute serialization and deserialization implemented (name and desc only)
- type comparison on client and device skipped at the moment
- custom component deserialization is weird at the moment, any attribute added might corrupt deserialization
- property object class deserialization was not handled properly
- for now only function blocks can have property object class assigned (others probably don't make sense)