### PR TITLE
Rework constant data rule

### DIFF
--- a/changelog/changelog_2.0.0-3.0.0.txt
+++ b/changelog/changelog_2.0.0-3.0.0.txt
@@ -42,6 +42,16 @@ Description:
 + [function] ErrCode IMirroredSignalPrivate::getMirroredDomainSignal(IMirroredSignalConfig** domainSignals)
 + [function] ErrCode IMirroredSignalPrivate::setMirroredDomainSignal(IMirroredSignalConfig* domainSignal)
 
+25.04.2023
+Description:
+    Constant rule rework in openDAQ core and support for native streaming
+    
+-m [factory] DataRulePtr ConstantDataRule(const NumberPtr& value)
++m [factory] DataRulePtr ConstantDataRule()
++  [factory] template <class T> DataPacketPtr ConstantDataPacketWithDomain(const DataPacketPtr& domainPacket, const DataDescriptorPtr& descriptor, uint64_t sampleCount, T initialValue, const std::vector<ConstantPosAndValue<T>>& otherValues = {})
+-m [factory] DataPacketPtr DataPacketWithExternalMemory(const DataPacketPtr& domainPacket, const DataDescriptorPtr& descriptor, uint64_t sampleCount, void* data, const DeleterPtr& deleter, NumberPtr offset = nullptr)
++m [factory] DataPacketPtr DataPacketWithExternalMemory(const DataPacketPtr& domainPacket, const DataDescriptorPtr& descriptor, uint64_t sampleCount, void* data, const DeleterPtr& deleter, NumberPtr offset = nullptr, SizeT bufferSize = std::numeric_limits<SizeT>::max())
+
 21.03.2023
 Description:
 	- Move create fb/device logic to module manager

--- a/core/opendaq/opendaq/mocks/mock_channel.cpp
+++ b/core/opendaq/opendaq/mocks/mock_channel.cpp
@@ -34,7 +34,7 @@ void MockChannelImpl::createSignals()
             .setSampleType(SampleType::Float32)
             .setName(name)
             .setDimensions(daq::List<daq::IDimension>())
-            .setRule(ConstantDataRule(1.0))
+            .setRule(ConstantDataRule())
             .build();
     };
 

--- a/core/opendaq/opendaq/mocks/mock_fb.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb.cpp
@@ -44,7 +44,7 @@ void MockFunctionBlockImpl::createSignals()
             .setSampleType(SampleType::Float32)
             .setName(name)
             .setDimensions(daq::List<daq::IDimension>())
-            .setRule(ConstantDataRule(1.0))
+            .setRule(ConstantDataRule())
             .build();
     };
 

--- a/core/opendaq/opendaq/mocks/mock_nested_fb.cpp
+++ b/core/opendaq/opendaq/mocks/mock_nested_fb.cpp
@@ -35,7 +35,7 @@ void MockNestedFunctionBlockImpl::createSignals()
             .setSampleType(SampleType::Float32)
             .setName(name)
             .setDimensions(daq::List<daq::IDimension>())
-            .setRule(ConstantDataRule(1.0))
+            .setRule(ConstantDataRule())
             .build();
     };
 

--- a/core/opendaq/signal/include/opendaq/data_descriptor_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_descriptor_impl.h
@@ -55,8 +55,8 @@ public:
     bool INTERFACE_FUNC hasScalingCalc() const override;
 
     // IDataRuleCalcPrivate
-    void* INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount) const override;
-    void INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void** output) const override;
+    void* INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize) const override;
+    void INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize, void** output) const override;
     bool INTERFACE_FUNC hasDataRuleCalc() const override;
 
     // ISerializable

--- a/core/opendaq/signal/include/opendaq/data_packet.h
+++ b/core/opendaq/signal/include/opendaq/data_packet.h
@@ -144,16 +144,40 @@ DECLARE_OPENDAQ_INTERFACE(IDataPacket, IPacket)
  * @param sampleCount The number of samples in the packet.
  * @param offset Optional packet offset parameter, used to calculate the data of the packet
  * if the Data rule of the Signal descriptor is not explicit.
- * @param allocator Optional allocator that allocates memory for packets.
- *
- * If the caller does not pass allocator object, the SDK will use internal allocator.
  */
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, DataPacket, IDataPacket,
     IDataDescriptor*, descriptor,
     SizeT, sampleCount,
+    INumber*, offset
+)
+
+/*!
+ * @brief Creates a Data packet with a given descriptor, sample count, an optional packet offset,
+ * external memory location for data, custom deleter function and buffer size of external memory.
+ * 
+ * @param descriptor The descriptor of the signal sending the data.
+ * @param sampleCount The number of samples in the packet.
+ * @param offset Optional packet offset parameter, used to calculate the data of the packet
+ * if the Data rule of the Signal descriptor is not explicit.
+ * @param externalMemory The pointer to the location of buffer data.
+ * @param deleter Custom deleter callback that is called when the packet is destroyed
+ * @param bufferSize The size of the external memory.
+ *
+ * Use this factory when pointer to create a packet which uses an existing memory. The memory should not be
+ * freed or written until the packet is destroyed. A deleter callback should be passed as a parameter that
+ * is called when the packet is destroyed. The callback should free the memory provided. If bufferSize parameter
+ * is equal to SizeT max, the buffer size will be calculated from the descriptor.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, DataPacketWithExternalMemory, IDataPacket,
+    IDataPacket*, domainPacket,
+    IDataDescriptor*, descriptor,
+    SizeT, sampleCount,
     INumber*, offset,
-    IAllocator*, allocator
+    void*, externalMemory,
+    IDeleter*, deleter,
+    SizeT, bufferSize
 )
 
 /*!
@@ -164,17 +188,45 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
  * @param sampleCount The number of samples in the packet.
  * @param offset Optional packet offset parameter, used to calculate the data of the packet
  * if the Data rule of the Signal descriptor is not explicit.
- * @param allocator Optional allocator that allocates memory for packets.
  *
- * If the caller does not pass allocator object, the SDK will use internal allocator.
  */
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, DataPacketWithDomain, IDataPacket,
     IDataPacket*, domainPacket,
     IDataDescriptor*, descriptor,
     SizeT, sampleCount,
