### PR TITLE
Make DeviceDomain a standalone object in DeviceImpl

### DIFF
--- a/bindings/python/opendaq/generated/component/py_component.cpp
+++ b/bindings/python/opendaq/generated/component/py_component.cpp
@@ -64,7 +64,7 @@ void defineIComponent(pybind11::module_ m, PyDaqIntf<daq::IComponent, daq::IProp
             const auto objectPtr = daq::ComponentPtr::Borrow(object);
             objectPtr.setActive(active);
         },
-        "Returns true if the component is active; false otherwise. / Sets the component to be either active or inactive.");
+        "Returns true if the component is active; false otherwise. / Sets the component to be either active or inactive. Also recursively sets the `active` field of all child components if component is a folder.");
     cls.def_property_readonly("context",
         [](daq::IComponent *object)
         {

--- a/bindings/python/opendaq/generated/device/py_device.cpp
+++ b/bindings/python/opendaq/generated/device/py_device.cpp
@@ -236,4 +236,11 @@ void defineIDevice(pybind11::module_ m, PyDaqIntf<daq::IDevice, daq::IFolder> cl
         },
         py::arg("configuration"),
         "Loads the configuration of the device from string.");
+    cls.def_property_readonly("ticks_since_origin",
+        [](daq::IDevice *object)
+        {
+            const auto objectPtr = daq::DevicePtr::Borrow(object);
+            return objectPtr.getTicksSinceOrigin();
+        },
+        "Gets the number of ticks passed since the device's absolute origin.");
 }

--- a/bindings/python/opendaq/generated/device/py_device_domain.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_domain.cpp
@@ -37,6 +37,8 @@ void defineIDeviceDomain(pybind11::module_ m, PyDaqIntf<daq::IDeviceDomain, daq:
 {
     cls.doc() = "Contains information about the domain of the device.";
 
+    m.def("DeviceDomain", &daq::DeviceDomain_Create);
+
     cls.def_property_readonly("tick_resolution",
         [](daq::IDeviceDomain *object)
         {
@@ -45,13 +47,6 @@ void defineIDeviceDomain(pybind11::module_ m, PyDaqIntf<daq::IDeviceDomain, daq:
         },
         py::return_value_policy::take_ownership,
         "Gets domain (usually time) between two consecutive ticks. Resolution is provided in a domain unit.");
-    cls.def_property_readonly("ticks_since_origin",
-        [](daq::IDeviceDomain *object)
-        {
-            const auto objectPtr = daq::DeviceDomainPtr::Borrow(object);
-            return objectPtr.getTicksSinceOrigin();
-        },
-        "Gets the number of ticks passed since the device's absolute origin.");
     cls.def_property_readonly("origin",
         [](daq::IDeviceDomain *object)
         {

--- a/bindings/python/opendaq/generated/device/py_device_info_config.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_info_config.cpp
@@ -38,6 +38,7 @@ void defineIDeviceInfoConfig(pybind11::module_ m, PyDaqIntf<daq::IDeviceInfoConf
     cls.doc() = "Configuration component of Device info objects. Contains setter methods that are available until the object is frozen.";
 
     m.def("DeviceInfoConfig", &daq::DeviceInfoConfig_Create);
+    m.def("DeviceInfoConfigWithCustomSdkVersion", &daq::DeviceInfoConfigWithCustomSdkVersion_Create);
 
     cls.def_property("name",
         nullptr,

--- a/bindings/python/opendaq/generated/signal/py_data_packet.cpp
+++ b/bindings/python/opendaq/generated/signal/py_data_packet.cpp
@@ -112,4 +112,12 @@ void defineIDataPacket(pybind11::module_ m, PyDaqIntf<daq::IDataPacket, daq::IPa
             return objectPtr.getPacketId();
         },
         "Gets the unique packet id.");
+    cls.def_property_readonly("last_value",
+        [](daq::IDataPacket *object)
+        {
+            const auto objectPtr = daq::DataPacketPtr::Borrow(object);
+            return baseObjectToPyObject(objectPtr.getLastValue());
+        },
+        py::return_value_policy::take_ownership,
+        "Gets the data packet last value");
 }

--- a/changelog/changelog_2.0.0-3.0.0.txt
+++ b/changelog/changelog_2.0.0-3.0.0.txt
@@ -1,5 +1,17 @@
 11.03.2023
 Description:
+	- Make DeviceDomain a standalone object in DeviceImpl
+		- Devices no longer override the DeviceDomain getters, but instead set it via the protected `setDeviceDomain` method
+		- Changing the DeviceDomain triggers a core event
+	- Move getTicksSinceOrigin to IDevice
+	
++ [factory] DeviceDomainPtr DeviceDomain(const RatioPtr& tickResolution, const StringPtr& origin, const UnitPtr& unit)
+- [function] IDeviceDomain::getTicksSinceOrigin(UInt* ticks)
++ [function] IDevice::getTicksSinceOrigin(UInt* ticks)
++ [factory] CoreEventArgsPtr CoreEventArgsDeviceDomainChanged(const DeviceDomainPtr& deviceDomain)
+
+11.03.2023
+Description:
     Update native transport protocol - initiate streaming only upon client request;
     New protocol message type added: PAYLOAD_TYPE_STREAMING_PROTOCOL_INIT_REQUEST = 11
 

--- a/core/coreobjects/include/coreobjects/core_event_args.h
+++ b/core/coreobjects/include/coreobjects/core_event_args.h
@@ -232,6 +232,17 @@ BEGIN_NAMESPACE_OPENDAQ
  *
  * The ID of the event is 140, and the event name is "TypeRemoved".
  *
+ * @subsubsection opendaq_core_event_types_domain_changed Device domain changed
+ *
+ * Triggered whenever the "Domain" of a device changes.
+ *
+ * The sender of the above event types is the device of which domain changed.
+ *
+ * The "DeviceDomainChanged" event contains the following parameters:
+ *  - The device domain under the key "DeviceDomain"
+ *
+ * The ID of the event is 150, and the event name is "DeviceDomainChanged".
+ *
  * @subsection opendaq_core_event_muting Muting core events
  *
  * Components, as previously mentioned, do not trigger core events until they are connected to the root of the

--- a/core/coreobjects/include/coreobjects/core_event_args_ids.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_ids.h
@@ -42,6 +42,7 @@ enum class CoreEventId : uint32_t
     StatusChanged = 120,
     TypeAdded = 130,
     TypeRemoved = 140,
+    DeviceDomainChanged = 150,
 };
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/core_event_args_impl.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_impl.h
@@ -59,6 +59,8 @@ namespace core_event_args_impl
                 return "TypeAdded";
             case CoreEventId::TypeRemoved:
                 return "TypeRemoved";
+            case CoreEventId::DeviceDomainChanged:
+                return "DeviceDomainChanged";
             default:
                 break;
         }
@@ -224,6 +226,8 @@ inline bool CoreEventArgsImpl::validateParameters() const
             return parameters.hasKey("Type");
         case CoreEventId::TypeRemoved:
             return parameters.hasKey("TypeName");
+        case CoreEventId::DeviceDomainChanged:
+            return parameters.hasKey("DeviceDomain");
         default:
             break;
     }

--- a/core/opendaq/device/include/opendaq/core_opendaq_event_args.h
+++ b/core/opendaq/device/include/opendaq/core_opendaq_event_args.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <coreobjects/core_event_args.h>
 #include <opendaq/component.h>
+#include <opendaq/device_domain.h>
 #include <opendaq/signal.h>
 
 BEGIN_NAMESPACE_OPENDAQ
@@ -126,6 +127,16 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     IList*, tags
 )
 
+/*!
+ * @brief Creates Core event args that are passed as argument when the domain of a device changes.
+ * @param deviceDomain The new device domain
+ *
+ * The ID of the event is 150, and the event name is "DeviceDomainChanged".
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, CoreEventArgsDeviceDomainChanged, ICoreEventArgs,
+    IDeviceDomain*, deviceDomain
+)
 
 /*!@}*/
 

--- a/core/opendaq/device/include/opendaq/core_opendaq_event_args_factory.h
+++ b/core/opendaq/device/include/opendaq/core_opendaq_event_args_factory.h
@@ -18,6 +18,7 @@
 #include <coreobjects/core_event_args_factory.h>
 #include <opendaq/core_opendaq_event_args.h>
 #include <opendaq/signal_ptr.h>
+#include <opendaq/device_domain_ptr.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -136,6 +137,17 @@ inline CoreEventArgsPtr CoreEventArgsTagsChanged(const ListPtr<IString>& tags)
     return obj;
 }
 
