### PR TITLE
Allow convertible openDAQ structs over OPC UA

### DIFF
--- a/core/coretypes/include/coretypes/type_manager_impl.h
+++ b/core/coretypes/include/coretypes/type_manager_impl.h
@@ -48,6 +48,7 @@ public:
 private:
     DictPtr<IString, IType> types;
     ProcedurePtr coreEventCallback;
+    std::unordered_set<std::string> reservedTypeNames;
 };
 
 OPENDAQ_REGISTER_DESERIALIZE_FACTORY(TypeManagerImpl)

--- a/core/coretypes/src/struct_builder_impl.cpp
+++ b/core/coretypes/src/struct_builder_impl.cpp
@@ -1,6 +1,7 @@
 #include <coretypes/struct_builder_impl.h>
 #include <coretypes/validation.h>
 #include <coretypes/struct_factory.h>
+#include <coretypes/enumeration_ptr.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -93,8 +94,21 @@ ErrCode StructBuilderImpl::set(IString* name, IBaseObject* field)
     else
     {
         for (size_t i = 0; i < names.getCount(); ++i)
-            if (names[i] == namePtr && SimpleType(fieldPtr.getCoreType())!= structType.getFieldTypes()[i])
-                return OPENDAQ_ERR_INVALIDPARAMETER;
+        {
+            if (names[i] == namePtr)
+            {
+                TypePtr type;
+                if (const auto _struct = fieldPtr.asPtrOrNull<IStruct>(); _struct.assigned())
+                    type = _struct.getStructType();
+                else if (const auto _enum = fieldPtr.asPtrOrNull<IEnumeration>(); _enum.assigned())
+                    type = _enum.getEnumerationType();
+                else
+                    type = SimpleType(fieldPtr.getCoreType());
+
+                if (type != structType.getFieldTypes()[i])
+                    return OPENDAQ_ERR_INVALIDPARAMETER;
+            }
+        }
     }
 
     fields.set(name, field);

--- a/core/coretypes/src/type_manager_impl.cpp
+++ b/core/coretypes/src/type_manager_impl.cpp
@@ -3,11 +3,15 @@
 #include <coretypes/type_manager_ptr.h>
 #include <coretypes/baseobject_factory.h>
 #include <coretypes/serialized_object_ptr.h>
+#include <cctype>
 
 BEGIN_NAMESPACE_OPENDAQ
 
 TypeManagerImpl::TypeManagerImpl()
     : types(Dict<IString, IType>())
+    , reservedTypeNames({
+    "argumentinfo", "callableinfo", "unit", "complexnumber", "ratio", "devicetype", "functionblocktype",
+    "servertype", "datadescriptor", "datarule", "dimension", "dimensionrule", "range", "scaling"})
 {
 }
 
@@ -20,7 +24,12 @@ ErrCode TypeManagerImpl::addType(IType* type)
     const auto typeName = typePtr.getName();
     if (!typeName.assigned() || typeName == "")
         return OPENDAQ_ERR_INVALIDPARAMETER;
-    
+
+    std::string typeStr = typeName;
+    std::transform(typeStr.begin(), typeStr.end(), typeStr.begin(),[](char c){ return std::tolower(c); });
+    if (reservedTypeNames.count(typeStr))
+        return OPENDAQ_ERR_INVALIDPARAMETER;
+
     if (types.hasKey(typeName))
         return OPENDAQ_ERR_ALREADYEXISTS;
 

--- a/core/coretypes/tests/test_type_manager.cpp
+++ b/core/coretypes/tests/test_type_manager.cpp
@@ -9,7 +9,7 @@ TEST_F(TypeManagerTest, AddType)
 {
     auto manager = TypeManager();
     manager.addType(SimpleType(ctInt));
-    manager.addType(RatioStructType());
+    ASSERT_THROW(manager.addType(RatioStructType()), InvalidParameterException);
     manager.addType(StructType("foo", List<IString>("field"), List<IType>(SimpleType(ctString))));
 }
 
