### PR TITLE
Support getLastValue for structs in core and fix bug in struct builder with tests

### DIFF
--- a/core/coretypes/include/coretypes/struct_builder_ptr.h
+++ b/core/coretypes/include/coretypes/struct_builder_ptr.h
@@ -189,7 +189,7 @@ public:
     }
 
     /*!
-     * @brief Gets the value of a field with the given name.
+     * @brief Sets the value of a field with the given name.
      * @param name The name of the queried field.
      * @param field The value of the field.
      */

--- a/core/opendaq/reader/tests/test_stream_reader.cpp
+++ b/core/opendaq/reader/tests/test_stream_reader.cpp
@@ -864,6 +864,7 @@ protected:
                                         .build();
 
         canMsgDescriptor = DataDescriptorBuilder()
+                                          .setName("Can")
                                           .setSampleType(SampleType::Struct)
                                           .setStructFields(List<IDataDescriptor>(arbIdDescriptor, lengthDescriptor, dataDescriptor))
                                           .build();

--- a/core/opendaq/signal/include/opendaq/binary_data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/binary_data_packet_impl.h
@@ -67,7 +67,7 @@ public:
     ErrCode INTERFACE_FUNC getData(void** address) override;
     ErrCode INTERFACE_FUNC getDataSize(SizeT* dataSize) override;
     ErrCode INTERFACE_FUNC getRawDataSize(SizeT* dataSize) override;
-    ErrCode INTERFACE_FUNC getLastValue(IBaseObject** value) override;
+    ErrCode INTERFACE_FUNC getLastValue(IBaseObject** value, ITypeManager* typeManager = nullptr) override;
 
 private:
     DataPacketPtr domainPacket;
@@ -185,7 +185,7 @@ ErrCode BinaryDataPacketImpl<ExternalMemory>::getRawDataSize(SizeT* rawDataSize)
 }
 
 template <bool ExternalMemory>
