### PR TITLE
NodeId as String not as numeric for Properties

### DIFF
--- a/shared/libraries/opcua/opcuaserver/include/opcuaserver/opcuaaddnodeparams.h
+++ b/shared/libraries/opcua/opcuaserver/include/opcuaserver/opcuaaddnodeparams.h
@@ -62,6 +62,7 @@ class AddVariableNodeParams : public GenericAddNodeParams<UA_VariableAttributes>
 public:
     AddVariableNodeParams(const OpcUaNodeId& requestedNewNodeId);
     AddVariableNodeParams(const OpcUaNodeId& requestedNewNodeId, const OpcUaNodeId& parentNodeId);
+    AddVariableNodeParams(const std::string& name, const OpcUaNodeId& parentNodeId);
 
     void setDataType(const OpcUaNodeId& dataTypeId);
 
@@ -73,6 +74,8 @@ class AddMethodNodeParams : public GenericAddNodeParams<UA_MethodAttributes>
 public:
     AddMethodNodeParams(const OpcUaNodeId& requestedNewNodeId);
     AddMethodNodeParams(const OpcUaNodeId& requestedNewNodeId, const OpcUaNodeId& parentNodeId);
+    AddMethodNodeParams(const std::string& name, const OpcUaNodeId& parentNodeId);
+
     ~AddMethodNodeParams();
 
     UA_MethodCallback method{};

--- a/shared/libraries/opcua/opcuaserver/include/opcuaserver/opcuaserver.h
+++ b/shared/libraries/opcua/opcuaserver/include/opcuaserver/opcuaserver.h
@@ -137,6 +137,7 @@ private:
                                          const UA_ExtensionObject* userIdentityToken,
                                          void** sessionContext);
     static void closeSession(UA_Server* server, UA_AccessControl* ac, const UA_NodeId* sessionId, void* sessionContext);
+    static UA_StatusCode generateChildId(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext, const UA_NodeId *sourceNodeId, const UA_NodeId *targetParentNodeId, const UA_NodeId *referenceTypeId, UA_NodeId *targetNodeId);
     static UA_StatusCode authenticateUser(OpcUaServer* serverInstance, const UA_ExtensionObject* userIdentityToken);
 
     // missing UA_Server void* member workaround...

--- a/shared/libraries/opcua/opcuaserver/src/opcuaaddnodeparams.cpp
+++ b/shared/libraries/opcua/opcuaserver/src/opcuaaddnodeparams.cpp
@@ -2,6 +2,19 @@
 
 BEGIN_NAMESPACE_OPENDAQ_OPCUA
 
+/*RequestedNodeIdBaseOnName*/
+
+static daq::opcua::OpcUaNodeId RequestedNodeIdBaseOnName(const std::string& name, const OpcUaNodeId& parentNodeId)
+{
+    if (parentNodeId.getValue().identifierType == UA_NODEIDTYPE_STRING)
+    {
+        std::string newNodeIdStr = utils::ToStdString(parentNodeId.getValue().identifier.string) + "/" + name;
+        return OpcUaNodeId(parentNodeId.getNamespaceIndex(), newNodeIdStr);
+    }
+    return UA_NODEID_NULL;
+}
+
+
 /*AddNodeParams*/
 
 AddNodeParams::AddNodeParams(const OpcUaNodeId& requestedNewNodeId, const OpcUaNodeId& parentNodeId, const OpcUaNodeId& referenceTypeId)
