### PR TITLE
Fix serial number in simulator

### DIFF
--- a/simulator/Vagrantfile
+++ b/simulator/Vagrantfile
@@ -119,9 +119,9 @@ Vagrant.configure("2") do |config|
     # Make systemd service run on boot (before login)
     config.vm.provision "shell", inline: "sudo systemctl enable simulator"
 	
-	#Set permissions
-	config.vm.provision "shell", inline: "sudo chmod -R 777 /home/opendaq/"
-	config.vm.provision "shell", inline: "sudo chmod -R 777 /etc/avahi/services/"
+	# Set permissions
+	config.vm.provision "shell", inline: "sudo chown opendaq:opendaq -hR /home/opendaq/"
+	config.vm.provision "shell", inline: "sudo chown opendaq:opendaq -hR /etc/avahi/services/"
 
     # Reduce memory usage
     config.vm.provision :shell, :inline => <<-SCRIPT

--- a/simulator/Vagrantfile
+++ b/simulator/Vagrantfile
@@ -113,17 +113,8 @@ Vagrant.configure("2") do |config|
     # Copy files to /home/opendaq/
     config.vm.provision "shell", inline: "cp /tmp/{opcuatms.service,native_streaming.service,opendaq-config.json,simulator.service,configurator.py} /home/opendaq/"
 
-    # Configure serial numbers and local ids with configurator and delete it
-    config.vm.provision "shell", inline: "cd /home/opendaq/ && python3 configurator.py && rm configurator.py"
-
-    # Move MDNS services configs
-    config.vm.provision "shell", inline: "mv /home/opendaq/{opcuatms.service,native_streaming.service} /etc/avahi/services/"
-    
     # Move systemd service file
     config.vm.provision "shell", inline: "mv /home/opendaq/simulator.service /etc/systemd/system/"
-
-    # Move opendaq-config.json file
-    config.vm.provision "shell", inline: "mv /home/opendaq/opendaq-config.json /home/opendaq/opendaq/"
     
     # Make systemd service run on boot (before login)
     config.vm.provision "shell", inline: "sudo systemctl enable simulator"

--- a/simulator/Vagrantfile
+++ b/simulator/Vagrantfile
@@ -120,8 +120,8 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: "sudo systemctl enable simulator"
 	
 	# Set permissions
-	config.vm.provision "shell", inline: "sudo chown opendaq:opendaq -hR /home/opendaq/"
-	config.vm.provision "shell", inline: "sudo chown opendaq:opendaq -hR /etc/avahi/services/"
+    config.vm.provision "shell", inline: "sudo chown opendaq:opendaq -hR /home/opendaq/"
+    config.vm.provision "shell", inline: "sudo chown opendaq:opendaq -hR /etc/avahi/services/"
 
     # Reduce memory usage
     config.vm.provision :shell, :inline => <<-SCRIPT

--- a/simulator/Vagrantfile
+++ b/simulator/Vagrantfile
@@ -118,6 +118,10 @@ Vagrant.configure("2") do |config|
     
     # Make systemd service run on boot (before login)
     config.vm.provision "shell", inline: "sudo systemctl enable simulator"
+	
+	#Set permissions
+	config.vm.provision "shell", inline: "sudo chmod -R 777 /home/opendaq/"
+	config.vm.provision "shell", inline: "sudo chmod -R 777 /etc/avahi/services/"
 
     # Reduce memory usage
     config.vm.provision :shell, :inline => <<-SCRIPT

--- a/simulator/configurator.py
+++ b/simulator/configurator.py
@@ -1,9 +1,9 @@
 import json
-from uuid import getnode as get_mac
+import netifaces
 from xml.etree import ElementTree
 
 # serial number = mac address
-serial = str(get_mac())
+serial = netifaces.ifaddresses("enp0s3")[netifaces.AF_LINK][0]["addr"]
 header = ("<?xml version=\"1.0\" standalone='no'?>"
           "<!--*-nxml-*-->\n<!DOCTYPE service-group SYSTEM \"avahi-service.dtd\">\n")
 

--- a/simulator/configurator.py
+++ b/simulator/configurator.py
@@ -34,6 +34,6 @@ def configure_serial_in_service(filename, keyword):
         file.write(string)
 
 
-configure_local_id_in_json("opendaq-config.json", "opendaq")
-configure_serial_in_service("opcuatms.service", "serialNumber")
-configure_serial_in_service("native_streaming.service", "serialNumber")
+configure_local_id_in_json("/home/opendaq/opendaq-config.json", "opendaq")
+configure_serial_in_service("/home/opendaq/opcuatms.service", "serialNumber")
+configure_serial_in_service("/home/opendaq/native_streaming.service", "serialNumber")

