### PR TITLE
Native config protocol has the wrong packet header size on the armv7l

### DIFF
--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -80,7 +80,7 @@ protected:
 
 private:
     ContextPtr daqContext;
-    size_t id;
+    uint64_t id;
     SendRequestCallback sendRequestCallback;
     ComponentDeserializeCallback rootDeviceDeserializeCallback;
     SerializerPtr serializer;
@@ -96,11 +96,11 @@ private:
                                                             IntfID* intfID);
     BaseObjectPtr createRpcRequest(const StringPtr& name, const ParamsDictPtr& params) const;
     StringPtr createRpcRequestJson(const StringPtr& name, const ParamsDictPtr& params);
-    PacketBuffer createRpcRequestPacketBuffer(size_t id, const StringPtr& name, const ParamsDictPtr& params);
+    PacketBuffer createRpcRequestPacketBuffer(uint64_t id, const StringPtr& name, const ParamsDictPtr& params);
     BaseObjectPtr parseRpcReplyPacketBuffer(const PacketBuffer& packetBuffer,
                                             const ComponentDeserializeContextPtr& context = nullptr,
                                             bool isGetRootDeviceReply = false);
-    size_t generateId();
+    uint64_t generateId();
 
     BaseObjectPtr sendComponentCommandInternal(const StringPtr& command,
                                                const ParamsDictPtr& params,

--- a/shared/libraries/config_protocol/src/config_protocol.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol.cpp
@@ -5,7 +5,7 @@
 namespace daq::config_protocol
 {
 
-PacketBuffer::PacketBuffer(PacketType packetType, size_t id, const void* payload, size_t payloadSize)
+PacketBuffer::PacketBuffer(PacketType packetType, uint64_t id, const void* payload, size_t payloadSize)
     : captured(false)
 {
     buffer = allocateHeaderAndPayload(payloadSize);
@@ -148,12 +148,12 @@ PacketType PacketBuffer::getPacketType() const
     return buffer->type;
 }
 
-void PacketBuffer::setId(size_t id)
+void PacketBuffer::setId(uint64_t id)
 {
     buffer->id = id;
 }
 
-size_t PacketBuffer::getId() const
+uint64_t PacketBuffer::getId() const
 {
     return buffer->id;
 }
@@ -173,13 +173,13 @@ void* PacketBuffer::getPayload() const
     return static_cast<void*>(buffer + 1);
 }
 
-PacketBuffer PacketBuffer::createGetProtocolInfoRequest(size_t id)
+PacketBuffer PacketBuffer::createGetProtocolInfoRequest(uint64_t id)
 {
     auto packetBuffer = PacketBuffer(PacketType::getProtocolInfo, id, nullptr, 0);
     return packetBuffer;
 }
 
-PacketBuffer PacketBuffer::createGetProtocolInfoReply(size_t id, uint16_t currentVersion, const std::vector<uint16_t>& supportedVersions)
+PacketBuffer PacketBuffer::createGetProtocolInfoReply(uint64_t id, uint16_t currentVersion, const std::vector<uint16_t>& supportedVersions)
 {
     const auto payloadSize = sizeof(uint16_t) + sizeof(uint16_t) +
                              supportedVersions.size() * sizeof(uint16_t);
@@ -219,7 +219,7 @@ void PacketBuffer::parseProtocolInfoReply(uint16_t& currentVersion, std::vector<
     std::memcpy(supportedVersions.data(), payload, supportedVersions.size() * sizeof(uint16_t));
 }
 
-PacketBuffer PacketBuffer::createUpgradeProtocolRequest(size_t id, uint16_t version)
+PacketBuffer PacketBuffer::createUpgradeProtocolRequest(uint64_t id, uint16_t version)
 {
     auto packetBuffer = PacketBuffer(PacketType::upgradeProtocol, id, &version, sizeof(uint16_t));
     return packetBuffer;
@@ -236,7 +236,7 @@ void PacketBuffer::parseProtocolUpgradeRequest(uint16_t& version) const
     version = *(static_cast<uint16_t*>(getPayload()));
 }
 
-PacketBuffer PacketBuffer::createUpgradeProtocolReply(size_t id, bool success)
+PacketBuffer PacketBuffer::createUpgradeProtocolReply(uint64_t id, bool success)
 {
     uint8_t success_ = success ? 1 : 0;
     auto packetBuffer = PacketBuffer(PacketType::upgradeProtocol, id, &success_, sizeof(uint8_t));
@@ -254,13 +254,13 @@ void PacketBuffer::parseProtocolUpgradeReply(bool& success) const
     success = *(static_cast<uint8_t*>(getPayload())) != 0 ? true : false;
 }
 
-PacketBuffer PacketBuffer::createRpcRequestOrReply(size_t id, const char* json, size_t jsonSize)
+PacketBuffer PacketBuffer::createRpcRequestOrReply(uint64_t id, const char* json, size_t jsonSize)
 {
     auto packetBuffer = PacketBuffer(PacketType::rpc, id, json, jsonSize);
     return packetBuffer;
 }
 
-PacketBuffer PacketBuffer::createInvalidRequestReply(size_t id)
+PacketBuffer PacketBuffer::createInvalidRequestReply(uint64_t id)
 {
     auto packetBuffer = PacketBuffer(PacketType::invalidRequest, id, nullptr, 0);
     return packetBuffer;
@@ -292,7 +292,7 @@ StringPtr PacketBuffer::parseRpcRequestOrReply() const
 
 PacketBuffer PacketBuffer::createServerNotification(const char* json, size_t jsonSize)
 {
-    auto packetBuffer = PacketBuffer(PacketType::serverNotification, std::numeric_limits<size_t>::max(), json, jsonSize);
+    auto packetBuffer = PacketBuffer(PacketType::serverNotification, std::numeric_limits<uint64_t>::max(), json, jsonSize);
     return packetBuffer;
 }
 

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -24,7 +24,7 @@ ConfigProtocolClientComm::ConfigProtocolClientComm(const ContextPtr& daqContext,
 {
 }
 
-size_t ConfigProtocolClientComm::generateId()
+uint64_t ConfigProtocolClientComm::generateId()
 {
     return id++;
 }
@@ -136,7 +136,7 @@ StringPtr ConfigProtocolClientComm::createRpcRequestJson(const StringPtr& name, 
     return serializer.getOutput();
 }
 
-PacketBuffer ConfigProtocolClientComm::createRpcRequestPacketBuffer(const size_t id,
+PacketBuffer ConfigProtocolClientComm::createRpcRequestPacketBuffer(const uint64_t id,
                                                                     const StringPtr& name,
                                                                     const ParamsDictPtr& params)
 {

--- a/shared/libraries/config_protocol/tests/CMakeLists.txt
+++ b/shared/libraries/config_protocol/tests/CMakeLists.txt
@@ -22,6 +22,10 @@ target_link_libraries(${TEST_APP} PRIVATE
     GTest::GTest GTest::gmock
 )
 
+add_dependencies(${TEST_APP} ${SDK_TARGET_NAMESPACE}::ref_device_module
+                             ${SDK_TARGET_NAMESPACE}::ref_fb_module
+)
+
 set_target_properties(${TEST_APP} PROPERTIES DEBUG_POSTFIX _debug)
 
 add_test(NAME ${TEST_APP}

--- a/shared/libraries/config_protocol/tests/test_config_packet.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_packet.cpp
@@ -165,7 +165,7 @@ TEST_F(ConfigPacketTest, ServerNotification)
 
     const PacketBuffer packetBuffer(packetBufferSource.getBuffer(), false);
 
-    ASSERT_EQ(packetBuffer.getId(), std::numeric_limits<size_t>::max());
+    ASSERT_EQ(packetBuffer.getId(), std::numeric_limits<uint64_t>::max());
     const auto json1 = packetBuffer.parseServerNotification();
 
     ASSERT_EQ(json1, json);


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] Pull request title reflects its content
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# Description:

The packet header size should be the same on all platforms.