### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/build_antora_docs.yml
+++ b/.github/workflows/build_antora_docs.yml
@@ -12,10 +12,10 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
 
@@ -35,7 +35,7 @@ jobs:
         working-directory: ${{ env.site_path }}
         run: zip -r ${{ env.site_zip }} .
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: openDAQ_SDK_User_Guide
           path: ${{ env.site_zip }}

--- a/.github/workflows/check_headers.yml
+++ b/.github/workflows/check_headers.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install license-header-checker to ./shared/tools/license-header-checker/bin
         working-directory: ./shared/tools/license-header-checker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
         run : git config --global --add safe.directory '*'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
       - name: Install build dependencies
         run: |
@@ -503,7 +503,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
         with:
           name: Unit Test Results (${{ matrix.name }})
           path: /junit_reports/unit
@@ -515,14 +515,14 @@ jobs:
 
       - name: Upload package
         if: matrix.cpack != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
         with:
           name: Packages (${{ matrix.name }})
           path: ${{ env.package_path }}
           retention-days: 7
 
       - name: Upload PIP packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
         with:
           name: PIP Package (${{ matrix.name }})
           path: ${{ env.build_path }}/wheels/opendaq*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Build and Test openDAQ
 
 on:
   workflow_dispatch:
+  push: # TODO: debug only, delete
+    branches:
+      - github-actions-versions-bump
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: Build and Test openDAQ
 
 on:
   workflow_dispatch:
-  push: # TODO: debug only, delete
-    branches:
-      - github-actions-versions-bump
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install ninja-build
         if: matrix.cmake_generator == 'Ninja'
@@ -95,6 +95,7 @@ jobs:
       # https://github.com/actions/runner-images/issues/10001
       - name: Setup MSVC toolchain
         uses: ilammy/msvc-dev-cmd@v1
+
       - name: Remove outdated clang
         shell: pwsh
         run: mv 'C:\Program Files\LLVM' 'C:\Program Files\LLVM_old'
@@ -147,7 +148,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (${{ matrix.name }})
           path: ${{ env.test_path }}
@@ -159,7 +160,7 @@ jobs:
 
       - name: Upload package
         if: matrix.cpack != ''
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Packages (${{ matrix.name }})
           path: ${{ env.package_path }}
@@ -170,7 +171,7 @@ jobs:
         if: matrix.name == 'Windows VS 2022 x64 Release'
         env:
           dotnetBuildPath: "${{ env.dotnet_bin_path }}/${{ matrix.cmake_generator_platform }}/${{ matrix.cmake_build_type }}"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.windows_x64_artifact }}
           path: |
@@ -265,7 +266,7 @@ jobs:
         run : git config --global --add safe.directory '*'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install additional dependencies
         run: |
@@ -297,7 +298,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (${{ matrix.name }})
           path: /junit_reports/unit
@@ -309,7 +310,7 @@ jobs:
 
       - name: Upload package
         if: matrix.cpack != ''
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Packages (${{ matrix.name }})
           path: ${{ env.package_path }}
@@ -318,7 +319,7 @@ jobs:
       - name: Upload binaries for .NET Bindings NuGet package
         # "There can be only one."
         if: matrix.name == 'Ubuntu 22.04 gcc-12 Release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.linux_x64_artifact }}
           path: |
@@ -454,7 +455,7 @@ jobs:
         run : git config --global --add safe.directory '*'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
@@ -499,7 +500,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (${{ matrix.name }})
           path: /junit_reports/unit
@@ -511,14 +512,14 @@ jobs:
 
       - name: Upload package
         if: matrix.cpack != ''
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Packages (${{ matrix.name }})
           path: ${{ env.package_path }}
           retention-days: 7
 
       - name: Upload PIP packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PIP Package (${{ matrix.name }})
           path: ${{ env.build_path }}/wheels/opendaq*.whl
@@ -549,10 +550,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install ninja-build
-        uses: seanmiddleditch/gha-setup-ninja@v3
+        uses: seanmiddleditch/gha-setup-ninja@v4
         with:
           version: 1.10.2
       - name: Set up Python
@@ -581,7 +582,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (${{ matrix.name }})
           path: ${{ env.test_path }}
@@ -612,11 +613,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install ninja-build
         if: matrix.cmake_generator == 'Ninja'
-        uses: seanmiddleditch/gha-setup-ninja@v3
+        uses: seanmiddleditch/gha-setup-ninja@v4
         with:
           version: 1.10.2
 