+/*!
+ * @brief Creates Core event args that are passed as argument when the domain of a device changes.
+ * @param deviceDomain The new device domain
+ *
+ * The ID of the event is 150, and the event name is "DeviceDomainChanged".
+ */
+inline CoreEventArgsPtr CoreEventArgsDeviceDomainChanged(const DeviceDomainPtr& deviceDomain)
+{
+    CoreEventArgsPtr obj(CoreEventArgsDeviceDomainChanged_Create(deviceDomain));
+    return obj;
+}
 /*!@}*/
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/include/opendaq/device.h
+++ b/core/opendaq/device/include/opendaq/device.h
@@ -236,6 +236,14 @@ DECLARE_OPENDAQ_INTERFACE(IDevice, IFolder)
      * @param configuration Serialized configuration of the device.
      */
     virtual ErrCode INTERFACE_FUNC loadConfiguration(IString* configuration) = 0;
+
+    /*!
+     * @brief Gets the number of ticks passed since the device's absolute origin.
+     * @param[out] ticks The number of ticks.
+     *
+     * To scale the ticks into a domain unit, the Device's Domain should be used.
+     */
+    virtual ErrCode INTERFACE_FUNC getTicksSinceOrigin(UInt* ticks) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/device/include/opendaq/device_domain.h
+++ b/core/opendaq/device/include/opendaq/device_domain.h
@@ -50,15 +50,9 @@ DECLARE_OPENDAQ_INTERFACE(IDeviceDomain, IBaseObject)
 {
     /*!
      * @brief Gets domain (usually time) between two consecutive ticks. Resolution is provided in a domain unit.
-     * @param[out] resolution The device's resolution.
+     * @param[out] tickResolution The device's resolution.
      */
-    virtual ErrCode INTERFACE_FUNC getTickResolution(IRatio** resolution) = 0;
-
-    /*!
-     * @brief Gets the number of ticks passed since the device's absolute origin.
-     * @param[out] ticks The number of ticks.
-     */
-    virtual ErrCode INTERFACE_FUNC getTicksSinceOrigin(UInt* ticks) = 0;
+    virtual ErrCode INTERFACE_FUNC getTickResolution(IRatio** tickResolution) = 0;
 
     /*!
      * @brief Gets the device's absolute origin. Most often this is a time epoch in the ISO 8601 format.
@@ -73,5 +67,12 @@ DECLARE_OPENDAQ_INTERFACE(IDeviceDomain, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getUnit(IUnit** unit) = 0;
 };
 /*!@}*/
+
+OPENDAQ_DECLARE_CLASS_FACTORY(LIBRARY_FACTORY, DeviceDomain,
+    IRatio*, tickResolution,
+    IString*, origin,
+    IUnit*, unit
+)
+
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/include/opendaq/device_domain_factory.h
+++ b/core/opendaq/device/include/opendaq/device_domain_factory.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <coretypes/struct_type_factory.h>
+#include <coretypes/simple_type_factory.h>
+#include <opendaq/device_domain_ptr.h>
+#include <coreobjects/unit_factory.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+/*!
+ * @ingroup opendaq_device_domain
+ * @addtogroup opendaq_device_domain_factories Factories
+ * @{
+ */
+
+inline DeviceDomainPtr DeviceDomain(const RatioPtr& tickResolution, const StringPtr& origin, const UnitPtr& unit)
+{
+    DeviceDomainPtr obj(DeviceDomain_Create(tickResolution, origin, unit));
+    return obj;
+}
+
+inline StructTypePtr DeviceDomainStructType()
+{
+    return StructType(
+        "deviceDomain",
+        List<IString>("tickResolution", "origin", "unit"),
+        List<IBaseObject>(Ratio(1, 1), "", "", Unit("s", -1, "second", "time")),
+        List<IType>(RatioStructType(), SimpleType(ctString), UnitStructType()));
+}
+
+/*!@}*/
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/include/opendaq/device_domain_impl.h
+++ b/core/opendaq/device/include/opendaq/device_domain_impl.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2023 Blueberry d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <opendaq/device_domain_ptr.h>
+#include <coretypes/intfs.h>
+#include <coretypes/string_ptr.h>
+#include <coretypes/struct_impl.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+class DeviceDomainImpl : public GenericStructImpl<IDeviceDomain, IStruct>
+{
+public:
+    explicit DeviceDomainImpl(RatioPtr tickResolution, StringPtr origin, UnitPtr unit);
+
+    ErrCode INTERFACE_FUNC getTickResolution(IRatio** tickResolution) override;
+    ErrCode INTERFACE_FUNC getOrigin(IString** origin) override;
+    ErrCode INTERFACE_FUNC getUnit(IUnit** unit) override;
+
+    // ISerializable
+    ErrCode INTERFACE_FUNC serialize(ISerializer* serializer) override;
+    ErrCode INTERFACE_FUNC getSerializeId(ConstCharPtr* id) const override;
+
+    static ConstCharPtr SerializeId();
+    static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* /*context*/, IFunction* /*factoryCallback*/, IBaseObject** obj);
+};
+
+OPENDAQ_REGISTER_DESERIALIZE_FACTORY(DeviceDomainImpl)
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -49,10 +49,10 @@ using DeviceBase = GenericDevice<IDevice, TTraits...>;
 using Device = DeviceBase<>;
 
 template <typename TInterface, typename... Interfaces>
-class GenericDevice : public SignalContainerImpl<TInterface, IDeviceDomain, IDevicePrivate, Interfaces...>
+class GenericDevice : public SignalContainerImpl<TInterface, IDevicePrivate, Interfaces...>
 {
 public:
-    using Super = SignalContainerImpl<TInterface, IDeviceDomain, IDevicePrivate, Interfaces...>;
+    using Super = SignalContainerImpl<TInterface, IDevicePrivate, Interfaces...>;
     using Self = GenericDevice<TInterface, Interfaces...>;
 
     GenericDevice(const ContextPtr& ctx,
@@ -62,10 +62,7 @@ public:
 
     virtual DeviceInfoPtr onGetInfo();
 
-    virtual RatioPtr onGetResolution();
     virtual uint64_t onGetTicksSinceOrigin();
-    virtual std::string onGetOrigin();
-    virtual UnitPtr onGetDomainUnit();
 
     virtual DictPtr<IString, IFunctionBlockType> onGetAvailableFunctionBlockTypes();
     virtual FunctionBlockPtr onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config);
@@ -109,11 +106,7 @@ public:
     ErrCode INTERFACE_FUNC saveConfiguration(IString** configuration) override;
     ErrCode INTERFACE_FUNC loadConfiguration(IString* configuration) override;
 
-    // IDeviceDomain
-    ErrCode INTERFACE_FUNC getTickResolution(IRatio** resolution) override;
     ErrCode INTERFACE_FUNC getTicksSinceOrigin(uint64_t* ticks) override;
-    ErrCode INTERFACE_FUNC getOrigin(IString** origin) override;
-    ErrCode INTERFACE_FUNC getUnit(IUnit** unit) override;
 
     // ISerializable
     ErrCode INTERFACE_FUNC getSerializeId(ConstCharPtr* id) const override;
@@ -128,9 +121,6 @@ protected:
     std::vector<StreamingInfoPtr> streamingOptions;
     LoggerComponentPtr loggerComponent;
     bool isRootDevice;
-    UnitPtr domainUnit;
-    RatioPtr domainTickResolution;
-    StringPtr domainOrigin;
 
     template <class ChannelImpl, class... Params>
     ChannelPtr createAndAddChannel(const FolderConfigPtr& parentFolder, const StringPtr& localId, Params&&... params);
@@ -139,6 +129,8 @@ protected:
 
     void addSubDevice(const DevicePtr& device);
     void removeSubDevice(const DevicePtr& device);
+
+    void setDeviceDomain(const DeviceDomainPtr& domain);
 
     DevicePtr createAndAddSubDevice(const StringPtr& connectionString, const PropertyObjectPtr& config);
 
@@ -160,6 +152,8 @@ protected:
     void updateObject(const SerializedObjectPtr& obj) override;
     bool clearFunctionBlocksOnUpdate() override;
 
+    void setDeviceDomainNoCoreEvent(const DeviceDomainPtr& domain);
+
 private:
     void getChannelsFromFolder(ListPtr<IChannel>& channelList, const FolderPtr& folder, const SearchFilterPtr& searchFilter, bool filterChannels = true);
     ListPtr<ISignal> getSignalsRecursiveInternal(const SearchFilterPtr& searchFilter);
@@ -168,6 +162,7 @@ private:
     ListPtr<IDevice> getDevicesRecursive(const SearchFilterPtr& searchFilter);
 
     std::unordered_map<std::string, size_t> functionBlockCountMap;
+    DeviceDomainPtr deviceDomain;
 };
 
 template <typename TInterface, typename... Interfaces>
@@ -222,7 +217,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::getDomain(IDeviceDomain** devi
 {
     OPENDAQ_PARAM_NOT_NULL(deviceDomain);
 
-    *deviceDomain = this->template thisInterface<IDeviceDomain>();
+    *deviceDomain = this->deviceDomain.addRefAndReturn();
     return OPENDAQ_SUCCESS;
 }
 
@@ -427,25 +422,6 @@ bool GenericDevice<TInterface, Interfaces...>::hasChannel(const FolderConfigPtr&
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode GenericDevice<TInterface, Interfaces...>::getTickResolution(IRatio** resolution)
-{
-    OPENDAQ_PARAM_NOT_NULL(resolution);
-
-    RatioPtr resolutionPtr;
-    const ErrCode errCode = wrapHandlerReturn(this, &Self::onGetResolution, resolutionPtr);
-
-    *resolution = resolutionPtr.detach();
-
-    return errCode;
-}
-
-template <typename TInterface, typename... Interfaces>
-RatioPtr GenericDevice<TInterface, Interfaces...>::onGetResolution()
-{
-    return domainTickResolution;
-}
-
-template <typename TInterface, typename... Interfaces>
 ErrCode GenericDevice<TInterface, Interfaces...>::getTicksSinceOrigin(uint64_t* ticks)
 {
     OPENDAQ_PARAM_NOT_NULL(ticks);
@@ -459,41 +435,6 @@ template <typename TInterface, typename... Interfaces>
 uint64_t GenericDevice<TInterface, Interfaces...>::onGetTicksSinceOrigin()
 {
     return 0;
-}
-
-template <typename TInterface, typename... Interfaces>
-ErrCode GenericDevice<TInterface, Interfaces...>::getOrigin(IString** origin)
-{
-    OPENDAQ_PARAM_NOT_NULL(origin);
-
-    std::string originStr;
-    ErrCode errCode = wrapHandlerReturn(this, &Self::onGetOrigin, originStr);
-
-    *origin = String(originStr).detach();
-
-    return errCode;
-}
-
-template <typename TInterface, typename... Interfaces>
-std::string GenericDevice<TInterface, Interfaces...>::onGetOrigin()
-{
-    if (domainOrigin.assigned())
-        return domainOrigin.toStdString();
-
-    return {};
-}
-
-template <typename TInterface, typename... Interfaces>
-ErrCode GenericDevice<TInterface, Interfaces...>::getUnit(IUnit** unit)
-{
-    OPENDAQ_PARAM_NOT_NULL(unit);
-
-    UnitPtr unitPtr;
-    const ErrCode errCode = wrapHandlerReturn(this, &Self::onGetDomainUnit, unitPtr);
-
-    *unit = unitPtr.detach();
-
-    return errCode;
 }
 
 template <typename TInterface, typename... Interfaces>
@@ -537,12 +478,6 @@ ErrCode GenericDevice<TInterface, Interfaces...>::Deserialize(ISerializedObject*
                        className);
                 }).detach();
         });