-inline ErrCode INTERFACE_FUNC BinaryDataPacketImpl<ExternalMemory>::getLastValue(IBaseObject** value)
+inline ErrCode INTERFACE_FUNC BinaryDataPacketImpl<ExternalMemory>::getLastValue(IBaseObject** value, ITypeManager* typeManager)
 {
     OPENDAQ_PARAM_NOT_NULL(value);
 

--- a/core/opendaq/signal/include/opendaq/data_packet.h
+++ b/core/opendaq/signal/include/opendaq/data_packet.h
@@ -18,6 +18,7 @@
 #include <opendaq/packet.h>
 #include <opendaq/data_descriptor.h>
 #include <coretypes/number.h>
+#include <coretypes/type_manager.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -26,6 +27,7 @@ BEGIN_NAMESPACE_OPENDAQ
  * [interfaceSmartPtr(IDataPacket, GenericDataPacketPtr)]
  * [interfaceSmartPtr(IPacket, GenericPacketPtr)]
  * [interfaceLibrary(INumber, CoreTypes)]
+ * [interfaceLibrary(ITypeManager, CoreTypes)]
  */
 
 /*!
@@ -123,11 +125,13 @@ DECLARE_OPENDAQ_INTERFACE(IDataPacket, IPacket)
     /*!
      * @brief Gets the data packet last value
      * @param[out] value The IBaseObject value can be a nullptr if there is no value, or if the data type is not supported by the function.
+     * @param typeManager Optional ITypeManager value can be provided to enable getLastValue for IStruct.
+     *
      * If a value is assigned, it can be cast based on the signal description to IFloat if the type is Float32 or Float64,
      * to IInteger if the type is Int8 through Int64 or UInt8 through UInt64, to IComplexNumber if type is ComplexFloat32 or ComplexFloat64,
      * or to IRange if the type is RangeInt64.
      */
-    virtual ErrCode INTERFACE_FUNC getLastValue(IBaseObject** value) = 0;
+    virtual ErrCode INTERFACE_FUNC getLastValue(IBaseObject** value, ITypeManager* typeManager = nullptr) = 0;
 };
 
 /*!@}*/

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -301,67 +301,67 @@ inline BaseObjectPtr DataPacketImpl<TInterface>::dataToObj(void*& addr, const Sa
     {
         case SampleType::Float32:
         {
-            auto data = static_cast<float*>(addr);
+            const auto data = static_cast<float*>(addr);
             return Floating(*data);
         }
         case SampleType::Float64:
         {
-            auto data = static_cast<double*>(addr);
+            const auto data = static_cast<double*>(addr);
             return Floating(*data);
         }
         case SampleType::Int8:
         {
-            auto data = static_cast<int8_t*>(addr);
+            const auto data = static_cast<int8_t*>(addr);
             return Integer(*data);
         }
         case SampleType::UInt8:
         {
-            auto data = static_cast<uint8_t*>(addr);
+            const auto data = static_cast<uint8_t*>(addr);
             return Integer(*data);
         }
         case SampleType::Int16:
         {
-            auto data = static_cast<int16_t*>(addr);
+            const auto data = static_cast<int16_t*>(addr);
             return Integer(*data);
         }
         case SampleType::UInt16:
         {
-            auto data = static_cast<uint16_t*>(addr);
+            const auto data = static_cast<uint16_t*>(addr);
             return Integer(*data);
         }
         case SampleType::Int32:
         {
-            auto data = static_cast<int32_t*>(addr);
+            const auto data = static_cast<int32_t*>(addr);
             return Integer(*data);
         }
         case SampleType::UInt32:
         {
-            auto data = static_cast<uint32_t*>(addr);
+            const auto data = static_cast<uint32_t*>(addr);
             return Integer(*data);
         }
         case SampleType::Int64:
         {
-            auto data = static_cast<int64_t*>(addr);
+            const auto data = static_cast<int64_t*>(addr);
             return Integer(*data);
         }
         case SampleType::UInt64:
         {
-            auto data = static_cast<uint64_t*>(addr);
+            const auto data = static_cast<uint64_t*>(addr);
             return Integer(*data);
         }
         case SampleType::RangeInt64:
         {
-            auto data = static_cast<int64_t*>(addr);
+            const auto data = static_cast<int64_t*>(addr);
             return Range(data[0], data[1]);
         }
         case SampleType::ComplexFloat32:
         {
-            auto data = static_cast<float*>(addr);
+            const auto data = static_cast<float*>(addr);
             return ComplexNumber(data[0], data[1]);
         }
         case SampleType::ComplexFloat64:
         {
-            auto data = static_cast<double*>(addr);
+            const auto data = static_cast<double*>(addr);
             return ComplexNumber(data[0], data[1]);
         }
         default:

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -448,7 +448,7 @@ ErrCode DataPacketImpl<TInterface>::getLastValue(IBaseObject** value)
 
     const auto sampleType = descriptor.getSampleType();
 
-    addr = (char*) addr + (sampleCount - 1) * descriptor.getRawSampleSize();
+    addr = static_cast<char*>(addr) + (sampleCount - 1) * descriptor.getRawSampleSize();
 
     if (sampleType == SampleType::Struct)
     {

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -54,8 +54,8 @@ public:
 
 private:
     bool isDataEqual(const DataPacketPtr& dataPacket) const;
-    BaseObjectPtr dataToObj(void*& addr, const SampleType& type) const;
-    StructPtr buildStructFromPacket(void*& addr, const DataDescriptorPtr& descriptor, const TypeManagerPtr& typeManager) const;
+    BaseObjectPtr dataToObj(void* addr, const SampleType& type) const;
+    StructPtr buildStructFromPacket(void* addr, const DataDescriptorPtr& descriptor, const TypeManagerPtr& typeManager) const;
 
     AllocatorPtr allocator;
     DataDescriptorPtr descriptor;
@@ -294,7 +294,7 @@ bool DataPacketImpl<TInterface>::isDataEqual(const DataPacketPtr& dataPacket) co
 }
 
 template <typename TInterface>
-inline BaseObjectPtr DataPacketImpl<TInterface>::dataToObj(void*& addr, const SampleType& type) const
+inline BaseObjectPtr DataPacketImpl<TInterface>::dataToObj(void* addr, const SampleType& type) const
 {
     switch (type)
     {
@@ -371,7 +371,7 @@ inline BaseObjectPtr DataPacketImpl<TInterface>::dataToObj(void*& addr, const Sa
 }
 
 template <typename TInterface>
-inline StructPtr DataPacketImpl<TInterface>::buildStructFromPacket(void*& addr,
+inline StructPtr DataPacketImpl<TInterface>::buildStructFromPacket(void* addr,
                                                                    const DataDescriptorPtr& descriptor,
                                                                    const TypeManagerPtr& typeManager) const
 {

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -360,6 +360,10 @@ BaseObjectPtr dataToObj(void* addr, SampleType type)
             auto data = static_cast<double*>(addr);
             return ComplexNumber(data[0], data[1]);
         }
+        default:
+        {
+            return BaseObject();
+        }
     }
 }
 

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -55,6 +55,8 @@ public:
 private:
     bool isDataEqual(const DataPacketPtr& dataPacket) const;
 
+    StructTypePtr createStructTypeFromDescriptor(DataDescriptorPtr dataDescriptor) const;
+
     AllocatorPtr allocator;
     DataDescriptorPtr descriptor;
     SizeT sampleCount;
@@ -292,6 +294,21 @@ bool DataPacketImpl<TInterface>::isDataEqual(const DataPacketPtr& dataPacket) co
 }
 
 template <typename TInterface>
+inline StructTypePtr DataPacketImpl<TInterface>::createStructTypeFromDescriptor(DataDescriptorPtr dataDescriptor) const
+{
+    auto fields = dataDescriptor.getStructFields();
+    auto fieldNames = List<IString>();
+    auto fieldTypes = List<IType>();
+    for (auto field& : fields)
+    {
+    }
+
+    StructTypePtr structType = StructType(dataDescriptor.getName(), fieldNames, fieldTypes);
+
+    return StructTypePtr();
+}
+
+template <typename TInterface>
 ErrCode DataPacketImpl<TInterface>::getLastValue(IBaseObject** value)
 {
     OPENDAQ_PARAM_NOT_NULL(value);
@@ -390,6 +407,14 @@ ErrCode DataPacketImpl<TInterface>::getLastValue(IBaseObject** value)
         {
             auto data = static_cast<double*>(addr);
             *value = ComplexNumber(data[idx * 2], data[idx * 2 + 1]).detach();
+            break;
+        }
+        case SampleType::Struct:
+        {
+            const auto typeManager = TypeManager();
+            // const auto structType = createStructTypeFromDescriptor();
+            // typeManager.addType(structType);
+
             break;
         }
         default:

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -422,14 +422,16 @@ ErrCode DataPacketImpl<TInterface>::getLastValue(IBaseObject** value, ITypeManag
 
     if (sampleType == SampleType::Struct)
     {
-        auto structPtr = buildStructFromPacket(addr, descriptor, typeManager);
-        *value = structPtr.detach();
-    }
-    else
-    {
-        *value = dataToObj(addr, sampleType).detach();
+        return daqTry(
+            [&]()
+            {
+                auto structPtr = buildStructFromPacket(addr, descriptor, typeManager);
+                *value = structPtr.detach();
+                return OPENDAQ_SUCCESS;
+            });
     }
 
+    *value = dataToObj(addr, sampleType).detach();
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -397,6 +397,7 @@ TypePtr createTypeFromDescriptor(DataDescriptorPtr descriptor)
                 type = SimpleType(CoreType::ctComplexNumber);
                 break;
             case SampleType::Struct:
+                // Recursion
                 type = createTypeFromDescriptor(field);
                 break;
             default:

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -423,7 +423,7 @@ inline StructPtr DataPacketImpl<TInterface>::buildStructFromPacket(void*& addr,
 {
     const StructTypePtr structType = createTypeFromDescriptor(descriptor);
     typeManager.addType(structType);
-    auto builder = StructBuilder(structType.getName(), typeManager);
+    const auto builder = StructBuilder(structType.getName(), typeManager);
 
     const auto fields = descriptor.getStructFields();
     const auto fieldNames = structType.getFieldNames();

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -291,7 +291,7 @@ bool DataPacketImpl<TInterface>::isDataEqual(const DataPacketPtr& dataPacket) co
     return data == dataPacket.getRawData() || std::memcmp(data, dataPacket.getRawData(), rawDataSize) == 0;
 }
 
-BaseObjectPtr dataToObj(void* addr, SampleType type)
+BaseObjectPtr dataToObj(void*& addr, const SampleType& type)
 {
     switch (type)
     {
@@ -367,7 +367,7 @@ BaseObjectPtr dataToObj(void* addr, SampleType type)
     }
 }
 
-TypePtr createTypeFromDescriptor(DataDescriptorPtr descriptor)
+TypePtr createTypeFromDescriptor(const DataDescriptorPtr& descriptor)
 {
     const auto fields = descriptor.getStructFields();
     auto fieldNames = List<IString>();

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -54,6 +54,9 @@ public:
 
 private:
     bool isDataEqual(const DataPacketPtr& dataPacket) const;
+    BaseObjectPtr dataToObj(void*& addr, const SampleType& type) const;
+    TypePtr createTypeFromDescriptor(const DataDescriptorPtr& descriptor) const;
+    StructPtr buildStructFromPacket(void*& addr, const DataDescriptorPtr& descriptor, const TypeManagerPtr& typeManager) const;
 
     AllocatorPtr allocator;
     DataDescriptorPtr descriptor;
@@ -291,7 +294,8 @@ bool DataPacketImpl<TInterface>::isDataEqual(const DataPacketPtr& dataPacket) co
     return data == dataPacket.getRawData() || std::memcmp(data, dataPacket.getRawData(), rawDataSize) == 0;
 }
 
-BaseObjectPtr dataToObj(void*& addr, const SampleType& type)
+template <typename TInterface>
+inline BaseObjectPtr DataPacketImpl<TInterface>::dataToObj(void*& addr, const SampleType& type) const
 {
     switch (type)
     {
@@ -367,7 +371,9 @@ BaseObjectPtr dataToObj(void*& addr, const SampleType& type)
     }
 }
 
-TypePtr createTypeFromDescriptor(const DataDescriptorPtr& descriptor)
+// TODO Delete this?
+template <typename TInterface>
+inline TypePtr DataPacketImpl<TInterface>::createTypeFromDescriptor(const DataDescriptorPtr& descriptor) const
 {
     const auto fields = descriptor.getStructFields();
     auto fieldNames = List<IString>();
@@ -402,6 +408,7 @@ TypePtr createTypeFromDescriptor(const DataDescriptorPtr& descriptor)
                 break;
             default:
                 type = SimpleType(CoreType::ctUndefined);
+                // TODO support string, list? + test
         }
         fieldNames.pushBack(field.getName());
         fieldTypes.pushBack(type);
@@ -409,7 +416,10 @@ TypePtr createTypeFromDescriptor(const DataDescriptorPtr& descriptor)
     return StructType(descriptor.getName(), fieldNames, fieldTypes);
 }
 
-StructPtr buildStructFromPacket(void*& addr, const DataDescriptorPtr& descriptor, const TypeManagerPtr& typeManager)
+template <typename TInterface>
+inline StructPtr DataPacketImpl<TInterface>::buildStructFromPacket(void*& addr,
+                                                                   const DataDescriptorPtr& descriptor,
+                                                                   const TypeManagerPtr& typeManager) const
 {
     const StructTypePtr structType = createTypeFromDescriptor(descriptor);
     typeManager.addType(structType);

--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -409,7 +409,7 @@ TypePtr createTypeFromDescriptor(const DataDescriptorPtr& descriptor)
     return StructType(descriptor.getName(), fieldNames, fieldTypes);
 }
 
-StructPtr buildStructFromPacket(void*& addr, DataDescriptorPtr& descriptor, const TypeManagerPtr& typeManager)
+StructPtr buildStructFromPacket(void*& addr, const DataDescriptorPtr& descriptor, const TypeManagerPtr& typeManager)
 {
     const StructTypePtr structType = createTypeFromDescriptor(descriptor);
     typeManager.addType(structType);
@@ -420,18 +420,19 @@ StructPtr buildStructFromPacket(void*& addr, DataDescriptorPtr& descriptor, cons
 
     for (size_t i = 0; i < fieldNames.getCount(); i++)
     {
-        const auto sampleType = fields[i].getSampleType();
+        const auto field = fields[i];
+        const auto sampleType = field.getSampleType();
 
         if (sampleType == SampleType::Struct)
         {
-            auto structPtr = buildStructFromPacket(addr, fields[i], typeManager);
+            const auto structPtr = buildStructFromPacket(addr, field, typeManager);
             builder.set(fieldNames[i], structPtr);
         }
         else
         {
-            auto obj = dataToObj(addr, sampleType);
+            const auto obj = dataToObj(addr, sampleType);
             builder.set(fieldNames[i], obj);
-            auto temp = static_cast<char*>(addr);
+            const auto temp = static_cast<char*>(addr);
             addr = temp + getSampleSize(sampleType);
         }
     }

--- a/core/opendaq/signal/include/opendaq/signal.h
+++ b/core/opendaq/signal/include/opendaq/signal.h
@@ -132,6 +132,7 @@ DECLARE_OPENDAQ_INTERFACE(ISignal, IComponent)
     /*!
      * @brief Gets the signal last value
      * @param[out] value The IBaseObject value can be a nullptr if there is no value, or if the data type is not supported by the function.
+     * 
      * If a value is assigned, it can be cast based on the signal description to IFloat if the type is Float32 or Float64,
      * to IInteger if the type is Int8 through Int64 or UInt8 through UInt64, to IComplexNumber if type is ComplexFloat32 or ComplexFloat64,
      * or to IRange if the type is RangeInt64.

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -15,22 +15,22 @@
  */
 
 #pragma once
-#include <opendaq/signal.h>
-#include <opendaq/signal_events.h>
-#include <opendaq/signal_config.h>
-#include <opendaq/context_ptr.h>
-#include <opendaq/data_descriptor_ptr.h>
-#include <opendaq/connection_ptr.h>
-#include <opendaq/signal_config_ptr.h>
-#include <opendaq/signal_private_ptr.h>
-#include <opendaq/event_packet_ptr.h>
 #include <coretypes/string_ptr.h>
-#include <opendaq/utility_sync.h>
-#include <opendaq/packet_factory.h>
-#include <opendaq/signal_events_ptr.h>
 #include <coretypes/validation.h>
 #include <opendaq/component_impl.h>
+#include <opendaq/connection_ptr.h>
+#include <opendaq/context_ptr.h>
+#include <opendaq/data_descriptor_ptr.h>
+#include <opendaq/event_packet_ptr.h>
 #include <opendaq/input_port_private_ptr.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/signal.h>
+#include <opendaq/signal_config.h>
+#include <opendaq/signal_config_ptr.h>
+#include <opendaq/signal_events.h>
+#include <opendaq/signal_events_ptr.h>
+#include <opendaq/signal_private_ptr.h>
+#include <opendaq/utility_sync.h>
 #include <utility>
 
 BEGIN_NAMESPACE_OPENDAQ
@@ -42,7 +42,10 @@ BEGIN_NAMESPACE_OPENDAQ
 #endif
 #endif
 
-#define SIGNAL_AVAILABLE_ATTRIBUTES {"Public", "DomainSignal", "RelatedSignals"}
+#define SIGNAL_AVAILABLE_ATTRIBUTES                \
+    {                                              \
+        "Public", "DomainSignal", "RelatedSignals" \
+    }
 
 template <typename TInterface, typename... Interfaces>
 class SignalBase;
@@ -99,6 +102,7 @@ public:
 
     static ConstCharPtr SerializeId();
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
+
 protected:
     void serializeCustomObjectValues(const SerializerPtr& serializer, bool forUpdate) override;
     void updateObject(const SerializedObjectPtr& obj) override;
@@ -115,7 +119,7 @@ protected:
                                        const FunctionPtr& factoryCallback) override;
 
     ErrCode lockAllAttributesInternal() override;
-    
+
 #ifdef WORKAROUND_MEMBER_INLINE_VARIABLE
     static std::unordered_set<std::string> signalAvailableAttributes;
 #else
@@ -139,6 +143,7 @@ private:
     void triggerRelatedSignalsChanged();
     void disconnectInputPort(const ConnectionPtr& connection);
     void clearConnections(std::vector<ConnectionPtr>& connections);
+    TypePtr createTypeFromDescriptor(const DataDescriptorPtr& descriptor) const;
 };
 
 #ifdef WORKAROUND_MEMBER_INLINE_VARIABLE
@@ -148,10 +153,10 @@ std::unordered_set<std::string> SignalBase<TInterface, Interfaces...>::signalAva
 
 template <typename TInterface, typename... Interfaces>
 SignalBase<TInterface, Interfaces...>::SignalBase(const ContextPtr& context,
-                                      DataDescriptorPtr descriptor,
-                                      const ComponentPtr& parent,
-                                      const StringPtr& localId,
-                                      const StringPtr& className)
+                                                  DataDescriptorPtr descriptor,
+                                                  const ComponentPtr& parent,
+                                                  const StringPtr& localId,
+                                                  const StringPtr& className)
     : Super(context, parent, localId, className)
     , dataDescriptor(std::move(descriptor))
     , isPublic(true)
@@ -204,8 +209,8 @@ ErrCode SignalBase<TInterface, Interfaces...>::setPublic(Bool isPublic)
     if (!this->coreEventMuted && this->coreEvent.assigned())
     {
         const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
-                CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "Public"}, {"Public", this->isPublic}}));
-        
+            CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "Public"}, {"Public", this->isPublic}}));
+
         this->triggerCoreEvent(args);
     }
     return OPENDAQ_SUCCESS;
