### PR TITLE
Fixed InvalidParameterException exception when trying to set Enumerat…

### DIFF
--- a/core/coretypes/include/coretypes/struct_impl.h
+++ b/core/coretypes/include/coretypes/struct_impl.h
@@ -22,6 +22,7 @@
 #include <coretypes/dictobject_factory.h>
 #include <coretypes/baseobject_factory.h>
 #include <coretypes/struct_ptr.h>
+#include <coretypes/enumeration_ptr.h>
 #include <coretypes/type_manager_ptr.h>
 #include <coretypes/struct_type_factory.h>
 #include <coretypes/stringobject_factory.h>
@@ -153,6 +154,10 @@ GenericStructImpl<StructInterface, Interfaces...>::GenericStructImpl(const Strin
             const auto ct = val.getCoreType();
             if (ct == ctStruct)
                 types.pushBack(val.asPtr<IStruct>().getStructType());
+            else if (ct == ctEnumeration)
+            {
+                types.pushBack(val.asPtr<IEnumeration>().getEnumerationType());
+            }
             else
                 types.pushBack(SimpleType(ct));
         }

--- a/core/coretypes/src/struct_builder_impl.cpp
+++ b/core/coretypes/src/struct_builder_impl.cpp
@@ -100,7 +100,7 @@ ErrCode StructBuilderImpl::set(IString* name, IBaseObject* field)
                 TypePtr enumerationFieldType, type;
 
                 // If struct field is an enumeration, check if the enumeration type of the new field
