### PR TITLE
[TBBAS-1367] Make Enumeration and EnumerationType behave close to native Python enums

### DIFF
--- a/bindings/python/core_types/generated/py_enumeration.cpp
+++ b/bindings/python/core_types/generated/py_enumeration.cpp
@@ -48,18 +48,22 @@ void defineIEnumeration(pybind11::module_ m, PyDaqIntf<daq::IEnumeration, daq::I
         },
         py::return_value_policy::take_ownership,
         "Gets the Enumeration's type.");
-    cls.def_property_readonly("value",
+    cls.def_property_readonly("name",
         [](daq::IEnumeration *object)
         {
             const auto objectPtr = daq::EnumerationPtr::Borrow(object);
             return objectPtr.getValue().toStdString();
         },
         "Gets the Enumeration value as String containing the name of the enumerator constant.");
-    cls.def_property_readonly("int_value",
+    cls.def_property_readonly("value",
         [](daq::IEnumeration *object)
         {
             const auto objectPtr = daq::EnumerationPtr::Borrow(object);
             return objectPtr.getIntValue();
         },
         "Gets the Enumeration value as Integer enumerator constant.");
+    cls.def("__str__", [](daq::IEnumeration *object) { 
+        const auto objectPtr = daq::EnumerationPtr::Borrow(object);
+        return baseObjectToPyObject(objectPtr.getEnumerationType().getName() + "." + objectPtr.getValue());
+    });
 }

--- a/bindings/python/core_types/generated/py_enumeration_type.cpp
+++ b/bindings/python/core_types/generated/py_enumeration_type.cpp
@@ -30,7 +30,7 @@
 
 PyDaqIntf<daq::IEnumerationType, daq::IType> declareIEnumerationType(pybind11::module_ m)
 {
-    return wrapInterface<daq::IEnumerationType, daq::IType>(m, "IEnumerationType");
+    return wrapInterface<daq::IEnumerationType, daq::IType>(m, "IEnumerationType", py::dynamic_attr());
 }
 
 void defineIEnumerationType(pybind11::module_ m, PyDaqIntf<daq::IEnumerationType, daq::IType> cls)
@@ -71,4 +71,63 @@ void defineIEnumerationType(pybind11::module_ m, PyDaqIntf<daq::IEnumerationType
             return objectPtr.getCount();
         },
         "Gets the number of enumerators within the Enumeration Type.");
+    cls.def("__getattr__", [](daq::IEnumerationType *object, const std::string &value) {
+        const auto objectPtr = daq::EnumerationTypePtr::Borrow(object);
+        
+        daq::DictPtr<daq::IString, daq::IInteger> dict = objectPtr.getAsDictionary();
+        if(!dict.hasKey(value)) {
+            throw py::attribute_error("EnumType has no value named " + value);
+        }
+
+        auto pyObject = py::cast(InterfaceWrapper<daq::IEnumerationType>(objectPtr.addRefAndReturn()));
+        auto typeManager = pyObject.attr("__type_manager").cast<daq::ITypeManager*>();
+        const auto typeManagerPtr = daq::TypeManagerPtr::Borrow(typeManager);
+        const auto enumName = objectPtr.getName();
+
+        return daq::Enumeration_Create(enumName, daq::String(value), typeManagerPtr);
+    });
+    cls.def("__dir__", [](daq::IEnumerationType *object) {
+        const auto objectPtr = daq::EnumerationTypePtr::Borrow(object);
+        auto keys = objectPtr.getAsDictionary().getKeyList();
+
+        // Add method names to the list of keys
+        keys->pushBack(daq::String("enumerator_names"));
+        keys->pushBack(daq::String("as_dictionary"));
+        keys->pushBack(daq::String("get_enumerator_int_value"));
+        keys->pushBack(daq::String("count"));
+
+        return baseObjectToPyObject(keys);
+    });
+    cls.def("__getitem__", [](daq::IEnumerationType *object, const std::string &value) {
+        const auto objectPtr = daq::EnumerationTypePtr::Borrow(object);
+
+        daq::DictPtr<daq::IString, daq::IInteger> dict = objectPtr.getAsDictionary();
+        if(!dict.hasKey(value)) {
+            throw py::key_error("EnumType has no value named " + value);
+        }
+
+        auto pyObject = py::cast(InterfaceWrapper<daq::IEnumerationType>(objectPtr.addRefAndReturn()));
+        auto typeManager = pyObject.attr("__type_manager").cast<daq::ITypeManager*>();
+        const auto typeManagerPtr = daq::TypeManagerPtr::Borrow(typeManager);
+        const auto enumName = objectPtr.getName();
+
+        return daq::Enumeration_Create(enumName, daq::String(value), typeManagerPtr);
+    });
+    cls.def("__call__", [](daq::IEnumerationType *object, int value) {
+        const auto objectPtr = daq::EnumerationTypePtr::Borrow(object);
+
+        daq::DictPtr<daq::IString, daq::IInteger> dict = objectPtr.getAsDictionary();
+        for(const auto& pair : dict) {
+            if(pair.second == value) {
+                auto pyObject = py::cast(InterfaceWrapper<daq::IEnumerationType>(objectPtr.addRefAndReturn()));
+                auto typeManager = pyObject.attr("__type_manager").cast<daq::ITypeManager*>();
+                const auto typeManagerPtr = daq::TypeManagerPtr::Borrow(typeManager);
+                const auto enumName = objectPtr.getName();
+
+                return daq::Enumeration_Create(enumName, pair.first, typeManagerPtr);
+            }
+        }
+
+        throw py::value_error("EnumType has no value with value " + std::to_string(value));
+    });
 }