-}
-
-template <typename TInterface, typename... Interfaces>
-UnitPtr GenericDevice<TInterface, Interfaces...>::onGetDomainUnit()
-{
-    return domainUnit;
 }
 
 template <typename TInterface, typename... Interfaces>
@@ -1047,6 +982,17 @@ void GenericDevice<TInterface, Interfaces...>::removeSubDevice(const DevicePtr& 
     devices.removeItem(device);
 }
 
+template <typename TInterface, typename ... Interfaces>
+void GenericDevice<TInterface, Interfaces...>::setDeviceDomain(const DeviceDomainPtr& domain)
+{
+    this->deviceDomain = domain;
+
+    if (!this->coreEventMuted && this->coreEvent.assigned())
+    {
+        this->triggerCoreEvent(CoreEventArgsDeviceDomainChanged(this->deviceDomain));
+    }
+}
+
 template <typename TInterface, typename... Interfaces>
 inline IoFolderConfigPtr GenericDevice<TInterface, Interfaces...>::addIoFolder(const std::string& localId,
                                                                                const IoFolderConfigPtr& parent)
@@ -1102,30 +1048,10 @@ void GenericDevice<TInterface, Interfaces...>::serializeCustomObjectValues(const
             deviceInfo.serialize(serializer);
         }
 
-        DeviceDomainPtr deviceDomain;
-        checkErrorInfo(this->getDomain(&deviceDomain));
         if (deviceDomain.assigned())
         {
-            const auto origin = deviceDomain.getOrigin();
-            if (origin.assigned())
-            {
-                serializer.key("domainOrigin");
-                serializer.writeString(deviceDomain.getOrigin());
-            }
-
-            const auto resolution = deviceDomain.getTickResolution();
-            if (resolution.assigned())
-            {
-                serializer.key("domainResolution");
-                resolution.serialize(serializer);
-            }
-
-            const auto unit = deviceDomain.getUnit();
-            if (unit.assigned())
-            {
-                serializer.key("domainUnit");
-                unit.serialize(serializer);
-            }
+            serializer.key("deviceDomain");
+            deviceDomain.serialize(serializer);
         }
     }
 }
@@ -1220,14 +1146,10 @@ void GenericDevice<TInterface, Interfaces...>::deserializeCustomObjectValues(con
         deviceInfo.freeze();
     }
 