@@ -239,6 +244,50 @@ void SignalBase<TInterface, Interfaces...>::onListenedStatusChanged(bool /*liste
 }
 
 template <typename TInterface, typename... Interfaces>
+inline TypePtr SignalBase<TInterface, Interfaces...>::createTypeFromDescriptor(const DataDescriptorPtr& descriptor) const
+{
+    const auto fields = descriptor.getStructFields();
+    auto fieldNames = List<IString>();
+    auto fieldTypes = List<IType>();
+
+    for (auto const& field : fields)
+    {
+        TypePtr type;
+        switch (field.getSampleType())
+        {
+            case SampleType::Float32:
+            case SampleType::Float64:
+                type = SimpleType(CoreType::ctFloat);
+                break;
+            case SampleType::Int8:
+            case SampleType::UInt8:
+            case SampleType::Int16:
+            case SampleType::UInt16:
+            case SampleType::Int32:
+            case SampleType::UInt32:
+            case SampleType::Int64:
+            case SampleType::UInt64:
+                type = SimpleType(CoreType::ctInt);
+                break;
+            case SampleType::ComplexFloat32:
+            case SampleType::ComplexFloat64:
+                type = SimpleType(CoreType::ctComplexNumber);
+                break;
+            case SampleType::Struct:
+                // Recursion
+                type = createTypeFromDescriptor(field);
+                break;
+            default:
+                type = SimpleType(CoreType::ctUndefined);
+                // TODO support string, list? + test
+        }
+        fieldNames.pushBack(field.getName());
+        fieldTypes.pushBack(type);
+    }
+    return StructType(descriptor.getName(), fieldNames, fieldTypes);
+}
+
+template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::setDescriptor(IDataDescriptor* descriptor)
 {
     OPENDAQ_PARAM_NOT_NULL(descriptor);
@@ -262,6 +311,26 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDescriptor(IDataDescriptor* de
                 if (signalPtr.assigned())
                     valueSignalsOfDomainSignal.push_back(std::move(signalPtr));
             }
+
+            if (dataDescriptor.getSampleType() == SampleType::Struct)
+            {
+                auto typeManager = context.getTypeManager();
+                const auto name = dataDescriptor.getName();
+                const StructTypePtr structType = createTypeFromDescriptor(dataDescriptor);
+
+                if (!typeManager.hasType(name))
+                {
+                    typeManager.addType(structType);
+                }
+                else
+                {
+                    if (structType != typeManager.getType(name))
+                    {
+                        const auto loggerComponent = context.getLogger().getOrAddComponent("Signal");
+                        LOG_W("Type {} already exists in the type manager!", name);
+                    }
+                }
+            }
         }
     }
 
@@ -278,15 +347,12 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDescriptor(IDataDescriptor* de
     if (!this->coreEventMuted && this->coreEvent.assigned())
     {
         const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
-                CoreEventId::DataDescriptorChanged,
-                Dict<IString, IBaseObject>({{"DataDescriptor", dataDescriptor}}));
-        
+            CoreEventId::DataDescriptorChanged, Dict<IString, IBaseObject>({{"DataDescriptor", dataDescriptor}}));
+
         this->triggerCoreEvent(args);
     }
 
-    return success
-        ? OPENDAQ_SUCCESS
-        : OPENDAQ_IGNORED;
+    return success ? OPENDAQ_SUCCESS : OPENDAQ_IGNORED;
 }
 
 template <typename TInterface, typename... Interfaces>
@@ -310,7 +376,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDomainSignal(ISignal* signal)
 {
     {
         std::scoped_lock lock(this->sync);
-        
+
         if (this->lockedAttributes.count("DomainSignal"))
         {
             if (this->context.assigned() && this->context.getLogger().assigned())
@@ -339,9 +405,8 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDomainSignal(ISignal* signal)
     if (!this->coreEventMuted && this->coreEvent.assigned())
     {
         const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
-                CoreEventId::AttributeChanged,
-                Dict<IString, IBaseObject>({{"AttributeName", "DomainSignal"}, {"DomainSignal", domainSignal}}));
-        
+            CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "DomainSignal"}, {"DomainSignal", domainSignal}}));
+
         this->triggerCoreEvent(args);
     }
 
@@ -467,7 +532,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::clearRelatedSignals()
         std::scoped_lock lock(this->sync);
         relatedSignals.clear();
     }
-    
+
     triggerRelatedSignalsChanged();
     return OPENDAQ_SUCCESS;
 }
@@ -507,7 +572,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::sendPacket(IPacket* packet)
         return OPENDAQ_SUCCESS;
     }
 
-    return  OPENDAQ_IGNORED;
+    return OPENDAQ_IGNORED;
 }
 
 template <typename TInterface, typename... Interfaces>
@@ -522,7 +587,7 @@ bool SignalBase<TInterface, Interfaces...>::sendPacketInternal(const PacketPtr& 
     return true;
 }
 
-template <typename TInterface, typename ... Interfaces>
+template <typename TInterface, typename... Interfaces>
 void SignalBase<TInterface, Interfaces...>::triggerRelatedSignalsChanged()
 {
     if (!this->coreEventMuted && this->coreEvent.assigned())
@@ -532,9 +597,8 @@ void SignalBase<TInterface, Interfaces...>::triggerRelatedSignalsChanged()
             sigs.pushBack(sig);
 
         const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
-                CoreEventId::AttributeChanged,
-                Dict<IString, IBaseObject>({{"AttributeName", "RelatedSignals"}, {"RelatedSignals", sigs}}));
-        
+            CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "RelatedSignals"}, {"RelatedSignals", sigs}}));
+
         this->triggerCoreEvent(args);
     }
 }
@@ -687,23 +751,30 @@ ConstCharPtr SignalBase<TInterface, Interfaces...>::SerializeId()
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode SignalBase<TInterface, Interfaces...>::Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj)
+ErrCode SignalBase<TInterface, Interfaces...>::Deserialize(ISerializedObject* serialized,
+                                                           IBaseObject* context,
+                                                           IFunction* factoryCallback,
+                                                           IBaseObject** obj)
 {
     OPENDAQ_PARAM_NOT_NULL(obj);
     return daqTry(
         [&obj, &serialized, &context, &factoryCallback]()
         {
-            *obj = Super::DeserializeComponent(
-                       serialized,
-                       context,
-                       factoryCallback,
-                       [](const SerializedObjectPtr& serialized,
-                          const ComponentDeserializeContextPtr& deserializeContext,
-                          const StringPtr& className)
-                       {
-                           return createWithImplementation<ISignalConfig, SignalImpl>(
-                               deserializeContext.getContext(), nullptr, deserializeContext.getParent(), deserializeContext.getLocalId(), className);
-                       }).detach();
+            *obj =
+                Super::DeserializeComponent(serialized,
+                                            context,
+                                            factoryCallback,
+                                            [](const SerializedObjectPtr& serialized,
+                                               const ComponentDeserializeContextPtr& deserializeContext,
+                                               const StringPtr& className)
+                                            {
+                                                return createWithImplementation<ISignalConfig, SignalImpl>(deserializeContext.getContext(),
+                                                                                                           nullptr,
+                                                                                                           deserializeContext.getParent(),
+                                                                                                           deserializeContext.getLocalId(),
+                                                                                                           className);
+                                            })
+                    .detach();
         });
 }
 
@@ -738,14 +809,13 @@ void SignalBase<TInterface, Interfaces...>::updateObject(const SerializedObjectP
     Super::updateObject(obj);
 }
 
-
 template <typename TInterface, typename... Interfaces>
 int SignalBase<TInterface, Interfaces...>::getSerializeFlags()
 {
     return ComponentSerializeFlag_SerializeActiveProp;
 }
 
-template <typename TInterface, typename ... Interfaces>
+template <typename TInterface, typename... Interfaces>
 void SignalBase<TInterface, Interfaces...>::disconnectInputPort(const ConnectionPtr& connection)
 {
     const auto inputPort = connection.getInputPort();
@@ -757,7 +827,7 @@ void SignalBase<TInterface, Interfaces...>::disconnectInputPort(const Connection
     }
 }
 
-template <typename TInterface, typename ... Interfaces>
+template <typename TInterface, typename... Interfaces>
 void SignalBase<TInterface, Interfaces...>::clearConnections(std::vector<ConnectionPtr>& connections)
 {
     for (auto& connection : connections)
@@ -780,7 +850,6 @@ void SignalBase<TInterface, Interfaces...>::removed()
             if (sigPrivate.assigned())
                 sigPrivate.clearDomainSignalWithoutNotification();
         }
-
     }
 
     domainSignalReferences.clear();
@@ -798,8 +867,8 @@ BaseObjectPtr SignalBase<TInterface, Interfaces...>::getDeserializedParameter(co
 
 template <typename TInterface, typename... Interfaces>
 void SignalBase<TInterface, Interfaces...>::deserializeCustomObjectValues(const SerializedObjectPtr& serializedObject,
-                                                                    const BaseObjectPtr& context,
-                                                                    const FunctionPtr& factoryCallback)
+                                                                          const BaseObjectPtr& context,
+                                                                          const FunctionPtr& factoryCallback)
 {
     Super::deserializeCustomObjectValues(serializedObject, context, factoryCallback);
     if (serializedObject.hasKey("domainSignalId"))
@@ -825,7 +894,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setStreamed(Bool streamed)
     return OPENDAQ_IGNORED;
 }
 
-template <typename TInterface, typename ... Interfaces>
+template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::lockAllAttributesInternal()
 {
     for (const auto& str : this->signalAvailableAttributes)
@@ -839,14 +908,14 @@ ErrCode SignalBase<TInterface, Interfaces...>::enableKeepLastValue(Bool enabled)
 {
     std::scoped_lock lock(this->sync);
     keepLastPacket = enabled;
-    
+
     if (!keepLastPacket)
         lastDataPacket = nullptr;
     return OPENDAQ_SUCCESS;
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode SignalBase<TInterface, Interfaces...>::getLastValue(IBaseObject ** value)
+ErrCode SignalBase<TInterface, Interfaces...>::getLastValue(IBaseObject** value)
 {
     OPENDAQ_PARAM_NOT_NULL(value);
     std::scoped_lock lock(this->sync);

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -311,7 +311,7 @@ inline void SignalBase<TInterface, Interfaces...>::addToTypeManagerRecursively(c
         {
             // Struct type with same name but diffrent structure exists in the type manager
             // Give warning
-            const auto loggerComponent = context.getLogger().getOrAddComponent("Signal");
+            const auto loggerComponent = this->context.getLogger().getOrAddComponent("Signal");
             LOG_W("Struct type with name {} already exists in the type manager, but it is different!", name);
         }
     }
@@ -345,7 +345,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDescriptor(IDataDescriptor* de
             if (dataDescriptor.getSampleType() == SampleType::Struct)
             {
                 const StructTypePtr structType = createTypeFromDescriptor(dataDescriptor);
-                auto typeManager = context.getTypeManager();
+                auto typeManager = this->context.getTypeManager();
                 addToTypeManagerRecursively(typeManager, dataDescriptor, structType);
             }
         }
@@ -937,7 +937,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::getLastValue(IBaseObject ** value
     if (!lastDataPacket.assigned() || lastDataPacket.getSampleCount() == 0)
         return OPENDAQ_IGNORED;
 
-    auto typeManager = context.getTypeManager();
+    auto typeManager = this->context.getTypeManager();
     return lastDataPacket->getLastValue(value, typeManager);
 }
 

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -308,6 +308,11 @@ inline void SignalBase<TInterface, Interfaces...>::addToTypeManagerRecursively(c
         const auto loggerComponent = this->context.getLogger().getOrAddComponent("Signal");
         LOG_W("Couldn't add type {} to type manager: {}", type.getName(), e.what());
     }
+    catch (...)
+    {
+        const auto loggerComponent = this->context.getLogger().getOrAddComponent("Signal");
+        LOG_W("Couldn't add type {} to type manager!", type.getName());
+    }
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -309,7 +309,7 @@ inline void SignalBase<TInterface, Interfaces...>::addToTypeManagerRecursively(c
     {
         if (type != typeManager.getType(name))
         {
-            // Struct type with same name exists in the type manager
+            // Struct type with same name but diffrent structure exists in the type manager
             // Give warning
             const auto loggerComponent = context.getLogger().getOrAddComponent("Signal");
             LOG_W("Struct type with name {} already exists in the type manager, but it is different!", name);

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -15,22 +15,22 @@
  */
 
 #pragma once
-#include <coretypes/string_ptr.h>
-#include <coretypes/validation.h>
-#include <opendaq/component_impl.h>
-#include <opendaq/connection_ptr.h>
+#include <opendaq/signal.h>
+#include <opendaq/signal_events.h>
+#include <opendaq/signal_config.h>
 #include <opendaq/context_ptr.h>
 #include <opendaq/data_descriptor_ptr.h>
-#include <opendaq/event_packet_ptr.h>
-#include <opendaq/input_port_private_ptr.h>
-#include <opendaq/packet_factory.h>
-#include <opendaq/signal.h>
-#include <opendaq/signal_config.h>
+#include <opendaq/connection_ptr.h>
 #include <opendaq/signal_config_ptr.h>
-#include <opendaq/signal_events.h>
-#include <opendaq/signal_events_ptr.h>
 #include <opendaq/signal_private_ptr.h>
+#include <opendaq/event_packet_ptr.h>
+#include <coretypes/string_ptr.h>
 #include <opendaq/utility_sync.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/signal_events_ptr.h>
+#include <coretypes/validation.h>
+#include <opendaq/component_impl.h>
+#include <opendaq/input_port_private_ptr.h>
 #include <utility>
 
 BEGIN_NAMESPACE_OPENDAQ
@@ -42,10 +42,7 @@ BEGIN_NAMESPACE_OPENDAQ
 #endif
 #endif
 
-#define SIGNAL_AVAILABLE_ATTRIBUTES                \
-    {                                              \
-        "Public", "DomainSignal", "RelatedSignals" \
-    }
+#define SIGNAL_AVAILABLE_ATTRIBUTES {"Public", "DomainSignal", "RelatedSignals"}
 
 template <typename TInterface, typename... Interfaces>
 class SignalBase;
@@ -102,7 +99,6 @@ public:
 
     static ConstCharPtr SerializeId();
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
-
 protected:
     void serializeCustomObjectValues(const SerializerPtr& serializer, bool forUpdate) override;
     void updateObject(const SerializedObjectPtr& obj) override;
@@ -119,7 +115,7 @@ protected:
                                        const FunctionPtr& factoryCallback) override;
 
     ErrCode lockAllAttributesInternal() override;