@@ -41,6 +54,12 @@ AddObjectNodeParams::AddObjectNodeParams(const OpcUaNodeId& requestedNewNodeId, 
 {
 }
 
+AddVariableNodeParams::AddVariableNodeParams(const std::string& name, const OpcUaNodeId& parentNodeId)
+    : GenericAddNodeParams<UA_VariableAttributes>(
+                  RequestedNodeIdBaseOnName(name, parentNodeId), parentNodeId, OpcUaNodeId(UA_NS0ID_HASPROPERTY), UA_VariableAttributes_default)
+{
+}
+
 /*AddVariableNodeParams*/
 
 AddVariableNodeParams::AddVariableNodeParams(const OpcUaNodeId& requestedNewNodeId)
@@ -69,6 +88,12 @@ AddMethodNodeParams::AddMethodNodeParams(const OpcUaNodeId& requestedNewNodeId)
 AddMethodNodeParams::AddMethodNodeParams(const OpcUaNodeId& requestedNewNodeId, const OpcUaNodeId& parentNodeId)
     : GenericAddNodeParams<UA_MethodAttributes>(
           requestedNewNodeId, parentNodeId, OpcUaNodeId(UA_NS0ID_HASPROPERTY), UA_MethodAttributes_default)
+{
+}
+
+AddMethodNodeParams::AddMethodNodeParams(const std::string& name, const OpcUaNodeId& parentNodeId)
+    : GenericAddNodeParams<UA_MethodAttributes>(
+                  RequestedNodeIdBaseOnName(name, parentNodeId), parentNodeId, OpcUaNodeId(UA_NS0ID_HASPROPERTY), UA_MethodAttributes_default)
 {
 }
 

--- a/shared/libraries/opcua/opcuaserver/src/opcuaserver.cpp
+++ b/shared/libraries/opcua/opcuaserver/src/opcuaserver.cpp
@@ -600,27 +600,36 @@ void OpcUaServer::closeSession(UA_Server* server, UA_AccessControl* ac, const UA
 }
 
 
-UA_StatusCode OpcUaServer::generateChildId(UA_Server *server, const UA_NodeId *sessionId, void *sessionContext, const UA_NodeId *sourceNodeId, const UA_NodeId *targetParentNodeId, const UA_NodeId *referenceTypeId, UA_NodeId *targetNodeId)
+UA_StatusCode OpcUaServer::generateChildId(UA_Server* server,
+                                           const UA_NodeId*/*sessionId*/,
+                                           void*/*sessionContext*/,
+                                           const UA_NodeId* sourceNodeId,
+                                           const UA_NodeId* targetParentNodeId,
+                                           const UA_NodeId*/*referenceTypeId*/,
+                                           UA_NodeId* targetNodeId)
 {
     if (targetParentNodeId->identifierType == UA_NODEIDTYPE_STRING) {
-        std::string newNodeIdStr;
-        std::string parentNodeIdStr = utils::ToStdString(targetParentNodeId->identifier.string);
+        const std::string parentNodeIdStr = utils::ToStdString(targetParentNodeId->identifier.string);
         std::string objectTypeIdStr;
+		
         if (sourceNodeId->identifierType == UA_NODEIDTYPE_STRING)
         {
-            objectTypeIdStr = opcua::utils::ToStdString(sourceNodeId->identifier.string);
+            objectTypeIdStr = utils::ToStdString(sourceNodeId->identifier.string);
         }
         else if (sourceNodeId->identifierType == UA_NODEIDTYPE_NUMERIC)
         {
-            UA_QualifiedName* browseName = UA_QualifiedName_new();;
+            UA_QualifiedName* browseName = UA_QualifiedName_new();
             UA_Server_readBrowseName(server, *sourceNodeId, browseName);
-            objectTypeIdStr = opcua::utils::ToStdString(browseName->name);
+            objectTypeIdStr = utils::ToStdString(browseName->name);
             UA_QualifiedName_delete(browseName);
         }
+        else
+        {
+            return UA_STATUSCODE_GOOD;
+        }
 
-        parentNodeIdStr.append("/");
-        newNodeIdStr = parentNodeIdStr + objectTypeIdStr;
-        *targetNodeId = UA_NODEID_STRING_ALLOC(targetParentNodeId->namespaceIndex, const_cast<char*>(newNodeIdStr.c_str()));
+        const auto newNodeIdStr = parentNodeIdStr + "/" + objectTypeIdStr;
+        *targetNodeId = UA_NODEID_STRING_ALLOC(targetParentNodeId->namespaceIndex, newNodeIdStr.c_str());
     }
 
     return UA_STATUSCODE_GOOD;

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
@@ -229,8 +229,7 @@ void TmsServerPropertyObject::addMethodPropertyNode(const PropertyPtr& prop, uin
 {
     const auto name = prop.getName();
     OpcUaNodeId parentId = methodParentNodeId.isNull() ? nodeId : methodParentNodeId;
-    OpcUaNodeId newNodeId(0);
-    AddMethodNodeParams params(newNodeId, parentId);
+    AddMethodNodeParams params(name, parentId);
     params.referenceTypeId = OpcUaNodeId(UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT));
 
     const auto callableInfo = prop.getCallableInfo();

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_variable.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_variable.cpp
@@ -21,7 +21,7 @@ opcua::OpcUaNodeId TmsServerVariable<CoreType>::createNode(const opcua::OpcUaNod
     this->typeBrowseName = this->readTypeBrowseName();
     std::string name = this->getBrowseName();
 
-    auto params = AddVariableNodeParams(UA_NODEID_NULL, parentNodeId);
+    auto params = AddVariableNodeParams(name, parentNodeId);
     configureVariableNodeAttributes(params.attr);
     params.setBrowseName(name);
     params.typeDefinition = this->getTmsTypeId();

--- a/shared/libraries/ping/include/ping/icmp_header.h
+++ b/shared/libraries/ping/include/ping/icmp_header.h
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <istream>
 #include <ostream>
+#include <cstdint>
 
 // ICMP header for both IPv4 and IPv6.
 //


### PR DESCRIPTION
In opendaq only objects had a nodeID as string. With this PR also Properties / Variables have a numeric node id.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