-    if (serializedObject.hasKey("domainOrigin"))
-        domainOrigin = serializedObject.readString("domainOrigin");
-
-    if (serializedObject.hasKey("domainResolution"))
-        domainTickResolution = serializedObject.readObject("domainResolution");
-
-    if (serializedObject.hasKey("domainUnit"))
-        domainUnit = serializedObject.readObject("domainUnit");
+    if (serializedObject.hasKey("deviceDomain"))
+    {
+        deviceDomain = serializedObject.readObject("deviceDomain");
+    }
 
     this->template deserializeDefaultFolder<IComponent>(serializedObject, context, factoryCallback, ioFolder, "IO");
     this->template deserializeDefaultFolder<IDevice>(serializedObject, context, factoryCallback, devices, "Dev");
@@ -1291,12 +1213,23 @@ void GenericDevice<TInterface, Interfaces...>::updateObject(const SerializedObje
             }
         }
     }
+
+    if (obj.hasKey("deviceDomain"))
+    {
+        deviceDomain = obj.readObject("deviceDomain");
+    }
 }
 
 template <typename TInterface, typename... Interfaces>
 bool GenericDevice<TInterface, Interfaces...>::clearFunctionBlocksOnUpdate()
 {
     return true;
+}
+
+template <typename TInterface, typename ... Interfaces>
+void GenericDevice<TInterface, Interfaces...>::setDeviceDomainNoCoreEvent(const DeviceDomainPtr& domain)
+{
+    this->deviceDomain = domain;
 }
 
 OPENDAQ_REGISTER_DESERIALIZE_FACTORY(Device)

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1154,7 +1154,7 @@ void GenericDevice<TInterface, Interfaces...>::deserializeCustomObjectValues(con
     this->template deserializeDefaultFolder<IComponent>(serializedObject, context, factoryCallback, ioFolder, "IO");
     this->template deserializeDefaultFolder<IDevice>(serializedObject, context, factoryCallback, devices, "Dev");
 
-    const std::set<std::string> ignoredKeys{"__type", "deviceInfo", "deviceDomain", "deviceUnit", "deviceResolution", "properties", "propValues"};
+    const std::set<std::string> ignoredKeys{"__type", "deviceInfo", "deviceDomain", "properties", "propValues"};
 
     const auto keys = serializedObject.getKeys();
     for (const auto& key : serializedObject.getKeys())

--- a/core/opendaq/device/src/CMakeLists.txt
+++ b/core/opendaq/device/src/CMakeLists.txt
@@ -25,6 +25,12 @@ source_group("device" FILES ${SDK_HEADERS_DIR}/device.h
                             device_info_impl.cpp
 )
 
+source_group("device_domain" FILES ${SDK_HEADERS_DIR}/device_domain.h
+                                   ${SDK_HEADERS_DIR}/device_domain_impl.h
+                                   ${SDK_HEADERS_DIR}/device_domain_factory.h
+                                   device_domain_impl.cpp
+)
+
 source_group("device_type" FILES ${SDK_HEADERS_DIR}/device_type.h
                                  ${SDK_HEADERS_DIR}/device_type_impl.h
                                  ${SDK_HEADERS_DIR}/device_type_factory.h
@@ -47,6 +53,7 @@ set(SRC_Cpp device_info_impl.cpp
             io_folder_impl.cpp
             device_type_impl.cpp
             core_opendaq_event_args_impl.cpp
+            device_domain_impl.cpp
 )
 
 set(SRC_PublicHeaders device_info_factory.h
@@ -59,10 +66,13 @@ set(SRC_PublicHeaders device_info_factory.h
                       device_private.h
                       core_opendaq_event_args_factory.h
                       core_opendaq_event_args.h
+                      device_domain_factory.h
+                      core_opendaq_event_args.h
 )
 
 set(SRC_PrivateHeaders device_info_impl.h
                        device_type_impl.h
+                       device_domain_impl.h
 )
 
 prepend_include(${MAIN_TARGET} SRC_PrivateHeaders)

--- a/core/opendaq/device/src/core_opendaq_event_args_impl.cpp
+++ b/core/opendaq/device/src/core_opendaq_event_args_impl.cpp
@@ -62,6 +62,13 @@ ErrCode PUBLIC_EXPORT createCoreEventArgsTagsChanged(ICoreEventArgs** objTmp, IL
     return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, CoreEventId, IDict*>(objTmp, CoreEventId::TagsChanged, dict);
 }
 
+extern "C"
+ErrCode PUBLIC_EXPORT createCoreEventArgsDeviceDomainChanged(ICoreEventArgs** objTmp, IDeviceDomain* deviceDomain)
+{
+    const auto dict = Dict<IString, IBaseObject>({{"DeviceDomain", deviceDomain}});
+    return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, CoreEventId, IDict*>(objTmp, CoreEventId::DeviceDomainChanged, dict);
+}
+
 #endif
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/src/device_domain_impl.cpp
+++ b/core/opendaq/device/src/device_domain_impl.cpp
@@ -1,0 +1,124 @@
+#include <coretypes/validation.h>
+#include <opendaq/device_domain_impl.h>
+#include <opendaq/device_domain_factory.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+namespace detail
+{
+    static const StructTypePtr unitStructType = UnitStructType();
+}
+
+DeviceDomainImpl::DeviceDomainImpl(RatioPtr tickResolution, StringPtr origin, UnitPtr unit)
+    : GenericStructImpl<IDeviceDomain, IStruct>(
+        detail::unitStructType,
+        Dict<IString, IBaseObject>(
+            {{"tickResolution", std::move(tickResolution)}, {"origin", std::move(origin)}, {"unit", std::move(unit)}}))
+{
+}
+
+ErrCode DeviceDomainImpl::getTickResolution(IRatio** tickResolution)
+{
+    OPENDAQ_PARAM_NOT_NULL(tickResolution);
+
+    *tickResolution = this->fields.get("tickResolution").asPtr<IRatio>().addRefAndReturn();;
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DeviceDomainImpl::getOrigin(IString** origin)
+{
+    OPENDAQ_PARAM_NOT_NULL(origin);
+
+    *origin = this->fields.get("origin").asPtr<IString>().addRefAndReturn();;
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DeviceDomainImpl::getUnit(IUnit** unit)
+{
+    OPENDAQ_PARAM_NOT_NULL(unit);
+
+    *unit = this->fields.get("unit").asPtr<IUnit>().addRefAndReturn();;
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DeviceDomainImpl::serialize(ISerializer* serializer)
+{
+    OPENDAQ_PARAM_NOT_NULL(serializer);
+
+    serializer->startTaggedObject(this);
+    {
+        const RatioPtr resolution = this->fields.get("tickResolution");
+        if (resolution.assigned())
+        {
+            serializer->key("tickResolution");
+            resolution.serialize(serializer);
+        }
+        
+        const StringPtr origin = this->fields.get("origin");
+        if (origin.assigned() && origin != "")
+        {
+            serializer->key("origin");
+            serializer->writeString(origin.getCharPtr(), origin.getLength());
+        }
+        
+        const UnitPtr unit = this->fields.get("unit");
+        if (unit.assigned())
+        {
+            serializer->key("unit");
+            unit.serialize(serializer);
+        }
+    }
+
+    serializer->endObject();
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DeviceDomainImpl::getSerializeId(ConstCharPtr* id) const
+{
+    OPENDAQ_PARAM_NOT_NULL(id);
+
+    *id = SerializeId();
+    return OPENDAQ_SUCCESS;
+}
+
+ConstCharPtr DeviceDomainImpl::SerializeId()
+{
+    return "DeviceDomain";
+}
+
+ErrCode DeviceDomainImpl::Deserialize(ISerializedObject* serialized, IBaseObject*, IFunction*, IBaseObject** obj)
+{
+    OPENDAQ_PARAM_NOT_NULL(serialized);
+    OPENDAQ_PARAM_NOT_NULL(obj);
+    SerializedObjectPtr serializedObj = SerializedObjectPtr::Borrow(serialized);
+
+    RatioPtr resolution;
+    StringPtr origin;
+    UnitPtr unit;
+    
+    if (serializedObj.hasKey("tickResolution"))
+    {
+        resolution = serializedObj.readObject("tickResolution");
+    }
+    
+    if (serializedObj.hasKey("origin"))
+    {
+        origin = serializedObj.readString("origin");
+    }
+
+    if (serializedObj.hasKey("unit"))
+    {
+        unit = serializedObj.readObject("unit");
+    }
+
+    *obj = DeviceDomain(resolution, origin, unit).as<IBaseObject>();
+    return OPENDAQ_SUCCESS;
+}
+
+OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, DeviceDomain,
+    IRatio*, tickResolution,
+    IString*, origin,
+    IUnit*, unit
+)
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/opendaq/include/opendaq/instance_impl.h
+++ b/core/opendaq/opendaq/include/opendaq/instance_impl.h
@@ -24,7 +24,7 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-class InstanceImpl final : public ImplementationOfWeak<IInstance, IDeviceDomain, ISerializable, IUpdatable>
+class InstanceImpl final : public ImplementationOfWeak<IInstance, ISerializable, IUpdatable>
 {
 public:
     explicit InstanceImpl(ContextPtr context, const StringPtr& localId);
@@ -73,10 +73,7 @@ public:
     ErrCode INTERFACE_FUNC loadConfiguration(IString* configuration) override;
 
     // IDeviceDomain
-    ErrCode INTERFACE_FUNC getTickResolution(IRatio** resolution) override;
     ErrCode INTERFACE_FUNC getTicksSinceOrigin(uint64_t* ticks) override;
-    ErrCode INTERFACE_FUNC getOrigin(IString** origin) override;
-    ErrCode INTERFACE_FUNC getUnit(IUnit** unit) override;
 
     // IComponent
 

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/device.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/device.h
@@ -43,6 +43,7 @@ struct MockDevice : MockGenericSignalContainer<MockDevice, IDevice>
     MOCK_METHOD(ErrCode, removeFunctionBlock, (IFunctionBlock*), (override MOCK_CALL));
     MOCK_METHOD(ErrCode, saveConfiguration, (IString**), (override MOCK_CALL));
     MOCK_METHOD(ErrCode, loadConfiguration, (IString*), (override MOCK_CALL));
+    MOCK_METHOD(ErrCode, getTicksSinceOrigin, (UInt*), (override MOCK_CALL));
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_physical_device.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_physical_device.h
@@ -30,10 +30,9 @@ public:
     ~MockPhysicalDeviceImpl();
      
     daq::DeviceInfoPtr onGetInfo() override;
-    daq::RatioPtr onGetResolution() override;
     uint64_t onGetTicksSinceOrigin() override;
-    std::string onGetOrigin() override;
-    daq::UnitPtr onGetDomainUnit() override;
+
+    void setDeviceDomainHelper(const DeviceDomainPtr& deviceDomain);
 
 protected:
     void startAcq();

--- a/core/opendaq/opendaq/mocks/mock_physical_device.cpp
+++ b/core/opendaq/opendaq/mocks/mock_physical_device.cpp
@@ -8,6 +8,8 @@
 #include <opendaq/folder_ptr.h>
 #include <coreobjects/callable_info_factory.h>
 
+#include "opendaq/device_domain_factory.h"
+
 using namespace daq;
 
 inline MockPhysicalDeviceImpl::MockPhysicalDeviceImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
@@ -59,6 +61,8 @@ inline MockPhysicalDeviceImpl::MockPhysicalDeviceImpl(const ContextPtr& ctx, con
     const PropertyObjectPtr thisPtr = this->borrowPtr<PropertyObjectPtr>();
     thisPtr.addProperty(StringProperty("TestProperty", "Test").detach());
     this->tags.add("phys_device");
+
+    this->setDeviceDomain(DeviceDomain(Ratio(123, 456), "origin", Unit("unit_symbol", 987, "unit_name", "unit_quantity")));
 }
 
 MockPhysicalDeviceImpl::~MockPhysicalDeviceImpl()
@@ -92,24 +96,14 @@ DeviceInfoPtr MockPhysicalDeviceImpl::onGetInfo()
     return deviceInfo;
 }
 
-RatioPtr MockPhysicalDeviceImpl::onGetResolution()
-{
-    return Ratio(123, 456);
-}
-
 uint64_t MockPhysicalDeviceImpl::onGetTicksSinceOrigin()
 {
     return 789;
 }
 
-std::string MockPhysicalDeviceImpl::onGetOrigin()
+void MockPhysicalDeviceImpl::setDeviceDomainHelper(const DeviceDomainPtr& deviceDomain)
 {
-    return "origin";
-}
-
-UnitPtr MockPhysicalDeviceImpl::onGetDomainUnit()
-{
-    return Unit("unit_symbol", 987, "unit_name", "unit_quantity");
+    this->setDeviceDomain(deviceDomain);
 }
 
 void MockPhysicalDeviceImpl::startAcq()

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -338,42 +338,9 @@ ErrCode InstanceImpl::getSignalsRecursive(IList** signals, ISearchFilter* search
     return rootDevice->getSignalsRecursive(signals, searchFilter);
 }
 
-// IDeviceDomain
-
-ErrCode InstanceImpl::getTickResolution(IRatio** resolution)
-{
-    const auto deviceDomain = rootDevice.asPtrOrNull<IDeviceDomain>();
-    if (deviceDomain.assigned())
-        return deviceDomain->getTickResolution(resolution);
-
-    return makeErrorInfo(OPENDAQ_ERR_NOINTERFACE, "Root device does not contain a device domain.");
-}
-
 ErrCode InstanceImpl::getTicksSinceOrigin(uint64_t* ticks)
 {
-    const auto deviceDomain = rootDevice.asPtrOrNull<IDeviceDomain>();
-    if (deviceDomain.assigned())
-        return deviceDomain->getTicksSinceOrigin(ticks);
-
-    return makeErrorInfo(OPENDAQ_ERR_NOINTERFACE, "Root device does not contain a device domain.");
-}
-
-ErrCode InstanceImpl::getOrigin(IString** origin)
-{
-    const auto deviceDomain = rootDevice.asPtrOrNull<IDeviceDomain>();
-    if (deviceDomain.assigned())
-        return deviceDomain->getOrigin(origin);
-
-    return makeErrorInfo(OPENDAQ_ERR_NOINTERFACE, "Root device does not contain a device domain.");
-}
-
-ErrCode InstanceImpl::getUnit(IUnit** unit)
-{
-    const auto deviceDomain = rootDevice.asPtrOrNull<IDeviceDomain>();
-    if (deviceDomain.assigned())
-        return deviceDomain->getUnit(unit);
-
-    return makeErrorInfo(OPENDAQ_ERR_NOINTERFACE, "Root device does not contain a device domain.");
+    return rootDevice->getTicksSinceOrigin(ticks);
 }
 
 ErrCode InstanceImpl::getLocalId(IString** localId)

--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -1438,19 +1438,20 @@ TEST_F(CoreEventTest, TypeRemoved)
 TEST_F(CoreEventTest, DomainChanged)
 {
     const auto device = instance.getDevices()[0];
-    auto mock = dynamic_cast<MockPhysicalDeviceImpl*>(device.getObject());
+    const auto mock = dynamic_cast<MockPhysicalDeviceImpl*>(device.getObject());
 
     int changeCount = 0;
     getOnCoreEvent() +=
-        [&](const ComponentPtr& comp, const CoreEventArgsPtr& args)
+        [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
     {
         ASSERT_EQ(args.getEventId(), static_cast<int>(CoreEventId::DeviceDomainChanged));
         ASSERT_EQ(args.getEventName(), "DeviceDomainChanged");
         ASSERT_TRUE(args.getParameters().hasKey("DeviceDomain"));
         changeCount++;
     };
-    DeviceDomainPtr domain1 = DeviceDomain(Ratio(1, 1), "foo", Unit("test"));
-    DeviceDomainPtr domain2 = DeviceDomain(Ratio(1, 1), "bar", Unit("test1"));
+
+    const DeviceDomainPtr domain1 = DeviceDomain(Ratio(1, 1), "foo", Unit("test"));
+    const DeviceDomainPtr domain2 = DeviceDomain(Ratio(1, 1), "bar", Unit("test1"));
 
     mock->setDeviceDomainHelper(domain1);
     ASSERT_EQ(device.getDomain().getOrigin(), "foo");

--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -15,6 +15,8 @@
 #include <coreobjects/property_object_factory.h>
 #include <coreobjects/property_object_protected_ptr.h>
 #include <opendaq/component_status_container_private_ptr.h>
+#include <opendaq/mock/mock_physical_device.h>
+#include <opendaq/device_domain_factory.h>
 
 using namespace daq;
 
@@ -1431,4 +1433,33 @@ TEST_F(CoreEventTest, TypeRemoved)
     typeManager.removeType("StructType2");
 
     ASSERT_EQ(removeCount, 3);
+}
+
+TEST_F(CoreEventTest, DomainChanged)
+{
+    const auto device = instance.getDevices()[0];
+    auto mock = dynamic_cast<MockPhysicalDeviceImpl*>(device.getObject());
+
+    int changeCount = 0;
+    getOnCoreEvent() +=
+        [&](const ComponentPtr& comp, const CoreEventArgsPtr& args)
+    {
+        ASSERT_EQ(args.getEventId(), static_cast<int>(CoreEventId::DeviceDomainChanged));
+        ASSERT_EQ(args.getEventName(), "DeviceDomainChanged");
+        ASSERT_TRUE(args.getParameters().hasKey("DeviceDomain"));
+        changeCount++;
+    };
+    DeviceDomainPtr domain1 = DeviceDomain(Ratio(1, 1), "foo", Unit("test"));
+    DeviceDomainPtr domain2 = DeviceDomain(Ratio(1, 1), "bar", Unit("test1"));
+
+    mock->setDeviceDomainHelper(domain1);
+    ASSERT_EQ(device.getDomain().getOrigin(), "foo");
+
+    mock->setDeviceDomainHelper(domain2);
+    ASSERT_EQ(device.getDomain().getOrigin(), "bar");
+
+    mock->setDeviceDomainHelper(domain1);
+    ASSERT_EQ(device.getDomain().getOrigin(), "foo");
+
+    ASSERT_EQ(changeCount, 3);
 }

--- a/modules/audio_device_module/include/audio_device_module/audio_device_impl.h
+++ b/modules/audio_device_module/include/audio_device_module/audio_device_impl.h
@@ -39,12 +39,7 @@ public:
 
     // IDevice
     DeviceInfoPtr onGetInfo() override;
-
-    // IDeviceDomain
-    RatioPtr onGetResolution() override;
     uint64_t onGetTicksSinceOrigin() override;
-    std::string onGetOrigin() override;
-    UnitPtr onGetDomainUnit() override;
 
     void addData(const void* data, size_t sampleCount);
 

--- a/modules/audio_device_module/src/audio_device_impl.cpp
+++ b/modules/audio_device_module/src/audio_device_impl.cpp
@@ -8,6 +8,7 @@
 #include <opendaq/data_rule_factory.h>
 #include <opendaq/custom_log.h>
 #include <opendaq/device_type_factory.h>
+#include <opendaq/device_domain_factory.h>
 
 BEGIN_NAMESPACE_AUDIO_DEVICE_MODULE
 
@@ -28,6 +29,10 @@ AudioDeviceImpl::AudioDeviceImpl(const std::shared_ptr<MiniaudioContext>& maCont
     createAudioChannel();
 
     start();
+    
+    this->setDeviceDomain(DeviceDomain(Ratio(1, maDevice.sampleRate),
+                                       "",
+                                       UnitBuilder().setName("second").setSymbol("s").setQuantity("time").build()));
 }
 
 AudioDeviceImpl::~AudioDeviceImpl()
@@ -56,29 +61,9 @@ DeviceInfoPtr AudioDeviceImpl::onGetInfo()
     return CreateDeviceInfo(maContext, info);
 }
 
-RatioPtr AudioDeviceImpl::onGetResolution()
-{
-    if (started)
-        return Ratio(1, maDevice.sampleRate);
-
-    return Ratio(0, 1);
-}
-
 uint64_t AudioDeviceImpl::onGetTicksSinceOrigin()
 {
     return 0;
-}
-
-std::string AudioDeviceImpl::onGetOrigin()
-{
-    return "";
-}
-
-UnitPtr AudioDeviceImpl::onGetDomainUnit()
-{
-    auto unitPtr = daq::UnitBuilder().setName("second").setSymbol("s").setQuantity("time").build();
-
-    return unitPtr;
 }
 
 void AudioDeviceImpl::initProperties()

--- a/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
+++ b/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
@@ -39,12 +39,8 @@ public:
     DeviceInfoPtr onGetInfo() override;
     DevicePtr onAddDevice(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
     FunctionBlockPtr onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config) override;
-
-    // IDeviceDomain
-    RatioPtr onGetResolution() override;
     uint64_t onGetTicksSinceOrigin() override;
-    std::string onGetOrigin() override;
-    UnitPtr onGetDomainUnit() override;
+
 private:
     void initClock();
     void initIoFolder();

--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -7,7 +7,7 @@
 #include <fmt/format.h>
 #include <opendaq/custom_log.h>
 #include <opendaq/device_type_factory.h>
-
+#include <opendaq/device_domain_factory.h>
 #include <utility>
 
 BEGIN_NAMESPACE_REF_DEVICE_MODULE
@@ -67,11 +67,6 @@ DeviceInfoPtr RefDeviceImpl::onGetInfo()
     return RefDeviceImpl::CreateDeviceInfo(id);
 }
 
-RatioPtr RefDeviceImpl::onGetResolution()
-{
-    return RefChannelImpl::getResolution();
-}
-
 uint64_t RefDeviceImpl::onGetTicksSinceOrigin()
 {
     auto microSecondsSinceDeviceStart = getMicroSecondsSinceDeviceStart();
@@ -84,18 +79,6 @@ std::chrono::microseconds RefDeviceImpl::getMicroSecondsSinceDeviceStart() const
     auto currentTime = std::chrono::steady_clock::now();
     auto microSecondsSinceDeviceStart = std::chrono::duration_cast<std::chrono::microseconds>(currentTime - startTime);
     return microSecondsSinceDeviceStart;
-}
-
-std::string RefDeviceImpl::onGetOrigin()
-{
-    return RefChannelImpl::getEpoch();
-}
-
-UnitPtr RefDeviceImpl::onGetDomainUnit()
-{
-    auto unitPtr = daq::UnitBuilder().setName("second").setSymbol("s").setQuantity("time").build();
-
-    return unitPtr;
 }
 
 DevicePtr RefDeviceImpl::onAddDevice(const StringPtr& connectionString, const PropertyObjectPtr& config)
@@ -176,6 +159,8 @@ void RefDeviceImpl::initClock()
     auto startAbsTime = std::chrono::system_clock::now();
 
     microSecondsFromEpochToDeviceStart = std::chrono::duration_cast<std::chrono::microseconds>(startAbsTime.time_since_epoch());
+
+    this->setDeviceDomain(DeviceDomain(RefChannelImpl::getResolution(), RefChannelImpl::getEpoch(), UnitBuilder().setName("second").setSymbol("s").setQuantity("time").build()));
 }
 
 void RefDeviceImpl::initIoFolder()

--- a/modules/ref_device_module/tests/test_ref_device_module.cpp
+++ b/modules/ref_device_module/tests/test_ref_device_module.cpp
@@ -176,9 +176,8 @@ TEST_F(RefDeviceModuleTest, DeviceDomainTicksSinceEpoch)
     auto module = CreateModule();
 
     auto device = module.createDevice("daqref://device1", nullptr);
-    auto domain = device.getDomain();
 
-    auto res = domain.getTicksSinceOrigin();
+    auto res = device.getTicksSinceOrigin();
     ASSERT_GT(res, 0u);
 }
 

--- a/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -162,7 +162,7 @@ TEST_F(OpcuaDeviceModulesTest, DeviceInfoAndDomain)
     ASSERT_EQ(domain.getTickResolution(), serverRefDeviceDomain.getTickResolution());
     ASSERT_EQ(domain.getOrigin(), serverRefDeviceDomain.getOrigin());
     ASSERT_NO_THROW(domain.getUnit());
-    ASSERT_NO_THROW(domain.getTicksSinceOrigin());
+    ASSERT_NO_THROW(refDevice.getTicksSinceOrigin());
 }
 
 TEST_F(OpcuaDeviceModulesTest, DeviceDynamicFeatures)

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -184,6 +184,7 @@ void ConfigClientComponentBaseImpl<Impl>::handleRemoteCoreObjectInternal(const C
         case CoreEventId::ComponentRemoved:
         case CoreEventId::TypeAdded:
         case CoreEventId::TypeRemoved:
+        case CoreEventId::DeviceDomainChanged:
         default:
             break;
     }

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -60,6 +60,7 @@ protected:
 private:
     void componentAdded(const CoreEventArgsPtr& args);
     void componentRemoved(const CoreEventArgsPtr& args);
+    void deviceDomainChanged(const CoreEventArgsPtr& args);
 };
 
 template <class TDeviceBase>
@@ -146,6 +147,9 @@ void GenericConfigClientDeviceImpl<TDeviceBase>::handleRemoteCoreObjectInternal(
             break;
         case CoreEventId::ComponentRemoved:
             componentRemoved(args);
+            break;
+        case CoreEventId::DeviceDomainChanged:
+            deviceDomainChanged(args);
             break;
         case CoreEventId::PropertyValueChanged:
         case CoreEventId::PropertyObjectUpdateEnd:
@@ -256,5 +260,12 @@ void GenericConfigClientDeviceImpl<TDeviceBase>::componentRemoved(const CoreEven
     checkErrorInfo(TDeviceBase::hasItem(id, &hasItem));
     if (hasItem)
         this->removeComponentById(id);
+}
+
+template <class TDeviceBase>
+void GenericConfigClientDeviceImpl<TDeviceBase>::deviceDomainChanged(const CoreEventArgsPtr& args)
+{
+    const DeviceDomainPtr domain = args.getParameters().get("DeviceDomain");
+    this->setDeviceDomain(domain);
 }
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_folder_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_folder_impl.h
@@ -167,6 +167,7 @@ void ConfigClientBaseFolderImpl<Impl>::handleRemoteCoreObjectInternal(const Comp
         case CoreEventId::StatusChanged:
         case CoreEventId::TypeAdded:
         case CoreEventId::TypeRemoved:
+        case CoreEventId::DeviceDomainChanged:
         default:
             break;
     }

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
@@ -162,6 +162,7 @@ inline void ConfigClientInputPortImpl::handleRemoteCoreObjectInternal(const Comp
         case CoreEventId::StatusChanged:
         case CoreEventId::TypeAdded:
         case CoreEventId::TypeRemoved:
+        case CoreEventId::DeviceDomainChanged:
         default:
             break;
     }

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_signal_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_signal_impl.h
@@ -114,6 +114,7 @@ inline void ConfigClientSignalImpl::handleRemoteCoreObjectInternal(const Compone
         case CoreEventId::StatusChanged:
         case CoreEventId::TypeAdded:
         case CoreEventId::TypeRemoved:
+        case CoreEventId::DeviceDomainChanged:
         default:
             break;
     }

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_device.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_device.h
@@ -73,7 +73,7 @@ inline BaseObjectPtr ConfigServerDevice::getInfo(const DevicePtr& device, const 
 
 inline BaseObjectPtr ConfigServerDevice::getTicksSinceOrigin(const DevicePtr& device, const ParamsDictPtr& params)
 {
-    return device.getDomain().getTicksSinceOrigin();
+    return device.getTicksSinceOrigin();
 }
 
 }

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -308,7 +308,6 @@ void ConfigProtocolServer::coreEventCallback(ComponentPtr& component, CoreEventA
     sendNotification(packed);
 }
 
-
 ListPtr<IBaseObject> ConfigProtocolServer::packCoreEvent(const ComponentPtr& component, const CoreEventArgsPtr& args)
 {
     const auto globalId = component.assigned() ? component.getGlobalId() : "";
@@ -335,6 +334,8 @@ ListPtr<IBaseObject> ConfigProtocolServer::packCoreEvent(const ComponentPtr& com
         case CoreEventId::StatusChanged:
         case CoreEventId::TypeAdded:
         case CoreEventId::TypeRemoved:
+        case CoreEventId::DeviceDomainChanged:
+        default:
             packedEvent.pushBack(args);
     }
     

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -247,9 +247,9 @@ TEST_F(ConfigProtocolIntegrationTest, DomainInfo)
 TEST_F(ConfigProtocolIntegrationTest, GetTicksSinceOrigin)
 {
     const auto clientSubDevice = clientDevice.getDevices()[0];
-    ASSERT_EQ(clientSubDevice.getDomain().getTicksSinceOrigin(), 0u);
-    ASSERT_EQ(clientSubDevice.getDomain().getTicksSinceOrigin(), 1u);
-    ASSERT_EQ(clientSubDevice.getDomain().getTicksSinceOrigin(), 2u);
+    ASSERT_EQ(clientSubDevice.getTicksSinceOrigin(), 0u);
+    ASSERT_EQ(clientSubDevice.getTicksSinceOrigin(), 1u);
+    ASSERT_EQ(clientSubDevice.getTicksSinceOrigin(), 2u);
 }
 
 TEST_F(ConfigProtocolIntegrationTest, GetAvailableFunctionBlockTypes)

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -13,6 +13,7 @@
 #include <opendaq/tags_private_ptr.h>
 #include <opendaq/component_status_container_private_ptr.h>
 #include <opendaq/component_status_container_ptr.h>
+#include <opendaq/device_domain_factory.h>
 #include <coreobjects/property_object_factory.h>
 #include "test_utils.h"
 #include "config_protocol/config_protocol_server.h"
@@ -1364,4 +1365,34 @@ TEST_F(ConfigCoreEventTest, ComponentUpdateEndDescriptorChanged)
     ASSERT_EQ(clientDeviceSig.getDescriptor(), newDesc);
 
     ASSERT_EQ(updateCount, 1);
+}
+
+TEST_F(ConfigCoreEventTest, DomainChanged)
+{
+    int changeCount = 0;
+    auto mock = dynamic_cast<test_utils::MockDevice2Impl*>(serverDevice.getObject());
+
+    clientContext.getOnCoreEvent() +=
+        [&](const ComponentPtr& comp, const CoreEventArgsPtr& args)
+        {
+            ASSERT_EQ(args.getEventId(), static_cast<Int>(CoreEventId::DeviceDomainChanged));
+            ASSERT_EQ(args.getEventName(), "DeviceDomainChanged");
+            ASSERT_TRUE(args.getParameters().hasKey("DeviceDomain"));
+            ASSERT_EQ(comp, clientDevice);
+            changeCount++;
+        };
+
+    DeviceDomainPtr domain1 = DeviceDomain(Ratio(1, 1), "foo", Unit("test"));
+    DeviceDomainPtr domain2 = DeviceDomain(Ratio(1, 1), "bar", Unit("test1"));
+
+    mock->setDeviceDomainHelper(domain1);
+    ASSERT_EQ(clientDevice.getDomain().getOrigin(), "foo");
+
+    mock->setDeviceDomainHelper(domain2);
+    ASSERT_EQ(clientDevice.getDomain().getOrigin(), "bar");
+
+    mock->setDeviceDomainHelper(domain1);
+    ASSERT_EQ(clientDevice.getDomain().getOrigin(), "foo");
+
+    ASSERT_EQ(changeCount, 3);
 }

--- a/shared/libraries/config_protocol/tests/test_utils.cpp
+++ b/shared/libraries/config_protocol/tests/test_utils.cpp
@@ -6,6 +6,7 @@
 #include "coreobjects/validator_factory.h"
 #include "opendaq/context_factory.h"
 #include "opendaq/component_status_container_private_ptr.h"
+#include "opendaq/device_domain_factory.h"
 
 namespace daq::config_protocol::test_utils
 {
@@ -215,6 +216,8 @@ MockDevice1Impl::MockDevice1Impl(const ContextPtr& ctx, const ComponentPtr& pare
     addNestedFunctionBlock(fb);
 
     fb.getInputPorts()[0].connect(sig);
+
+    setDeviceDomain(DeviceDomain(Ratio(1, 100), "N/A" , Unit("s", -1, "second", "time")));
 }
 
 DictPtr<IString, IFunctionBlockType> MockDevice1Impl::onGetAvailableFunctionBlockTypes()
@@ -254,24 +257,9 @@ DeviceInfoPtr MockDevice1Impl::onGetInfo()
     return info;
 }
 
-RatioPtr MockDevice1Impl::onGetResolution()
-{
-    return Ratio(1, 100);
-}
-
 uint64_t MockDevice1Impl::onGetTicksSinceOrigin()
 {
     return ticksSinceOrigin++;
-}
-
-std::string MockDevice1Impl::onGetOrigin()
-{
-    return "N/A";
-}
-
-UnitPtr MockDevice1Impl::onGetDomainUnit()
-{
-    return Unit("s", -1, "second", "time");
 }
 
 MockDevice2Impl::MockDevice2Impl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)

--- a/shared/libraries/config_protocol/tests/test_utils.h
+++ b/shared/libraries/config_protocol/tests/test_utils.h
@@ -57,10 +57,7 @@ namespace daq::config_protocol::test_utils
         FunctionBlockPtr onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config) override;
         void onRemoveFunctionBlock(const FunctionBlockPtr& functionBlock) override;
         DeviceInfoPtr onGetInfo() override;