-    INumber*, offset,
-    IAllocator*, allocator
+    INumber*, offset
 )
 
-END_NAMESPACE_OPENDAQ
+/*!
+ * @brief Creates a Data packet with a given constat rule descriptor, initial constant value,
+ * and other constant values.
+ * @param domainPacket The Data packet carrying domain data.
+ * @param descriptor The descriptor of the signal sending the data.
+ * @param sampleCount The number of samples in the packet.
+ * @param initialValue The initial constant value.
+ * @param otherValues The other constant values. 
+ * @param otherValueCount The number of other constant values.
+ *
+ * The values in the packet are calculated by constant rule. The initial value is taken as a constant.
+ * Other values are used to change the constant value within the packet. Any number of other constant values
+ * can be used. Other values are passed as an array of struct with uint32_t sample position field and value field.
+ * Value field (as well as initial value) are of type defined as sample type in the descriptor.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(LIBRARY_FACTORY,
+                                             ConstantDataPacketWithDomain,
+                                             IDataPacket,
+                                             IDataPacket*,
+                                             domainPacket,
+                                             IDataDescriptor*,
+                                             descriptor,
+                                             SizeT,
+                                             sampleCount,
+                                             void*,
+                                             initialValue,
+                                             void*,
+                                             otherValues,
+                                             SizeT,
+                                             otherValueCount)
+
+    END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/include/opendaq/data_rule.h
+++ b/core/opendaq/signal/include/opendaq/data_rule.h
@@ -114,11 +114,9 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
 
 /*!
  * @brief Creates a DataRule with a Constant rule type configuration.
- * @param constant Constant value to be used in the rule.
  */
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
-    LIBRARY_FACTORY, ConstantDataRule, IDataRule,
-    INumber*, constant
+    LIBRARY_FACTORY, ConstantDataRule, IDataRule
 )
 
 /*!

--- a/core/opendaq/signal/include/opendaq/data_rule_calc.h
+++ b/core/opendaq/signal/include/opendaq/data_rule_calc.h
@@ -27,12 +27,12 @@ class DataRuleCalc
 public:
     virtual ~DataRuleCalc() = default;
 
-    virtual void* calculateRule(const NumberPtr& packetOffset, SizeT sampleCount)
+    virtual void* calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize)
     {
         return nullptr;
     }
     
-    virtual void calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void** output)
+    virtual void calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize, void** output)
     {
     }
 };
@@ -44,8 +44,8 @@ template <typename T>
 class DataRuleCalcTyped : public DataRuleCalc
 {
 public:
-    void* calculateRule(const NumberPtr& packetOffset, SizeT sampleCount) override;
-    void calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void** output) override;
+    void* calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize) override;
+    void calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize, void** output) override;
 
 private:
     friend DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType);
@@ -54,10 +54,10 @@ private:
     explicit DataRuleCalcTyped(const DataRulePtr& rule);
 
     void* calculateLinearRule(const NumberPtr& packetOffset, SizeT sampleCount) const;
-    void* calculateConstantRule(SizeT sampleCount);
+    void* calculateConstantRule(SizeT sampleCount, void* input, SizeT inputSize);
 
     void calculateLinearRule(const NumberPtr& packetOffset, SizeT sampleCount, void** output) const;
-    void calculateConstantRule(SizeT sampleCount, void** output);
+    void calculateConstantRule(SizeT sampleCount, void* input, SizeT inputSize, void** output);
 
 
     DataRuleType type;
@@ -82,11 +82,6 @@ std::vector<T> DataRuleCalcTyped<T>::ParseRuleParameters(const DictPtr<IString, 
         parameters.push_back(delta);
         parameters.push_back(start);
     }
-    else if (type == DataRuleType::Constant)
-    {
-        T constant = ruleParameters.get("constant");
-        parameters.push_back(constant);
-    }
 
     return parameters;
 }
@@ -102,12 +97,6 @@ inline std::vector<RangeType64> DataRuleCalcTyped<RangeType64>::ParseRuleParamet
         parameters.push_back(delta);
         parameters.push_back(start);
     }
-    else if (type == DataRuleType::Constant)
-    {
-        RangeType64 constant = (RangeType64::Type) ruleParameters.get("constant");
-        parameters.push_back(constant);
-    }
-
     return parameters;
 }
 
@@ -122,16 +111,11 @@ inline std::vector<uint8_t> DataRuleCalcTyped<uint8_t>::ParseRuleParameters(cons
         parameters.push_back(static_cast<uint8_t>(delta));
         parameters.push_back(static_cast<uint8_t>(start));
     }
-    else if (type == DataRuleType::Constant)
-    {
-        int16_t constant = ruleParameters.get("constant");
-        parameters.push_back(static_cast<uint8_t>(constant));
-    }
     return parameters;
 }
 
 template <typename T>
-void* DataRuleCalcTyped<T>::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount)
+void* DataRuleCalcTyped<T>::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize)
 {
     switch (type)
     {
@@ -139,7 +123,7 @@ void* DataRuleCalcTyped<T>::calculateRule(const NumberPtr& packetOffset, SizeT s
         case DataRuleType::Linear:
             return calculateLinearRule(packetOffset, sampleCount);
         case DataRuleType::Constant:
-            return calculateConstantRule(sampleCount);
+            return calculateConstantRule(sampleCount, input, inputSize);
         case DataRuleType::Other:
         case DataRuleType::Explicit:
             break;
@@ -149,7 +133,7 @@ void* DataRuleCalcTyped<T>::calculateRule(const NumberPtr& packetOffset, SizeT s
 }
 
 template <typename T>
-void DataRuleCalcTyped<T>::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void** output)
+void DataRuleCalcTyped<T>::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize, void** output)
 {
     switch (type)
     {
@@ -157,7 +141,7 @@ void DataRuleCalcTyped<T>::calculateRule(const NumberPtr& packetOffset, SizeT sa
             calculateLinearRule(packetOffset, sampleCount, output);
             return;
         case DataRuleType::Constant:
-            calculateConstantRule(sampleCount, output);
+            calculateConstantRule(sampleCount, input, inputSize, output);
             return;
         case DataRuleType::Other:
         case DataRuleType::Explicit:
@@ -179,13 +163,13 @@ void* DataRuleCalcTyped<T>::calculateLinearRule(const NumberPtr& packetOffset, S
 }
 
 template <typename T>
-void* DataRuleCalcTyped<T>::calculateConstantRule(SizeT sampleCount)
+void* DataRuleCalcTyped<T>::calculateConstantRule(SizeT sampleCount, void* input, SizeT inputSize)
 {
     auto output = std::malloc(sampleCount * sizeof(T));
     if (!output)
         throw NoMemoryException("Memory allocation failed.");
 
-    this->calculateConstantRule(sampleCount, &output);
+    this->calculateConstantRule(sampleCount, input, inputSize, &output);
     return output;
 }
 
@@ -212,12 +196,40 @@ void DataRuleCalcTyped<T>::calculateLinearRule(const NumberPtr& packetOffset, Si
 }
 
 template <typename T>
-void DataRuleCalcTyped<T>::calculateConstantRule(SizeT sampleCount, void** output)
+void DataRuleCalcTyped<T>::calculateConstantRule(SizeT sampleCount, void* input, SizeT inputSize, void** output)
 {
+    if (inputSize < sizeof(T))
+        throw InvalidParameterException("Constant rule data packet must have at least one value");
+
+    constexpr size_t entrySize = sizeof(T) + sizeof(uint32_t);
+    const size_t entryCount = (inputSize - sizeof(T)) / entrySize;
+
     T* outputTyped = static_cast<T*>(*output);
-    const T constant = parameters[0];
-    for (SizeT i = 0; i < sampleCount; ++i)
-        outputTyped[i] = constant;
+    T constant = *static_cast<T*>(input);
+
+    SizeT currentEntry = 0;
+    auto* entryPtr = (reinterpret_cast<uint8_t*>(input) + sizeof(T));
+
+    SizeT sampleIndex = 0;
+    while (sampleIndex < sampleCount)
+    {
+        SizeT upToSamples;
+        T nextConstantValue{};
+        if (currentEntry++ == entryCount)
+            upToSamples = sampleCount;
+        else
+        {
+            upToSamples = *(reinterpret_cast<uint32_t*>(entryPtr));
+            entryPtr += sizeof(uint32_t);
+            nextConstantValue = *(reinterpret_cast<T*>(entryPtr));
+            entryPtr += sizeof(T);
+        }
+
+        for (; sampleIndex < upToSamples; sampleIndex++)
+            outputTyped[sampleIndex] = constant;
+
+        constant = nextConstantValue;
+    }
 }
 
 static DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType)

--- a/core/opendaq/signal/include/opendaq/data_rule_calc_private.h
+++ b/core/opendaq/signal/include/opendaq/data_rule_calc_private.h
@@ -38,7 +38,7 @@ DECLARE_OPENDAQ_INTERFACE(IDataRuleCalcPrivate, IBaseObject)
      * @param sampleCount The number of samples in the packet.
      * @returns A pointer to the calculated data.
      */