-
+    
 #ifdef WORKAROUND_MEMBER_INLINE_VARIABLE
     static std::unordered_set<std::string> signalAvailableAttributes;
 #else
@@ -156,10 +152,10 @@ std::unordered_set<std::string> SignalBase<TInterface, Interfaces...>::signalAva
 
 template <typename TInterface, typename... Interfaces>
 SignalBase<TInterface, Interfaces...>::SignalBase(const ContextPtr& context,
-                                                  DataDescriptorPtr descriptor,
-                                                  const ComponentPtr& parent,
-                                                  const StringPtr& localId,
-                                                  const StringPtr& className)
+                                      DataDescriptorPtr descriptor,
+                                      const ComponentPtr& parent,
+                                      const StringPtr& localId,
+                                      const StringPtr& className)
     : Super(context, parent, localId, className)
     , dataDescriptor(std::move(descriptor))
     , isPublic(true)
@@ -212,8 +208,8 @@ ErrCode SignalBase<TInterface, Interfaces...>::setPublic(Bool isPublic)
     if (!this->coreEventMuted && this->coreEvent.assigned())
     {
         const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
-            CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "Public"}, {"Public", this->isPublic}}));
-
+                CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "Public"}, {"Public", this->isPublic}}));
+        
         this->triggerCoreEvent(args);
     }
     return OPENDAQ_SUCCESS;