--- a/simulator/opendaq-config.json
+++ b/simulator/opendaq-config.json
@@ -5,7 +5,7 @@
         },
     "Scheduler": 
         {
-            "WorkerNnum": 0
+            "WorkersNum": 0
         },
     "Logging": 
         {

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -8,6 +8,10 @@ Type=simple
 Restart=always
 RestartSec=1
 User=opendaq
+ExecStartPre=python3 /home/opendaq/configurator.py
+ExecStartPre=cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
+ExecStartPre=cp /home/opendaq/{opcuatms.service,native_streaming.service} /etc/avahi/services/
+ExecStartPre=sudo service avahi-daemon restart
 Environment=LD_LIBRARY_PATH=/home/opendaq/opendaq/lib
 ExecStart=/home/opendaq/opendaq/application_simulator
 

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -12,7 +12,7 @@ ExecStartPre=python3 /home/opendaq/configurator.py
 ExecStartPre=cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
 ExecStartPre=cp /home/opendaq/opcuatms.service /etc/avahi/services/
 ExecStartPre=cp /home/opendaq/native_streaming.service /etc/avahi/services/
-ExecStartPre=service avahi-daemon restart
+ExecStartPre=echo opendaq | sudo -S systemctl mask avahi-daemon && sudo systemctl disable avahi-daemon && sudo systemctl stop avahi-daemon
 Environment=LD_LIBRARY_PATH=/home/opendaq/opendaq/lib
 ExecStart=/home/opendaq/opendaq/application_simulator
 

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=openDAQ simulator service
 After=network.target
+Before=avahi-daemon.service
 StartLimitIntervalSec=0
 
 [Service]

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -9,9 +9,9 @@ Restart=always
 RestartSec=1
 User=opendaq
 ExecStartPre=python3 /home/opendaq/configurator.py
-ExecStartPre=cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
-ExecStartPre=cp /home/opendaq/{opcuatms.service,native_streaming.service} /etc/avahi/services/
-ExecStartPre=sudo service avahi-daemon restart
+ExecStartPre=echo opendaq | sudo -S cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
+ExecStartPre=echo opendaq | sudo -S cp /home/opendaq/{opcuatms.service,native_streaming.service} /etc/avahi/services/
+ExecStartPre=echo opendaq | sudo -S service avahi-daemon restart
 Environment=LD_LIBRARY_PATH=/home/opendaq/opendaq/lib
 ExecStart=/home/opendaq/opendaq/application_simulator
 

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -10,7 +10,8 @@ RestartSec=1
 User=opendaq
 ExecStartPre=python3 /home/opendaq/configurator.py
 ExecStartPre=cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
-ExecStartPre=cp /home/opendaq/{opcuatms.service,native_streaming.service} /etc/avahi/services/
+ExecStartPre=cp /home/opendaq/opcuatms.service /etc/avahi/services/
+ExecStartPre=cp /home/opendaq/native_streaming.service /etc/avahi/services/
 ExecStartPre=service avahi-daemon restart
 Environment=LD_LIBRARY_PATH=/home/opendaq/opendaq/lib
 ExecStart=/home/opendaq/opendaq/application_simulator

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -12,7 +12,6 @@ ExecStartPre=python3 /home/opendaq/configurator.py
 ExecStartPre=cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
 ExecStartPre=cp /home/opendaq/opcuatms.service /etc/avahi/services/
 ExecStartPre=cp /home/opendaq/native_streaming.service /etc/avahi/services/
-ExecStartPre=echo opendaq | sudo -S service avahi-daemon restart
 Environment=LD_LIBRARY_PATH=/home/opendaq/opendaq/lib
 ExecStart=/home/opendaq/opendaq/application_simulator
 

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -12,7 +12,7 @@ ExecStartPre=python3 /home/opendaq/configurator.py
 ExecStartPre=cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
 ExecStartPre=cp /home/opendaq/opcuatms.service /etc/avahi/services/
 ExecStartPre=cp /home/opendaq/native_streaming.service /etc/avahi/services/
-ExecStartPre=echo opendaq | sudo -S systemctl mask avahi-daemon && sudo systemctl disable avahi-daemon && sudo systemctl stop avahi-daemon
+ExecStartPre=echo opendaq | sudo -S service avahi-daemon restart
 Environment=LD_LIBRARY_PATH=/home/opendaq/opendaq/lib
 ExecStart=/home/opendaq/opendaq/application_simulator
 

--- a/simulator/simulator.service
+++ b/simulator/simulator.service
@@ -9,9 +9,9 @@ Restart=always
 RestartSec=1
 User=opendaq
 ExecStartPre=python3 /home/opendaq/configurator.py
-ExecStartPre=echo opendaq | sudo -S cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
-ExecStartPre=echo opendaq | sudo -S cp /home/opendaq/{opcuatms.service,native_streaming.service} /etc/avahi/services/
-ExecStartPre=echo opendaq | sudo -S service avahi-daemon restart
+ExecStartPre=cp /home/opendaq/opendaq-config.json /home/opendaq/opendaq/
+ExecStartPre=cp /home/opendaq/{opcuatms.service,native_streaming.service} /etc/avahi/services/
+ExecStartPre=service avahi-daemon restart
 Environment=LD_LIBRARY_PATH=/home/opendaq/opendaq/lib
 ExecStart=/home/opendaq/opendaq/application_simulator
 


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

# Description:

* Serial number is determined by the actual MAC address
* Serial number is configured in services and localId is configured in `opendaq-config.json` on each boot (instead of once when creating the virtual machine) before `simulator.service` is started
* `simulator.service` is configured to start before `avahi-daemon.service`
* Fixed a typo in `opendaq-config.json`