-    virtual void* INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount) const = 0;
+    virtual void* INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize) const = 0;
 
     /*!
      * @brief Calculates the data according to the rule.
@@ -46,7 +46,8 @@ DECLARE_OPENDAQ_INTERFACE(IDataRuleCalcPrivate, IBaseObject)
      * @param sampleCount The number of samples in the packet.
      * @param[out] output A pointer to the calculated data.
      */
-    virtual void INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void** output) const = 0;
+    virtual void INTERFACE_FUNC calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize, void** output)
+        const = 0;
 
     /*!
      * @brief Checks whether the Data Rule Calculator is available for packet or not.

--- a/core/opendaq/signal/include/opendaq/data_rule_factory.h
+++ b/core/opendaq/signal/include/opendaq/data_rule_factory.h
@@ -63,11 +63,10 @@ inline DataRulePtr LinearDataRule(const NumberPtr& delta, const NumberPtr& start
 
 /*!
  * @brief Creates a DataRule with a Constant rule type configuration.
- * @param constant Constant value to be used in the rule.
  */
-inline DataRulePtr ConstantDataRule(const NumberPtr& constant)
+inline DataRulePtr ConstantDataRule()
 {
-    DataRulePtr obj(ConstantDataRule_Create(constant));
+    DataRulePtr obj(ConstantDataRule_Create());
     return obj;
 }
 

--- a/core/opendaq/signal/include/opendaq/data_rule_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_rule_impl.h
@@ -28,9 +28,8 @@ class DataRuleImpl final : public GenericStructImpl<IDataRule, IStruct, IRulePri
 public:
     explicit DataRuleImpl(DataRuleType ruleType, const DictPtr<IString, IBaseObject>& params);
     explicit DataRuleImpl(DataRuleType ruleType, const NumberPtr& param1, const NumberPtr& param2);
-    explicit DataRuleImpl(const NumberPtr& constant);
-    explicit DataRuleImpl();
-    explicit DataRuleImpl(IDataRuleBuilder * dataRuleBuilder);
+    explicit DataRuleImpl(DataRuleType ruleType);
+    explicit DataRuleImpl(IDataRuleBuilder* dataRuleBuilder);
     
     ErrCode INTERFACE_FUNC getType(DataRuleType* type) override;
     ErrCode INTERFACE_FUNC getParameters(IDict** parameters) override;

