### PR TITLE
Downgrade benjlevesque/short-sha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -444,7 +444,7 @@ jobs:
       - name: Get short SHA
         if: github.ref == 'refs/heads/main'
         id: short-sha
-        uses: benjlevesque/short-sha@v3.0
+        uses: benjlevesque/short-sha@v2.2 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
       - name: Rename Wheels (main)
         working-directory: ${{ env.wheels_path }}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:
Downgrade benjlevesque/short-sha GitHub action from `@v3.0` to `@2.2` in `deploy.yml` for `manylinux2014 gcc Release` due to node 20 not available error