### PR TITLE
cmake: find_dependency(spdlog) and fix path to openDAQUtils.cmake

### DIFF
--- a/cmake/openDAQConfig.cmake.in
+++ b/cmake/openDAQConfig.cmake.in
@@ -19,6 +19,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(fmt REQUIRED)
 find_dependency(tsl-ordered-map REQUIRED)
 find_dependency(date REQUIRED)
+find_dependency(spdlog REQUIRED)
 
 find_package(xxHash QUIET)
 if (NOT xxHash_FOUND)

--- a/cmake/openDAQConfig.cmake.in
+++ b/cmake/openDAQConfig.cmake.in
@@ -28,4 +28,4 @@ if (NOT xxHash_FOUND)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/openDAQ.cmake)
-include(openDAQUtils)
+include(${CMAKE_CURRENT_LIST_DIR}/openDAQUtils.cmake)


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] Pull request title reflects its content
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# Description:

This PR adjusts the openDAQConfig.cmake.in template file, which is used by find_package(openDAQ). There are two changes. The first is to use the correct path to openDAQUtils.cmake in all contexts (in particular include() contexts). The second is to include find_dependency(spdlog) which causes projects depending on openDAQ to also load spdlog, which is a required dependency; without this, projects using openDAQ must explicitly find_package(spdlog).