@@ -397,7 +393,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDomainSignal(ISignal* signal)
 {
     {
         std::scoped_lock lock(this->sync);
-
+        
         if (this->lockedAttributes.count("DomainSignal"))
         {
             if (this->context.assigned() && this->context.getLogger().assigned())
@@ -426,8 +422,9 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDomainSignal(ISignal* signal)
     if (!this->coreEventMuted && this->coreEvent.assigned())
     {
         const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
-            CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "DomainSignal"}, {"DomainSignal", domainSignal}}));
-
+                CoreEventId::AttributeChanged,
+                Dict<IString, IBaseObject>({{"AttributeName", "DomainSignal"}, {"DomainSignal", domainSignal}}));
+        
         this->triggerCoreEvent(args);
     }
 
@@ -553,7 +550,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::clearRelatedSignals()
         std::scoped_lock lock(this->sync);
         relatedSignals.clear();
     }
-
+    
     triggerRelatedSignalsChanged();
     return OPENDAQ_SUCCESS;
 }
@@ -593,7 +590,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::sendPacket(IPacket* packet)
         return OPENDAQ_SUCCESS;
     }
 
-    return OPENDAQ_IGNORED;
+    return  OPENDAQ_IGNORED;
 }
 
 template <typename TInterface, typename... Interfaces>