@@ -654,7 +655,7 @@ jobs:
           }
 
       - name: Upload PIP packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PIP Package (${{ matrix.name }})
           path: ${{ env.build_path }}/wheels/*.whl
@@ -683,9 +684,9 @@ jobs:
   #
   #   steps:
   #
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - name: Checkout
-  #       uses: actions/checkout@v3
+  #       uses: actions/checkout@v4
   #
   #     - name: Install build dependencies
   #       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -412,7 +412,7 @@ jobs:
           yum install -y git awscli
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
       - name: Install build dependencies
         run: |
@@ -452,7 +452,7 @@ jobs:
         run: |
           rename "s/-cp/_${{ steps.short-sha.outputs.sha }}-cp/" *.whl
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -466,7 +466,7 @@ jobs:
           aws s3 cp . "s3://${{ env.s3bucket }}/${{ env.s3wheels_linux_x86_64_path }}" --recursive
 
       - name: Upload Wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
         with:
           name: Wheels (${{ matrix.name }})
           path: ${{ env.wheels_path }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,12 +65,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v2.2
+        uses: benjlevesque/short-sha@v3
 
       - name: Configure and build Wheels
         if: matrix.cmake_generator_platform != 'Win32'
@@ -126,7 +126,7 @@ jobs:
         working-directory: build
         run: cpack -C ${{ matrix.cmake_build_type }} -G ${{ matrix.cpack }}
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -176,7 +176,7 @@ jobs:
           aws s3 cp . "s3://${{ env.s3bucket }}/${{ env.s3wheels_win_amd64_path }}" --recursive
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Package (${{ matrix.name }})
           path: ${{ env.package_path }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload Wheels
         if: matrix.cmake_generator_platform != 'Win32'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Wheels (${{ matrix.name }})
           path: ${{ env.wheels_path }}
@@ -195,7 +195,7 @@ jobs:
         if: matrix.name == 'Windows VS 2022 x64 Release'
         env:
           dotnetBuildPath: "${{ env.dotnet_bin_path }}/${{ matrix.cmake_generator_platform }}/${{ matrix.cmake_build_type }}"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.windows_x64_artifact }}
           path: |
@@ -246,7 +246,7 @@ jobs:
           apt-get install -y git openssh-client rename
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
@@ -281,7 +281,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v2.2
+        uses: benjlevesque/short-sha@v3
 
       - name: Rename package (main)
         working-directory: ${{ env.package_path_rel }}
@@ -310,7 +310,7 @@ jobs:
         working-directory: build/doc_doxygen/html
         run: zip -r "../../cpp_api_reference.zip" .
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -323,7 +323,7 @@ jobs:
           aws s3 cp . s3://${{ env.s3bucket }}/${{ env.s3sdk_path }}/ --recursive
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Package (${{ matrix.name }})
           path: ${{ env.package_path_rel }}
@@ -337,7 +337,7 @@ jobs:
           aws s3 cp "cpp_api_reference.zip" "s3://${{ env.s3bucket }}/${{ env.s3docpath }}/"
 
       - name: Upload API reference
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: API Reference
           path: "build/cpp_api_reference.zip"
@@ -351,13 +351,13 @@ jobs:
           aws s3 cp opendaq-${{ steps.daq_version.outputs.DAQ_VERSION }}-examples.zip s3://${{ env.s3bucket }}/${{ env.s3sdk_path }}/
 
       - name: Upload temporary package for simulator
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.simulator_package_artifact }}
           path: ${{ env.package_path_rel }}
 
       - name: Upload simulator app
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.simulator_app_artifact }}
           path: build/bin/application_simulator
@@ -365,7 +365,7 @@ jobs:
       - name: Upload binaries for .NET Bindings NuGet package
         # "There can be only one."
         if: matrix.name == 'Ubuntu 20.04 gcc-10 Release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.linux_x64_artifact }}
           path: |
@@ -412,7 +412,7 @@ jobs:
           yum install -y git awscli
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
@@ -444,7 +444,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v2.2
+        uses: benjlevesque/short-sha@v3
 
       - name: Rename Wheels (main)
         working-directory: ${{ env.wheels_path }}
@@ -452,7 +452,7 @@ jobs:
         run: |
           rename "s/-cp/_${{ steps.short-sha.outputs.sha }}-cp/" *.whl
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -466,7 +466,7 @@ jobs:
           aws s3 cp . "s3://${{ env.s3bucket }}/${{ env.s3wheels_linux_x86_64_path }}" --recursive
 
       - name: Upload Wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Wheels (${{ matrix.name }})
           path: ${{ env.wheels_path }}
@@ -490,7 +490,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install tools
         run: |
@@ -498,13 +498,13 @@ jobs:
           sudo apt-get install -y virtualbox vagrant
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.simulator_package_artifact }}
           path: ${{ env.simulator_directory }}
 
       - name: Download simulator app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.simulator_app_artifact }}
           path: ${{ env.simulator_directory }}
@@ -523,7 +523,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v2.2
+        uses: benjlevesque/short-sha@v3
 
       - name: Define simulator name
         id: simulator_name
@@ -558,7 +558,7 @@ jobs:
           vboxmanage export ${{ steps.simulator_name.outputs.SIMULATOR_NAME }} -o ${{ steps.simulator_name.outputs.SIMULATOR_NAME }}.ova --options manifest,nomacs
           ls -hl ${{ steps.simulator_name.outputs.SIMULATOR_NAME }}.ova
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -570,14 +570,14 @@ jobs:
           aws s3 cp ${{ steps.simulator_name.outputs.SIMULATOR_NAME }}.ova s3://${{ env.s3bucket }}/${{ env.s3simulatorpath }}/
 
       - name: Upload OVA image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.simulator_name.outputs.SIMULATOR_NAME }}-ova-image
           path: simulator/${{ steps.simulator_name.outputs.SIMULATOR_NAME }}.ova
           retention-days: 7
 
       - name: Delete unused artifacts
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: |
             ${{ env.simulator_app_artifact }}
@@ -590,10 +590,10 @@ jobs:
     timeout-minutes: 4
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
 
@@ -614,7 +614,7 @@ jobs:
         working-directory: ${{ env.build_path }}/site/
         run: zip -r ${{ env.build_path }}/user_guide.zip .
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -634,7 +634,7 @@ jobs:
             wget ${{ secrets.DEPLOY_DOCUMENTATION_URL_AND_TOKEN }}
           fi
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: openDAQ_SDK_User_Guide
           path: ${{ env.build_path }}/user_guide.zip
@@ -670,7 +670,7 @@ jobs:
 
     steps:
       - name: Download NuGet artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.dotnet_bindings.outputs.nuget_artifact_name }}
           path: ${{ env.package_path }}
@@ -679,7 +679,7 @@ jobs:
         run: |
           Get-ChildItem -Path .\* -Include *.nupkg | Rename-Item -NewName {$_.FullName.ToLower()}
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v3
+        uses: benjlevesque/short-sha@v3.0
 
       - name: Configure and build Wheels
         if: matrix.cmake_generator_platform != 'Win32'
@@ -281,7 +281,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v3
+        uses: benjlevesque/short-sha@v3.0
 
       - name: Rename package (main)
         working-directory: ${{ env.package_path_rel }}
@@ -444,7 +444,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v3
+        uses: benjlevesque/short-sha@v3.0
 
       - name: Rename Wheels (main)
         working-directory: ${{ env.wheels_path }}
@@ -523,7 +523,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v3
+        uses: benjlevesque/short-sha@v3.0
 
       - name: Define simulator name
         id: simulator_name

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -313,7 +313,7 @@ jobs:
           yum install -y git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
       - name: Install build dependencies
         run: |
@@ -343,7 +343,7 @@ jobs:
           done
 
       - name: Upload Wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
         with:
           name: Wheels (${{ matrix.name }})
           path: ${{ env.wheels_path }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure and build Wheels
         if: matrix.cmake_generator_platform != 'Win32'
@@ -117,7 +117,7 @@ jobs:
           Get-ChildItem -Path .\* -Include *.nupkg | Rename-Item -NewName {$_.FullName.ToLower()}
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Package (${{ matrix.name }})
           path: ${{ env.package_path }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload Wheels
         if: matrix.cmake_generator_platform != 'Win32'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Wheels (${{ matrix.name }})
           path: ${{ env.wheels_path }}
@@ -136,7 +136,7 @@ jobs:
         if: matrix.name == 'Windows VS 2022 x64 Release'
         env:
           dotnetBuildPath: "${{ env.dotnet_bin_path }}/${{ matrix.cmake_generator_platform }}/${{ matrix.cmake_build_type }}"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.windows_x64_artifact }}
           path: |
@@ -187,7 +187,7 @@ jobs:
           apt-get install -y git openssh-client rename
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
@@ -238,27 +238,27 @@ jobs:
         run: zip -r "../../opendaq-${{ steps.daq_version.outputs.DAQ_VERSION }}_cpp_api_reference.zip" .
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Package (${{ matrix.name }})
           path: ${{ env.package_path_rel }}
           retention-days: 7
 
       - name: Upload API reference
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: API Reference
           path: "build/opendaq-${{ steps.daq_version.outputs.DAQ_VERSION }}_cpp_api_reference.zip"
           retention-days: 7
 
       - name: Upload temporary package for simulator
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.simulator_package_artifact }}
           path: ${{ env.package_path_rel }}
 
       - name: Upload simulator app
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.simulator_app_artifact }}
           path: build/bin/application_simulator
@@ -266,7 +266,7 @@ jobs:
       - name: Upload binaries for .NET Bindings NuGet package
         # "There can be only one."
         if: ${{ matrix.name == 'Ubuntu 20.04 gcc-10 Release' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.linux_x64_artifact }}
           path: |
@@ -313,7 +313,7 @@ jobs:
           yum install -y git
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
@@ -343,7 +343,7 @@ jobs:
           done
 
       - name: Upload Wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Wheels (${{ matrix.name }})
           path: ${{ env.wheels_path }}
@@ -367,7 +367,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install tools
         run: |
@@ -375,13 +375,13 @@ jobs:
           sudo apt-get install -y virtualbox vagrant
 
       - name: Download package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.simulator_package_artifact }}
           path: ${{ env.simulator_directory }}
 
       - name: Download simulator app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.simulator_app_artifact }}
           path: ${{ env.simulator_directory }}
@@ -425,14 +425,14 @@ jobs:
           ls -hl ${{ steps.simulator_name.outputs.SIMULATOR_NAME }}.ova
 
       - name: Upload OVA image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.simulator_name.outputs.SIMULATOR_NAME }}-ova-image
           path: simulator/${{ steps.simulator_name.outputs.SIMULATOR_NAME }}.ova
           retention-days: 7
 
       - name: Delete unused artifacts
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: |
             ${{ env.simulator_app_artifact }}

--- a/.github/workflows/reusable_nuget_creation_and_test.yml
+++ b/.github/workflows/reusable_nuget_creation_and_test.yml
@@ -67,16 +67,16 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download artifacts for Windows x64
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.windows_x64_artifact }}
           path: ${{ env.nuget_work_path_win_x64 }}
 
       - name: Download artifacts for Linux
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.linux_x64_artifact }}
           path: ${{ env.nuget_work_path_linux_x64 }}
@@ -115,14 +115,14 @@ jobs:
         # packing without building as the binaries (artifacts) have been downloaded before (handled in *.csproj)
 
       - name: Upload package (openDAQ.Net NuGet)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.nuget_artifact }}
           path: ${{ env.nuget_work_path }}/win-x64/openDAQ.Net.*.nupkg
           retention-days: 7
 
       - name: Delete no longer needed artifacts
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: |
             ${{ env.windows_x64_artifact }}
@@ -156,10 +156,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download NuGet package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.nuget_artifact }}
           path: ${{ env.nuget_work_path_win_x64 }}
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload NuGet package test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results (openDAQ.Net NuGet)
           path: ${{ env.test_path }}

--- a/.github/workflows/trigger_downstream_deployment.yml
+++ b/.github/workflows/trigger_downstream_deployment.yml
@@ -14,7 +14,7 @@ jobs:
     name: Trigger Github documentation deployment
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PIPELINES_PAT }}
           repository: openDAQ/opendaq.github.io
@@ -32,7 +32,7 @@ jobs:
         uses: tj-actions/branch-names@v8
 
       - name: Check for changelog changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: Repository Dispatch
         if: steps.check-pat.outputs.pat_available == 'true'
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PIPELINES_PAT }}
           repository: openDAQ/openDAQ-Pipelines


### PR DESCRIPTION
Update the following GitHub Actions to latest major version to avoid ugly deprecation warnings:

* actions/upload-artifact
* actions/download-artifact
* geekyeggo/delete-artifact
* actions/setup-node
* actions/checkout
* aws-actions/configure-aws-credentials
* seanmiddleditch/gha-setup-ninja
* benjlevesque/short-sha
* peter-evans/repository-dispatch
* dorny/paths-filter

in all workflows.

**Note**

The following actions:

 * actions/checkout
 * actions/upload-artifact
 * aws-actions/configure-aws-credentials
 
are left `@v3` (as opposed to `@v4`) in `ci.yml`, `deploy.yml`, and `package.yml` for `manylinux2014 gcc Release` due to an error (node 20 not available). Appropriate TODOs were added, as [Node 16 has reached its end of life](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).