### PR TITLE
<TBBAS-1468> Integrate streaming-LT range and post scaling metadata

### DIFF
--- a/external/streaming_protocol/CMakeLists.txt
+++ b/external/streaming_protocol/CMakeLists.txt
@@ -6,8 +6,8 @@ endif()
 
 opendaq_dependency(
     NAME                streaming_protocol
-    REQUIRED_VERSION    1.0.1
+    REQUIRED_VERSION    1.2.0
     GIT_REPOSITORY      https://github.com/openDAQ/streaming-protocol-lt.git
-    GIT_REF             v1.0.1
+    GIT_REF             v1.2.0
     EXPECT_TARGET       daq::streaming_protocol
 )

--- a/modules/tests/test_ws_siggen_integration/siggen_config.json
+++ b/modules/tests/test_ws_siggen_integration/siggen_config.json
@@ -2,12 +2,33 @@
 	"signals" : {
 		"Signal1_Sync" : {
 			"dataType" : "real64",
-			"function" : "sine",
-			"amplitude" : 10,
+			"function" : "impulse",
+			"amplitude" : 5,
 			"offset" : 0,
 			"frequency" : 2,
 			"samplePeriod" : "10ms",
-			"explicitTime": false
+			"explicitTime": false,
+			"range" : {
+				"low" : -15,
+				"high" : 15
+			}
+		},
+		"Signal2_Sync_PostScaling" : {
+			"dataType" : "int32",
+			"function" : "impulse",
+			"amplitude" : 5,
+			"offset" : 0,
+			"frequency" : 2,
+			"samplePeriod" : "10ms",
+			"explicitTime": false,
+			"range" : {
+				"low" : -15,
+				"high" : 15
+			},
+			"postScaling" : {
+				"scale" : 2,
+				"offset" : 5
+			}
 		}
 	 },
 	 "executionTime": "100s",

--- a/modules/tests/test_ws_siggen_integration/test_websocket_siggen.cpp
+++ b/modules/tests/test_ws_siggen_integration/test_websocket_siggen.cpp
@@ -27,7 +27,7 @@ TEST_P(SiggenTest, GetRemoteDeviceObjects)
 
     ASSERT_EQ(client.getDevices().getCount(), 1u);
     auto signals = client.getSignalsRecursive();
-    ASSERT_EQ(signals.getCount(), 2u);
+    ASSERT_EQ(signals.getCount(), 4u);
 }
 
 TEST_P(SiggenTest, SyncSignalDescriptors)
@@ -45,7 +45,42 @@ TEST_P(SiggenTest, SyncSignalDescriptors)
 
     EXPECT_EQ(dataDescriptor.getSampleType(), SampleType::Float64);
     EXPECT_EQ(dataDescriptor.getRule().getType(), DataRuleType::Explicit);