--- a/core/opendaq/signal/include/opendaq/packet_factory.h
+++ b/core/opendaq/signal/include/opendaq/packet_factory.h
@@ -30,41 +30,74 @@ BEGIN_NAMESPACE_OPENDAQ
  */
 
 /*!
- * @brief Creates a Data packet with a given descriptor, sample count, an optional
- * packet offset and an optional allocator.
+ * @brief Creates a Data packet with a given descriptor, sample count, and an optional
+ * packet offset.
  * @param descriptor The descriptor of the signal sending the data.
  * @param sampleCount The number of samples in the packet.
  * @param offset Optional packet offset parameter, used to calculate the data of the packet
  * if the Data rule of the Signal descriptor is not explicit.
- * @param allocator A memory allocator to use for buffers.
  */
 inline DataPacketPtr DataPacket(const DataDescriptorPtr& descriptor,
                                 uint64_t sampleCount,
-                                const NumberPtr& offset = nullptr,
-                                AllocatorPtr allocator = nullptr)
+                                const NumberPtr& offset = nullptr)
 {
-    DataPacketPtr obj(DataPacket_Create(descriptor, sampleCount, offset, std::move(allocator)));
+    DataPacketPtr obj(DataPacket_Create(descriptor, sampleCount, offset));
     return obj;
 }
 
 /*!
  * @brief Creates a Data packet with a given descriptor, sample count,
- * a reference to a packet that describes the domain (time) data, an optional packet offset
- * and an optional allocator.
+ * a reference to a packet that describes the domain (time) data, and an optional packet offset.
  * @param domainPacket The Data packet carrying domain data.
  * @param descriptor The descriptor of the signal sending the data.
  * @param sampleCount The number of samples in the packet.
  * @param offset Optional packet offset parameter, used to calculate the data of the packet
  * if the Data rule of the Signal descriptor is not explicit.
- * @param allocator A memory allocator to use for buffers.
  */
 inline DataPacketPtr DataPacketWithDomain(const DataPacketPtr& domainPacket,
                                           const DataDescriptorPtr& descriptor,
                                           uint64_t sampleCount,
-                                          NumberPtr offset = nullptr,
-                                          AllocatorPtr allocator = nullptr)
+                                          NumberPtr offset = nullptr)
 {
-    DataPacketPtr obj(DataPacketWithDomain_Create(domainPacket, descriptor, sampleCount, offset, std::move(allocator)));
+    DataPacketPtr obj(DataPacketWithDomain_Create(domainPacket, descriptor, sampleCount, offset));
+    return obj;
+}
+
+template <class T>
+struct ConstantPosAndValue
+{
+    uint32_t pos;
+    T value;
+};
+
+/*!
+ * @brief Creates a Data packet with a given constat rule descriptor, initial constant value,
+ * and other constant values.
+ * @param domainPacket The Data packet carrying domain data.
+ * @param descriptor The descriptor of the signal sending the data.
+ * @param initialValue The initial constant value.
+ * @param otherValues The other constant values.
+ *
+ * The values in the packet are calculated by constant rule. The initial value is taken as a constant.
+ * Other values are used to change the constant value within the packet. Any number of other constant values
+ * can be used. Other values are passed as an array of struct with uint32_t sample position field and value field.
+ * Value field (as well as initial value) are of type defined as sample type in the descriptor.
+ */
+template <class T>
+DataPacketPtr ConstantDataPacketWithDomain(const DataPacketPtr& domainPacket,
+                                           const DataDescriptorPtr& descriptor,
+                                           uint64_t sampleCount,
+                                           T initialValue,
+                                           const std::vector<ConstantPosAndValue<T>>& otherValues = {})
+{
+    DataPacketPtr obj(ConstantDataPacketWithDomain_Create(
+        domainPacket,
+        descriptor,
+        sampleCount,
+        reinterpret_cast<void*>(&initialValue),
+        reinterpret_cast<void*>(const_cast<ConstantPosAndValue<T>*>(otherValues.data())),
+        otherValues.size()));
+
     return obj;
 }
 
@@ -72,6 +105,7 @@ inline DataPacketPtr DataPacketWithDomain(const DataPacketPtr& domainPacket,
  * @brief Creates a Data packet with a given descriptor, sample count,
  * a reference to a packet that describes the domain (time) data,
  * pointer to an existing memory location and a deleter, and an optional packet offset.
+ * 
  * @param domainPacket The Data packet carrying domain data.
  * @param descriptor The descriptor of the signal sending the data.
  * @param sampleCount The number of samples in the packet.
@@ -85,13 +119,16 @@ inline DataPacketPtr DataPacketWithExternalMemory(const DataPacketPtr& domainPac
                                           uint64_t sampleCount,
                                           void* data,
                                           const DeleterPtr& deleter,
-                                          NumberPtr offset = nullptr)
+                                          NumberPtr offset = nullptr,
+                                          SizeT bufferSize = std::numeric_limits<SizeT>::max())
 {
-    DataPacketPtr obj(DataPacketWithDomain_Create(domainPacket,
-                                                  descriptor,
-                                                  sampleCount,
-                                                  offset,
-                                                  std::move(ExternalAllocator(data, deleter))));
+    DataPacketPtr obj(DataPacketWithExternalMemory_Create(domainPacket,
+                                                          descriptor,
+                                                          sampleCount,
+                                                          offset,
+                                                          data,
+                                                          deleter,
+                                                          bufferSize));
     return obj;
 }
 

--- a/core/opendaq/signal/src/data_descriptor_impl.cpp
+++ b/core/opendaq/signal/src/data_descriptor_impl.cpp
@@ -240,7 +240,8 @@ ErrCode DataDescriptorImpl::validate()
                                      "When using post scaling, the data rule type must be explicit, and the resolution and origin must "
                                      "not be configured.");
 
