### PR TITLE
Add python gui example as openDAQ package's __main__ entrypoint

### DIFF
--- a/bindings/python/package/METADATA.in
+++ b/bindings/python/package/METADATA.in
@@ -45,7 +45,7 @@ The package is available as binary wheels for Python 3.8-3.12. It has been built
 On supported systems you can install it with:
 
 ```bash
-pip install opendaq
+$ pip install opendaq
 ```
 
 Quick-start
@@ -75,3 +75,14 @@ Name: Device 1 Connection string: daqref://device1
 ```
 
 More examples can be found under https://docs.opendaq.com/manual/.
+
+GUI
+---
+
+Python openDAQ(TM) package comes with a reference Tk GUI implementation, allowing you to quickly connect to any
+openDAQ(TM) device and inspect or configure it.
+
+To run the GUI, invoke the package from the command line using `-m` flag:
+```bash
+$ python -m opendaq
+```

--- a/bindings/python/package/build_pip.py
+++ b/bindings/python/package/build_pip.py
@@ -102,6 +102,7 @@ wheel_tag = auto_wheel_tag(modules.opendaq) if not wheel_tag else wheel_tag
 path_build_pip_source_dir = os.path.dirname(__file__)
 package_version = read_opendaq_version(
     os.path.join(path_build_pip_source_dir, '..', '..', '..', 'opendaq_version')) if not package_version else package_version
+examples_dir = os.path.join(path_build_pip_source_dir, '..', '..', '..', 'examples', 'python')
 
 if not modules.libs:
     print(f'Could not find any libraries in {build_bin_dir}')
@@ -142,6 +143,7 @@ for module in modules.modules:
     shutil.copy(os.path.join(build_bin_dir, module),
                 os.path.join(path_stage_package, 'modules'))
 shutil.copy(os.path.join(build_bin_dir, modules.opendaq), path_stage_package)
+shutil.copy(os.path.join(examples_dir, 'gui_demo.py'), os.path.join(path_stage_package, '__main__.py'))
 
 # an empty file signalling to python that auto-complete should be enabled
 pathlib.Path(os.path.join(path_stage_package, 'py.typed')).touch()


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [ ] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

With this commit, running `py -m opendaq [args]` directly executes the tk GUI example. Having a quick access to a GUI for openDAQ seems like a really nice feature.

This might be controversial so feel free to just close the pull request. Would appreciate a check by @mojca and @Yarikk26 as well.