-    EXPECT_EQ(dataDescriptor.getValueRange(), Range(-15.0, 15.0)); // default set by openDAQ client
+    EXPECT_EQ(dataDescriptor.getValueRange(), Range(-15, 15));
+
+    EXPECT_FALSE(dataDescriptor.getPostScaling().assigned());
+
+    EXPECT_EQ(dataDescriptor.getDimensions().getCount(), 0u);
+    EXPECT_EQ(dataDescriptor.getMetadata().getCount(), 0u);
+    EXPECT_FALSE(dataDescriptor.getUnit().assigned());
+
+    EXPECT_EQ(domainDescriptor.getRule().getType(), DataRuleType::Linear);
+    EXPECT_EQ(domainDescriptor.getUnit().getSymbol(), "s");
+    EXPECT_EQ(domainDescriptor.getUnit().getQuantity(), "time");
+    EXPECT_NE(domainDescriptor.getOrigin(), "");
+    EXPECT_NE(domainDescriptor.getTickResolution().getNumerator(), 0);
+    EXPECT_NE(domainDescriptor.getTickResolution().getDenominator(), 0);
+}
+
+TEST_P(SiggenTest, SyncPostScalingSignalDescriptors)
+{
+    auto client = CreateClientInstance(GetParam());
+
+    auto signal  = client.getSignalsRecursive()[1];
+
+    EXPECT_EQ(signal.getLocalId(), "Signal2_Sync_PostScaling");
+
+    DataDescriptorPtr dataDescriptor = signal.getDescriptor();
+    DataDescriptorPtr domainDescriptor = signal.getDomainSignal().getDescriptor();
+
+    EXPECT_EQ(signal.getName(), "value");
+
+    EXPECT_EQ(dataDescriptor.getSampleType(), SampleType::Float64);
+    EXPECT_EQ(dataDescriptor.getRule().getType(), DataRuleType::Explicit);
+    EXPECT_EQ(dataDescriptor.getValueRange(), Range(-15, 15));
+
+    ASSERT_TRUE(dataDescriptor.getPostScaling().assigned());
+    EXPECT_EQ(dataDescriptor.getPostScaling().getParameters().get("scale"), 2);
+    EXPECT_EQ(dataDescriptor.getPostScaling().getParameters().get("offset"), 5);
 
     EXPECT_EQ(dataDescriptor.getDimensions().getCount(), 0u);
     EXPECT_EQ(dataDescriptor.getMetadata().getCount(), 0u);
@@ -63,7 +98,7 @@ TEST_P(SiggenTest, DISABLED_AsyncSignalDescriptors)
 {
     auto client = CreateClientInstance(GetParam());
 
-    auto signal  = client.getSignalsRecursive()[1];
+    auto signal  = client.getSignalsRecursive()[2];
 
     EXPECT_EQ(signal.getLocalId(), "Signal2_Async");
 
@@ -74,7 +109,7 @@ TEST_P(SiggenTest, DISABLED_AsyncSignalDescriptors)
 
     EXPECT_EQ(dataDescriptor.getSampleType(), SampleType::Float64);
     EXPECT_EQ(dataDescriptor.getRule().getType(), DataRuleType::Explicit);
-    EXPECT_EQ(dataDescriptor.getValueRange(), Range(-15.0, 15.0)); // default set by openDAQ client
+    EXPECT_EQ(dataDescriptor.getValueRange(), Range(-15, 15));
 
     EXPECT_EQ(dataDescriptor.getDimensions().getCount(), 0u);
     EXPECT_EQ(dataDescriptor.getMetadata().getCount(), 0u);

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/signal_descriptor_converter.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/signal_descriptor_converter.h
@@ -52,8 +52,9 @@ private:
     static void SetLinearTimeRule(const daq::DataRulePtr& rule, daq::streaming_protocol::LinearTimeSignalPtr linearStream);
     static daq::SampleType Convert(daq::streaming_protocol::SampleType dataType);
     static daq::streaming_protocol::SampleType Convert(daq::SampleType sampleType);
-    static void DecodeInterpretationObject(const nlohmann::json& extra, DataDescriptorBuilderPtr& dataDescriptor);
-    static void DecodeBitsInterpretationObject(const nlohmann::json& bits, DataDescriptorBuilderPtr& dataDescriptor);
+    static daq::RangePtr CreateDefaultRange(daq::SampleType sampleType);
+    static void DecodeInterpretationObject(const nlohmann::json& extra, DataDescriptorBuilderPtr& dataDescriptorBuilder);
+    static void DecodeBitsInterpretationObject(const nlohmann::json& bits, DataDescriptorBuilderPtr& dataDescriptorBuilder);
     static nlohmann::json DictToJson(const DictPtr<IString, IBaseObject>& dict);
     static DictPtr<IString, IBaseObject> JsonToDict(const nlohmann::json& json);
 };

--- a/shared/libraries/websocket_streaming/src/signal_descriptor_converter.cpp
+++ b/shared/libraries/websocket_streaming/src/signal_descriptor_converter.cpp
@@ -28,22 +28,23 @@ BEGIN_NAMESPACE_OPENDAQ_WEBSOCKET_STREAMING
 SubscribedSignalInfo SignalDescriptorConverter::ToDataDescriptor(const daq::streaming_protocol::SubscribedSignal& subscribedSignal)
 {
     SubscribedSignalInfo sInfo;
+    auto dataDescriptorBuilder = DataDescriptorBuilder();
 
     // *** meta "definition" start ***
     // get metainfo received via signal "definition" object and stored in SubscribedSignal struct
-    auto dataDescriptor = DataDescriptorBuilder().setRule(GetRule(subscribedSignal));
+    dataDescriptorBuilder.setRule(GetRule(subscribedSignal));
 
     if (subscribedSignal.isTimeSignal())
     {
         uint64_t numerator = 1;
         uint64_t denominator = subscribedSignal.timeBaseFrequency();
         auto resolution = Ratio(static_cast<daq::Int>(numerator), static_cast<daq::Int>(denominator));
-        dataDescriptor.setTickResolution(resolution);
+        dataDescriptorBuilder.setTickResolution(resolution);
     }
 
     daq::streaming_protocol::SampleType streamingSampleType = subscribedSignal.dataValueType();
     daq::SampleType daqSampleType = Convert(streamingSampleType);
-    dataDescriptor.setSampleType(daqSampleType);
+    dataDescriptorBuilder.setSampleType(daqSampleType);
 
     sInfo.signalName = subscribedSignal.memberName();
 
@@ -54,30 +55,51 @@ SubscribedSignalInfo SignalDescriptorConverter::ToDataDescriptor(const daq::stre
                          "",
                          subscribedSignal.unitQuantity());
 
-        dataDescriptor.setUnit(unit);
+        dataDescriptorBuilder.setUnit(unit);
     }
 
-    dataDescriptor.setOrigin(subscribedSignal.timeBaseEpochAsString());
+    dataDescriptorBuilder.setOrigin(subscribedSignal.timeBaseEpochAsString());
+
+    auto streamingRange = subscribedSignal.range();
+    if (streamingRange.isUnlimited())
+    {
+        // An unlimited range indicates that it is not set within the "definition" object.
+        // Since the range is used to configure the renderer, we need to set a default value for fusion
+        // (non-openDAQ) device signals.
+        // If the signal is owned by an openDAQ-enabled server, the value range, if present,
+        // is specified within the "definition" object or alternatively might be set within
+        // the "interpretation" object, if so that value will override the default one.
+        if (!subscribedSignal.isTimeSignal())
+            dataDescriptorBuilder.setValueRange(CreateDefaultRange(dataDescriptorBuilder.getSampleType()));
+    }
+    else
+    {
+        dataDescriptorBuilder.setValueRange(Range(streamingRange.low, streamingRange.high));
+    }
+
+    // get linear post scaling from signal definition if it is not default - one-to-one scaling
+    auto streamingLinearPostScaling = subscribedSignal.postScaling();
+    if (!streamingLinearPostScaling.isOneToOne())
+    {
+        auto daqLinearPostScaling = LinearScaling(streamingLinearPostScaling.scale,
+                                                  streamingLinearPostScaling.offset,
+                                                  daqSampleType,
+                                                  ScaledSampleType::Float64);
+        dataDescriptorBuilder.setPostScaling(daqLinearPostScaling);
+        // overwrite sample type when linear scaling is present
+        dataDescriptorBuilder.setSampleType(SampleType::Float64);
+    }
     // *** meta "definition" end ***
 
-    if (!subscribedSignal.isTimeSignal())
-    {
-        // "definition" object does not contain signal value range used to configure renderer,
-        // we need to set the some default value for the fusion (non-openDAQ) device signals
-        // if the signal is owned by the openDAQ-enabled server
-        // than the value range from "interpretation" will overwrite the default value
-        dataDescriptor.setValueRange(daq::Range(-15.0, 15.0));
-    }
-
     auto bitsInterpretation = subscribedSignal.bitsInterpretationObject();
-    DecodeBitsInterpretationObject(bitsInterpretation, dataDescriptor);
+    DecodeBitsInterpretationObject(bitsInterpretation, dataDescriptorBuilder);
 
     // --- meta "interpretation" start ---
     // overwrite/add descriptor fields with ones from optional "interpretation" object
     auto extra = subscribedSignal.interpretationObject();
-    DecodeInterpretationObject(extra, dataDescriptor);
+    DecodeInterpretationObject(extra, dataDescriptorBuilder);
 
-    sInfo.dataDescriptor = dataDescriptor.build();
+    sInfo.dataDescriptor = dataDescriptorBuilder.build();
     if (extra.count("sig_name") > 0)
         sInfo.signalProps.name = extra["sig_name"];
     if (extra.count("sig_desc") > 0)
@@ -111,6 +133,24 @@ void SignalDescriptorConverter::ToStreamedValueSignal(const daq::SignalPtr& valu
     UnitPtr unit = dataDescriptor.getUnit();
     if (unit.assigned())
         valueStream->setUnit(unit.getId(), unit.getSymbol());
+
+    if (dataDescriptor.getValueRange().assigned())
+    {
+        auto daqRange = dataDescriptor.getValueRange();
+        daq::streaming_protocol::Range streamingRange;
+        streamingRange.high = daqRange.getHighValue().getFloatValue();
+        streamingRange.low = daqRange.getLowValue().getFloatValue();
+        valueStream->setRange(streamingRange);
+    }
+
+    auto daqPostScaling = dataDescriptor.getPostScaling();
+    if (daqPostScaling.assigned() && daqPostScaling.getType() == daq::ScalingType::Linear)
+    {
+        daq::streaming_protocol::PostScaling streamingLinearPostScaling;
+        streamingLinearPostScaling.scale = daqPostScaling.getParameters().get("scale");
+        streamingLinearPostScaling.offset = daqPostScaling.getParameters().get("offset");
+        valueStream->setPostScaling(streamingLinearPostScaling);
+    }
     // *** meta "definition" end ***
 
     // --- meta "interpretation" start ---
@@ -301,6 +341,47 @@ daq::streaming_protocol::SampleType SignalDescriptorConverter::Convert(daq::Samp
     }
 }
 
+daq::RangePtr SignalDescriptorConverter::CreateDefaultRange(daq::SampleType sampleType)
+{
+    switch (sampleType)
+    {
+        case daq::SampleType::UInt8:
+            return Range(std::numeric_limits<uint8_t>::lowest(), std::numeric_limits<uint8_t>::max());
+            break;
+        case daq::SampleType::Int8:
+            return Range(std::numeric_limits<int8_t>::lowest(), std::numeric_limits<int8_t>::max());
+            break;
+        case daq::SampleType::UInt16:
+            return Range(std::numeric_limits<uint16_t>::lowest(), std::numeric_limits<uint16_t>::max());
+            break;
+        case daq::SampleType::Int16:
+            return Range(std::numeric_limits<int16_t>::lowest(), std::numeric_limits<int16_t>::max());
+            break;
+        case daq::SampleType::UInt32:
+            return Range(std::numeric_limits<uint32_t>::lowest(), std::numeric_limits<uint32_t>::max());
+            break;
+        case daq::SampleType::Int32:
+            return Range(std::numeric_limits<int32_t>::lowest(), std::numeric_limits<int32_t>::max());
+            break;
+        case daq::SampleType::UInt64:
+            // range integer values are of signed type so the highest value is max of signed type
+            return Range(std::numeric_limits<uint64_t>::lowest(), std::numeric_limits<int64_t>::max());
+            break;
+        case daq::SampleType::Int64:
+            return Range(std::numeric_limits<int64_t>::lowest(), std::numeric_limits<int64_t>::max());
+            break;
+        case daq::SampleType::Float32:
+            return Range(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max());
+            break;
+        case daq::SampleType::Float64:
+            return Range(std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max());
+            break;
+        default:
+            return nullptr;
+            break;
+    }
+}
+
 void SignalDescriptorConverter::EncodeInterpretationObject(const DataDescriptorPtr& dataDescriptor, nlohmann::json& extra)
 {
     // put descriptor name into interpretation object
@@ -351,32 +432,32 @@ void SignalDescriptorConverter::EncodeInterpretationObject(const DataDescriptorP
     }
 }
 
-void SignalDescriptorConverter::DecodeBitsInterpretationObject(const nlohmann::json& bits, DataDescriptorBuilderPtr& dataDescriptor)
+void SignalDescriptorConverter::DecodeBitsInterpretationObject(const nlohmann::json& bits, DataDescriptorBuilderPtr& dataDescriptorBuilder)
 {
     if (!bits.empty() && bits.is_array())
     {
-        auto metadata = dataDescriptor.getMetadata();
+        auto metadata = dataDescriptorBuilder.getMetadata();
         metadata.set("bits", bits.dump());
     }
 }
 
-void SignalDescriptorConverter::DecodeInterpretationObject(const nlohmann::json& extra, DataDescriptorBuilderPtr& dataDescriptor)
+void SignalDescriptorConverter::DecodeInterpretationObject(const nlohmann::json& extra, DataDescriptorBuilderPtr& dataDescriptorBuilder)
 {
     // sets descriptor name when corresponding field is present in interpretation object
     if (extra.count("desc_name") > 0)
-        dataDescriptor.setName(extra["desc_name"]);
+        dataDescriptorBuilder.setName(extra["desc_name"]);
 
     if (extra.count("metadata") > 0)
     {
         auto meta = JsonToDict(extra["metadata"]);
-        dataDescriptor.setMetadata(meta);
+        dataDescriptorBuilder.setMetadata(meta);
     }
 
     if (extra.count("unit") > 0)
     {
         auto unitObj = extra["unit"];
         auto unit = Unit(unitObj["symbol"], unitObj["id"], unitObj["name"], unitObj["quantity"]);
-        dataDescriptor.setUnit(unit);
+        dataDescriptorBuilder.setUnit(unit);
     }
 
     if (extra.count("range") > 0)
@@ -385,11 +466,11 @@ void SignalDescriptorConverter::DecodeInterpretationObject(const nlohmann::json&
         auto low = std::stoi(std::string(rangeObj["low"]));
         auto high = std::stoi(std::string(rangeObj["high"]));
         auto range = Range(low, high);
-        dataDescriptor.setValueRange(range);
+        dataDescriptorBuilder.setValueRange(range);
     }
 
     if (extra.count("origin") > 0)
-        dataDescriptor.setOrigin(extra["origin"]);
+        dataDescriptorBuilder.setOrigin(extra["origin"]);
 
     if (extra.count("rule") > 0)
     {
@@ -397,7 +478,7 @@ void SignalDescriptorConverter::DecodeInterpretationObject(const nlohmann::json&
         params.freeze();
 
         auto rule = DataRuleBuilder().setType(extra["rule"]["type"]).setParameters(params).build();
-        dataDescriptor.setRule(rule);
+        dataDescriptorBuilder.setRule(rule);
     }
 
     if (extra.count("scaling") > 0)
@@ -411,10 +492,10 @@ void SignalDescriptorConverter::DecodeInterpretationObject(const nlohmann::json&
                            .setScalingType(extra["scaling"]["scalingType"])
                            .setParameters(params)
                            .build();
-        dataDescriptor.setPostScaling(scaling);
+        dataDescriptorBuilder.setPostScaling(scaling);
 
         // overwrite sample type when scaling is present
-        dataDescriptor.setSampleType(convertScaledToSampleType(scaling.getOutputSampleType()));
+        dataDescriptorBuilder.setSampleType(convertScaledToSampleType(scaling.getOutputSampleType()));
     }
 }
 


### PR DESCRIPTION
* encode/decode signal value range and linear scaling parameters within the LT "definition" metadata
* keep compatibility with older client/server versions by also using "interpretation" metadata to transmit range and scaling parameters

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