-            if (!(dataRule.getType() == DataRuleType::Explicit || dataRule.getType() == DataRuleType::Other))
+            if (!(dataRule.getType() == DataRuleType::Explicit || dataRule.getType() == DataRuleType::Constant ||
+                  dataRule.getType() == DataRuleType::Other))
             {
                 if (sampleType > SampleType::RangeInt64)
                     return makeErrorInfo(OPENDAQ_ERR_INVALID_SAMPLE_TYPE, "Implicit data rule types can only be real numbers.");
@@ -338,18 +339,18 @@ bool DataDescriptorImpl::hasScalingCalc() const
 }
 
 // IDataRuleCalcPrivate
-void* DataDescriptorImpl::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount) const
+void* DataDescriptorImpl::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize) const
 {
     if (dataRuleCalc)
-        return dataRuleCalc->calculateRule(packetOffset, sampleCount);
+        return dataRuleCalc->calculateRule(packetOffset, sampleCount, input, inputSize);
 
     return nullptr;
 }
 
-void DataDescriptorImpl::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void** output) const
+void DataDescriptorImpl::calculateRule(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize, void** output) const
 {
     if (dataRuleCalc)
-        dataRuleCalc->calculateRule(packetOffset, sampleCount, output);
+        dataRuleCalc->calculateRule(packetOffset, sampleCount, input, inputSize, output);
 }
 
 bool DataDescriptorImpl::hasDataRuleCalc() const

--- a/core/opendaq/signal/src/data_packet_impl.cpp
+++ b/core/opendaq/signal/src/data_packet_impl.cpp
@@ -8,8 +8,7 @@ OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
     IDataPacket, createDataPacket,
     IDataDescriptor*, descriptor,
     SizeT, sampleCount,
-    INumber*, offset,
-    IAllocator*, allocator
+    INumber*, offset
 )
 
 OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
@@ -18,8 +17,30 @@ OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
     IDataPacket*, domainPacket,
     IDataDescriptor*, descriptor,
     SizeT, sampleCount,
+    INumber*, offset
+)
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
+    LIBRARY_FACTORY, DataPacketImpl<IDataPacket>,
+    IDataPacket, createDataPacketWithExternalMemory,
+    IDataPacket*, domainPacket,
+    IDataDescriptor*, descriptor,
+    SizeT, sampleCount,
     INumber*, offset,
-    IAllocator*, allocator
+    void*, externalMemory,
+    IDeleter*, deleter,
+    SizeT, bufferSize
+)
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
+    LIBRARY_FACTORY, DataPacketImpl<IDataPacket>,
+    IDataPacket, createConstantDataPacketWithDomain,
+    IDataPacket*, domainPacket,
+    IDataDescriptor*, descriptor,
+    SizeT, sampleCount,
+    void*, initialValue,
+    void*, otherValues,
+    SizeT, otherValueCount
 )
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/tests/test_allocated_packets.cpp
+++ b/core/opendaq/signal/tests/test_allocated_packets.cpp
@@ -20,21 +20,6 @@ static DataDescriptorPtr setupDescriptor(SampleType sampleType)
 
 // Tests
 
