### PR TITLE
Fix weak ref crashing in multi reader if exception is thrown in constructor

### DIFF
--- a/core/coretypes/include/coretypes/intfs.h
+++ b/core/coretypes/include/coretypes/intfs.h
@@ -571,6 +571,23 @@ protected:
         return refCount->strong;
     }
 
+    int releaseWeakRefOnException()
+    {
+        const auto newRefCount = std::atomic_fetch_sub_explicit(&refCount->strong, 1, std::memory_order_acq_rel) - 1;
+        assert(newRefCount >= 0);
+
+        if (newRefCount == 0)
+        {
+            const auto newWeakRefCount = std::atomic_fetch_sub_explicit(&refCount->weak, 1, std::memory_order_acq_rel) - 1;
+            if (newWeakRefCount != 0)
+            {
+                refCount.release();
+            }
+        }
+
+        return newRefCount;
+    }
+
     int internalAddRefNoCheck()
     {
         return std::atomic_fetch_add_explicit(&refCount->strong, 1, std::memory_order_relaxed);

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -1943,3 +1943,25 @@ TEST_F(MultiReaderTest, SampleRateDividerRequiredRate)
         ASSERT_EQ(domain[i][0] - lastTimeStamp[i], dividers[i]);
     }
 }
+
+TEST_F(MultiReaderTest, MultiReaderExcetionOnConstructor)
+{
+    readSignals.reserve(1);
+
+    auto& sig0 = addSignal(0, 523, createDomainSignal("2022-09-27T00:02:03+00:00", nullptr, LinearDataRule(1, 0)));  // 1000 Hz
+
+    MultiReaderPtr mr;
+    try
+    {
+        mr = MultiReaderEx(signalsToList(), SampleType::Float64, SampleType::Int64, ReadMode::Scaled, ReadTimeoutType::All, 500, false);
+    }
+    catch (...)
+    {
+        
+    }
+
+    for (Int i = 0; i < 5; i++)
+    {
+        sig0.createAndSendPacket(i);
+    }
+}


### PR DESCRIPTION
Objects with weak ref support crash if weak ref has been added in constructor. This is my attempt at solving the issue. Perhaps there is a better way of doing it.