@@ -70,7 +70,6 @@ TEST_F(TypeManagerTest, Serialization)
     manager.addType(SimpleType(ctInt));
     manager.addType(SimpleType(ctString));
     manager.addType(StructType("foo", List<IString>("string"), List<IBaseObject>("foo"), List<IType>(SimpleType(ctString))));
-    manager.addType(RatioStructType());
 
     const auto serializer = JsonSerializer();
     
@@ -93,4 +92,37 @@ TEST_F(TypeManagerTest, InterfaceId)
 TEST_F(TypeManagerTest, InterfaceIdString)
 {
     ASSERT_EQ(daqInterfaceIdString<ITypeManager>(), "{EBD840C6-7E32-51F4-B063-63D0B09F4240}");
+}
+
+TEST_F(TypeManagerTest, ProtectedStructNames)
+{
+    std::vector<std::string> protectedNames{{"argumentinfo",
+                                             "callableinfo",
+                                             "unit",
+                                             "complexnumber",
+                                             "ratio",
+                                             "devicetype",
+                                             "functionblocktype",
+                                             "servertype",
+                                             "datadescriptor",
+                                             "datarule",
+                                             "dimension",
+                                             "dimensionrule",
+                                             "range",
+                                             "scaling"}};
+
+    const auto typeManager = TypeManager();
+    for (const auto& name : protectedNames)
+    {
+        std::string uppercase = name;
+        std::transform(uppercase.begin(), uppercase.end(), uppercase.begin(), [](char c) { return std::toupper(c); });
+
+        const auto type1 = StructType(name, List<IString>("field"), List<IType>(SimpleType(ctString)));
+        const auto type2 = StructType(uppercase, List<IString>("field"), List<IType>(SimpleType(ctString)));
+
+        ASSERT_THROW(typeManager.addType(type1), InvalidParameterException);
+        ASSERT_THROW(typeManager.addType(type2), InvalidParameterException);
+    }
+
+
 }

--- a/shared/libraries/opcuatms/opcuatms/include/opcuatms/core_types_utils.h
+++ b/shared/libraries/opcuatms/opcuatms/include/opcuatms/core_types_utils.h
@@ -39,5 +39,6 @@ OpcUaVariant UnwrapIfVariant(const OpcUaVariant& variant);
 const UA_DataType* GetUAStructureDataTypeByName(const std::string& structName);
 const UA_DataType* GetUAEnumerationDataTypeByName(const std::string& enumerationName);
 const std::string GetUATypeName(UA_UInt16 namespaceIndex, UA_UInt32 identifierNumeric);
+bool nativeStructConversionSupported(const std::string& structName);
 
 END_NAMESPACE_OPENDAQ_OPCUA