-        RatioPtr onGetResolution() override;
         uint64_t onGetTicksSinceOrigin() override;
-        std::string onGetOrigin() override;
-        UnitPtr onGetDomainUnit() override;
 
     protected:
         bool clearFunctionBlocksOnUpdate() override
@@ -85,6 +82,11 @@ namespace daq::config_protocol::test_utils
         void removeComponentHelper(const std::string& id)
         {
             removeComponentById(id);
+        }
+        
+        void setDeviceDomainHelper(const DeviceDomainPtr& deviceDomain)
+        {
+            setDeviceDomain(deviceDomain);
         }
 
     protected:

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_device_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_device_impl.h
@@ -32,16 +32,15 @@ public:
                                  const opcua::OpcUaNodeId& nodeId,
                                  const FunctionPtr& createStreamingCallback,
                                  bool isRootDevice);
+    
+    ErrCode INTERFACE_FUNC getDomain(IDeviceDomain** deviceDomain) override;
 
 protected:
     void findAndCreateSubdevices();
     DevicePtr onAddDevice(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
     void onRemoveDevice(const DevicePtr& device) override;
     DeviceInfoPtr onGetInfo() override;
-    RatioPtr onGetResolution() override;
     uint64_t onGetTicksSinceOrigin() override;
-    std::string onGetOrigin() override;
-    UnitPtr onGetDomainUnit() override;
     void findAndCreateFunctionBlocks();
     void findAndCreateSignals();
     void findAndCreateInputsOutputs();
@@ -55,8 +54,6 @@ protected:
     void setUpStreamings();
     void connectToStreamings();
 
-    DeviceInfoConfigPtr deviceInfo;
-
     // Streaming related members
     std::vector<StreamingPtr> streamings;
     FunctionPtr createStreamingCallback;
@@ -66,11 +63,7 @@ private:
     void fetchTimeDomain();
     void fetchTicksSinceOrigin();
 
-    bool timeDomainFetched = false;
-    RatioPtr resolution;
     SizeT ticksSinceOrigin{};
-    StringPtr origin;
-    UnitPtr domainUnit;
     LoggerPtr logger;
     LoggerComponentPtr loggerComponent;
 };

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
@@ -102,7 +102,7 @@ void TmsServerDevice::bindCallbacks()
                 uaDeviceDomain->resolution.numerator = deviceDomain.getTickResolution().getNumerator();
                 uaDeviceDomain->resolution.denominator = deviceDomain.getTickResolution().getDenominator();
                 uaDeviceDomain->origin = ConvertToOpcUaString(deviceDomain.getOrigin()).getDetachedValue();
