### PR TITLE
Fix getLastValue bug

### DIFF
--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -418,7 +418,7 @@ ErrCode DataPacketImpl<TInterface>::getLastValue(IBaseObject** value, ITypeManag
 
     const auto sampleType = descriptor.getSampleType();
 
-    addr = static_cast<char*>(addr) + (sampleCount - 1) * descriptor.getRawSampleSize();
+    addr = static_cast<char*>(addr) + (sampleCount - 1) * descriptor.getSampleSize();
 
     if (sampleType == SampleType::Struct)
     {

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -873,6 +873,42 @@ TEST_F(SignalTest, GetLastValueStruct)
     ASSERT_DOUBLE_EQ(structPtr.get("Float64"), 15.1);
 }
 
+TEST_F(SignalTest, GetLastValueLinearDataRule)
+{
+    const auto signal = Signal(NullContext(), nullptr, "sig");
+    auto descriptor = DataDescriptorBuilder().setRule(LinearDataRule(3, 2)).setName("test").setSampleType(SampleType::Float64).build();
+
+    auto dataPacket = DataPacket(descriptor, 5, 7);
+
+    signal.sendPacket(dataPacket);
+
+    auto lastValuePacket = signal.getLastValue();
+    FloatPtr ptr;
+    ASSERT_NO_THROW(ptr = lastValuePacket.asPtr<IFloat>());
+    ASSERT_EQ(ptr, 21.0);
+}
+
+TEST_F(SignalTest, GetLastValueLinearScaling)
+{
+    const auto signal = Signal(NullContext(), nullptr, "sig");
+    auto descriptor = DataDescriptorBuilder()
+                          .setPostScaling(LinearScaling(3, 7, SampleType::Int32, ScaledSampleType::Float64))
+                          .setName("test")
+                          .setSampleType(SampleType::Float64)
+                          .build();
+
+    auto dataPacket = DataPacket(descriptor, 5);
+    auto data = static_cast<int32_t*>(dataPacket.getRawData());
+    data[4] = 4;
+
+    signal.sendPacket(dataPacket);
+
+    auto lastValuePacket = signal.getLastValue();
+    FloatPtr ptr;
+    ASSERT_NO_THROW(ptr = lastValuePacket.asPtr<IFloat>());
+    ASSERT_EQ(ptr, 19.0);
+}
+
 TEST_F(SignalTest, GetLastValueStructNoSetDescriptor)
 {
     // Create signal


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:
Use getSampleSize instead of getRawSampleSize in getLastValue so that LinearDataRule and LinearScaling work properly with tests.