### PR TITLE
Time readers wrong timestamps on Windows bug fix

### DIFF
--- a/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
+++ b/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
@@ -206,7 +206,9 @@ private:
     }
 
     template <typename ValueType, typename DomainType, typename ReaderType>
-    static inline std::tuple<SampleTypeVariant, DomainTypeVariant> read(const ReaderType& reader, size_t count, [[maybe_unused]] size_t timeoutMs)
+    static inline std::tuple<SampleTypeVariant, DomainTypeVariant> read(const ReaderType& reader,
+                                                                        size_t count,
+                                                                        [[maybe_unused]] size_t timeoutMs)
     {
         using DomainVectorType = typename std::conditional<std::is_same<DomainType, std::chrono::system_clock::time_point>::value,
                                                            std::vector<int64_t>,
@@ -227,12 +229,11 @@ private:
             static_assert(sizeof(std::chrono::system_clock::time_point::rep) == sizeof(int64_t));
             if constexpr (ReaderHasReadWithTimeout<ReaderType, ValueType>::value)
             {
-                reader->readWithDomain(
-                    values.data(), reinterpret_cast<std::chrono::system_clock::time_point*>(domain.data()), &count, timeoutMs, nullptr);
+                reader->readWithDomain(values.data(), domain.data(), &count, timeoutMs, nullptr);
             }
             else
             {
-                reader->readWithDomain(values.data(), reinterpret_cast<std::chrono::system_clock::time_point*>(domain.data()), &count, nullptr);
+                reader->readWithDomain(values.data(), domain.data(), &count, nullptr);
             }
         }
         else
@@ -257,7 +258,17 @@ private:
 
         std::string domainDtype;
         if constexpr (std::is_same_v<DomainType, std::chrono::system_clock::time_point>)
+        {
             domainDtype = "datetime64[ns]";
+            std::transform(domain.begin(),
+                           domain.end(),
+                           domain.begin(),
+                           [](int64_t timestamp)
+                           {
+                               const auto t = std::chrono::system_clock::time_point(std::chrono::system_clock::duration(timestamp));
+                               return std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count();
+                           });
+        }
 
         auto valuesArray = toPyArray(std::move(values), shape);
         auto domainArray = toPyArray(std::move(domain), shape, domainDtype);


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

Fixed a bug for timed versions of readers caused by not converting internal clock ticks to unix timestamps on Windows