--- a/shared/libraries/opcuatms/opcuatms/src/converters/core_types_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/converters/core_types_converter.cpp
@@ -135,7 +135,8 @@ IntegerPtr StructConverter<IInteger, UA_Byte>::ToDaqObject(const UA_Byte& value,
 template <>
 OpcUaObject<UA_Byte> StructConverter<IInteger, UA_Byte>::ToTmsType(const IntegerPtr& object, const ContextPtr& /*context*/)
 {
-    return {static_cast<UA_Byte>(object)};
+    const int64_t val = object;
+    return {static_cast<UA_Byte>(val)};
 }
 
 template <>

--- a/shared/libraries/opcuatms/opcuatms/src/core_types_utils.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/core_types_utils.cpp
@@ -15,6 +15,7 @@ BEGIN_NAMESPACE_OPENDAQ_OPCUA
 
 namespace details
 {
+
 static std::unordered_map<OpcUaNodeId, CoreType> nodeIdToCoreTypeMap = {
     {OpcUaNodeId(0, UA_NS0ID_BOOLEAN), ctBool},
     {OpcUaNodeId(0, UA_NS0ID_FLOAT), ctFloat},
@@ -31,6 +32,9 @@ static std::unordered_map<OpcUaNodeId, CoreType> nodeIdToCoreTypeMap = {
     {OpcUaNodeId(0, UA_NS0ID_RATIONALNUMBER), ctRatio},
     {OpcUaNodeId(NAMESPACE_DAQBT, UA_DAQBTID_RATIONALNUMBER64), ctRatio},
     {OpcUaNodeId(0, UA_DAQBTID_RATIONALNUMBER64), ctRatio}};
+
+static std::unordered_set<std::string> convertibleNativeStructs = {
+    "unit", "range", "argumentInfo", "complexNumber", "functionBlockType"};
 }
 
 StringPtr ConvertToDaqCoreString(const UA_String& uaString)
@@ -291,6 +295,11 @@ const UA_DataType* GetUAEnumerationDataTypeByName(const std::string& enumeration
     }
 
     return nullptr;
+}
+
+bool nativeStructConversionSupported(const std::string& structName)
+{
+    return details::convertibleNativeStructs.count(structName);
 }
 
 END_NAMESPACE_OPENDAQ_OPCUA

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_context.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_context.h
@@ -48,6 +48,7 @@ public:
     void readObjectAttributes(const OpcUaNodeId& nodeId, bool forceRead = false);
     size_t getMaxNodesPerBrowse();
     size_t getMaxNodesPerRead();
+    void addEnumerationTypesToTypeManager();
 
     template <class I, class Ptr = typename InterfaceToSmartPtr<I>::SmartPtr>
     Ptr getObject(const opcua::OpcUaNodeId& nodeId)
@@ -76,6 +77,7 @@ protected:
     size_t maxNodesPerBrowse = 0;
     size_t maxNodesPerRead = 0;
     WeakRefPtr<IDevice> rootDevice;
+    bool enumerationTypesAdded = false;
 
     void initReferenceBrowser();
     void initAttributeReader();

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/tms_client.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/tms_client.h
@@ -33,7 +33,6 @@ public:
               const FunctionPtr& createStreamingCallback);
 
     daq::DevicePtr connect();
-    void AddEnumerationTypesToTypeManager();
 
 
 protected:

--- a/shared/libraries/opcuatms/opcuatms_client/src/tms_client.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/tms_client.cpp
@@ -56,9 +56,7 @@ daq::DevicePtr TmsClient::connect()
     client->runIterate();
 
     tmsClientContext = std::make_shared<TmsClientContext>(client, context);
-
-    //On connect add server broadcasted enumeration types to the type manager
-    AddEnumerationTypesToTypeManager();
+    tmsClientContext->addEnumerationTypesToTypeManager();
 
     OpcUaNodeId rootDeviceNodeId;
     std::string rootDeviceBrowseName;
@@ -84,60 +82,6 @@ daq::DevicePtr TmsClient::connect()
     const auto connectTime = std::chrono::duration<double>(endTime - startTime);
     LOG_D("Connected to openDAQ OPC UA server {}. Connect took {:.2f} s.", opcUaUrl, connectTime.count());
     return device;