@@ -608,7 +605,7 @@ bool SignalBase<TInterface, Interfaces...>::sendPacketInternal(const PacketPtr& 
     return true;
 }
 
-template <typename TInterface, typename... Interfaces>
+template <typename TInterface, typename ... Interfaces>
 void SignalBase<TInterface, Interfaces...>::triggerRelatedSignalsChanged()
 {
     if (!this->coreEventMuted && this->coreEvent.assigned())
@@ -618,8 +615,9 @@ void SignalBase<TInterface, Interfaces...>::triggerRelatedSignalsChanged()
             sigs.pushBack(sig);
 
         const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
-            CoreEventId::AttributeChanged, Dict<IString, IBaseObject>({{"AttributeName", "RelatedSignals"}, {"RelatedSignals", sigs}}));
-
+                CoreEventId::AttributeChanged,
+                Dict<IString, IBaseObject>({{"AttributeName", "RelatedSignals"}, {"RelatedSignals", sigs}}));
+        
         this->triggerCoreEvent(args);
     }
 }
@@ -772,30 +770,23 @@ ConstCharPtr SignalBase<TInterface, Interfaces...>::SerializeId()
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode SignalBase<TInterface, Interfaces...>::Deserialize(ISerializedObject* serialized,
-                                                           IBaseObject* context,
-                                                           IFunction* factoryCallback,
-                                                           IBaseObject** obj)
+ErrCode SignalBase<TInterface, Interfaces...>::Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj)
 {
     OPENDAQ_PARAM_NOT_NULL(obj);
     return daqTry(
         [&obj, &serialized, &context, &factoryCallback]()
         {
-            *obj =
-                Super::DeserializeComponent(serialized,
-                                            context,
-                                            factoryCallback,
-                                            [](const SerializedObjectPtr& serialized,
-                                               const ComponentDeserializeContextPtr& deserializeContext,
-                                               const StringPtr& className)
-                                            {
-                                                return createWithImplementation<ISignalConfig, SignalImpl>(deserializeContext.getContext(),
-                                                                                                           nullptr,
-                                                                                                           deserializeContext.getParent(),
-                                                                                                           deserializeContext.getLocalId(),
-                                                                                                           className);
-                                            })
-                    .detach();
+            *obj = Super::DeserializeComponent(
+                       serialized,
+                       context,
+                       factoryCallback,
+                       [](const SerializedObjectPtr& serialized,
+                          const ComponentDeserializeContextPtr& deserializeContext,
+                          const StringPtr& className)
+                       {
+                           return createWithImplementation<ISignalConfig, SignalImpl>(
+                               deserializeContext.getContext(), nullptr, deserializeContext.getParent(), deserializeContext.getLocalId(), className);
+                       }).detach();
         });
 }
 
@@ -830,13 +821,14 @@ void SignalBase<TInterface, Interfaces...>::updateObject(const SerializedObjectP
     Super::updateObject(obj);
 }
 
+
 template <typename TInterface, typename... Interfaces>
 int SignalBase<TInterface, Interfaces...>::getSerializeFlags()
 {
     return ComponentSerializeFlag_SerializeActiveProp;
 }
 
-template <typename TInterface, typename... Interfaces>
+template <typename TInterface, typename ... Interfaces>
 void SignalBase<TInterface, Interfaces...>::disconnectInputPort(const ConnectionPtr& connection)
 {
     const auto inputPort = connection.getInputPort();
@@ -848,7 +840,7 @@ void SignalBase<TInterface, Interfaces...>::disconnectInputPort(const Connection
     }
 }
 
-template <typename TInterface, typename... Interfaces>
+template <typename TInterface, typename ... Interfaces>
 void SignalBase<TInterface, Interfaces...>::clearConnections(std::vector<ConnectionPtr>& connections)
 {
     for (auto& connection : connections)
@@ -871,6 +863,7 @@ void SignalBase<TInterface, Interfaces...>::removed()
             if (sigPrivate.assigned())
                 sigPrivate.clearDomainSignalWithoutNotification();
         }
+
     }
 
     domainSignalReferences.clear();
@@ -888,8 +881,8 @@ BaseObjectPtr SignalBase<TInterface, Interfaces...>::getDeserializedParameter(co
 
 template <typename TInterface, typename... Interfaces>
 void SignalBase<TInterface, Interfaces...>::deserializeCustomObjectValues(const SerializedObjectPtr& serializedObject,
-                                                                          const BaseObjectPtr& context,
-                                                                          const FunctionPtr& factoryCallback)
+                                                                    const BaseObjectPtr& context,
+                                                                    const FunctionPtr& factoryCallback)
 {
     Super::deserializeCustomObjectValues(serializedObject, context, factoryCallback);
     if (serializedObject.hasKey("domainSignalId"))
@@ -915,7 +908,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setStreamed(Bool streamed)
     return OPENDAQ_IGNORED;
 }
 
