### PR TITLE
Native streaming: cache last event packet and send it to secondary subscribed client

### DIFF
--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/streaming.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/streaming.h
@@ -45,7 +45,6 @@ struct MockStreaming : daq::StreamingImpl<IMockStreaming>
     MOCK_METHOD(void, onRemoveSignal, (const daq::MirroredSignalConfigPtr& signal), (override));
     MOCK_METHOD(void, onSubscribeSignal, (const daq::StringPtr& signalStreamingId), (override));
     MOCK_METHOD(void, onUnsubscribeSignal, (const daq::StringPtr& signalStreamingId), (override));
-    MOCK_METHOD(daq::EventPacketPtr, onCreateDataDescriptorChangedEventPacket, (const daq::StringPtr& signalStreamingId), (override));
 
     void makeSignalAvailable(const daq::StringPtr& signalStreamingId) override { addToAvailableSignals(signalStreamingId); }
     void makeSignalUnavailable(const daq::StringPtr& signalStreamingId) override { removeFromAvailableSignals(signalStreamingId); }
@@ -97,14 +96,6 @@ struct MockStreaming : daq::StreamingImpl<IMockStreaming>
                        {
                            if (signal.getRemoteId() == signalStreamingId)
                                 signal.template asPtr<daq::IMirroredSignalPrivate>().unsubscribeCompleted(this->connectionString);
-                       })
-            ));
-
-        ON_CALL(*this, onCreateDataDescriptorChangedEventPacket)
-            .WillByDefault(DoAll(
-                Invoke([&](const daq::StringPtr& signalStreamingId)
-                       {
-                           return daq::DataDescriptorChangedEventPacket(nullptr, nullptr);
                        })
             ));
     }

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_streaming.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_streaming.h
@@ -29,7 +29,6 @@ protected:
     void onRemoveSignal(const daq::MirroredSignalConfigPtr& signal) override;
     void onSubscribeSignal(const daq::StringPtr& signalStreamingIdd) override;
     void onUnsubscribeSignal(const daq::StringPtr& signalStreamingId) override;