-                uaDeviceDomain->ticksSinceOrigin = deviceDomain.getTicksSinceOrigin();
+                uaDeviceDomain->ticksSinceOrigin = object.getTicksSinceOrigin();
                 auto unit = StructConverter<IUnit, UA_EUInformationWithQuantity>::ToTmsType(deviceDomain.getUnit());
                 uaDeviceDomain->unit = unit.getDetachedValue();
 

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
@@ -231,7 +231,7 @@ TEST_F(TmsDeviceTest, DeviceGetTicksSinceOrigin)
     auto clientSubDevices = clientDevice.getDevices();
     auto clientSubDevice = clientSubDevices[1];
 
-    auto ticksSinceOrigin = clientSubDevice.asPtr<IDeviceDomain>(true).getTicksSinceOrigin();
+    auto ticksSinceOrigin = clientSubDevice.getTicksSinceOrigin();
     ASSERT_EQ(ticksSinceOrigin, 789);
 }
 
@@ -260,7 +260,7 @@ TEST_F(TmsDeviceTest, DeviceDomain)
     ASSERT_EQ(resolution.getNumerator(), 123);
     ASSERT_EQ(resolution.getDenominator(), 456);
 
-    auto ticksSinceOrigin = deviceDomain.getTicksSinceOrigin();
+    auto ticksSinceOrigin = clientSubDevice.getTicksSinceOrigin();
     ASSERT_EQ(ticksSinceOrigin, 789);
 
     auto origin = deviceDomain.getOrigin();


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Description:
- Make DeviceDomain a standalone object in DeviceImpl
  - Devices no longer override the DeviceDomain getters, but instead set it via the protected `setDeviceDomain` method 
  - Changing the DeviceDomain triggers a core event
- Move getTicksSinceOrigin to IDevice