### PR TITLE
Fix memory leak in ListPtr::toVector

### DIFF
--- a/core/corecontainers/include/coretypes/listptr.h
+++ b/core/corecontainers/include/coretypes/listptr.h
@@ -290,19 +290,7 @@ public:
      */
     std::vector<TValuePtr> toVector()
     {
-        std::vector<TValuePtr> vector;
-
-        SizeT size;
-        IBaseObject* obj;
-        this->object->getCount(&size);
-
-        for (SizeT i = 0; i < size; i++)
-        {
-            this->object->getItemAt(i, &obj);
-            vector.push_back(obj);
-        }
-
-        return vector;
+        return std::vector<TValuePtr>(begin(), end());
     }
 };
 

--- a/core/coretypes/tests/test_listobject.cpp
+++ b/core/coretypes/tests/test_listobject.cpp
@@ -836,3 +836,14 @@ TEST_F(ListObjectTest, InterfaceIdString)
 {
     ASSERT_EQ(daqInterfaceIdString<IList>(), "{E7866BCC-0563-5504-B61B-A8116B614D8F}");
 }
+
+TEST_F(ListObjectTest, ToVector)
+{
+    auto obj1 = List<IInteger>(1, 2, 3);
+    auto obj1Vector = obj1.toVector();
+
+    ASSERT_EQ(obj1Vector.size(), 3u);
+    ASSERT_EQ(obj1Vector[0], 1);
+    ASSERT_EQ(obj1Vector[1], 2);
+    ASSERT_EQ(obj1Vector[2], 3);
+}


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

Fix memory leak of vector elements in ListPtr::toVector