-    daq::EventPacketPtr onCreateDataDescriptorChangedEventPacket(const daq::StringPtr& signalStreamingId) override;
 };
 
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(

--- a/core/opendaq/opendaq/mocks/mock_streaming.cpp
+++ b/core/opendaq/opendaq/mocks/mock_streaming.cpp
@@ -33,11 +33,6 @@ void MockStreamingImpl::onUnsubscribeSignal(const StringPtr& /*signalStreamingId
 
 }
 
-EventPacketPtr MockStreamingImpl::onCreateDataDescriptorChangedEventPacket(const StringPtr& /*signalStreamingId*/)
-{
-    return DataDescriptorChangedEventPacket(nullptr, nullptr);
-}
-
 OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE(
     INTERNAL_FACTORY,
     MockStreaming, IStreaming,

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -48,7 +48,7 @@ TEST_F(InstanceTest, InstanceGetters)
 TEST_F(InstanceTest, GetSetRootDevice)
 {
     auto instance = test_helpers::setupInstance();
-    ASSERT_EQ(instance.getRootDevice().getInfo().getName(), String("daq_client"));
+    ASSERT_EQ(instance.getRootDevice().getInfo().getName(), String("openDAQ Client"));
     instance.setRootDevice("daq_client_device");
 }
 
@@ -70,7 +70,7 @@ TEST_F(InstanceTest, SetRootDeviceWithConfig)
 TEST_F(InstanceTest, RootDeviceWithModuleFunctionBlocks)
 {
     auto instance = test_helpers::setupInstance();
-    ASSERT_EQ(instance.getRootDevice().getInfo().getName(), String("daq_client"));
+    ASSERT_EQ(instance.getRootDevice().getInfo().getName(), String("openDAQ Client"));
     instance.setRootDevice("mock_phys_device");
 
     auto fbs = instance.getFunctionBlocks();
@@ -104,7 +104,7 @@ TEST_F(InstanceTest, RootDeviceWithModuleFunctionBlocks)
 TEST_F(InstanceTest, DeviceInformation)
 {
     auto instance = test_helpers::setupInstance();
-    ASSERT_EQ(instance.getInfo().getName(), String("daq_client"));
+    ASSERT_EQ(instance.getInfo().getName(), String("openDAQ Client"));
 }
 
 TEST_F(InstanceTest, DeviceSignals)
@@ -367,7 +367,7 @@ TEST_F(InstanceTest, InstanceBuilderSetGet)
                                 .setModuleManager(moduleManager)
                                 .setSchedulerWorkerNum(1)
                                 .setScheduler(scheduler)
-                                .setDefaultRootDeviceLocalId("DefaultRootDeviceLocalId")
+                                .setDefaultRootDeviceLocalId("openDAQ Client")
                                 .setRootDevice("test")
                                 .setDefaultRootDeviceInfo(defaultRootDeviceInfo);
     
@@ -386,7 +386,7 @@ TEST_F(InstanceTest, InstanceBuilderSetGet)
     ASSERT_EQ(instanceBuilder.getModuleManager(), moduleManager);
     ASSERT_EQ(instanceBuilder.getSchedulerWorkerNum(), 1u);
     ASSERT_EQ(instanceBuilder.getScheduler(), scheduler);
-    ASSERT_EQ(instanceBuilder.getDefaultRootDeviceLocalId(), "DefaultRootDeviceLocalId");
+    ASSERT_EQ(instanceBuilder.getDefaultRootDeviceLocalId(), "openDAQ Client");
     ASSERT_EQ(instanceBuilder.getRootDevice(), "test");
     ASSERT_EQ(instanceBuilder.getDefaultRootDeviceInfo(), defaultRootDeviceInfo);
 }
@@ -442,7 +442,7 @@ TEST_F(InstanceTest, InstanceCreateFactory)
                                 .setGlobalLogLevel(LogLevel::Debug)
                                 .setModuleManager(moduleManager)
                                 .setScheduler(scheduler)
-                                .setDefaultRootDeviceLocalId("DefaultRootDeviceLocalId")
+                                .setDefaultRootDeviceLocalId("openDAQ Client")
                                 .setDefaultRootDeviceInfo(defaultRootDeviceInfo)
                                 .setSchedulerWorkerNum(1)
                                 .build();
@@ -452,7 +452,7 @@ TEST_F(InstanceTest, InstanceCreateFactory)
     ASSERT_EQ(instance.getContext().getScheduler(), scheduler);
     ASSERT_EQ(instance.getContext().getScheduler().isMultiThreaded(), true);
     ASSERT_EQ(instance.getContext().getModuleManager(), moduleManager);
-    ASSERT_EQ(instance.getRootDevice().getName(), "DefaultRootDeviceLocalId"); 
+    ASSERT_EQ(instance.getRootDevice().getName(), "openDAQ Client");
 
     ASSERT_EQ(instance.getInfo(), defaultRootDeviceInfo);
 }

--- a/core/opendaq/streaming/include/opendaq/streaming_impl.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_impl.h
@@ -59,7 +59,6 @@ public:
     // IStreamingPrivate
     ErrCode INTERFACE_FUNC subscribeSignal(const StringPtr& signalRemoteId, const StringPtr& domainSignalRemoteId) override;
     ErrCode INTERFACE_FUNC unsubscribeSignal(const StringPtr& signalRemoteId, const StringPtr& domainSignalRemoteId) override;
-    EventPacketPtr INTERFACE_FUNC createDataDescriptorChangedEventPacket(const StringPtr& signalRemoteId) override;
     ErrCode INTERFACE_FUNC detachRemovedSignal(const StringPtr& signalRemoteId) override;
 
 protected:
@@ -98,13 +97,6 @@ protected:
      * @param signalStreamingId The streaming ID of the signal to be unsubscribed.
      */
     virtual void onUnsubscribeSignal(const StringPtr& signalStreamingId) = 0;
-
-    /*!
-     * @brief A function is invoked on creation of an initial DataDescriptor Changed Event Packet.
-     * @param signalRemoteId The global remote ID of the signal for which the event is created.
-     * @return The created DataDescriptor Changed Event Packet
-     */
-    virtual EventPacketPtr onCreateDataDescriptorChangedEventPacket(const StringPtr& signalStreamingId) = 0;
 
     void onPacket(const StringPtr& signalId, const PacketPtr& packet);
     void handleEventPacket(const MirroredSignalConfigPtr& signal, const EventPacketPtr& eventPacket);
@@ -576,24 +568,6 @@ void StreamingImpl<Interfaces...>::resubscribeAvailableSignal(const StringPtr& s
         }
     }
     // else - corresponding signal was not added, no actions required
-}
-
-template <typename... Interfaces>
-EventPacketPtr StreamingImpl<Interfaces...>::createDataDescriptorChangedEventPacket(const StringPtr& signalRemoteId)
-{
-    std::scoped_lock lock(sync);
-
-    StringPtr signalStreamingId = getSignalStreamingId(signalRemoteId);
-
-    if (signalStreamingId.assigned())
-    {
-        return onCreateDataDescriptorChangedEventPacket(signalStreamingId);
-    }
-    else
-    {
-        LOG_E("Signal with remote id {} is not available", signalRemoteId);
-        return DataDescriptorChangedEventPacket(nullptr, nullptr);
-    }
 }
 
 template <typename... Interfaces>