-template <typename TInterface, typename... Interfaces>
+template <typename TInterface, typename ... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::lockAllAttributesInternal()
 {
     for (const auto& str : this->signalAvailableAttributes)
@@ -929,14 +922,14 @@ ErrCode SignalBase<TInterface, Interfaces...>::enableKeepLastValue(Bool enabled)
 {
     std::scoped_lock lock(this->sync);
     keepLastPacket = enabled;
-
+    
     if (!keepLastPacket)
         lastDataPacket = nullptr;
     return OPENDAQ_SUCCESS;
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode SignalBase<TInterface, Interfaces...>::getLastValue(IBaseObject** value)
+ErrCode SignalBase<TInterface, Interfaces...>::getLastValue(IBaseObject ** value)
 {
     OPENDAQ_PARAM_NOT_NULL(value);
     std::scoped_lock lock(this->sync);

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -299,21 +299,14 @@ inline void SignalBase<TInterface, Interfaces...>::addToTypeManagerRecursively(c
             addToTypeManagerRecursively(typeManager, fields[i], fieldTypes[i]);
 
     const auto name = descriptor.getName();
-    if (!typeManager.hasType(name))
+    try
     {
-        // Struct type doesn't exist in the type manager
-        // Add it
         typeManager.addType(type);
     }
-    else
+    catch (const std::exception& e)
     {
-        if (type != typeManager.getType(name))
-        {
-            // Struct type with same name but diffrent structure exists in the type manager
-            // Give warning
-            const auto loggerComponent = this->context.getLogger().getOrAddComponent("Signal");
-            LOG_W("Struct type with name {} already exists in the type manager, but it is different!", name);
-        }
+        const auto loggerComponent = this->context.getLogger().getOrAddComponent("Signal");
+        LOG_W("Couldn't add type {} to type manager: {}", type.getName(), e.what());
     }
 }
 

--- a/core/opendaq/signal/src/data_descriptor_impl.cpp
+++ b/core/opendaq/signal/src/data_descriptor_impl.cpp
@@ -218,12 +218,13 @@ ErrCode DataDescriptorImpl::validate()
             valid = origin != "" ? false : valid;
             valid = resolution.assigned() ? false : valid;
             valid = scaling.assigned() ? false : valid;
+            valid = !name.assigned() || name == "" ? false : valid;
 
             if (!valid)
             {
                 return makeErrorInfo(OPENDAQ_ERR_INVALIDSTATE,
                                      "A Data descriptor with struct members can only have the name and dimensions configured. Its rule "
-                                     "type must be explicit and Sample type set to Struct");
+                                     "type must be explicit and Sample type set to Struct. It's name must be assigned and musn't be empty.");
             }
 
             structFields.freeze();

--- a/core/opendaq/signal/tests/test_data_descriptor.cpp
+++ b/core/opendaq/signal/tests/test_data_descriptor.cpp
@@ -321,6 +321,7 @@ TEST_F(DataDescriptorTest, DataDescriptorSampleSizeStruct)
         .build();
 
     const auto canMsgDescriptor = DataDescriptorBuilder()
+        .setName("Struct")
         .setSampleType(SampleType::Struct)
         .setStructFields(List<IDataDescriptor>(arbIdDescriptor, lengthDescriptor, dataDescriptor))
         .build();
@@ -345,6 +346,7 @@ TEST_F(DataDescriptorTest, DataDescriptorSampleSizeMixedStruct)
                                     .build();
 
     const auto canMsgDescriptor = DataDescriptorBuilder()
+        .setName("Struct")
         .setSampleType(SampleType::Struct)
         .setStructFields(List<IDataDescriptor>(arbIdDescriptor, lengthDescriptor, dataDescriptor))
         .build();

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -448,7 +448,7 @@ TEST_F(DataPacketTest, GetLastValueNested)
     ASSERT_EQ(ptr.get("Int32"), 42);
 }
 
-TEST_F(DataPacketTest, GetLastValueNestedNoTypeManager)
+TEST_F(DataPacketTest, GetLastValueNoTypeManager)
 {
     const auto descriptor =
         DataDescriptorBuilder()

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -393,6 +393,7 @@ TEST_F(DataPacketTest, PacketWithStructSampleType)
         .build();
 
     const auto canMsgDescriptor = DataDescriptorBuilder()
+        .setName("Can")
         .setSampleType(SampleType::Struct)
         .setStructFields(List<IDataDescriptor>(arbIdDescriptor, lengthDescriptor, dataDescriptor))
         .build();

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -462,5 +462,5 @@ TEST_F(DataPacketTest, GetLastValueNoTypeManager)
     const auto data = static_cast<int32_t*>(packet.getData());
     data[4] = 42;
 
-    ASSERT_THROW(packet.getLastValue(), daq::InvalidParameterException);
+    ASSERT_THROW(packet.getLastValue(), InvalidParameterException);
 }

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -462,5 +462,5 @@ TEST_F(DataPacketTest, GetLastValueNoTypeManager)
     const auto data = static_cast<int32_t*>(packet.getData());
     data[4] = 42;
 
-    ASSERT_THROW(packet.getLastValue(), InvalidParameterException);
+    ASSERT_THROW(packet.getLastValue(), daq::InvalidParameterException);
 }

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -461,7 +461,7 @@ TEST_F(DataPacketTest, GetLastValueNestedNoTypeManager)
     const auto data = static_cast<int32_t*>(packet.getData());
     data[4] = 42;
 
-    ASSERT_ANY_THROW(packet.getLastValue());
+    ASSERT_THROW(packet.getLastValue(), InvalidParameterException);
 }
 
 

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -9,7 +9,7 @@
 
 using DataPacketTest = testing::Test;
 
-BEGIN_NAMESPACE_OPENDAQ
+using namespace daq;
 
 // Helper methods
 
@@ -464,6 +464,3 @@ TEST_F(DataPacketTest, GetLastValueNoTypeManager)
 
     ASSERT_THROW(packet.getLastValue(), InvalidParameterException);
 }
-
-
-END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -429,10 +429,12 @@ TEST_F(SignalTest, SignalDescriptorStructSameNameDifferentDescriptor)
     signal2.sendPacket(dataPacket2);
 
     const auto lv1 = signal1.getLastValue();
+    StructPtr sp1;
+    ASSERT_NO_THROW(sp1 = lv1.asPtr<IStruct>());
+    ASSERT_EQ(sp1.get("Int32"), 4);
+
     // TODO
     // signal2.getLastValue();
-
-    ASSERT_EQ(lv1, 4);
 }
 
 TEST_F(SignalTest, SendNullPacket)

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -5,6 +5,7 @@
 #include <opendaq/context_factory.h>
 #include <opendaq/data_descriptor_factory.h>
 #include <opendaq/deserialize_component_ptr.h>
+#include <opendaq/input_port_factory.h>
 #include <opendaq/packet_factory.h>
 #include <opendaq/removable_ptr.h>
 #include <opendaq/signal_events.h>
@@ -12,7 +13,6 @@
 #include <opendaq/signal_factory.h>
 #include <opendaq/signal_private_ptr.h>
 #include <opendaq/tags_factory.h>
-#include <opendaq/input_port_factory.h>
 
 using SignalTest = testing::Test;
 
@@ -434,7 +434,7 @@ TEST_F(SignalTest, SignalDescriptorStructSameNameDifferentDescriptor)
     ASSERT_EQ(sp1.get("Int32"), 4);
 
     // Throws because descriptor2 has the same name as descriptor1 and hence the the struct type can't be added to the type manager
-    ASSERT_THROW(signal2.getLastValue(), daq::InvalidParameterException);
+    ASSERT_THROW(signal2.getLastValue(), InvalidParameterException);
 }
 
 TEST_F(SignalTest, SendNullPacket)
@@ -777,7 +777,6 @@ TEST_F(SignalTest, GetLastValueComplexFloat64)
     ASSERT_DOUBLE_EQ(complexPtr.getImaginary(), 9.1);
 }
 
-
 TEST_F(SignalTest, TestSignalActiveSendPacket)
 {
     const auto context = NullContext();
@@ -911,7 +910,7 @@ TEST_F(SignalTest, GetLastValueStructNoSetDescriptor)
 
     // Call getLastValue
     // Throws becuase we didn't use signal.setDescriptor
-    ASSERT_THROW(signal.getLastValue(), daq::NotFoundException);
+    ASSERT_THROW(signal.getLastValue(), NotFoundException);
 }
 
 TEST_F(SignalTest, GetLastValueStructNested)

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -745,8 +745,8 @@ TEST_F(SignalTest, GetLastValueStruct)
     signal.sendPacket(dataPacket);
 
     auto lastValuePacket = signal.getLastValue();