-                // is the same as the original enumeartion field ofd the struct
+                // is the same as the original field of the struct
                 if (const auto _enum = fieldPtr.asPtrOrNull<IEnumeration>(); _enum.assigned())
                 {
                     type = _enum.getEnumerationType();

--- a/core/coretypes/src/struct_builder_impl.cpp
+++ b/core/coretypes/src/struct_builder_impl.cpp
@@ -97,7 +97,7 @@ ErrCode StructBuilderImpl::set(IString* name, IBaseObject* field)
         {
             if (names[i] == namePtr)
             {
-                TypePtr enumerationFieldType, type;
+                TypePtr type;
 
                 if (const auto _struct = fieldPtr.asPtrOrNull<IStruct>(); _struct.assigned())
                     type = _struct.getStructType();

--- a/core/coretypes/src/struct_builder_impl.cpp
+++ b/core/coretypes/src/struct_builder_impl.cpp
@@ -99,22 +99,10 @@ ErrCode StructBuilderImpl::set(IString* name, IBaseObject* field)
             {
                 TypePtr enumerationFieldType, type;
 
-                // If struct field is an enumeration, check if the enumeration type of the new field
-                // is the same as the original field of the struct
-                if (const auto _enum = fieldPtr.asPtrOrNull<IEnumeration>(); _enum.assigned())
-                {
-                    type = _enum.getEnumerationType();
-                    const auto enumerationField = fields.get(name).asPtrOrNull<IEnumeration>();
-                    enumerationFieldType = enumerationField.getEnumerationType();
-
-                    if (type != enumerationFieldType)
-                        return OPENDAQ_ERR_INVALIDPARAMETER;
-
-                    break;
-                }
-
                 if (const auto _struct = fieldPtr.asPtrOrNull<IStruct>(); _struct.assigned())
                     type = _struct.getStructType();
+                else if (const auto _enum = fieldPtr.asPtrOrNull<IEnumeration>(); _enum.assigned())
+                    type = _enum.getEnumerationType();
                 else
                     type = SimpleType(fieldPtr.getCoreType());
 

--- a/core/coretypes/src/struct_builder_impl.cpp
+++ b/core/coretypes/src/struct_builder_impl.cpp
@@ -12,7 +12,7 @@ StructBuilderImpl::StructBuilderImpl(const StringPtr& name, const TypeManagerPtr
 
     const auto defaultValues = structType.getFieldDefaultValues();
     const auto names = structType.getFieldNames();
-    
+
     for (size_t i = 0 ; i < names.getCount(); ++i)
     {
         if (defaultValues.assigned())
@@ -100,8 +100,6 @@ ErrCode StructBuilderImpl::set(IString* name, IBaseObject* field)
                 TypePtr type;
                 if (const auto _struct = fieldPtr.asPtrOrNull<IStruct>(); _struct.assigned())
                     type = _struct.getStructType();
-                else if (const auto _enum = fieldPtr.asPtrOrNull<IEnumeration>(); _enum.assigned())
-                    type = _enum.getEnumerationType();
                 else
                     type = SimpleType(fieldPtr.getCoreType());
 

--- a/core/coretypes/src/struct_builder_impl.cpp
+++ b/core/coretypes/src/struct_builder_impl.cpp
@@ -97,7 +97,22 @@ ErrCode StructBuilderImpl::set(IString* name, IBaseObject* field)
         {
             if (names[i] == namePtr)
             {
-                TypePtr type;
+                TypePtr enumerationFieldType, type;
+
+                // If struct field is an enumeration, check if the enumeration type of the new field
+                // is the same as the original enumeartion field ofd the struct
+                if (const auto _enum = fieldPtr.asPtrOrNull<IEnumeration>(); _enum.assigned())
+                {
+                    type = _enum.getEnumerationType();
+                    const auto enumerationField = fields.get(name).asPtrOrNull<IEnumeration>();
+                    enumerationFieldType = enumerationField.getEnumerationType();
+
+                    if (type != enumerationFieldType)
+                        return OPENDAQ_ERR_INVALIDPARAMETER;
+
+                    break;
+                }
+
                 if (const auto _struct = fieldPtr.asPtrOrNull<IStruct>(); _struct.assigned())
                     type = _struct.getStructType();
                 else

--- a/shared/libraries/opcuatms/opcuatms/src/converters/generic_struct_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/converters/generic_struct_converter.cpp
@@ -17,8 +17,10 @@ namespace detail
         const auto ct = obj.getCoreType();
         if (ct == ctStruct)
             return obj.asPtr<IStruct>().getStructType();
-
-        return SimpleType(ct);
+        else if (ct == ctEnumeration)
+            return obj.asPtr<IEnumeration>().getEnumerationType();
+        else
+            return SimpleType(ct);
     }
 }
 
@@ -108,7 +110,7 @@ StructPtr VariantConverter<IStruct>::ToDaqObject(const OpcUaVariant& variant, co
                 }
                 else
                 {
-                    daqMembers.set(member->memberName, nullptr); 
+                    daqMembers.set(member->memberName, nullptr);
                     src += sizeof(size_t*);
                     memberTypes.pushBack(SimpleType(ctUndefined));
                 }

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
@@ -146,18 +146,22 @@ TEST_F(TmsFusionDevice, FullBridge)
     const auto newExcitationVoltage = StructBuilder(fullBridge.get("ExcitationVoltage"))
                                    .set("NominalValueRange", Range(1.2, 6.2))
                                    .set("ActualValue", 5.9)
+                                   .set("Type", Enumeration("ExcitationTypeEnumeration", "ACVoltage", objManager))
+                                   .set("Frequency", 0)
+                                   .set("NominalValue", 5.0)
                                    .build();
 
     const auto newFullBridge = StructBuilder(fullBridge)
                                .set("ExcitationVoltage", newExcitationVoltage)
                                .set("UsedWires", 9)
                                .set("Resistance", 100.1)
+                               .set("MaximumElectrical", 8.0)
                                .build();
 
     fusionAmp.setPropertyValue("FullBridge", newFullBridge);
     const auto serverFullBridge = obj.getPropertyValue("FullBridge");
     const auto clientFullBridge = fusionAmp.getPropertyValue("FullBridge");
-    
+
     ASSERT_EQ(serverFullBridge, clientFullBridge);
     ASSERT_EQ(serverFullBridge, newFullBridge);
 }


### PR DESCRIPTION
Fixed InvalidParameterException when trying to set an Enumeration Field of a Struct property.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [xI have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
_enum.getEnumerationType() returns the actual Enumeration type which would never match to the core type of the struct field (enumeration). Removing the special case for enums solved the problem.
Extended unit tests to also set the Type field from the FullBridge struct.
