### PR TITLE
Recursive active call + input port logic

### DIFF
--- a/core/opendaq/component/include/opendaq/component.h
+++ b/core/opendaq/component/include/opendaq/component.h
@@ -77,7 +77,8 @@ DECLARE_OPENDAQ_INTERFACE(IComponent, IPropertyObject)
     virtual ErrCode INTERFACE_FUNC getActive(Bool* active) = 0;
 
     /*!
-     * @brief Sets the component to be either active or inactive.
+     * @brief Sets the component to be either active or inactive. Also recursively sets the `active` field
+     * of all child components if component is a folder.
      * @param active The new active state of the component.
      * @retval OPENDAQ_IGNORED if "Active" is part of the component's list of locked attributes,
      * or if the new active value is equal to the previous.

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -69,7 +69,7 @@ public:
     ErrCode INTERFACE_FUNC getLocalId(IString** localId) override;
     ErrCode INTERFACE_FUNC getGlobalId(IString** globalId) override;
     ErrCode INTERFACE_FUNC getActive(Bool* active) override;
-    ErrCode INTERFACE_FUNC setActive(Bool active) override;
+    virtual ErrCode INTERFACE_FUNC setActive(Bool active) override;
     ErrCode INTERFACE_FUNC getContext(IContext** context) override;
     ErrCode INTERFACE_FUNC getParent(IComponent** parent) override;
     ErrCode INTERFACE_FUNC getName(IString** name) override;
@@ -114,6 +114,7 @@ protected:
     virtual void removed();
     virtual ErrCode lockAllAttributesInternal();
     ListPtr<IComponent> searchItems(const SearchFilterPtr& searchFilter, const std::vector<ComponentPtr>& items);
+    void setActiveRecursive(const std::vector<ComponentPtr>& items, Bool active);
 
     std::mutex sync;
     ContextPtr context;
@@ -823,6 +824,21 @@ ListPtr<IComponent> ComponentImpl<Intf, Intfs...>::searchItems(const SearchFilte
         childList.pushBack(signal);
 
     return childList.detach();
+}
+
+template <class Intf, class ... Intfs>
+void ComponentImpl<Intf, Intfs...>::setActiveRecursive(const std::vector<ComponentPtr>& items, Bool active)
+{
+    const bool muted = this->coreEventMuted;
+    const auto propInternalPtr = this->template borrowPtr<PropertyObjectInternalPtr>();
+    if (!muted)
+        propInternalPtr.disableCoreEventTrigger();
+
+    for (const auto& item : items)
+        item.setActive(active);
+    
+    if (!muted)
+        propInternalPtr.enableCoreEventTrigger();
 }
 
 template <class Intf, class... Intfs>

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -191,6 +191,9 @@ GenericDevice<TInterface, Interfaces...>::GenericDevice(const ContextPtr& ctx,
     devices.asPtr<IComponentPrivate>().lockAllAttributes();
     ioFolder.asPtr<IComponentPrivate>().lockAllAttributes();
 
+    devices.asPtr<IComponentPrivate>().unlockAttributes(List<IString>("Active"));
+    ioFolder.asPtr<IComponentPrivate>().unlockAttributes(List<IString>("Active"));
+
     this->addProperty(StringProperty("UserName", ""));
     this->addProperty(StringProperty("Location", ""));
 }

--- a/core/opendaq/device/tests/test_tree_traversal.cpp
+++ b/core/opendaq/device/tests/test_tree_traversal.cpp
@@ -173,3 +173,17 @@ TEST_F(TreeTraversalTest, InputPorts)
     ASSERT_EQ(fb.getInputPorts().getCount(), 1u);
     ASSERT_EQ(device.getItems(Recursive(InterfaceId(IInputPort::Id))).getCount(), 78u);
 }
+
+TEST_F(TreeTraversalTest, SetActive)
+{
+    auto device = createWithImplementation<IDevice, TestDevice>(NullContext(), nullptr, "dev", true);
+    const auto components = device.getItems(Recursive(Any()));
+
+    device.setActive(false);
+    for (const auto& comp : components)
+        ASSERT_FALSE(comp.getActive());
+    
+    device.setActive(true);
+    for (const auto& comp : components)
+        ASSERT_TRUE(comp.getActive());
+}

--- a/core/opendaq/functionblock/include/opendaq/function_block_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block_impl.h
@@ -130,6 +130,7 @@ FunctionBlockImpl<TInterface, Interfaces...>::FunctionBlockImpl(const FunctionBl
     this->defaultComponents.insert("IP");
     inputPorts = this->template addFolder<IInputPort>("IP", nullptr);
     inputPorts.asPtr<IComponentPrivate>().lockAllAttributes();
+    inputPorts.asPtr<IComponentPrivate>().unlockAttributes(List<IString>("Active"));
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/input_port.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/input_port.h
@@ -54,5 +54,11 @@ struct MockInputPort : daq::MockGenericComponent<MockInputPort, daq::IInputPortC
             .WillRepeatedly(DoAll(
                 Return(OPENDAQ_SUCCESS)
             ));
+
+        EXPECT_CALL(*this, getActive)
+            .Times(AnyNumber())
+            .WillRepeatedly(DoAll(
+                Return(OPENDAQ_SUCCESS)
+            ));
     }
 };

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/input_port.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/input_port.h
@@ -45,20 +45,16 @@ struct MockInputPort : daq::MockGenericComponent<MockInputPort, daq::IInputPortC
     MOCK_METHOD(daq::ErrCode, getCustomData, (daq::IBaseObject** customData), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, setCustomData, (daq::IBaseObject* customData), (override MOCK_CALL));
 
+    daq::Bool active = true;
+
     MockInputPort()
     {
         using namespace testing;
 
-        EXPECT_CALL(*this, notifyPacketEnqueued)
-            .Times(AnyNumber())
-            .WillRepeatedly(DoAll(
-                Return(OPENDAQ_SUCCESS)
-            ));
+        EXPECT_CALL(*this, notifyPacketEnqueued).Times(AnyNumber()).WillRepeatedly(DoAll(Return(OPENDAQ_SUCCESS)));
 
         EXPECT_CALL(*this, getActive)
             .Times(AnyNumber())
-            .WillRepeatedly(DoAll(
-                Return(OPENDAQ_SUCCESS)
-            ));
+            .WillRepeatedly(DoAll(Invoke([&](daq::Bool* active) { *active = this->active; }), Return(OPENDAQ_SUCCESS)));
     }
 };

--- a/core/opendaq/signal/src/connection_impl.cpp
+++ b/core/opendaq/signal/src/connection_impl.cpp
@@ -18,8 +18,9 @@ ErrCode ConnectionImpl::enqueue(IPacket* packet)
 
     if (!port.getActive())
     {
-        void* intf;
-        if (OPENDAQ_FAILED(packet->borrowInterface(IEventPacket::Id, &intf)))
+        PacketType type;
+        packet->getType(&type);
+        if (type != PacketType::Event)
             return OPENDAQ_IGNORED;
     }
 
@@ -38,8 +39,9 @@ ErrCode INTERFACE_FUNC ConnectionImpl::enqueueOnThisThread(IPacket* packet)
     
     if (!port.getActive())
     {
-        void* intf;
-        if (OPENDAQ_FAILED(packet->borrowInterface(IEventPacket::Id, &intf)))
+        PacketType type;
+        packet->getType(&type);
+        if (type != PacketType::Event)
             return OPENDAQ_IGNORED;
     }
 

--- a/core/opendaq/signal/src/connection_impl.cpp
+++ b/core/opendaq/signal/src/connection_impl.cpp
@@ -16,6 +16,13 @@ ErrCode ConnectionImpl::enqueue(IPacket* packet)
 {
     OPENDAQ_PARAM_NOT_NULL(packet);
 
+    if (!port.getActive())
+    {
+        void* intf;
+        if (OPENDAQ_FAILED(packet->borrowInterface(IEventPacket::Id, &intf)))
+            return OPENDAQ_IGNORED;
+    }
+
     withLock([&packet, this]()
     {
         packets.emplace_back(packet);
@@ -28,6 +35,13 @@ ErrCode ConnectionImpl::enqueue(IPacket* packet)
 ErrCode INTERFACE_FUNC ConnectionImpl::enqueueOnThisThread(IPacket* packet)
 {
     OPENDAQ_PARAM_NOT_NULL(packet);
+    
+    if (!port.getActive())
+    {
+        void* intf;
+        if (OPENDAQ_FAILED(packet->borrowInterface(IEventPacket::Id, &intf)))
+            return OPENDAQ_IGNORED;
+    }
 
     withLock([&packet, this]()
     {

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -12,6 +12,7 @@
 #include <opendaq/signal_factory.h>
 #include <opendaq/signal_private_ptr.h>
 #include <opendaq/tags_factory.h>
+#include <opendaq/input_port_factory.h>
 
 using SignalTest = testing::Test;
 
@@ -660,6 +661,48 @@ TEST_F(SignalTest, GetLastValueComplexFloat64)
     ASSERT_NO_THROW(complexPtr = lastValuePacket.asPtr<IComplexNumber>());
     ASSERT_DOUBLE_EQ(complexPtr.getReal(), 8.1);
     ASSERT_DOUBLE_EQ(complexPtr.getImaginary(), 9.1);
+}
+
+TEST_F(SignalTest, TestSignalActiveSendPacket)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    auto descriptor = DataDescriptorBuilder().setName("test").setSampleType(SampleType::Float64).build();
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    auto dataPacket = DataPacket(descriptor, 1);
+    signal.sendPacket(dataPacket);
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 2);
+
+    signal.setActive(false);
+    signal.sendPacket(dataPacket);
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 2);
+
+    auto descriptor1 = DataDescriptorBuilder().setName("test").setSampleType(SampleType::Int16).build();
+    signal.setDescriptor(descriptor1);
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 3);
+}
+
+TEST_F(SignalTest, TestInputPortActiveSendPacket)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    auto descriptor = DataDescriptorBuilder().setName("test").setSampleType(SampleType::Float64).build();
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    auto dataPacket = DataPacket(descriptor, 1);
+    signal.sendPacket(dataPacket);
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 2);
+
+    ip.setActive(false);
+    signal.sendPacket(dataPacket);
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 2);
+
+    auto descriptor1 = DataDescriptorBuilder().setName("test").setSampleType(SampleType::Int16).build();
+    signal.setDescriptor(descriptor1);
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 3);
 }
 
 END_NAMESPACE_OPENDAQ

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -81,6 +81,9 @@ ErrCode ConfigClientComponentBaseImpl<Impl>::getActive(Bool* active)
 template <class Impl>
 ErrCode ConfigClientComponentBaseImpl<Impl>::setActive(Bool active)
 {
+    if (this->coreEventMuted)
+        return Impl::setActive(active);
+
     return OPENDAQ_ERR_INVALID_OPERATION;
 }
 

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -600,6 +600,32 @@ TEST_F(ConfigCoreEventTest, ComponentAttributeChanged)
     ASSERT_EQ(changeCount, 8);
 }
 
+TEST_F(ConfigCoreEventTest, ComponentActiveChangedRecursive)
+{
+    int changeCount = 0;
+    clientContext.getOnCoreEvent() +=
+        [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+        {
+            ASSERT_EQ(args.getEventId(), static_cast<Int>(CoreEventId::AttributeChanged));
+            ASSERT_EQ(args.getEventName(), "AttributeChanged");
+            changeCount++;
+        };
+
+    serverDevice.asPtr<IComponentPrivate>().unlockAllAttributes();
+
+    const auto components = clientDevice.getItems(search::Recursive(search::Any()));
+
+    serverDevice.setActive(false);
+    for (const auto& comp : components)
+        ASSERT_FALSE(comp.getActive());
+
+    serverDevice.setActive(true);
+    for (const auto& comp : components)
+        ASSERT_TRUE(comp.getActive());
+
+    ASSERT_EQ(changeCount, 2);
+}
+
 TEST_F(ConfigCoreEventTest, DomainSignalAttributeChanged)
 {
     const FolderConfigPtr serverSigFolder = serverDevice.getItem("Sig");


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Description:

 - Connections no longer enqueue packets if input port is inactive.
 - `setActive` now recursively sets the active flag of all children