-    ComplexNumberPtr complexPtr;
-    ASSERT_NO_THROW(complexPtr = lastValuePacket.asPtr<IStructType>());
+    StructPtr structPtr;
+    ASSERT_NO_THROW(structPtr = lastValuePacket.asPtr<IStruct>());
     /* ASSERT_DOUBLE_EQ(complexPtr.getReal(), 8.1); // TODO
     ASSERT_DOUBLE_EQ(complexPtr.getImaginary(), 9.1);*/
 }

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -708,7 +708,6 @@ TEST_F(SignalTest, TestInputPortActiveSendPacket)
 TEST_F(SignalTest, GetLastValueStruct)
 {
     const auto signal = Signal(NullContext(), nullptr, "sig");
-    // auto descriptor = DataDescriptorBuilder().setName("test").setSampleType(SampleType::Struct).build(); // TODO
 
     const auto descriptor = DataDescriptorBuilder()
                                 .setName("MyTestStructType")
@@ -747,8 +746,10 @@ TEST_F(SignalTest, GetLastValueStruct)
     auto lastValuePacket = signal.getLastValue();
     StructPtr structPtr;
     ASSERT_NO_THROW(structPtr = lastValuePacket.asPtr<IStruct>());
-    /* ASSERT_DOUBLE_EQ(complexPtr.getReal(), 8.1); // TODO
-    ASSERT_DOUBLE_EQ(complexPtr.getImaginary(), 9.1);*/
+    ASSERT_EQ(structPtr.get("Int32"), 12);
+    ASSERT_DOUBLE_EQ(structPtr.get("Float64"), 15.1);
+    StructPtr nestedPtr = structPtr.get("Special").asPtr<IStruct>();
+    ASSERT_EQ(nestedPtr.get("NestedInt64"), 42);
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -910,6 +910,7 @@ TEST_F(SignalTest, GetLastValueStructNoSetDescriptor)
     signal.sendPacket(dataPacket);
 
     // Call getLastValue
+    // Throws becuase we didn't use signal.setDescriptor
     ASSERT_THROW(signal.getLastValue(), NotFoundException);
 }
 

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -434,7 +434,7 @@ TEST_F(SignalTest, SignalDescriptorStructSameNameDifferentDescriptor)
     ASSERT_EQ(sp1.get("Int32"), 4);
 
     // Throws because descriptor2 has the same name as descriptor1 and hence the the struct type can't be added to the type manager
-    ASSERT_THROW(signal2.getLastValue(), InvalidParameterException);
+    ASSERT_THROW(signal2.getLastValue(), daq::InvalidParameterException);
 }
 
 TEST_F(SignalTest, SendNullPacket)
@@ -911,7 +911,7 @@ TEST_F(SignalTest, GetLastValueStructNoSetDescriptor)
 
     // Call getLastValue
     // Throws becuase we didn't use signal.setDescriptor
-    ASSERT_THROW(signal.getLastValue(), NotFoundException);
+    ASSERT_THROW(signal.getLastValue(), daq::NotFoundException);
 }
 
 TEST_F(SignalTest, GetLastValueStructNested)

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -433,8 +433,8 @@ TEST_F(SignalTest, SignalDescriptorStructSameNameDifferentDescriptor)
     ASSERT_NO_THROW(sp1 = lv1.asPtr<IStruct>());
     ASSERT_EQ(sp1.get("Int32"), 4);
 
-    // TODO
-    // signal2.getLastValue();
+    // Throws because descriptor2 has the same name as descriptor1 and hence the the struct type can't be added to the type manager
+    ASSERT_THROW(signal2.getLastValue(), InvalidParameterException);
 }
 
 TEST_F(SignalTest, SendNullPacket)

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -16,7 +16,7 @@
 
 using SignalTest = testing::Test;
 
-BEGIN_NAMESPACE_OPENDAQ
+using namespace daq;
 
 class ConnectionMockImpl : public ImplementationOf<IConnection>
 {
@@ -1082,5 +1082,3 @@ TEST_F(SignalTest, GetLastValueStructDoublyNested)
     // Check fifth (doubly nested) member
     ASSERT_FLOAT_EQ(doublyNestedPtr.get("DoublyNestedFloat32"), 6.66f);
 }
-
-END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -705,4 +705,30 @@ TEST_F(SignalTest, TestInputPortActiveSendPacket)
     ASSERT_EQ(ip.getConnection().getPacketCount(), 3);
 }
 
+TEST_F(SignalTest, GetLastValueStruct)
+{
+    const auto signal = Signal(NullContext(), nullptr, "sig");
+    auto descriptor = DataDescriptorBuilder().setName("test").setSampleType(SampleType::Struct).build();
+
+    StructPtr ptr =
+        DataDescriptorBuilder()
+            .setName("MyTestStructType")
+            .setSampleType(SampleType::Struct)
+            .setStructFields(List<DataDescriptorPtr>(DataDescriptorBuilder().setName("Int").setSampleType(SampleType::Int64).build(),
+                                                     DataDescriptorBuilder().setName("Float").setSampleType(SampleType::Float64).build()))
+            .build();
+
+    auto dataPacket = DataPacket(descriptor, 5);
+    auto data = static_cast<StructPtr*>(dataPacket.getData());
+    data[4] = ptr;
+
+    signal.sendPacket(dataPacket);
+
+    auto lastValuePacket = signal.getLastValue();
+    ComplexNumberPtr complexPtr;
+    ASSERT_NO_THROW(complexPtr = lastValuePacket.asPtr<IStructType>());
+    /* ASSERT_DOUBLE_EQ(complexPtr.getReal(), 8.1);
+    ASSERT_DOUBLE_EQ(complexPtr.getImaginary(), 9.1);*/
+}
+
 END_NAMESPACE_OPENDAQ

--- a/docs/Antora/modules/background_info/pages/signals.adoc
+++ b/docs/Antora/modules/background_info/pages/signals.adoc
@@ -219,8 +219,8 @@ Data Descriptors. When the Struct Fields list is filled, Packet buffers are cons
 the following manner: the data described by the first Data Descriptor is at the start, 
 followed by the data described by the second, and so on. 
 
-IMPORTANT: When configuring a Data Descriptor with Struct Fields, only the Dimensions and 
-Name can be configured in addition. Dimensions function the same way as with normal 
+IMPORTANT: When configuring a Data Descriptor with Struct Fields, the Name must be configured, 
+and additionally, only the Dimensions can be configured. Dimensions function the same way as with normal 
 Signal data, where each Sample will contain `n` structs, depending on the Dimension sizes.
 
 == Configuring Signals

--- a/docs/tests/test_signals.cpp
+++ b/docs/tests/test_signals.cpp
@@ -99,7 +99,7 @@ TEST_F(SignalsTest, StructData)
     auto struct1 = builder.build();
     auto struct2 = builder.build();
 
-    auto dataDesc = builder.setSampleType(SampleType::Struct).setStructFields(List<IDataDescriptor>(struct1, struct2)).build();
+    auto dataDesc = builder.setSampleType(SampleType::Struct).setName("Struct").setStructFields(List<IDataDescriptor>(struct1, struct2)).build();
 }
 
 


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:
Support getLastValue for structs in core, enable converting data descriptors to struct types for structs, enable recursively building structs form packets, and fix bug in struct builder implementation. Some test are also added for getLastValue for structs.