### PR TITLE
Supporting configuring custom x labels for 2d signals in renderer

### DIFF
--- a/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
+++ b/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
@@ -149,6 +149,8 @@ private:
     double customMaxValue;
     double yMaxValue;
     double yMinValue;
+    bool useCustomXAxisLabels;
+    ListPtr<Float> customXAxisLabels;
     sf::Vector2f topLeft;
     sf::Vector2f bottomRight;
     size_t signalContextIndex;


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:
example
    renderer.setPropertyValue("UseCustomXAxisLabels", true);
    renderer.setPropertyValue("CustomXAxisLabels", daq::List<daq::IFloat>(-75, -45, -15, 0, 34, 50));