### PR TITLE
Replace some casts with borrow

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -2476,7 +2476,7 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::DeserializeProp
 
     const auto keys = propValues.getKeys();
 
-    const auto protectedPropObjPtr = propObjPtr.asPtr<IPropertyObjectProtected>();
+    const auto protectedPropObjPtr = propObjPtr.asPtr<IPropertyObjectProtected>(true);
 
     for (const auto& key : keys)
     {

--- a/core/coretypes/include/coretypes/objectptr.h
+++ b/core/coretypes/include/coretypes/objectptr.h
@@ -209,6 +209,8 @@ public:
 
     static ObjectPtr<T> Borrow(T*&& obj) = delete;
 
+    static ObjectPtr<T> Borrow(const ObjectPtr<T>& ptr);
+
     /*!
      * @brief Adopts an interface.
      * @param obj The source interface.
@@ -1395,6 +1397,16 @@ typename InterfaceToSmartPtr<V>::SmartPtr ObjectPtr<T>::Borrow(U*& obj)
     objPtr.borrowed = true;
     return objPtr;
 }
+
+template <typename T>
+ObjectPtr<T> ObjectPtr<T>::Borrow(const ObjectPtr<T>& ptr)
+{
+    ObjectPtr<T> objPtr;
+    objPtr.object = ptr.getObject();
+    objPtr.borrowed = true;
+    return objPtr;
+}
+
 
 template <typename T>
 bool ObjectPtr<T>::equals(ObjectPtr<IBaseObject> other) const

--- a/core/coretypes/tests/test_objectptr.cpp
+++ b/core/coretypes/tests/test_objectptr.cpp
@@ -317,6 +317,15 @@ TEST_F(ObjectPtrTest, BorrowFromAnotherInterface)
     baseObject->releaseRef();
 }
 
+TEST_F(ObjectPtrTest, BorrowFromPtr)
+{
+    const auto obj = BaseObject();
+    const auto borrowedObj = BaseObjectPtr::Borrow(obj);
+    ASSERT_EQ(obj->addRef(), 2);
+    obj->releaseRef();
+}
+
+
 TEST_F(ObjectPtrTest, Detach)
 {
     auto obj = BaseObject();

--- a/core/opendaq/component/include/opendaq/folder_impl.h
+++ b/core/opendaq/component/include/opendaq/folder_impl.h
@@ -236,7 +236,7 @@ ErrCode FolderImpl<Intf, Intfs...>::addItem(IComponent* item)
                 CoreEventId::ComponentAdded,
                 Dict<IString, IBaseObject>({{"Component", component}}));
          this->triggerCoreEvent(args);
-         component.asPtr<IPropertyObjectInternal>().enableCoreEventTrigger();
+         component.asPtr<IPropertyObjectInternal>(true).enableCoreEventTrigger();
     }
 
     return OPENDAQ_SUCCESS;
@@ -336,7 +336,7 @@ ErrCode FolderImpl<Intf, Intfs...>::enableCoreEventTrigger()
 {
     for (const auto& child : items)
     {
-        const ErrCode err = child.second.template asPtr<IPropertyObjectInternal>()->enableCoreEventTrigger();
+        const ErrCode err = child.second.template asPtr<IPropertyObjectInternal>(true)->enableCoreEventTrigger();
         if (OPENDAQ_FAILED(err))
             return err;
     }
@@ -349,7 +349,7 @@ ErrCode FolderImpl<Intf, Intfs...>::disableCoreEventTrigger()
 {
     for (const auto& child : items)
     {
-        const ErrCode err = child.second.template asPtr<IPropertyObjectInternal>()->disableCoreEventTrigger();
+        const ErrCode err = child.second.template asPtr<IPropertyObjectInternal>(true)->disableCoreEventTrigger();
         if (OPENDAQ_FAILED(err))
             return err;
     }
@@ -421,7 +421,7 @@ void FolderImpl<Intf, Intfs...>::clearInternal()
 {
     for (auto& item : items)
     {
-        item.second.template asPtr<IPropertyObjectInternal>().disableCoreEventTrigger();
+        item.second.template asPtr<IPropertyObjectInternal>(true).disableCoreEventTrigger();
         item.second.remove();
 
         if (!this->coreEventMuted && this->coreEvent.assigned())
@@ -531,7 +531,7 @@ void FolderImpl<Intf, Intfs...>::onUpdatableUpdateEnd()
 
     for (const auto& item : items)
     {
-        const auto updatable = item.second.template asPtrOrNull<IUpdatable>();
+        const auto updatable = item.second.template asPtrOrNull<IUpdatable>(true);
         if (updatable.assigned())
             updatable.updateEnded();
     }
@@ -544,7 +544,7 @@ bool FolderImpl<Intf, Intfs...>::removeItemWithLocalIdInternal(const std::string
     if (it == items.end())
         return false;
 
-    it->second.template asPtr<IPropertyObjectInternal>().disableCoreEventTrigger();
+    it->second.template asPtr<IPropertyObjectInternal>(true).disableCoreEventTrigger();
     it->second.remove();
     items.erase(it);
     return true;

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -541,7 +541,7 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
                 }
 
                 // automatically skips streaming connection for local and pseudo (streaming) devices
-                auto mirroredDeviceConfigPtr = devicePtr.asPtrOrNull<IMirroredDeviceConfig>();
+                auto mirroredDeviceConfigPtr = devicePtr.asPtrOrNull<IMirroredDeviceConfig>(true);
                 if (mirroredDeviceConfigPtr.assigned())
                 {
                     errCode = daqTry([this, &mirroredDeviceConfigPtr, &configPtr]

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -216,8 +216,8 @@ DevicePtr NativeStreamingClientModule::createNativeDevice(const ContextPtr& cont
 
     deviceHelper->subscribeToCoreEvent(context);
 
-    device.asPtr<INativeDevicePrivate>()->attachDeviceHelper(std::move(deviceHelper));
-    device.asPtr<INativeDevicePrivate>()->setConnectionString(connectionString);
+    device.asPtr<INativeDevicePrivate>(true)->attachDeviceHelper(std::move(deviceHelper));
+    device.asPtr<INativeDevicePrivate>(true)->setConnectionString(connectionString);
 
     processingContextPool.emplace_back("Device " + device.getGlobalId() + " config protocol processing",
                                                     std::move(processingThread),

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -259,7 +259,7 @@ BaseObjectPtr ConfigProtocolClientComm::deserializeConfigComponent(const StringP
 
     if (typeId == "ComponentHolder")
     {
-        const auto remoteContext = context.asPtrOrNull<IConfigProtocolDeserializeContext>();
+        const auto remoteContext = context.asPtrOrNull<IConfigProtocolDeserializeContext>(true);
         if(serObj.hasKey("parentGlobalId") && context.assigned())
             remoteContext->setRemoteGlobalId(serObj.readString("parentGlobalId"));
     }
@@ -394,7 +394,7 @@ void ConfigProtocolClientComm::connectDomainSignals(const ComponentPtr& componen
     const auto dev = getRootDevice();
     if (!dev.assigned())
         return;
-    const auto topComponent = component;
+    const auto topComponent = ComponentPtr::Borrow(component);
 
     forEachComponent<ISignal>(
         component,
@@ -409,7 +409,7 @@ void ConfigProtocolClientComm::connectDomainSignals(const ComponentPtr& componen
                 {
                     const auto domainSingalRemoteId = domainSignalId.toStdString();
                     StringPtr topComponentRemoteId;
-                    checkErrorInfo(topComponent.asPtr<IConfigClientObject>()->getRemoteGlobalId(&topComponentRemoteId));
+                    checkErrorInfo(topComponent.asPtr<IConfigClientObject>(true)->getRemoteGlobalId(&topComponentRemoteId));
                     if (domainSingalRemoteId.find(topComponentRemoteId.toStdString() + "/") == 0)
                     {
                         auto restStr = domainSingalRemoteId.substr(topComponentRemoteId.toStdString().size() + 1);
@@ -439,8 +439,8 @@ void ConfigProtocolClientComm::setRemoteGlobalIds(const ComponentPtr& component,
         [&parentRemoteId](const ComponentPtr& comp)
         {
             StringPtr compRemoteId;
-            comp.asPtr<IConfigClientObject>()->getRemoteGlobalId(&compRemoteId);
-            comp.asPtr<IConfigClientObject>()->setRemoteGlobalId(parentRemoteId + compRemoteId);
+            comp.asPtr<IConfigClientObject>(true)->getRemoteGlobalId(&compRemoteId);
+            comp.asPtr<IConfigClientObject>(true)->setRemoteGlobalId(parentRemoteId + compRemoteId);
         });
 }
 


### PR DESCRIPTION
This PR is a side effect produced by debugging leaked device objects. The performance gain is insignificant, but I don't want to waste the effort.