-}
-
-void TmsClient::AddEnumerationTypesToTypeManager()
-{
-    if (!context.assigned() || !context.getTypeManager().assigned())
-        return; // TypeManager required. Do nothing.
-
-    auto typeManager = context.getTypeManager();
-
-    const auto DataTypeEnumerationNodeId = OpcUaNodeId(UA_NS0ID_ENUMERATION);
-    const auto& references = tmsClientContext->getReferenceBrowser()->browse(DataTypeEnumerationNodeId);
-    StructPtr EnumValuesStruct;
-    std::vector<OpcUaNodeId> vecEnumerationsNodeIds;
-
-    for (auto [browseName, ref] : references.byBrowseName)
-        vecEnumerationsNodeIds.push_back(ref->nodeId.nodeId);
-
-    //Cache NodeIds
-    tmsClientContext->getReferenceBrowser()->browseMultiple(vecEnumerationsNodeIds);
-
-    auto listEnumValues = List<IString>();
-
-    for (auto [browseName, ref] : references.byBrowseName)
-    {
-        //If type already exists, skip
-        if(typeManager.hasType(browseName))
-            continue;
-
-        const auto& references1 = tmsClientContext->getReferenceBrowser()->browse(ref->nodeId.nodeId);
-        for (auto [childBrowseName, ChildRef] : references1.byBrowseName)
-        {
-            const auto childNodeValue = client->readValue(ChildRef->nodeId.nodeId);
-            const auto childNodeObject = VariantConverter<IBaseObject>::ToDaqObject(childNodeValue, context);
-
-            if (childBrowseName == "EnumStrings")
-            {
-                for (auto value : childNodeObject.asPtr<IList>())
-                    listEnumValues.pushBack(value);
-            }
-            else if (childBrowseName == "EnumValues")
-            {
-                for (const auto& value : childNodeObject.asPtr<IList>())
-                {
-                    if (EnumValuesStruct = value.asPtrOrNull<IStruct>(); EnumValuesStruct.assigned())
-                        listEnumValues.pushBack(EnumValuesStruct.get("DisplayName"));
-                }
-            }
-        }
-
-        auto enumExcitationType = EnumerationType(browseName, listEnumValues);
-        typeManager.addType(enumExcitationType);
-
-        listEnumValues.clear();
-    }
 }
 
 void TmsClient::getRootDeviceNodeAttributes(OpcUaNodeId& nodeIdOut, std::string& browseNameOut)

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property.cpp
@@ -302,7 +302,7 @@ void TmsServerProperty::addReferenceTypeChildNodes()
     {
         StructPtr structPtr = this->parent.getRef().getPropertyValue(object.getName());
         std::string structTypeName =  structPtr.getStructType().getName();
-        if(GetUAStructureDataTypeByName(structTypeName) == nullptr)
+        if (!nativeStructConversionSupported(structTypeName) && GetUAStructureDataTypeByName(structTypeName) == nullptr)
             return;
     }
 

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
@@ -111,7 +111,7 @@ void TmsServerPropertyObject::addChildNodes()
                 if(structPtr.assigned())
                 {
                     std::string structTypeName = structPtr.getStructType().getName();
-                    if(GetUAStructureDataTypeByName(structTypeName) == nullptr)
+                    if (!nativeStructConversionSupported(structTypeName) && GetUAStructureDataTypeByName(structTypeName) == nullptr)
                         continue;
                 }
             }

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/tms_object_integration_test.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/tms_object_integration_test.cpp
@@ -20,8 +20,11 @@ void TmsObjectIntegrationTest::SetUp()
     logger = CreateLoggerWithDebugSink(debugSink);
 
     ctx = daq::NullContext(logger);
-    clientContext = std::make_shared<TmsClientContext>(client, ctx);
+    ctxClient = daq::NullContext(logger);
+    clientContext = std::make_shared<TmsClientContext>(client, ctxClient);
     serverContext = std::make_shared<TmsServerContext>(ctx, nullptr);
+
+    clientContext->addEnumerationTypesToTypeManager();
 }
 
 LastMessageLoggerSinkPrivatePtr TmsObjectIntegrationTest::getPrivateSink()
@@ -39,6 +42,7 @@ void TmsObjectIntegrationTest::TearDown()
     clientContext.reset();
     serverContext = nullptr;
     ctx = nullptr;
+    ctxClient = nullptr;
 
     TmsObjectTest::TearDown();
 }

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/tms_object_integration_test.h
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/tms_object_integration_test.h
@@ -34,6 +34,7 @@ protected:
 
     daq::LoggerPtr logger;
     daq::ContextPtr ctx;
+    daq::ContextPtr ctxClient;
 private:
     daq::LoggerSinkPtr debugSink;
 };


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Description:

- OPC UA structs that have a SDK native conversion are always converted to the SDK type
- List of reserved type names was added to type manager

# Missing:

- Tests for reserved type names in core