-TEST_F(AllocatedPacketsTest, TestDataPacket)
-{
-    const SampleType sampleType = SampleType::Float64;
-    const std::size_t sampleSize = getSampleSize(sampleType);
-    const SizeT sampleCount = 100;
-    auto allocator = MockAllocator::Strict();
-    DataPacketPtr packet;
-
-    EXPECT_CALL(allocator.mock(), allocate(_, sampleCount*sampleSize, sampleSize, _));
-    ASSERT_NO_THROW(packet = DataPacket(setupDescriptor(sampleType), sampleCount, 10, allocator));
-    ASSERT_NE(packet.getRawData(), nullptr);
-
-    EXPECT_CALL(allocator.mock(), free(_)).Times(AtLeast(1));
-}
-
 TEST_F(AllocatedPacketsTest, DataPacketWithExternalMemory)
 {
     const SampleType sampleType = SampleType::Float64;

--- a/core/opendaq/signal/tests/test_data_rules.cpp
+++ b/core/opendaq/signal/tests/test_data_rules.cpp
@@ -25,10 +25,9 @@ TEST_F(DataRulesTest, LinearDataRuleSetGet)
 
 TEST_F(DataRulesTest, ConstantDataRuleSetGet)
 {
-    const auto rule = ConstantDataRule(10.5);
+    const auto rule = ConstantDataRule();
 
     ASSERT_EQ(rule.getType(), DataRuleType::Constant);
-    ASSERT_EQ(rule.getParameters().get("constant"), 10.5);
 }
 
 TEST_F(DataRulesTest, ExplicitDataRule)
@@ -49,10 +48,10 @@ TEST_F(DataRulesTest, LinearDataRuleCopyFactory)
 
 TEST_F(DataRulesTest, ConstantDataRuleCopyFactory)
 {
-    const auto rule = ConstantDataRule(100);
+    const auto rule = ConstantDataRule();
     const auto ruleCopy = DataRuleBuilderCopy(rule).build();
 
-    ASSERT_EQ(ruleCopy.getParameters().get("constant"), 100);
+    ASSERT_EQ(ruleCopy.getType(), DataRuleType::Constant);
 }
 
 TEST_F(DataRulesTest, ExplicitDataRuleCopyFactory)
@@ -76,26 +75,6 @@ TEST_F(DataRulesTest, LinearDataRuleInvalidParameters)
 
     params.set("delta", 10);
     params.set("start", 10);
-    params.set("extra", 10);
-    ASSERT_THROW(ruleBuilder.build(), InvalidParametersException);
-
-    params.deleteItem("extra");
-    ASSERT_NO_THROW(ruleBuilder.build());
-}
-
-TEST_F(DataRulesTest, ConstantDataRuleInvalidParameters)
-{
-    auto ruleBuilder = DataRuleBuilder().setType(DataRuleType::Constant);
-    ASSERT_THROW(ruleBuilder.build(), InvalidParametersException);
-
-    auto params = Dict<IString, IBaseObject>();
-    ruleBuilder.setParameters(params);
-    ASSERT_THROW(ruleBuilder.build(), InvalidParametersException);
-
-    params.set("constant", "wrong");
-    ASSERT_THROW(ruleBuilder.build(), InvalidParametersException);
-
-    params.set("constant", 10);
     params.set("extra", 10);
     ASSERT_THROW(ruleBuilder.build(), InvalidParametersException);
 

--- a/docs/Antora/modules/background_info/pages/signals.adoc
+++ b/docs/Antora/modules/background_info/pages/signals.adoc
@@ -121,7 +121,7 @@ calculated depending on the Rule type. Currently, two rules are available in ope
 
 * **Linear Rule**: The Rule parameters include a `delta` and `start` numbers. The values are calculated according to the following equation: `PacketOffset + SampleIndex * delta + start`, where the `PacketOffset` is available on the Packet carrying the data and the `SampleIndex` represents the index of the data entry being calculated within a given packet.
 
-* **Constant Rule**: All values of the signal are equal to the `constant` Rule Number-type parameter.
+* **Constant Rule**: All values of the signal are equal to the `constant` defined in the packet.
 
 === Dimensions
 

--- a/docs/tests/test_signals.cpp
+++ b/docs/tests/test_signals.cpp
@@ -49,7 +49,7 @@ TEST_F(SignalsTest, DataDescriptor)
 TEST_F(SignalsTest, DataRule)
 {
     auto dataRule1 = LinearDataRule(10, 10);
-    auto dataRule2 = ConstantDataRule(10);
+    auto dataRule2 = ConstantDataRule();
     auto dataRule3 = ExplicitDataRule();
 
     ASSERT_TRUE(dataRule1.assigned());

--- a/modules/ref_device_module/include/ref_device_module/ref_channel_impl.h
+++ b/modules/ref_device_module/include/ref_device_module/ref_channel_impl.h
@@ -23,7 +23,7 @@
 
 BEGIN_NAMESPACE_REF_DEVICE_MODULE
 
-enum class WaveformType { Sine, Rect, None, Counter };
+enum class WaveformType { Sine, Rect, None, Counter, ConstantValue };
 
 DECLARE_OPENDAQ_INTERFACE(IRefChannel, IBaseObject)
 {
@@ -58,6 +58,7 @@ private:
     double ampl;
     double dc;
     double noiseAmpl;
+    double constantValue;
     double sampleRate;
     StructPtr customRange;
     bool clientSideScaling;

--- a/modules/ref_device_module/src/ref_channel_impl.cpp
+++ b/modules/ref_device_module/src/ref_channel_impl.cpp
@@ -25,6 +25,7 @@ RefChannelImpl::RefChannelImpl(const ContextPtr& context, const ComponentPtr& pa
     , ampl(0)
     , dc(0)
     , noiseAmpl(0)
+    , constantValue(0)
     , sampleRate(0)
     , index(init.index)
     , globalSampleRate(init.globalSampleRate)
@@ -55,11 +56,11 @@ void RefChannelImpl::signalTypeChangedIfNotUpdating(const PropertyValueEventArgs
 
 void RefChannelImpl::initProperties()
 {
-    const auto waveformProp = SelectionProperty("Waveform", List<IString>("Sine", "Rect", "None", "Counter"), 0);
+    const auto waveformProp = SelectionProperty("Waveform", List<IString>("Sine", "Rect", "None", "Counter", "Constant"), 0);
     
     objPtr.addProperty(waveformProp);
     objPtr.getOnPropertyValueWrite("Waveform") +=
-        [this](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& args) { waveformChanged(); };
+        [this](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& args) { signalTypeChangedIfNotUpdating(args); };
 
     const auto freqProp = FloatPropertyBuilder("Frequency", 10.0)
                               .setVisible(EvalValue("$Waveform < 2"))
@@ -159,6 +160,17 @@ void RefChannelImpl::initProperties()
     objPtr.addProperty(IntPropertyBuilder("PacketSize", 1000).setVisible(EvalValue("$FixedPacketSize")).build());
     objPtr.getOnPropertyValueWrite("PacketSize") +=
         [this](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& args) { packetSizeChanged(); };
+
+    const auto constantValueProp =
+        FloatPropertyBuilder("ConstantValue", 2.0)
+            .setVisible(EvalValue("$Waveform == 4"))
+            .setMinValue(-10.0)
+            .setMaxValue(10.0)
+            .build();
+
+    objPtr.addProperty(constantValueProp);
+    objPtr.getOnPropertyValueWrite("ConstantValue") +=
+        [this](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& args) { waveformChanged(); };
 }
 
 void RefChannelImpl::packetSizeChangedInternal()
@@ -181,8 +193,9 @@ void RefChannelImpl::waveformChangedInternal()
     dc = objPtr.getPropertyValue("DC");
     ampl = objPtr.getPropertyValue("Amplitude");
     noiseAmpl = objPtr.getPropertyValue("NoiseAmplitude");
-    LOG_I("Properties: Waveform {}, Frequency {}, DC {}, Amplitude {}, NoiseAmplitude {}",
-          objPtr.getPropertySelectionValue("Waveform").toString(), freq, dc, ampl, noiseAmpl);
+    constantValue = objPtr.getPropertyValue("ConstantValue");
+    LOG_I("Properties: Waveform {}, Frequency {}, DC {}, Amplitude {}, NoiseAmplitude {}, ConstantValue {}",
+          objPtr.getPropertySelectionValue("Waveform").toString(), freq, dc, ampl, noiseAmpl, constantValue);
 }
 
 void RefChannelImpl::updateSamplesGenerated()
@@ -215,6 +228,8 @@ void RefChannelImpl::signalTypeChangedInternal()
     clientSideScaling = objPtr.getPropertyValue("ClientSideScaling");
 
     customRange = objPtr.getPropertyValue("CustomRange");
+
+    waveformType = objPtr.getPropertyValue("Waveform");
 
     LOG_I("Properties: SampleRate {}, ClientSideScaling {}", sampleRate, clientSideScaling);
 }
@@ -265,57 +280,68 @@ void RefChannelImpl::collectSamples(std::chrono::microseconds curTime)
 void RefChannelImpl::generateSamples(int64_t curTime, uint64_t samplesGenerated, uint64_t newSamples)
 {
     const auto domainPacket = DataPacket(timeSignal.getDescriptor(), newSamples, curTime);
-    const auto dataPacket = DataPacketWithDomain(domainPacket, valueSignal.getDescriptor(), newSamples);
-
-    double* buffer;
-
-    if (clientSideScaling)
+    DataPacketPtr dataPacket;
+    if (waveformType == WaveformType::ConstantValue)
     {
-        buffer = static_cast<double*>(std::malloc(newSamples * sizeof(double)));
+        dataPacket = ConstantDataPacketWithDomain(domainPacket, valueSignal.getDescriptor(), newSamples, constantValue);
     }
     else
-        buffer = static_cast<double*>(dataPacket.getRawData());
-
-    switch(waveformType)
     {
-        case WaveformType::Counter:
+        dataPacket = DataPacketWithDomain(domainPacket, valueSignal.getDescriptor(), newSamples);
+
+        double* buffer;
+
+        if (clientSideScaling)
         {
-            for (uint64_t i = 0; i < newSamples; i++)
-                buffer[i] = static_cast<double>(counter++) / sampleRate;
-            break;
+            buffer = static_cast<double*>(std::malloc(newSamples * sizeof(double)));
         }
-        case WaveformType::Sine:
+        else
+            buffer = static_cast<double*>(dataPacket.getRawData());
+
+        switch(waveformType)
         {
-            for (uint64_t i = 0; i < newSamples; i++)
-                buffer[i] = std::sin(2.0 * PI * freq / sampleRate * static_cast<double>((samplesGenerated + i))) * ampl + dc + noiseAmpl * dist(re);
-            break;
-        }
-        case WaveformType::Rect:
-        {
-            for (uint64_t i = 0; i < newSamples; i++)
+            case WaveformType::Counter:
             {
-                double val = std::sin(2.0 * PI * freq / sampleRate * static_cast<double>((samplesGenerated + i)));
-                val = val > 0 ? 1.0 : -1.0;
-                buffer[i] = val * ampl + dc + noiseAmpl * dist(re);
+                for (uint64_t i = 0; i < newSamples; i++)
+                    buffer[i] = static_cast<double>(counter++) / sampleRate;
+                break;
             }
-            break;
+            case WaveformType::Sine:
+            {
+                for (uint64_t i = 0; i < newSamples; i++)
+                    buffer[i] = std::sin(2.0 * PI * freq / sampleRate * static_cast<double>((samplesGenerated + i))) * ampl + dc + noiseAmpl * dist(re);
+                break;
+            }
+            case WaveformType::Rect:
+            {
+                for (uint64_t i = 0; i < newSamples; i++)
+                {
+                    double val = std::sin(2.0 * PI * freq / sampleRate * static_cast<double>((samplesGenerated + i)));
+                    val = val > 0 ? 1.0 : -1.0;
+                    buffer[i] = val * ampl + dc + noiseAmpl * dist(re);
+                }
+                break;
+            }
+            case WaveformType::None:
+            {
+                for (uint64_t i = 0; i < newSamples; i++)
+                    buffer[i] = dc + noiseAmpl * dist(re);
+                break;
+            }
+            case WaveformType::ConstantValue:
+                break;
         }
-        case WaveformType::None:
+
+        if (clientSideScaling)
         {
-            for (uint64_t i = 0; i < newSamples; i++)
-                buffer[i] = dc + noiseAmpl * dist(re);
-            break;
+            double f = std::pow(2, 24);
+            auto packetBuffer = static_cast<uint32_t*>(dataPacket.getRawData());
+            for (size_t i = 0; i < newSamples; i++)
+                *packetBuffer++ = static_cast<uint32_t>((buffer[i] + 10.0) / 20.0 * f);
+
+            std::free(static_cast<void*>(buffer));
         }
-    }
 
-    if (clientSideScaling)
-    {
-        double f = std::pow(2, 24);
-        auto packetBuffer = static_cast<uint32_t*>(dataPacket.getRawData());
-        for (size_t i = 0; i < newSamples; i++)
-            *packetBuffer++ = static_cast<uint32_t>((buffer[i] + 10.0) / 20.0 * f);
-
-        std::free(static_cast<void*>(buffer));
     }
 
     valueSignal.sendPacket(dataPacket);
@@ -343,6 +369,11 @@ void RefChannelImpl::buildSignalDescriptors()
         const double scale = 20.0 / std::pow(2, 24);
         constexpr double offset = -10.0;
         valueDescriptor.setPostScaling(LinearScaling(scale, offset, SampleType::Int32, ScaledSampleType::Float64));
+    }
+
+    if (waveformType == WaveformType::ConstantValue)
+    {
+        valueDescriptor.setRule(ConstantDataRule());
     }
 
 

--- a/shared/libraries/opcuatms/opcuatms/src/converters/data_rule_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/converters/data_rule_converter.cpp
@@ -52,14 +52,14 @@ DataRulePtr StructConverter<IDataRule, UA_ConstantRuleDescriptionStructure>::ToD
         throw ConversionFailedException();
 
     const NumberPtr value = VariantConverter<INumber>::ToDaqObject(tmsStruct.value);
-    return ConstantDataRule(value);
+    return ConstantDataRule();
 }
 
 template <>
 OpcUaObject<UA_ConstantRuleDescriptionStructure> StructConverter<IDataRule, UA_ConstantRuleDescriptionStructure>::ToTmsType(
     const DataRulePtr& object, const ContextPtr& /*context*/)
 {
-    const NumberPtr value = object.getParameters().get("constant");
+    const NumberPtr value = Integer(0); // TODO: temporary solution until model is adapted
     OpcUaObject<UA_ConstantRuleDescriptionStructure> uaRuleDescription;
 
     uaRuleDescription->type = UA_STRING_ALLOC("constant");

--- a/shared/libraries/opcuatms/opcuatms/tests/test_variant_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/tests/test_variant_converter.cpp
@@ -222,14 +222,12 @@ TEST_F(VariantConverterTest, LinearDataRule)
 
 TEST_F(VariantConverterTest, ConstantDataRule)
 {
-    const DataRulePtr daqDataRule = ConstantDataRule(2.0);
-    const DataRulePtr daqDataRuleWrong = ConstantDataRule(1.0);
+    const DataRulePtr daqDataRule = ConstantDataRule();
 
     const auto variant = VariantConverter<IDataRule>::ToVariant(daqDataRule);
     const auto daqDataRuleOut = VariantConverter<IDataRule>::ToDaqObject(variant);
 
     ASSERT_TRUE(daqDataRuleOut.equals(daqDataRule));
-    ASSERT_FALSE(daqDataRuleOut.equals(daqDataRuleWrong));
 }
 
 TEST_F(VariantConverterTest, ExplicitDataRule)

--- a/shared/libraries/opcuatms/opcuatms/tests/test_variant_list_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/tests/test_variant_list_converter.cpp
@@ -240,7 +240,7 @@ TEST_F(VariantListConverterTest, DataRule)
 {
     auto list = List<IDataRule>();
     list.pushBack(LinearDataRule(2.0, 3.0));
-    list.pushBack(ConstantDataRule(100.0));
+    list.pushBack(ConstantDataRule());
     list.pushBack(ExplicitDataRule());
 
     const auto variant = VariantConverter<IDataRule>::ToArrayVariant(list);

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_signal.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_signal.cpp
@@ -43,7 +43,7 @@ public:
                                         .setSampleType(SampleType::Float32)
                                         .setName("Value Name")
                                         .setDimensions(List<IDimension>())
-                                        .setRule(ConstantDataRule(1.0))
+                                        .setRule(ConstantDataRule())
                                         .setUnit(Unit("symbol", 1, "name", "quantity"))  // Optional
                                         .setOrigin("Origin")                             // Optional
                                         .setValueRange(Range(0.0, 100.0))                // Optional
@@ -350,7 +350,7 @@ TEST_F(TmsSignalTest, AttrDescriptor)
     auto serverDataDescriptor = DataDescriptorBuilder()
                                     .setSampleType(SampleType::Float32)
                                     .setDimensions(List<IDimension>())
-                                    .setRule(ConstantDataRule(1.0))
+                                    .setRule(ConstantDataRule())
                                     .setUnit(Unit("symbol", 1, "name", "quantity"))  // Optional
                                     .setOrigin("Origin")                             // Optional
                                     .setValueRange(Range(0.0, 100.0))                // Optional
@@ -399,13 +399,7 @@ TEST_F(TmsSignalTest, AttrDescriptor)
     auto clientRule = clientDataDescriptor.getRule();
     ASSERT_EQ(clientRule.getType(), DataRuleType::Constant);
     auto clientRuleParameters = clientRule.getParameters();
-    ASSERT_EQ(clientRuleParameters.getCount(), 1u);
-    auto clientKeyList = clientRuleParameters.getKeyList();
-    auto clientValueList = clientRuleParameters.getValueList();
-    auto k = clientKeyList.getItemAt(0);
-    ASSERT_EQ(clientKeyList.getItemAt(0), "constant");
-    auto v = clientValueList.getItemAt(0);
-    ASSERT_EQ(clientValueList.getItemAt(0), 1.0);
+    ASSERT_EQ(clientRuleParameters.getCount(), 0u);
 
     auto clientUnit = clientDataDescriptor.getUnit();
     ASSERT_EQ(clientUnit.getQuantity(), "quantity");

--- a/shared/libraries/packet_streaming/src/packet_streaming_client.cpp
+++ b/shared/libraries/packet_streaming/src/packet_streaming_client.cpp
@@ -155,7 +155,8 @@ DataPacketPtr PacketStreamingClient::addDataPacketBuffer(const PacketBufferPtr& 
                                               dataPacketHeader->sampleCount,
                                               const_cast<void*>(packetBuffer->payload),
                                               Deleter([packetBuffer = packetBuffer](void*) mutable { packetBuffer.reset(); }),
-                                              offset);
+                                              offset,
+                                              dataPacketHeader->genericHeader.payloadSize);
     }
 
     queue.push({signalId, packet});

--- a/shared/libraries/websocket_streaming/src/signal_descriptor_converter.cpp
+++ b/shared/libraries/websocket_streaming/src/signal_descriptor_converter.cpp
@@ -174,8 +174,7 @@ daq::DataRulePtr SignalDescriptorConverter::GetRule(const daq::streaming_protoco
     {
         case daq::streaming_protocol::RULETYPE_CONSTANT:
         {
-            uint64_t start = subscribedSignal.time();
-            return ConstantDataRule(start);
+            return ConstantDataRule();
         }
         break;
         case daq::streaming_protocol::RULETYPE_EXPLICIT:


### PR DESCRIPTION
- removed constant value from constant data rule
- constant values are now part of a constant data packet
- simplest form is one value per packet
- support for inter-packet constant value changes
- allocator has been removed from data packet factory as it should be done in a different way
- new waveform type "constant" added to ref channel in ref device. It uses only one constant value per packet.
- first constant value is passed without sample number, other constant values in the packet must provide starting sample number
- documentation how to guide is missing.
- complex, struct types not supported atm (possible to do)