### PR TITLE
<TBBAS-1453> Write start domain value only upon signal subscribing in streaming-lt server

### DIFF
--- a/external/streaming_protocol/CMakeLists.txt
+++ b/external/streaming_protocol/CMakeLists.txt
@@ -6,8 +6,8 @@ endif()
 
 opendaq_dependency(
     NAME                streaming_protocol
-    REQUIRED_VERSION    0.10.12
+    REQUIRED_VERSION    0.10.15
     GIT_REPOSITORY      https://github.com/openDAQ/streaming-protocol-lt.git
-    GIT_REF             v0.10.12-1
+    GIT_REF             v0.10.15
     EXPECT_TARGET       daq::streaming_protocol
 )

--- a/shared/libraries/signal_generator/src/signal_generator.cpp
+++ b/shared/libraries/signal_generator/src/signal_generator.cpp
@@ -33,8 +33,9 @@ void SignalGenerator::generateSamplesTo(std::chrono::milliseconds currentTime)
     if (tick == 0)
         calculateAbsStartTick();
 
-    uint64_t currentTick = (double) currentTime.count() / 1000 * outputRate;
-    generatePacket(tick, currentTick - tick);
+    const double msToResolution = (double) resolution.getDenominator() / resolution.getNumerator() / 1000;
+    uint64_t currentTick = (double) currentTime.count() * msToResolution / 1000 * outputRate;
+    generatePacket(tick, (currentTick - tick) / msToResolution);
     tick = currentTick;
 }
 

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/output_signal.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/output_signal.h
@@ -62,6 +62,7 @@ protected:
     SignalStreamPtr stream;
     size_t sampleSize;
     bool subscribed;
+    bool writeStartDomainValue{false};
     std::mutex subscribedSync;
     daq::streaming_protocol::LogCallback logCallback;
 };

--- a/shared/libraries/websocket_streaming/src/output_signal.cpp
+++ b/shared/libraries/websocket_streaming/src/output_signal.cpp
@@ -190,8 +190,13 @@ void OutputSignal::writeEventPacket(const EventPacketPtr& packet)
 void OutputSignal::writeDataPacket(const DataPacketPtr& packet)
 {
     const auto domainPacket = packet.getDomainPacket();
-    if (domainPacket.assigned())
-        stream->setTimeStart(domainPacket.getOffset());
+    if (writeStartDomainValue)
+    {
+        if (domainPacket.assigned())
+            stream->setTimeStart(domainPacket.getOffset());
+
+        writeStartDomainValue = false;
+    }
 
     stream->addData(packet.getRawData(), packet.getSampleCount());
 }
@@ -263,9 +268,14 @@ void OutputSignal::setSubscribed(bool subscribed)
 
         this->subscribed = subscribed;
         if (subscribed)
+        {
             stream->subscribe();
+            writeStartDomainValue = true;
+        }
         else
+        {
             stream->unsubscribe();
+        }
     }
 }
 


### PR DESCRIPTION
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:
Integrates the latest modifications of Streaming-lt library