--- a/core/opendaq/streaming/include/opendaq/streaming_private.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_private.h
@@ -48,14 +48,6 @@ DECLARE_OPENDAQ_INTERFACE(IStreamingPrivate, IBaseObject)
     virtual ErrCode INTERFACE_FUNC unsubscribeSignal(const StringPtr& signalRemoteId, const StringPtr& domainSignalRemoteId) = 0;
 
     /*!
-     * @brief Creates an initial DataDescriptor Changed Event Packet for a signal using data received
-     * via the streaming.
-     * @param signalRemoteId The global remote ID of the signal for which the event packet should be created.
-     * @return The created DataDescriptor Changed Event Packet
-     */
-    virtual EventPacketPtr INTERFACE_FUNC createDataDescriptorChangedEventPacket(const StringPtr& signalRemoteId) = 0;
-
-    /*!
      * @brief Removes added signal without removing the streaming source from it.
      * @param signalRemoteId The global remote ID of the removed signal.
      * @retval OPENDAQ_ERR_NOTFOUND if a signal with corresponding remote Id was not added to the Streaming.

--- a/core/opendaq/streaming/tests/test_streaming.cpp
+++ b/core/opendaq/streaming/tests/test_streaming.cpp
@@ -477,7 +477,6 @@ TEST_F(TriggeredSubscriptionTest, BySingleConnection)
     signal.setActiveStreamingSource(streaming.ptr.getConnectionString());
     auto inputPort = InputPort(context, nullptr, "TestPort");
 
-    EXPECT_CALL(streaming.mock(), onCreateDataDescriptorChangedEventPacket(signal.getRemoteId())).Times(Exactly(1));
     EXPECT_CALL(streaming.mock(), onSubscribeSignal(signal.getRemoteId())).Times(Exactly(1));
     inputPort.connect(signal);
 
@@ -492,7 +491,6 @@ TEST_F(TriggeredSubscriptionTest, ByMultipleConnections)
     auto inputPort1 = InputPort(context, nullptr, "TestPort1");
     auto inputPort2 = InputPort(context, nullptr, "TestPort2");
 
-    EXPECT_CALL(streaming.mock(), onCreateDataDescriptorChangedEventPacket(signal.getRemoteId())).Times(Exactly(2));
     EXPECT_CALL(streaming.mock(), onSubscribeSignal(signal.getRemoteId())).Times(Exactly(1));
     inputPort1.connect(signal);
     inputPort2.connect(signal);
@@ -553,7 +551,6 @@ TEST_F(TriggeredSubscriptionTest, UnsubscribeBySignalRemove)
 
     auto inputPort = InputPort(context, nullptr, "TestPort");
 
-    EXPECT_CALL(streaming.mock(), onCreateDataDescriptorChangedEventPacket(signal.getRemoteId())).Times(Exactly(1));
     EXPECT_CALL(streaming.mock(), onSubscribeSignal(signal.getRemoteId())).Times(Exactly(1));
     inputPort.connect(signal);
 

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_impl.h
@@ -45,7 +45,6 @@ protected:
     void onRemoveSignal(const MirroredSignalConfigPtr& signal) override;
     void onSubscribeSignal(const StringPtr& signalStreamingId) override;
     void onUnsubscribeSignal(const StringPtr& signalStreamingId) override;
-    EventPacketPtr onCreateDataDescriptorChangedEventPacket(const StringPtr& signalStreamingId) override;
 
     void signalAvailableHandler(const StringPtr& signalStringId, const StringPtr& serializedSignal);
     void signalUnavailableHandler(const StringPtr& signalStringId);

--- a/modules/native_streaming_client_module/src/native_streaming_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_impl.cpp
@@ -229,9 +229,4 @@ void NativeStreamingImpl::onUnsubscribeSignal(const StringPtr& signalStreamingId
     transportClientHandler->unsubscribeSignal(signalStreamingId);
 }
 
-EventPacketPtr NativeStreamingImpl::onCreateDataDescriptorChangedEventPacket(const StringPtr& signalStreamingId)
-{
-    return transportClientHandler->getDataDescriptorChangedEventPacket(signalStreamingId);
-}
-
 END_NAMESPACE_OPENDAQ_NATIVE_STREAMING_CLIENT_MODULE

--- a/modules/tests/test_opendaq_device_modules/test_streaming.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_streaming.cpp
@@ -108,16 +108,48 @@ public:
 
         for (SizeT i = 0; i < count; i++)
         {
-            if (skipEventPackets &&
-                listA.getItemAt(i).getType() == PacketType::Event &&
+            if (listA.getItemAt(i).getType() == PacketType::Event &&
                 listB.getItemAt(i).getType() == PacketType::Event)
-                continue;
-            if (!BaseObjectPtr::Equals(listA.getItemAt(i), listB.getItemAt(i)))
             {
-                LOG_E("Packets at index {} differs: A - \"{}\", B - \"{}\"",
+                if (skipEventPackets)
+                    continue;
+                auto eventPacketA = listA.getItemAt(i).asPtr<IEventPacket>(true);
+                auto eventPacketB = listB.getItemAt(i).asPtr<IEventPacket>(true);
+
+                if (eventPacketA.getEventId() != eventPacketB.getEventId())
+                {
+                    LOG_E("Event id of packets at index {} differs: A - \"{}\", B - \"{}\"",
+                          i, eventPacketA.getEventId(), eventPacketB.getEventId());
+                }
+                else if(eventPacketA.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED &&
+                         eventPacketB.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED)
+                {
+                    const DataDescriptorPtr valueDataDescA = eventPacketA.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
+                    const DataDescriptorPtr domainDataDescA = eventPacketA.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
+
+                    const DataDescriptorPtr valueDataDescB = eventPacketB.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
+                    const DataDescriptorPtr domainDataDescB = eventPacketB.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
+
+                    LOG_E("Event parameters of packets at index {} differs:", i);
+                    LOG_E("packet A - \nvalue:\n\"{}\"\ndomain:\n\"{}\"",
+                          valueDataDescA.assigned() ? valueDataDescA.toString() : "null",
+                          domainDataDescA.assigned() ? domainDataDescA.toString() : "null");
+                    LOG_E("packet B - \nvalue:\n\"{}\"\ndomain:\n\"{}\"",
+                          valueDataDescB.assigned() ? valueDataDescB.toString() : "null",
+                          domainDataDescB.assigned() ? domainDataDescB.toString() : "null");
+                }
+                else
+                {
+                    LOG_E("Event packets at index {} differs: A - \"{}\", B - \"{}\"",
                           i, listA.getItemAt(i).toString(), listB.getItemAt(i).toString());
-                result = false;
+                }
             }
+            else
+            {
+                LOG_E("Data packets at index {} differs: A - \"{}\", B - \"{}\"",
+                      i, listA.getItemAt(i).toString(), listB.getItemAt(i).toString());
+            }
+            result = false;
         }
 
         return result;

--- a/modules/tests/test_opendaq_device_modules/test_streaming.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_streaming.cpp
@@ -108,48 +108,51 @@ public:
 
         for (SizeT i = 0; i < count; i++)
         {
-            if (listA.getItemAt(i).getType() == PacketType::Event &&
-                listB.getItemAt(i).getType() == PacketType::Event)
+            if (!BaseObjectPtr::Equals(listA.getItemAt(i), listB.getItemAt(i)))
             {
-                if (skipEventPackets)
-                    continue;
-                auto eventPacketA = listA.getItemAt(i).asPtr<IEventPacket>(true);
-                auto eventPacketB = listB.getItemAt(i).asPtr<IEventPacket>(true);
-
-                if (eventPacketA.getEventId() != eventPacketB.getEventId())
+                if (listA.getItemAt(i).getType() == PacketType::Event &&
+                    listB.getItemAt(i).getType() == PacketType::Event)
                 {
-                    LOG_E("Event id of packets at index {} differs: A - \"{}\", B - \"{}\"",
-                          i, eventPacketA.getEventId(), eventPacketB.getEventId());
-                }
-                else if(eventPacketA.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED &&
-                         eventPacketB.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED)
-                {
-                    const DataDescriptorPtr valueDataDescA = eventPacketA.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
-                    const DataDescriptorPtr domainDataDescA = eventPacketA.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
+                    if (skipEventPackets)
+                        continue;
+                    auto eventPacketA = listA.getItemAt(i).asPtr<IEventPacket>(true);
+                    auto eventPacketB = listB.getItemAt(i).asPtr<IEventPacket>(true);
 
-                    const DataDescriptorPtr valueDataDescB = eventPacketB.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
-                    const DataDescriptorPtr domainDataDescB = eventPacketB.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
+                    if (eventPacketA.getEventId() != eventPacketB.getEventId())
+                    {
+                        LOG_E("Event id of packets at index {} differs: A - \"{}\", B - \"{}\"",
+                              i, eventPacketA.getEventId(), eventPacketB.getEventId());
+                    }
+                    else if(eventPacketA.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED &&
+                             eventPacketB.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED)
+                    {
+                        const DataDescriptorPtr valueDataDescA = eventPacketA.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
+                        const DataDescriptorPtr domainDataDescA = eventPacketA.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
 
-                    LOG_E("Event parameters of packets at index {} differs:", i);
-                    LOG_E("packet A - \nvalue:\n\"{}\"\ndomain:\n\"{}\"",
-                          valueDataDescA.assigned() ? valueDataDescA.toString() : "null",
-                          domainDataDescA.assigned() ? domainDataDescA.toString() : "null");
-                    LOG_E("packet B - \nvalue:\n\"{}\"\ndomain:\n\"{}\"",
-                          valueDataDescB.assigned() ? valueDataDescB.toString() : "null",
-                          domainDataDescB.assigned() ? domainDataDescB.toString() : "null");
+                        const DataDescriptorPtr valueDataDescB = eventPacketB.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
+                        const DataDescriptorPtr domainDataDescB = eventPacketB.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
+
+                        LOG_E("Event parameters of packets at index {} differs:", i);
+                        LOG_E("packet A - \nvalue:\n\"{}\"\ndomain:\n\"{}\"",
+                              valueDataDescA.assigned() ? valueDataDescA.toString() : "null",
+                              domainDataDescA.assigned() ? domainDataDescA.toString() : "null");
+                        LOG_E("packet B - \nvalue:\n\"{}\"\ndomain:\n\"{}\"",
+                              valueDataDescB.assigned() ? valueDataDescB.toString() : "null",
+                              domainDataDescB.assigned() ? domainDataDescB.toString() : "null");
+                    }
+                    else
+                    {
+                        LOG_E("Event packets at index {} differs: A - \"{}\", B - \"{}\"",
+                              i, listA.getItemAt(i).toString(), listB.getItemAt(i).toString());
+                    }
                 }
                 else
                 {
-                    LOG_E("Event packets at index {} differs: A - \"{}\", B - \"{}\"",
+                    LOG_E("Data packets at index {} differs: A - \"{}\", B - \"{}\"",
                           i, listA.getItemAt(i).toString(), listB.getItemAt(i).toString());
                 }
+                result = false;
             }
-            else
-            {
-                LOG_E("Data packets at index {} differs: A - \"{}\", B - \"{}\"",
-                      i, listA.getItemAt(i).toString(), listB.getItemAt(i).toString());
-            }
-            result = false;
         }
 
         return result;

--- a/modules/tests/test_opendaq_device_modules/test_subdevices.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_subdevices.cpp
@@ -225,6 +225,13 @@ TEST_P(SubDevicesTest, LeafStreamingToClient)
 TEST_P(SubDevicesTest, LeafStreamingToGatewayAndClient)
 {
     SKIP_TEST_MAC_CI;
+
+    if (GetParam().second == StreamingType::WebsocketStreaming)
+    {
+        // skip test
+        return;
+    }
+
     auto subdevice1 = CreateSubdeviceInstance(1u);
     auto subdevice2 = CreateSubdeviceInstance(2u);
     auto gateway = CreateGatewayInstance();
@@ -264,6 +271,7 @@ TEST_P(SubDevicesTest, LeafStreamingToGatewayAndClient)
 
     ASSERT_TRUE(test_helpers::waitForAcknowledgement(gatewaySignalSubscribeFuture));
     ASSERT_TRUE(test_helpers::waitForAcknowledgement(clientSignalSubscribeFuture));
+
     double clientSamples[100];
     double gatewaySamples[100];
     for (int i = 0; i < 10; ++i)

--- a/modules/tests/test_ref_modules/test_ref_modules.cpp
+++ b/modules/tests/test_ref_modules/test_ref_modules.cpp
@@ -638,7 +638,7 @@ TEST_F(RefModulesTest, ClassifierRangeSize)
 
     auto signalDimension = classifierSignalDescription.getDimensions()[0];
 
-    ASSERT_EQ(signalDimension.getLabels(), List<NumberPtr>(-3, -2, -1, 0, 1, 2, 3));
+    ASSERT_EQ(signalDimension.getLabels(), List<Float>(-3, -2, -1, 0, 1, 2, 3));
 }
 
 TEST_F(RefModulesTest, ClassifierRangeSizeCustomClassCount)
@@ -654,7 +654,7 @@ TEST_F(RefModulesTest, ClassifierRangeSizeCustomClassCount)
 
     const auto signalDimension = classifierSignalDescription.getDimensions()[0];
 
-    ASSERT_EQ(signalDimension.getLabels(), List<NumberPtr>(-5, -1, 3, 7));
+    ASSERT_EQ(signalDimension.getLabels(), List<Float>(-5, -1, 3, 7));
 }
 
 TEST_F(RefModulesTest, ClassifierRangeSizeCustomClasses)

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/client_session_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/client_session_handler.h
@@ -41,8 +41,6 @@ public:
     void sendTransportLayerProperties(const PropertyObjectPtr& properties);
     void sendStreamingRequest();
 
-    EventPacketPtr getDataDescriptorChangedEventPacket(const SignalNumericIdType& signalNumericId);
-
 private:
     daq::native_streaming::ReadTask readHeader(const void* data, size_t size) override;
 

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_client_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_client_handler.h
@@ -76,7 +76,6 @@ public:
 
     void subscribeSignal(const StringPtr& signalStringId);
     void unsubscribeSignal(const StringPtr& signalStringId);
-    EventPacketPtr getDataDescriptorChangedEventPacket(const StringPtr& signalStringId);
 
     void sendConfigRequest(const config_protocol::PacketBuffer& packet);
     void sendStreamingRequest();

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
@@ -71,8 +71,6 @@ protected:
     SignalPtr findRegisteredSignal(const std::string &signalKey);
     SignalNumericIdType findSignalNumericId(const SignalPtr& signal);
 
-    static EventPacketPtr createDataDescriptorChangedEventPacket(const SignalPtr& signal);
-
     ContextPtr context;
     std::shared_ptr<boost::asio::io_context> ioContextPtr;
     LoggerPtr logger;

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/subscribers_registry.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/subscribers_registry.h
@@ -25,16 +25,16 @@
 
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL
 
-using SendToClientCallback = std::function<void(std::shared_ptr<ServerSessionHandler>& sessionHandler)>;
+using DoForClientCallback = std::function<void(std::shared_ptr<ServerSessionHandler>& sessionHandler)>;
 
 class SubscribersRegistry
 {
 public:
     explicit SubscribersRegistry(const ContextPtr& context);
 
-    void sendToClients(SendToClientCallback sendCallback);
-    void sendToSubscribers(const SignalPtr& signal, SendToClientCallback sendCallback);
-    void sendToClient(SessionPtr session, SendToClientCallback sendCallback);
+    void doForAllClients(DoForClientCallback sendCallback);
+    void doForSubscribedClients(const SignalPtr& signal, DoForClientCallback sendCallback);
+    void doForSingleClient(SessionPtr session, DoForClientCallback sendCallback);
 
     void registerSignal(const SignalPtr& signal);
     bool removeSignal(const SignalPtr& signal);
@@ -45,13 +45,18 @@ public:
     bool registerSignalSubscriber(const std::string& signalStringId, SessionPtr session);
     bool removeSignalSubscriber(const std::string& signalStringId, SessionPtr session);
 
+    void setLastEventPacket(const std::string& signalStringId, const EventPacketPtr& packet);
+    EventPacketPtr getLastEventPacket(const std::string& signalStringId);
+
 private:
+    using Clients = std::vector<std::shared_ptr<ServerSessionHandler>>;
     ContextPtr context;
     LoggerPtr logger;
     LoggerComponentPtr loggerComponent;
 
-    std::unordered_map<std::string, std::vector<std::shared_ptr<ServerSessionHandler>>> signalsSubscribers;
-    std::vector<std::shared_ptr<ServerSessionHandler>> sessionHandlers;
+    // key: signal global id,  value: tuple <vector of subscribed clients, last event packet>
+    std::unordered_map<std::string, std::tuple<Clients, EventPacketPtr>> registeredSignals;
+    Clients sessionHandlers;
     std::mutex sync;
 };
 

--- a/shared/libraries/native_streaming_protocol/src/client_session_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/client_session_handler.cpp
@@ -88,11 +88,6 @@ void ClientSessionHandler::sendStreamingRequest()
     session->scheduleWrite(tasks);
 }
 
-EventPacketPtr ClientSessionHandler::getDataDescriptorChangedEventPacket(const SignalNumericIdType& signalNumericId)
-{
-    return packetStreamingClient.getDataDescriptorChangedEventPacket(signalNumericId);
-}
-
 ReadTask ClientSessionHandler::readPacket(const void* data, size_t size)
 {
     size_t bytesDone = 0;

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
@@ -207,25 +207,6 @@ void NativeStreamingClientHandler::unsubscribeSignal(const StringPtr& signalStri
     }
 }
 
-EventPacketPtr NativeStreamingClientHandler::getDataDescriptorChangedEventPacket(const StringPtr& signalStringId)
-{
-    std::scoped_lock lock(registeredSignalsSync);
-
-    const auto it = std::find_if(std::begin(signalIds),
-                                 std::end(signalIds),
-                                 [signalStringId](const auto& pair)
-                                 {
-                                     return signalStringId == pair.second;
-                                 });
-
-    if (it != std::end(signalIds))
-    {
-        if (sessionHandler)
-            return sessionHandler->getDataDescriptorChangedEventPacket(it->first);
-    }
-    return DataDescriptorChangedEventPacket(nullptr, nullptr);
-}
-
 void NativeStreamingClientHandler::sendConfigRequest(const config_protocol::PacketBuffer& packet)
 {
     if (sessionHandler)

--- a/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
@@ -147,6 +147,8 @@ public:
         signalSubscribedHandler =
             [this](const SignalPtr& signal)
         {
+            if (initialEventPacket.assigned())
+                serverHandler->sendPacket(signal, initialEventPacket);
             signalSubscribedPromise.set_value(signal);
         };
 
@@ -204,8 +206,9 @@ public:
         return clientHandler;
     }
 
-    void startServer(const ListPtr<ISignal>& signalsList)
+    void startServer(const ListPtr<ISignal>& signalsList, const EventPacketPtr& eventPacket = nullptr)
     {
+        initialEventPacket = eventPacket;
         startIoOperations();
         serverHandler = std::make_shared<NativeStreamingServerHandler>(serverContext,
                                                                        ioContextPtrServer,
@@ -225,6 +228,7 @@ public:
 protected:
     std::vector<StreamingProtocolAttributes> clients;
 
+    EventPacketPtr initialEventPacket;
     OnSignalSubscribedCallback signalSubscribedHandler;
     OnSignalUnsubscribedCallback signalUnsubscribedHandler;
 
@@ -523,14 +527,18 @@ TEST_P(StreamingProtocolTest, RemoveSubscribedSignal)
     ASSERT_EQ(signalUnsubscribedFuture.get(), serverSignal);
 }
 
-TEST_P(StreamingProtocolTest, InitialEventPacket)
+TEST_P(StreamingProtocolTest, InitialEventPacketOnSubscribe)
 {
     const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
-    auto initialEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
+    auto firstEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
     auto serverSignal = SignalWithDescriptor(serverContext, valueDescriptor, nullptr, "signal");
 
-    startServer(List<ISignal>(serverSignal));
+    StringPtr clientSignalStringId;
 
+    // send event packet on first subscribe request
+    startServer(List<ISignal>(serverSignal), firstEventPacket);
+
+    // connect all clients
     for (auto& client : clients)
     {
         client.clientHandler = createClient(client, client.signalAvailableHandler);
@@ -538,20 +546,42 @@ TEST_P(StreamingProtocolTest, InitialEventPacket)
         client.clientHandler->sendStreamingRequest();
         ASSERT_EQ(client.streamingInitFuture.wait_for(timeout), std::future_status::ready);
 
+        ASSERT_EQ(client.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
+        clientSignalStringId = std::get<0>(client.signalAvailableFuture.get());
+    }
+
+    // subscribe all clients to signal
+    for (auto& client : clients)
+    {
+        client.clientHandler->subscribeSignal(clientSignalStringId);
+    }
+
+    ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
+
+    // wait for ack
+    for (auto& client : clients)
+    {
+        ASSERT_EQ(client.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
+    }
+
+    // check that all clients received event packet
+    for (auto& client : clients)
+    {
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
         auto [signalId, packet] = client.packetReceivedFuture.get();
         ASSERT_EQ(signalId, serverSignal.getGlobalId());
-        ASSERT_EQ(packet, initialEventPacket);
+        ASSERT_EQ(packet, firstEventPacket);
     }
 }
 
-TEST_P(StreamingProtocolTest, SendEventPacket)
+TEST_P(StreamingProtocolTest, InitialEventPacketPostSubscribe)
 {
     const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
-    auto initialEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
+    auto firstEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
     auto serverSignal = SignalWithDescriptor(serverContext, valueDescriptor, nullptr, "signal");
 
-    startServer(List<ISignal>(serverSignal));
+    // do not send event packet on first subscribe request
+    startServer(List<ISignal>(serverSignal), nullptr);
 
     for (auto& client : clients)
     {
@@ -561,14 +591,7 @@ TEST_P(StreamingProtocolTest, SendEventPacket)
         ASSERT_EQ(client.streamingInitFuture.wait_for(timeout), std::future_status::ready);
 
         ASSERT_EQ(client.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
-        auto [clientSignalStringId, serializedSignal] =
-            client.signalAvailableFuture.get();
-
-        // wait for initial event packet
-        ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
-        // reset packet future / promise
-        client.packetReceivedPromise = std::promise< std::tuple<StringPtr, PacketPtr> >();
-        client.packetReceivedFuture = client.packetReceivedPromise.get_future();
+        auto clientSignalStringId = std::get<0>(client.signalAvailableFuture.get());
 
         client.clientHandler->subscribeSignal(clientSignalStringId);
         ASSERT_EQ(client.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
@@ -576,25 +599,23 @@ TEST_P(StreamingProtocolTest, SendEventPacket)
 
     ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
 
-    const auto newValueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Binary).build();
-    auto serverEventPacket = DataDescriptorChangedEventPacket(newValueDescriptor, nullptr);
-    serverHandler->sendPacket(serverSignal, serverEventPacket);
-
+    serverHandler->sendPacket(serverSignal, firstEventPacket);
     for (auto& client : clients)
     {
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
         auto [signalId, packet] = client.packetReceivedFuture.get();
         ASSERT_EQ(signalId, serverSignal.getGlobalId());
-        ASSERT_EQ(packet, serverEventPacket);
+        ASSERT_EQ(packet, firstEventPacket);
     }
 }
 
-TEST_P(StreamingProtocolTest, SendPacketsNoSubscribers)
+TEST_P(StreamingProtocolTest, SendEventPacket)
 {
     const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
+    auto firstEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
     auto serverSignal = SignalWithDescriptor(serverContext, valueDescriptor, nullptr, "signal");
 
-    startServer(List<ISignal>(serverSignal));
+    startServer(List<ISignal>(serverSignal), firstEventPacket);
 
     for (auto& client : clients)
     {
@@ -603,18 +624,58 @@ TEST_P(StreamingProtocolTest, SendPacketsNoSubscribers)
         client.clientHandler->sendStreamingRequest();
         ASSERT_EQ(client.streamingInitFuture.wait_for(timeout), std::future_status::ready);
 
-        // wait for initial event packet
+        ASSERT_EQ(client.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
+        auto clientSignalStringId = std::get<0>(client.signalAvailableFuture.get());
+
+        client.clientHandler->subscribeSignal(clientSignalStringId);
+        ASSERT_EQ(client.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
+    }
+
+    ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
+
+    serverHandler->sendPacket(serverSignal, firstEventPacket);
+    for (auto& client : clients)
+    {
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
+        auto [signalId, packet] = client.packetReceivedFuture.get();
+        ASSERT_EQ(signalId, serverSignal.getGlobalId());
+        ASSERT_EQ(packet, firstEventPacket);
 
         // reset packet future / promise
         client.packetReceivedPromise = std::promise< std::tuple<StringPtr, PacketPtr> >();
         client.packetReceivedFuture = client.packetReceivedPromise.get_future();
     }
 
-    auto serverEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
-    auto serverDataPacket = DataPacket(valueDescriptor, 100);
+    const auto newValueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Binary).build();
+    auto secondEventPacket = DataDescriptorChangedEventPacket(newValueDescriptor, nullptr);
+    serverHandler->sendPacket(serverSignal, secondEventPacket);
 
-    serverHandler->sendPacket(serverSignal, serverEventPacket);
+    for (auto& client : clients)
+    {
+        ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
+        auto [signalId, packet] = client.packetReceivedFuture.get();
+        ASSERT_EQ(signalId, serverSignal.getGlobalId());
+        ASSERT_EQ(packet, secondEventPacket);
+    }
+}
+
+TEST_P(StreamingProtocolTest, SendPacketsNoSubscribers)
+{
+    const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
+    auto serverSignal = SignalWithDescriptor(serverContext, valueDescriptor, nullptr, "signal");
+    auto serverEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
+
+    startServer(List<ISignal>(serverSignal), serverEventPacket);
+
+    for (auto& client : clients)
+    {
+        client.clientHandler = createClient(client, client.signalAvailableHandler);
+        ASSERT_TRUE(client.clientHandler->connect(SERVER_ADDRESS, NATIVE_STREAMING_LISTENING_PORT));
+        client.clientHandler->sendStreamingRequest();
+        ASSERT_EQ(client.streamingInitFuture.wait_for(timeout), std::future_status::ready);
+    }
+
+    auto serverDataPacket = DataPacket(valueDescriptor, 100);
     serverHandler->sendPacket(serverSignal, serverDataPacket);
 
     // no subscribers - so packets wont be sent to clients
@@ -627,10 +688,11 @@ TEST_P(StreamingProtocolTest, SendPacketsNoSubscribers)
 TEST_P(StreamingProtocolTest, SendDataPacket)
 {
     const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
+    auto serverEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, nullptr);
     auto serverDataPacket = DataPacket(valueDescriptor, 100);
     auto serverSignal = SignalWithDescriptor(serverContext, valueDescriptor, nullptr, "signal");
 
-    startServer(List<ISignal>(serverSignal));
+    startServer(List<ISignal>(serverSignal), serverEventPacket);
 
     for (auto& client : clients)
     {
@@ -640,14 +702,7 @@ TEST_P(StreamingProtocolTest, SendDataPacket)
         ASSERT_EQ(client.streamingInitFuture.wait_for(timeout), std::future_status::ready);
 
         ASSERT_EQ(client.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
-        auto [clientSignalStringId, serializedSignal] =
-            client.signalAvailableFuture.get();
-
-        // wait for initial event packet
-        ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
-        // reset packet future / promise
-        client.packetReceivedPromise = std::promise< std::tuple<StringPtr, PacketPtr> >();
-        client.packetReceivedFuture = client.packetReceivedPromise.get_future();
+        auto clientSignalStringId = std::get<0>(client.signalAvailableFuture.get());
 
         client.clientHandler->subscribeSignal(clientSignalStringId);
         ASSERT_EQ(client.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
@@ -655,10 +710,22 @@ TEST_P(StreamingProtocolTest, SendDataPacket)
 
     ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
 
-    serverHandler->sendPacket(serverSignal, serverDataPacket);
-
     for (auto& client : clients)
     {
+        // wait for event packet
+        ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
+        auto [signalId, packet] = client.packetReceivedFuture.get();
+        ASSERT_EQ(signalId, serverSignal.getGlobalId());
+        ASSERT_EQ(packet, serverEventPacket);
+        // reset packet future / promise
+        client.packetReceivedPromise = std::promise< std::tuple<StringPtr, PacketPtr> >();
+        client.packetReceivedFuture = client.packetReceivedPromise.get_future();
+    }
+
+    serverHandler->sendPacket(serverSignal, serverDataPacket);
+    for (auto& client : clients)
+    {
+        // wait for data packet
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
         auto [signalId, packet] = client.packetReceivedFuture.get();
         ASSERT_EQ(signalId, serverSignal.getGlobalId());

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
@@ -70,7 +70,6 @@ public:
     std::string getTarget();
     bool isConnected();
     void setConnectTimeout(std::chrono::milliseconds timeout);
-    EventPacketPtr getDataDescriptorChangedEventPacket(const StringPtr& signalStringId);
     void subscribeSignals(const std::vector<std::string>& signalIds);
     void unsubscribeSignals(const std::vector<std::string>& signalIds);
 

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/websocket_streaming_impl.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/websocket_streaming_impl.h
@@ -38,7 +38,6 @@ protected:
     void onRemoveSignal(const MirroredSignalConfigPtr& signal) override;
     void onSubscribeSignal(const StringPtr& signalStreamingId) override;
     void onUnsubscribeSignal(const StringPtr& signalStreamingId) override;
-    EventPacketPtr onCreateDataDescriptorChangedEventPacket(const StringPtr& signalStreamingId) override;
 
     void prepareStreamingClient();
     void onAvailableSignals(const std::vector<std::string>& signalIds);

--- a/shared/libraries/websocket_streaming/src/streaming_client.cpp
+++ b/shared/libraries/websocket_streaming/src/streaming_client.cpp
@@ -213,14 +213,6 @@ void StreamingClient::setConnectTimeout(std::chrono::milliseconds timeout)
     this->connectTimeout = timeout;
 }
 
-EventPacketPtr StreamingClient::getDataDescriptorChangedEventPacket(const StringPtr& signalStringId)
-{
-    if (auto it = signals.find(signalStringId); it == signals.end())
-        return DataDescriptorChangedEventPacket(nullptr, nullptr);
-    else
-        return it->second->createDecriptorChangedPacket();
-}
-
 void StreamingClient::parseConnectionString(const std::string& url)
 {
     // this is not great but it is convenient until we have a way to pass configuration parameters to a client device

--- a/shared/libraries/websocket_streaming/src/websocket_streaming_impl.cpp
+++ b/shared/libraries/websocket_streaming/src/websocket_streaming_impl.cpp
@@ -48,11 +48,6 @@ void WebsocketStreamingImpl::onUnsubscribeSignal(const StringPtr& signalStreamin
     streamingClient->unsubscribeSignals({signalStreamingId.toStdString()});
 }
 
-EventPacketPtr WebsocketStreamingImpl::onCreateDataDescriptorChangedEventPacket(const StringPtr& signalStreamingId)
-{
-    return streamingClient->getDataDescriptorChangedEventPacket(signalStreamingId);
-}
-
 void WebsocketStreamingImpl::prepareStreamingClient()
 {
     auto packetCallback = [this](const StringPtr& signalId, const PacketPtr& packet)


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