--- a/bindings/python/tests/test_core_types.py
+++ b/bindings/python/tests/test_core_types.py
@@ -530,7 +530,7 @@ class TestStruct(opendaq_test.TestCase):
         self.assertEqual(struct.ratio.numerator, 1)
         self.assertEqual(struct.complexnumber.real, 1.0)
         self.assertEqual(struct.struct.string, 'string')
-        self.assertEqual(struct.enumeration.value, 'enum0')
+        self.assertEqual(struct.enumeration.name, 'enum0')
         self.assertIsNone(struct.undefined)
 
     def test_typenames_validation(self):
@@ -565,6 +565,42 @@ class TestStruct(opendaq_test.TestCase):
         #should be ok here
         type = daq.StructType(daq.String('valid_struct_name'), valid_names, default_values, typeList)
         type_manager.add_type(type)
+
+class TestEnumerations(opendaq_test.TestCase):
+
+    def test_enumeration(self):
+
+        type_manager = daq.TypeManager()
+
+        color_list = daq.List()
+        color_list.append(daq.String('RED'))
+        color_list.append(daq.String('GREEN'))
+        color_list.append(daq.String('BLUE'))
+
+        enum_type = daq.EnumerationType(daq.String('Color'), color_list, 0)
+
+        #unregistered type has no type manager inside
+        with self.assertRaises(AttributeError):
+            e = enum_type.RED
+        type_manager.add_type(enum_type)
+
+        with self.assertRaises(AttributeError):
+            e = enum_type.WHITE
+        with self.assertRaises(KeyError):
+            e = enum_type['WHITE']
+
+        enum_type_1 = type_manager.get_type('Color')
+
+        self.assertEqual(enum_type.RED, enum_type_1.RED)
+        self.assertNotEqual(enum_type.RED, enum_type.BLUE)
+        self.assertEqual(enum_type.RED.value, 0)
+        self.assertEqual(enum_type(0), enum_type.RED)
+        self.assertEqual(enum_type(0).name, 'RED')
+        self.assertEqual(enum_type['RED'], enum_type.RED)
+        self.assertEqual(enum_type['RED'].value, 0)
+        self.assertEqual(enum_type['RED'].name, 'RED')
+        unknown = int(enum_type.RED) + 10
+        self.assertEqual(unknown, 10)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

- Make Enumeration and EnumerationType behave close to native Python enums
- Tests updated
- Usage example is in the testcase
