### PR TITLE
Antora documentation: native protocols specifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -606,14 +606,23 @@ jobs:
           npm i @asciidoctor/tabs
           npm i @springio/antora-extensions
 
-      - name: Run Antora
+      - name: Run Antora to build user guide
         run: >
           [ "refs/heads/main" != "${{ github.ref }}" ] && npx antora antora-playbook.yml
           || (export DAQ_DEV_WEBSITE=docs-dev; npx antora antora-playbook-dev.yml)
 
-      - name: Compress Documentation
+      - name: Compress user guide Documentation
         working-directory: ${{ env.build_path }}/site/
         run: zip -r ${{ env.build_path }}/user_guide.zip .
+
+      - name: Run Antora to build protocols specs
+        run: >
+          [ "refs/heads/main" != "${{ github.ref }}" ] && npx antora antora-specs-playbook.yml
+          || (export DAQ_DEV_WEBSITE=docs-dev; npx antora antora-specs-playbook-dev.yml)
+
+      - name: Compress protocols specifications
+        working-directory: ${{ env.build_path }}/site_specs/
+        run: zip -r ${{ env.build_path }}/native_protocols_specs.zip .
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -625,6 +634,11 @@ jobs:
         run: |
           aws s3 rm "s3://${{ env.s3bucket }}/${{ env.s3docpath }}/"  --recursive --exclude '*' --include 'user_guide.zip'
           aws s3 cp ${{ env.build_path }}/user_guide.zip "s3://${{ env.s3bucket }}/${{ env.s3docpath }}/"
+
+      - name: Upload protocols specifications to S3
+        run: |
+          aws s3 rm "s3://${{ env.s3bucket }}/${{ env.s3docpath }}/"  --recursive --exclude '*' --include 'native_protocols_specs.zip'
+          aws s3 cp ${{ env.build_path }}/native_protocols_specs.zip "s3://${{ env.s3bucket }}/${{ env.s3docpath }}/"
 
       - name: Call the API to deploy the documentation
         run: |
@@ -639,6 +653,12 @@ jobs:
         with:
           name: openDAQ_SDK_User_Guide
           path: ${{ env.build_path }}/user_guide.zip
+          retention-days: 7
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openDAQ_SDK_Native_protocols_specifications
+          path: ${{ env.build_path }}/native_protocols_specs.zip
           retention-days: 7
 
   # using reusable workflow

--- a/antora-specs-playbook-dev.yml
+++ b/antora-specs-playbook-dev.yml
@@ -1,0 +1,28 @@
+site:
+  title: openDAQ protocols specifications
+  start_page: opendaq::overview.adoc
+output:
+  dir: ./build/site_specs
+asciidoc:
+  attributes:
+    page-pagination: true
+    tabs-sync-option: true
+    gpp: g++
+    docs-prefix: docs-dev
+    docs-website: https://{docs-prefix}.opendaq.com/
+  extensions:
+    - "@asciidoctor/tabs"
+
+antora:
+  extensions:
+    - require: "@springio/antora-extensions/tabs-migration-extension"
+
+content:
+  sources:
+  - url: .
+    branches: HEAD
+    start_path: docs/Antora-specs
+ui:
+  bundle:
+    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.3-opendaq/ui-bundle.zip
+    snapshot: true

--- a/antora-specs-playbook.yml
+++ b/antora-specs-playbook.yml
@@ -1,0 +1,28 @@
+site:
+  title: openDAQ protocols specifications
+  start_page: opendaq::overview.adoc
+output:
+  dir: ./build/site_specs
+asciidoc:
+  attributes:
+    page-pagination: true
+    tabs-sync-option: true
+    gpp: g++
+    docs-prefix: docs
+    docs-website: https://{docs-prefix}.opendaq.com/
+  extensions:
+    - "@asciidoctor/tabs"
+
+antora:
+  extensions:
+    - require: "@springio/antora-extensions/tabs-migration-extension"
+
+content:
+  sources:
+  - url: .
+    branches: HEAD
+    start_path: docs/Antora-specs
+ui:
+  bundle:
+    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.3-opendaq/ui-bundle.zip
+    snapshot: true

--- a/docs/Antora-specs/.asciidoctorconfig
+++ b/docs/Antora-specs/.asciidoctorconfig
@@ -1,0 +1,2 @@
+:stylesdir: {asciidoctorconfigdir}/ui-bundle/css
+:stylesheet: site.css

--- a/docs/Antora-specs/README.md
+++ b/docs/Antora-specs/README.md
@@ -1,0 +1,25 @@
+openDAQ protocols documentation
+=======================
+
+This directory contains files required to build the specifications of openDAQ native protocols.
+To build the documentation locally, execute the following Docker
+command in the root folder of this repository:
+
+```
+docker run -v ${PWD}:/antora:Z --rm -t antora/antora antora-specs-playbook.yml
+```
+
+The documentation is generated into the `build/site_specs/` directory.
+
+Building on a local machine
+===================
+Install Node.js
+
+Install the required NPM packages (remove `-g` to install on a per-user basis).
+On Windows you will need to have Administrator permissions to install globally.
+* `npm i -g antora`
+* `npm i -g @asciidoctor/tabs`
+* `npm i -g @springio/antora-extensions`
+
+Then in the repository root run
+`npx antora antora-specs-playbook.yml`

--- a/docs/Antora-specs/antora.yml
+++ b/docs/Antora-specs/antora.yml
@@ -1,0 +1,11 @@
+name: opendaq
+title: openDAQ protocols specification
+version: 3.1.0
+start_page: ROOT:overview.adoc
+asciidoc:
+  attributes:
+    page-toclevels: 3@
+    experimental: true
+nav:
+  - modules/packet_streaming/nav-packet-streaming.adoc
+  - modules/native_communication_protocol/nav-native-communication-protocol.adoc

--- a/docs/Antora-specs/modules/ROOT/nav-overview.adoc
+++ b/docs/Antora-specs/modules/ROOT/nav-overview.adoc
@@ -1,0 +1,1 @@
+* xref:overview.adoc[**Overview**]

--- a/docs/Antora-specs/modules/ROOT/pages/overview.adoc
+++ b/docs/Antora-specs/modules/ROOT/pages/overview.adoc
@@ -1,0 +1,12 @@
+= Overview
+
+The openDAQ(TM) provides the following native protocols:
+
+* xref:native_communication_protocol:introduction.adoc[**Native communication protocol specification**]: 
+The native communication protocol facilitates data transfer between data acquisition devices and client programs
+or gateway devices, minimizing data conversion and optimizing network traffic.
+* xref:packet_streaming:overview.adoc[**Packet streaming protocol specification**]: 
+The packet streaming protocol encodes openDAQ(TM) packets into a binary format for transmission
+across various transport protocols, establishing rules for decoding back into openDAQ(TM) packets on the receiver’s end.
+
+The listed specifications help developers understand the structure, functionality, and implementation details of these protocols.

--- a/docs/Antora-specs/modules/native_communication_protocol/nav-native-communication-protocol.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/nav-native-communication-protocol.adoc
@@ -1,0 +1,9 @@
+* xref:introduction.adoc[**Native communication protocol**]
+
+** xref:introduction.adoc[Introduction]
+** xref:glossary.adoc[Terminology and abbreviations]
+** xref:streaming.adoc[Streaming packages]
+// ** xref:configuration.adoc[Configuration packages]
+** xref:service.adoc[Protocol service packages]
+// ** xref:activity_monitoring.adoc[Connection activity monitoring]
+** xref:examples.adoc[Examples]

--- a/docs/Antora-specs/modules/native_communication_protocol/pages/activity_monitoring.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/pages/activity_monitoring.adoc
@@ -1,0 +1,2 @@
+= Connection activity monitoring
+// TODO

--- a/docs/Antora-specs/modules/native_communication_protocol/pages/configuration.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/pages/configuration.adoc
@@ -1,0 +1,2 @@
+= Configuration packages
+// TODO

--- a/docs/Antora-specs/modules/native_communication_protocol/pages/examples.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/pages/examples.adoc
@@ -1,0 +1,286 @@
+= Examples
+
+== How to emulate openDAQ(TM) native streaming server
+
+Here, we consider the minimal package flow required from the server-side perspective to enable the native communication protocol to stream a single value signal with domain signal.
+
+To simplify the example, let's assume that both the server and client are running on the same host. The server is reachable for the client via the IPv4 address "127.0.0.1" and port number 7420.
+The client is either the openDAQ(TM) client application, based on the provided <<An openDAQ client application code example,code snippet below>>, or the openDAQ(TM) Python GUI application. In both scenarios, the client uses the connection string
+"daq.ns://127.0.0.1:7420" to connect to the emulated server.
+
+The emulated server will advertise two signals:
+
+* _Value signal_: An asynchronous signal with a data type of double, having a symbolic ID of "/ValueSignal" and a numeric ID of "1"
+* _Domain signal_: A signal with a data type of unsigned 64-bit integer, featuring a symbolic ID of "/DomainSignal" and a numeric ID of "2"
+
+The server application needs to listen for incoming TCP connections on the loopback interface and port number 7420.
+Once an incoming TCP connection is accepted, it should be upgraded to a WebSocket connection following the procedure outlined in the Establishing a connection section.
+
+Once the connection is established, the server application should begin reading incoming data, expecting the receipt of a 4-byte package header first.
+Upon receiving a xref:streaming.adoc#init_req[Streaming initialization request] from the client, it should reply with two xref:streaming.adoc#available[Signal available notification packages]: one for the value signal and another for the domain signal.
+
+Below are examples of how the serialized signal strings inside signal available notifications might appear for the given scenario.
+
+_Value signal_:
+
+[source,json]
+----
+{
+    "__type": "Signal",
+    "domainSignalId": "/DomainSignal",
+    "dataDescriptor": {
+        "__type": "DataDescriptor",
+        "name": "",
+        "sampleType": 2,
+        "dimensions": [],
+        "rule": {
+            "__type": "DataRule",
+            "ruleType": 3,
+            "params": {
+                "__type": "Dict",
+                "values": []
+            }
+        },
+        "origin": "",
+        "metadata": {
+            "__type": "Dict",
+            "values": []
+        },
+        "structFields": []
+    },
+    "public": true,
+    "description": "Value signal description",
+    "name": "ValueSignalName"
+}
+----
+
+_Domain signal_:
+
+[source,json]
+----
+{
+    "__type": "Signal",
+    "dataDescriptor": {
+        "__type": "DataDescriptor",
+        "name": "",
+        "sampleType": 9,
+        "dimensions": [],
+        "rule": {
+            "__type": "DataRule",
+            "ruleType": 3,
+            "params": {
+                "__type": "Dict",
+                "values": []
+            }
+        },
+        "origin": "",
+        "metadata": {
+            "__type": "Dict",
+            "values": []
+        },
+        "structFields": []
+    },
+    "public": true,
+    "description": "Domain signal description",
+    "name": "DomainSignalName"
+}
+----
+
+Subsequently, the server application should send a xref:streaming.adoc#init_done_ack[Streaming initialization done acknowledgement] to finalize the streaming initialization process.
+Following this, the server application should continue to read incoming data.
+When it receives xref:streaming.adoc#subscribe_req[subscription requests] for the domain and value signals, it should respond with xref:streaming.adoc#subscribe_ack[subscription acknowledgements] for each request.
+
+Once these xref:streaming.adoc#subscribe_ack[subscription acknowledgments] are sent, both the value and domain signals are considered as subscribed, and the server application can start sending signal packets for these signals.
+Initially, the server should send the xref:packet_streaming:event_packet.adoc#ddc_event_packet[Data descriptor changed event packet], followed by the xref:packet_streaming:data_packet.adoc[data packets].
+
+=== An openDAQ client application code example
+
+[source,cpp]
+----
+#include <opendaq/opendaq.h>
+#include <chrono>
+#include <iostream>
+#include <thread>
+int main(int /*argc*/, const char* /*argv*/[])
+{
+    using namespace daq;
+    // Create a new Instance that we will use for all the interactions with the SDK
+    InstancePtr instance = Instance(MODULE_PATH);
+    // Connect to a Native streaming server
+    DevicePtr device = instance.addDevice("daq.ns://127.0.0.1:7420");
+    // Exit if connection failed
+    if (!device.assigned())
+    {
+        std::cerr << "Connection failed!" << std::endl;
+        return 0;
+    }
+    // Get the value signal
+    SignalPtr signal = device.getSignals()[0];
+    // Read data of value signal
+    const auto packetReader = PacketReader(signal);
+    while (true)
+    {
+        const auto packet = packetReader.read();
+        if (packet.assigned() && packet.getType() == PacketType::Data)
+        {
+            DataPacketPtr dataPacket = packet;
+            const auto data = reinterpret_cast<double*>(dataPacket.getData());
+            for (size_t index = 0; index < dataPacket.getSampleCount(); ++index)
+                std::cout << "Value signal data: " << data[index] << std::endl;
+        }
+        else
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+    return 0;
+----
+
+// == How to emulate openDAQ(TM) native configuration protocol server
+// TODO
+
+
+=== Package sequences examples
+
+==== Streaming connection initialization
+
+For connections that support the streaming feature, the streaming initialization step packages appear first.
+
+|===
+|Package direction |Package type |Package details
+
+|client → server
+|xref:service.adoc#properties[Transport layer properties]
+|Package type code in header 0xA
+
+|client → server
+|xref:streaming.adoc#init_req[Streaming initialization request]
+|Package type code in header 0xB
+
+|server → client
+|Domain xref:streaming.adoc#available[signal available notification]
+|Package type code in header 0x2
+
+|server → client
+|Value xref:streaming.adoc#available[signal available notification]
+|Package type code in header 0x2
+
+|server → client
+|xref:streaming.adoc#init_done_ack[Streaming initialization done acknowledgement]
+|Package type code in header 0x6
+|===
+
+==== Streaming connection signal data transmission
+
+For streaming-enabled connections, once the initialization step is completed, it is followed by packages
+related to transmitting the signal data. The typical sequence contains following packages.
+[NOTE]
+====
+The xref:streaming.adoc#packet[signal packet] packages with xref:packet_streaming:data_packet.adoc[data packets]
+typically present multiple times
+====
+
+|===
+|Package direction |Package type |Package details
+
+|client → server
+|Domain xref:streaming.adoc#subscribe_req[signal subscribe request]
+|Package type code in header 0x4
+
+|client → server
+|Value xref:streaming.adoc#subscribe_req[signal subscribe request]
+|Package type code in header 0x4
+
+|server → client
+|Domain xref:streaming.adoc#subscribe_ack[signal subscribe acknowledgement]
+|Package type code in header 0x7
+
+|server → client
+|Value xref:streaming.adoc#subscribe_ack[signal subscribe acknowledgement]
+|Package type code in header 0x7
+
+|server → client
+|Domain xref:streaming.adoc#packet[signal packet package] with
+xref:packet_streaming:event_packet.adoc#ddc_event_packet[data descriptor changed event packet]
+|Package type code in header 0x1 +
+Packet buffer type code in payload 0x0
+
+|server → client
+|Value xref:streaming.adoc#packet[signal packet package] with
+xref:packet_streaming:event_packet.adoc#ddc_event_packet[data descriptor changed event packet]
+|Package type code in header 0x1 +
+Packet buffer type code in payload 0x0
+
+|server → client
+|Domain xref:streaming.adoc#packet[signal packet package] with
+xref:packet_streaming:data_packet.adoc[data packet]
+|Package type code in header 0x1 +
+Packet buffer type code in payload 0x1
+
+|server → client
+|Value xref:streaming.adoc#packet[signal packet package] with
+xref:packet_streaming:data_packet.adoc[data packet]
+|Package type code in header 0x1 +
+Packet buffer type code in payload 0x1
+
+|client → server
+|Value xref:streaming.adoc#unsubscribe_req[signal unubscribe request]
+|Package type code in header 0x5
+
+|client → server
+|Domain xref:streaming.adoc#unsubscribe_req[signal unsubscribe request]
+|Package type code in header 0x5
+
+|server → client
+|Value xref:streaming.adoc#unsubscribe_ack[signal unsubscribe acknowledgement]
+|Package type code in header 0x8
+
+|server → client
+|Domain xref:streaming.adoc#unsubscribe_ack[signal unsubscribe acknowledgement]
+|Package type code in header 0x8
+|===
+
+==== Configuration connection initialization
+
+For configuration-enabled connections, the initialization step includes following packages.
+// TODO add links to config protocol pages and package details
+
+|===
+|Package direction |Package type |Package details
+
+|client → server
+|xref:service.adoc#properties[Transport layer properties]
+|Package type code in header 0xA
+
+|client → server
+|Get config protocol information request
+|Package type code in header 0x9
+
+|server → client
+|Config protocol information reply
+|Package type code in header 0x9
+
+|client → server
+|Config protocol upgrade request
+|Package type code in header 0x9
+
+|server → client
+|Config protocol upgrade reply
+|Package type code in header 0x9
+
+|client → server
+|Get type manager request
+|Package type code in header 0x9
+
+|server → client
+|Get type manager reply
+|Package type code in header 0x9
+
+|client → server
+|Get root device request
+|Package type code in header 0x9
+
+|server → client
+|Get root device reply
+|Package type code in header 0x9
+|===

--- a/docs/Antora-specs/modules/native_communication_protocol/pages/glossary.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/pages/glossary.adoc
@@ -1,0 +1,6 @@
+= Terminology and abbreviations
+
+== WebSocket
+Communications protocol, providing a simultaneous two-way communication channel over a single Transmission Control Protocol (TCP) connection.
+
+// TODO

--- a/docs/Antora-specs/modules/native_communication_protocol/pages/introduction.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/pages/introduction.adoc
@@ -1,0 +1,63 @@
+= Introduction
+
+== Document scope
+
+The main goal of the document is to provide developers in need of protocol support with substantial insights into the openDAQ(TM) native communication protocol.
+The document primarily focuses on the specifics of the openDAQ(TM) native communication protocol's transport/network layer. However, it does not extensively cover the serialization mechanisms
+for measured data or the serialization of the internal structure, topology, and properties of the acquisition device.
+
+== Protocol overview
+
+The openDAQ(TM) native communication protocol is intended to enable the transfer of data from data acquisition devices to client programs or intermediate devices, often referred to as gateway devices. 
+The protocol is designed to transfer data with a focus on minimizing conversions of native data structures utilized in the openDAQ(TM) SDK, and optimizing network traffic.
+
+The protocol involves two main entities: the server and the client. The server typically runs as a service on an acquisition device, while the client is part of a client program or embedded software
+on a gateway device.
+
+The native communication service is presented as a WebSocket service, accessible via three parameters: IPv4 or IPv6 address, port number (defaulting to 7420), and service path (e.g. "/").
+Each connected client is associated with a corresponding WebSocket endpoint from the server's perspective. The server's responsibilities include handling incoming WebSocket connections,
+processing incoming data packages from clients through WebSocket endpoints, and encoding outgoing packages to send through the same endpoint.
+
+On the client side, connection to the server is established using the known address, port, and path. The client sends request packages and processes responses and notifications from the server. 
+
+The mentioned data packages might be xref:streaming.adoc[streaming-related] - such as information about available signals, notifications when signals become unavailable, serialized signal packets;
+also these might be configuration protocol-related packages, or protocol xref:service.adoc[service packages].
+
+== Protocol package structure
+
+Each data package within the protocol comprises a 4-byte header, followed by a binary payload with a size of up to 268435455 bytes.
+
+=== Header
+
+The header of the data package is a 32-bit value in little-endian format. The least significant 28 bits represent the payload size as an unsigned integer value in little-endian format,
+while the most significant 4 bits represent the digital code of the package type.
+
+|===
+||4 bits (31 - 28)|28 bits (27 - 0)
+
+| 4 bytes
+| Package type code
+| Payload size in bytes
+
+| 0 - 268435455 bytes
+2+^| Payload (optional)
+|===
+
+=== Payload
+
+The payload of the data package can be up to 268435455 bytes in size. In cases where the payload is not present for header-only packages, the payload size is set to 0 by the corresponding bits
+of the package header. For other cases, the structure of the payload is specific to the package type and is encoded/decoded based on the package type code.
+
+== Error handling
+
+The openDAQ(TM) server and client-side implementations of the native communication protocol require every package to begin with the correct header, followed by a payload that matches that header.
+There isn't a specific mechanism for recovering from data corruption, so developers need to ensure the coherence and validity of the transmitted data.
+
+== Establishing a connection
+
+The connection procedure adheres to the standard process for establishing a WebSocket connection, involving several steps to transition from an HTTP connection to a WebSocket connection.
+
+The connection starts with the client establishing a TCP connection to the server. Then, it sends a WebSocket handshake HTTP upgrade request to the server.
+Upon receiving both the TCP connection and upgrade request, the server accepts them and responds to the client with a WebSocket handshake HTTP upgrade response.
+Once the client receives this response, the HTTP connection transitions to a WebSocket connection. From there, data can flow bidirectionally over this single connection in full-duplex mode,
+allowing both the client and server to send data independently at any time.

--- a/docs/Antora-specs/modules/native_communication_protocol/pages/service.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/pages/service.adoc
@@ -1,0 +1,29 @@
+= Protocol service packages
+
+[#properties]
+== Transport layer properties
+
+Once connected to the server, the client can send a package that contains a serialized openDAQ(TM) property object outlining a variety of protocol service parameters:
+
+[cols="1,1"]
+|===
+|Package type
+|_Transport layer properties_
+
+|Package type code
+|0xA
+
+|Direction
+|client → server
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Serialized property object string
+|0
+|String
+|Payload size
+|===

--- a/docs/Antora-specs/modules/native_communication_protocol/pages/streaming.adoc
+++ b/docs/Antora-specs/modules/native_communication_protocol/pages/streaming.adoc
@@ -1,0 +1,331 @@
+= Streaming
+
+== Overview
+
+Once the client establishes a connection with the server, it can begin streaming measured data using a subscription-based model. Here's how it works:
+
+* _Streaming initialization_: The client initiates the streaming process by sending an initialization request to the server.
+In response, the server sends packages containing information about each available signal. Once all signals are accounted for, the server sends an acknowledgment package to complete the initialization.
+* _Available/unavailable signal information_: The package sent by the server to notify the client about an available signal includes a unique non-zero numeric ID assigned by the server, a symbolic ID
+(global ID of the openDAQ(TM) signal), and a serialized string containing all relevant signal information, such as the signal descriptor and associated domain signal symbolic ID.
+The server notifies the client of any changes in signal availability - it sends packages to inform the client when new signals become available or when previously available signals become unavailable.
+* _Signal subscription_: After initialization, the client can subscribe or unsubscribe to any available signals at any time. When the server processes a subscription or unsubscription request,
+it sends a corresponding acknowledgment notification package to the client.
+* _Signal packet streaming_: For subscribed signals, the server sends packages containing the signal's packets.
+
+== Streaming packages types
+
+[#init_req]
+=== Streaming initialization request
+
+To initiate the streaming flow after connecting to the server, the client should send the corresponding request package:
+
+[cols="1,1"]
+|===
+|Package type
+|_Streaming initialization request_
+
+|Package type code
+|0xB
+
+|Direction
+|client → server
+
+2+^|Header-only package
+|===
+
+The server will respond with <<Signal available notification>> packages, one for each available signal, and acknowledge the completion of streaming initialization with a <<Streaming initialization done acknowledgement>> package.
+
+[#init_done_ack]
+=== Streaming initialization done acknowledgement 
+
+After the server completes streaming initialization by sending <<Signal available notification>> packages for all available signals in response to the <<Streaming initialization request>>,
+it sends a header-only notification package to the client. This helps the client to be aware that the initialization step is completed.
+
+[cols="1,1"]
+|===
+|Package type
+|_Streaming initialization done acknowledgement_
+
+|Package type code
+|0x6
+
+|Direction
+|server → client
+
+2+^|Header-only package
+|===
+
+[#available]
+=== Signal available notification
+
+The server sends a signal available notification package for each available signal during the streaming initialization stage. Additionally, after initialization is completed,
+it is also send to notify the client that a new signal has become available. The notification contains signal numeric and symbolic IDs, and the serialized signal form presented
+as a null-terminated JSON string, adhering to the standard openDAQ(TM) serialization format:
+
+[cols="1,1"]
+|===
+|Package type
+|_Signal available notification_
+
+|Package type code
+|0x2
+
+|Direction
+|server → client
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Signal numeric ID
+|0
+|Unsigned 32 bit integer
+|4
+
+|Signal symbolic ID size (in bytes)
+|4
+|Unsigned 16 bit integer
+|2
+
+|Signal symbolic ID
+|6
+|String
+|Signal symbolic ID size
+
+|Serialized signal string
+|6 + Signal symbolic ID size
+|String
+|Rest of the payload size
+|===
+
+_Serialized signal string example_:
+
+[source,json]
+----
+{
+    "__type": "Signal",
+    "domainSignalId": "/DomainSignal",
+    "dataDescriptor": {
+        "__type": "DataDescriptor",
+        "name": "",
+        "sampleType": 2,
+        "dimensions": [],
+        "rule": {
+            "__type": "DataRule",
+            "ruleType": 3,
+            "params": {
+                "__type": "Dict",
+                "values": []
+            }
+        },
+        "origin": "",
+        "metadata": {
+            "__type": "Dict",
+            "values": []
+        },
+        "structFields": []
+    },
+    "public": true,
+    "description": "Value signal description",
+    "name": "ValueSignalName"
+}
+----
+
+[#unavailable]
+=== Signal unavailable notification
+
+Once any previously available signal becomes unavailable, the server sends a signal unavailable notification package:
+
+[cols="1,1"]
+|===
+|Package type
+|_Signal unavailable notification_
+
+|Package type code
+|0x3
+
+|Direction
+|server → client
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Signal numeric ID
+|0
+|Unsigned 32 bit integer
+|4
+
+|Signal symbolic ID
+|4
+|String
+|Rest of the payload size
+|===
+
+[#subscribe_req]
+=== Signal subscribe request
+
+After connecting to the server and completing the streaming initialization, the client can request to subscribe to any of the available signals at any time. If the subscribed signal is a value signal,
+then the corresponding domain signal should also be subscribed to by the client side. If the client is using the openDAQ(TM) SDK, the domain signal is automatically subscribed along with the value signal.
+For custom client implementations, it is the developer's responsibility to ensure that the domain signal subscribe request is sent along with the subscribe request for the value signal.
+Subscribing to the domain signal should always precede that of the value signal.
+
+The subscribe request package contains the signal numeric and symbolic IDs:
+
+[cols="1,1"]
+|===
+|Package type
+|_Signal subscribe request_
+
+|Package type code
+|0x4
+
+|Direction
+|client → server
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Signal numeric ID
+|0
+|Unsigned 32 bit integer
+|4
+
+|Signal symbolic ID
+|4
+|String
+|Rest of the payload size
+|===
+
+[#unsubscribe_req]
+=== Signal unsubscribe request
+
+To unsubscribe previously subscribed signal, client sends corresponding request package:
+
+[cols="1,1"]
+|===
+|Package type
+|_Signal unsubscribe request_
+
+|Package type code
+|0x5
+
+|Direction
+|client → server
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Signal numeric ID
+|0
+|Unsigned 32 bit integer
+|4
+
+|Signal symbolic ID
+|4
+|String
+|Rest of the payload size
+|===
+
+[#subscribe_ack]
+=== Signal subscribe acknowledgement
+
+To notify the client that the requested signal <<Signal subscribe request,subscription>> has been completed by the server, it sends a corresponding acknowledgment notification package:
+
+[cols="1,1"]
+|===
+|Package type
+|_Signal subscribe acknowledgement_
+
+|Package type code
+|0x7
+
+|Direction
+|server → client
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Signal numeric ID
+|0
+|Unsigned 32 bit integer
+|4
+|===
+
+[#unsubscribe_ack]
+=== Signal unsubscribe acknowledgement
+
+To notify the client that the requested signal <<Signal unsubscribe request,unsubscription>> has been completed by the server, it sends a corresponding acknowledgment notification package:
+
+[cols="1,1"]
+|===
+|Package type
+|_Signal unsubscribe acknowledgement_
+
+|Package type code
+|0x8
+
+|Direction
+|server → client
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Signal numeric ID
+|0
+|Unsigned 32 bit integer
+|4
+|===
+
+[#packet]
+=== Signal packet
+
+After the client subscribes to the signal and server sends the corresponding <<Signal subscribe acknowledgement,acknowledgment>>, the server proceeds to transmit packages containing openDAQ(TM) packets. 
+These packages encapsulate measured xref:packet_streaming:data_packet.adoc[data packets] or serialized openDAQ(TM) xref:packet_streaming:event_packet.adoc[event packets].
+
+[cols="1,1"]
+|===
+|Package type
+|_Signal packet_
+
+|Package type code
+|0x1
+
+|Direction
+|server → client
+|===
+
+_Payload structure_:
+
+|===
+|Bytes group |Start position offset (in bytes) |Value type |Size in bytes
+
+|Packet buffer generic header
+|0
+|Binary data
+|12
+
+|Packet buffer extra header + payload
+|12
+|Binary data
+|Rest of the payload size
+|===
+
+The structure of the packet buffer header and payload is detailed in the xref:packet_streaming:format.adoc[packet streaming protocol specification]

--- a/docs/Antora-specs/modules/packet_streaming/nav-packet-streaming.adoc
+++ b/docs/Antora-specs/modules/packet_streaming/nav-packet-streaming.adoc
@@ -1,0 +1,8 @@
+* xref:overview.adoc[**Packet streaming protocol**]
+
+** xref:overview.adoc[Overview]
+** xref:format.adoc[Packet buffer format]
+** xref:data_packet.adoc[Data packets encoding]
+** xref:event_packet.adoc[Event packets encoding]
+** xref:internal.adoc[Protocol internal messages]
+** xref:examples.adoc[Examples]

--- a/docs/Antora-specs/modules/packet_streaming/pages/data_packet.adoc
+++ b/docs/Antora-specs/modules/packet_streaming/pages/data_packet.adoc
@@ -1,0 +1,91 @@
+= Data packet encoding
+
+openDAQ(TM) signal data packets are encoded into packet buffers consisting of a generic header of 12 bytes, an extra header of 32 bytes, and an optional payload representing the data samples of the packet.
+These packets can belong to either a value signal or a domain signal. Each data packet, whether it belongs to a value signal or a domain signal, has its own unique ID encoded in the extra header.
+For packets belonging to value signals, the extra header also includes a non-zero ID of the associated domain packet. This allows the client to locate the appropriate domain packet among the received
+packets to create a copy of the value signal data packet.
+
+The order of value/domain packets on the network is not defined. A value signal can receive its data packet before or after the associated domain packet is received.
+This approach implies that in certain scenarios, such as when value signals share the same domain signal, the copies of data packets recreated on the client side need to be retained for some time until
+they are no longer needed for any future recreated packets. This is supported by the protocol in two ways: for packets for which client copies can be released immediately,
+the server sets and the client handles the corresponding "Packet can be released" flag. For packets that need to be kept for a while by the client,
+the server creates separate packets release internal protocol message containing packet IDs to be released when the time comes.
+
+Another protocol-specific aspect pertains to the encoding of data packets for signals following either explicit or implicit data rules. In the case of explicit rules,
+measured samples are encoded into the payload of the packet buffer. However, for other types of rules, where data values can be calculated using an offset value,
+it is only the offset is encoded as part of the extra header without transferring measured values as a payload.
+
+|===
+||Bytes group |Start position offset (in bytes) |Value type |Size in bytes |Value
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0
+|unsigned 8 bit integer
+|1
+|44
+
+|Packet buffer type code
+|1
+|unsigned 8 bit integer
+|1
+|0x1
+
+|Packet streaming protocol version
+|2
+|unsigned 8 bit integer
+|1
+|-
+
+|xref:format.adoc#flags[Flags]
+|3
+|unsigned 8 bit integer
+|1
+|-
+
+|Signal numeric ID
+|4
+|unsigned 32 bit integer
+|4
+|-
+
+|Payload size
+|8
+|unsigned 32 bit integer
+|4
+|-
+
+.4+.^|Extra header
+
+|Packet ID
+|12
+|unsigned 64 bit integer
+|8
+|-
+
+|Domain packet ID
+|20
+|unsigned 64 bit integer
+|8
+|-
+
+|Sample count
+|28
+|unsigned 64 bit integer
+|8
+|-
+
+|Packet offset
+|36
+|signed 64 bit integer or double
+|8
+|-
+
+|Payload
+|Packet data
+|44
+|Binary
+|-
+|-
+|===

--- a/docs/Antora-specs/modules/packet_streaming/pages/event_packet.adoc
+++ b/docs/Antora-specs/modules/packet_streaming/pages/event_packet.adoc
@@ -1,0 +1,170 @@
+= Event packet encoding
+
+In addition to packets that carry measured signal data, openDAQ(TM) also uses packets to encode various types of events. This helps in monitoring changes in signal parameters and detecting losses and
+overlaps in measured data.
+
+[#ddc_event_packet]
+== Data descriptor changed event packet
+
+This type of event packet is utilized to monitor changes in signal parameters, ensuring accurate interpretation of measured data in light of these changes. Each packet of this type includes two openDAQ(TM)
+signal data descriptors: first mandatory descriptor that outlines the data structure and interpretation for the signal, and another optional descriptor for the associated domain signal.
+
+The Data Descriptor Changed Event Packet is strategically positioned at the start of the packet stream and acts as the initial packet before any subsequent xref:data_packet.adoc[data packets] containing measured data.
+It reappears whenever there are changes in signal parameters.
+
+The packet buffer for this event type consists of a 12-byte generic header and payload that includes the serialized forms of both signal descriptors.
+The serialized form is presented as a null-terminated JSON string, adhering to the standard openDAQ(TM) serialization format.
+
+|===
+||Bytes group |Start position offset (in bytes) |Value type |Size in bytes |Value
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0
+|unsigned 8 bit integer
+|1
+|12
+
+|Packet buffer type code
+|1
+|unsigned 8 bit integer
+|1
+|0x0
+
+|Packet streaming protocol version
+|2
+|unsigned 8 bit integer
+|1
+|-
+
+|xref:format.adoc#flags[Flags]
+|3
+|unsigned 8 bit integer
+|1
+|0x0
+
+|Signal numeric ID
+|4
+|unsigned 32 bit integer
+|4
+|-
+
+|Payload size
+|8
+|unsigned 32 bit integer
+|4
+|-
+
+|Payload
+|Packet data
+|12
+|Null terminated string
+|-
+|-
+|===
+
+=== Payload examples
+
+_Only value signal descriptor changed_:
+[source,json]
+{
+    "__type": "EventPacket",
+    "id": "DATA_DESCRIPTOR_CHANGED",
+    "params": {
+        "__type": "Dict",
+        "values": [
+            {
+                "key": "DataDescriptor",
+                "value": {
+                    "__type": "DataDescriptor",
+                    "name": "Domain",
+                    "sampleType": 9,
+                    "dimensions": [],
+                    "rule": {
+                        "__type": "DataRule",
+                        "ruleType": 3,
+                        "params": {
+                            "__type": "Dict",
+                            "values": []
+                        }
+                    },
+                    "origin": "",
+                    "metadata": {
+                        "__type": "Dict",
+                        "values": []
+                    },
+                    "structFields": []
+                }
+            },
+            {
+                "key": "DomainDataDescriptor",
+                "value": null
+            }
+        ]
+    }
+}
+----
+
+_Both descriptors changed_:
+[source,json]
+----
+{
+    "__type": "EventPacket",
+    "id": "DATA_DESCRIPTOR_CHANGED",
+    "params": {
+        "__type": "Dict",
+        "values": [
+            {
+                "key": "DataDescriptor",
+                "value": {
+                    "__type": "DataDescriptor",
+                    "name": "Value",
+                    "sampleType": 2,
+                    "dimensions": [],
+                    "rule": {
+                        "__type": "DataRule",
+                        "ruleType": 3,
+                        "params": {
+                            "__type": "Dict",
+                            "values": []
+                        }
+                    },
+                    "origin": "",
+                    "metadata": {
+                        "__type": "Dict",
+                        "values": []
+                    },
+                    "structFields": []
+                }
+            },
+            {
+                "key": "DomainDataDescriptor",
+                "value": {
+                    "__type": "DataDescriptor",
+                    "name": "Domain",
+                    "sampleType": 9,
+                    "dimensions": [],
+                    "rule": {
+                        "__type": "DataRule",
+                        "ruleType": 3,
+                        "params": {
+                            "__type": "Dict",
+                            "values": []
+                        }
+                    },
+                    "origin": "",
+                    "metadata": {
+                        "__type": "Dict",
+                        "values": []
+                    },
+                    "structFields": []
+                }
+            }
+        ]
+    }
+}
+----
+
+// == Gap packet
+// TODO

--- a/docs/Antora-specs/modules/packet_streaming/pages/examples.adoc
+++ b/docs/Antora-specs/modules/packet_streaming/pages/examples.adoc
@@ -1,0 +1,261 @@
+= Dataflow examples
+
+== Single asynchronous value signal and single domain signal
+
+The following example demonstrates the sequence of packet buffers needed to initialize packet streaming and transmit two samples of an asynchronous value signal.
+
+. _xref:event_packet.adoc#ddc_event_packet[Data descriptor changed event packet] for value signal_
++
+[cols="1,1,2"]
+|===
+|||
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0x0C
+
+|Packet buffer type code
+|0x00 (event)
+
+|Packet streaming protocol version
+|0x00
+
+|xref:format.adoc#flags[Flags]
+|0x00
+
+|Signal numeric ID
+|0x00000001
+
+|Payload size
+|0x0000026B
+
+2+^|Payload
+a|[source,json]
+----
+{
+  "__type": "EventPacket",
+  "id": "DATA_DESCRIPTOR_CHANGED",
+  "params": {
+    "__type": "Dict",
+    "values": [
+      {
+        "key": "DataDescriptor",
+        "value": {
+          "__type": "DataDescriptor",
+          "name": "Value",
+          "sampleType": 2,
+          "dimensions": [],
+          "rule": {
+            "__type": "DataRule",
+            "ruleType": 3,
+            "params": {
+              "__type": "Dict",
+              "values": []
+            }
+          },
+          "origin": "",
+          "metadata": {
+            "__type": "Dict",
+            "values": []
+          },
+          "structFields": []
+        }
+      },
+      {
+        "key": "DomainDataDescriptor",
+        "value": {
+          "__type": "DataDescriptor",
+          "name": "Domain",
+          "sampleType": 9,
+          "dimensions": [],
+          "rule": {
+            "__type": "DataRule",
+            "ruleType": 3,
+            "params": {
+              "__type": "Dict",
+              "values": []
+            }
+          },
+          "origin": "",
+          "metadata": {
+            "__type": "Dict",
+            "values": []
+          },
+          "structFields": []
+        }
+      }
+    ]
+  }
+}
+----
+|===
+
+. _xref:event_packet.adoc#ddc_event_packet[Data descriptor changed event packet] for domain signal_
++
+[cols="1,1,2"]
+|===
+|||
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0x0C
+
+|Packet buffer type code
+|0x00 (event)
+
+|Packet streaming protocol version
+|0x00
+
+|xref:format.adoc#flags[Flags]
+|0x00
+
+|Signal numeric ID
+|0x00000002
+
+|Payload size
+|0x0000018F
+
+2+^|Payload
+a|[source,json]
+----
+{
+  "__type": "EventPacket",
+  "id": "DATA_DESCRIPTOR_CHANGED",
+  "params": {
+    "__type": "Dict",
+    "values": [
+      {
+        "key": "DataDescriptor",
+        "value": {
+          "__type": "DataDescriptor",
+          "name": "Domain",
+          "sampleType": 9,
+          "dimensions": [],
+          "rule": {
+            "__type": "DataRule",
+            "ruleType": 3,
+            "params": {
+              "__type": "Dict",
+              "values": []
+            }
+          },
+          "origin": "",
+          "metadata": {
+            "__type": "Dict",
+            "values": []
+          },
+          "structFields": []
+        }
+      },
+      {
+        "key": "DomainDataDescriptor",
+        "value": null
+      }
+    ]
+  }
+}
+----
+|===
+
+. _Value signal xref:data_packet.adoc[data packet] (with release flag)_
++
+[cols="1,1,2"]
+|===
+|||
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0x2C
+
+|Packet buffer type code
+|0x01 (data)
+
+|Packet streaming protocol version
+|0x00
+
+|xref:format.adoc#flags[Flags]
+|0x01 (Release packet)
+
+|Signal numeric ID
+|0x00000001
+
+|Payload size
+|0x00000010
+
+.4+.^|Extra header
+
+|Packet ID
+|0x0000000000000010
+
+|Domain packet ID
+|0x0000000000000012
+
+|Sample count
+|0x0000000000000002
+
+|Packet offset
+|0x0000000000000000
+
+2+^|Payload
+| 1.445e14, -3.78e-4
+|===
+
+. _Domain signal xref:data_packet.adoc[data packet] explicit without offset (with release flag)_
++
+[cols="1,1,2"]
+|===
+|||
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0x2C
+
+|Packet buffer type code
+|0x01 (data)
+
+|Packet streaming protocol version
+|0x00
+
+|xref:format.adoc#flags[Flags]
+|0x01 (Release packet)
+
+|Signal numeric ID
+|0x00000002
+
+|Payload size
+|0x00000010
+
+.4+.^|Extra header
+
+|Packet ID
+|0x0000000000000012
+
+|Domain packet ID
+|0x0000000000000000
+
+|Sample count
+|0x0000000000000002
+
+|Packet offset
+|0x0000000000000000
+
+2+^|Payload
+|0x0000000000000001,0x0000000000000002
+
+|===
+
+////
+== Two synchronous value signals share single domain signal
+TODO
+
+. xref:event_packet.adoc#ddc_event_packet[Data descriptor changed event packet]
+. 1-st value signal xref:data_packet.adoc[data packet] (without release flag)
+. Domain signal xref:data_packet.adoc[data packet] with offset (without release flag)
+. 2-nd value signal xref:data_packet.adoc[data packet] (without release flag)
+. xref:internal.adoc#already_sent[Already sent packet] for domain packet
+. xref:internal.adoc#release[Packet release]
+////

--- a/docs/Antora-specs/modules/packet_streaming/pages/format.adoc
+++ b/docs/Antora-specs/modules/packet_streaming/pages/format.adoc
@@ -1,0 +1,66 @@
+= Packet buffer format
+
+Every packet buffer produced by server begins with a standard generic header that is 12 bytes in size, and may include an optional extra header and optional payload. 
+The presence of these optional parts varies depending on the type of packet buffer.
+
+The generic header specifies the version number of the streaming protocol. Currently, there is only one version of the protocol, which is identified as version “0”.
+
+[#generic_header]
+== Generic header
+
+|===
+| Bytes group | Start position offset (in bytes) | Value type | Size in bytes
+
+| Header size - including extra header length
+| 0
+| unsigned 8 bit integer
+| 1
+
+| Packet buffer type code
+| 1
+| unsigned 8 bit integer
+| 1
+
+| Packet streaming protocol version
+| 2
+| unsigned 8 bit integer
+| 1
+
+| xref:#flags[Flags]
+| 3
+| unsigned 8 bit integer
+| 1
+
+| Signal numeric ID
+| 4
+| unsigned 32 bit integer
+| 4
+
+| Payload size
+| 8
+| unsigned 32 bit integer
+| 4
+
+|===
+
+[#flags]
+== Packet buffer flags
+
+The generic header contains a 1-byte field with bit flags that determine how to interpret the contents of the packet buffer.
+
+|===
+| Flag bit | Flag bit mask | Flag bit offset
+
+| Packet can be released
+| 0x1
+| 0
+
+| Packet offset is of integer type
+| 0x2
+| 1
+
+| Packet offset is of double type
+| 0x4
+| 2
+
+|===

--- a/docs/Antora-specs/modules/packet_streaming/pages/internal.adoc
+++ b/docs/Antora-specs/modules/packet_streaming/pages/internal.adoc
@@ -1,0 +1,123 @@
+= Protocol internal messages
+
+In addition to packet buffer types representing openDAQ(TM) packets, the protocol also encompasses additional types interpreted as internal protocol messages,
+which may not be associated with a specific signal.
+
+[#release]
+== Packets release
+
+When the server detects that one or more xref:data_packet.adoc[data packets], previously encoded into packet buffers and sent to the client, are no longer referenced by any subsequent data packets,
+it generates a "packets release" internal protocol message. This message includes a xref:format.adoc#generic_header[generic header] and payload containing the IDs of the packets no longer needed.
+It notifies the client that the corresponding packet copies it has recreated are no longer required and can be released.
+
+|===
+||Bytes group |Start position offset (in bytes) |Value type |Size in bytes |Value
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0
+|unsigned 8 bit integer
+|1
+|12
+
+|Packet buffer type code
+|1
+|unsigned 8 bit integer
+|1
+|0x2
+
+|Packet streaming protocol version
+|2
+|unsigned 8 bit integer
+|1
+|-
+
+|xref:format.adoc#flags[Flags]
+|3
+|unsigned 8 bit integer
+|1
+|0x0
+
+|Signal numeric ID
+|4
+|unsigned 32 bit integer
+|4
+|0xFFFFFFFF
+
+|Payload size
+|8
+|unsigned 32 bit integer
+|4
+|-
+
+|Payload
+|IDs of data packets to release
+|12
+|Array of unsigned 64 bit integers
+|-
+|-
+|===
+
+[#already_sent]
+== Already sent packet buffer
+
+A single openDAQ(TM) xref:data_packet.adoc[data packet] can be used/shared by multiple signals. The packet streaming server will only transmit the data packet for the first signal.
+The data packet buffer does not include the “Can release” flag, therefor the client needs to keep/cache the packet buffer for subsequent (already sent) packet buffers.
+Other signals will then send “Already sent” packet buffers to notify the client that it should reuse the cached packet buffer for the new signal.
+
+|===
+||Bytes group |Start position offset (in bytes) |Value type |Size in bytes |Value
+
+.6+.^|xref:format.adoc#generic_header[Generic header]
+
+|Header size
+|0
+|unsigned 8 bit integer
+|1
+|28
+
+|Packet buffer type code
+|1
+|unsigned 8 bit integer
+|1
+|0x3
+
+|Packet streaming protocol version
+|2
+|unsigned 8 bit integer
+|1
+|-
+
+|xref:format.adoc#flags[Flags]
+|3
+|unsigned 8 bit integer
+|1
+|-
+
+|Related signal numeric ID
+|4
+|unsigned 32 bit integer
+|4
+|-
+
+|Payload size
+|8
+|unsigned 32 bit integer
+|4
+|0
+
+.2+.^|Extra header
+
+|Packet ID
+|12
+|unsigned 64 bit integer
+|8
+|-
+
+|Domain packet ID
+|20
+|unsigned 64 bit integer
+|8
+|-
+|===

--- a/docs/Antora-specs/modules/packet_streaming/pages/overview.adoc
+++ b/docs/Antora-specs/modules/packet_streaming/pages/overview.adoc
@@ -1,0 +1,11 @@
+= Overview
+
+The packet streaming protocol is designed to facilitate the encoding of openDAQ(TM) packets carrying measured signal data into a binary format suitable for transmission across various transport protocols,
+such as the xref:native_communication_protocol:introduction.adoc[openDAQ(TM) native communication protocol]
+utilizing WebSocket connections or any other appropriate binary protocol. Packet streaming protocol establishes the rules for decoding from binary format
+back into openDAQ(TM) packets on the receiver's end. Although primarily intended for openDAQ(TM) packets, this protocol can also be adapted to encode other forms of measured data in custom formats into the binary
+format supported by the packet streaming protocol. This binary format is referred to as a "packet buffer" within the protocol context.
+
+Functionally, the packet streaming protocol operates in a simplex mode, where one communication party, designated as the server, generates packet buffers for transmission. 
+These are sent to the other party, known as the client, via an independent transport protocol. The client then decodes these packet buffers back into openDAQ(TM) packets,
+which are subsequently forwarded along the openDAQ(TM) signal path. The protocol is designed under the assumption that only one client can be associated with one server.


### PR DESCRIPTION
## Type of change

- [x] This change requires a documentation update

# Description:

Adds an Antora versions of native protocols specs:
* [Packet streaming protocol](https://blueberrydaq.atlassian.net/wiki/spaces/~640b55549cba7ca0287bc6e0/pages/551288854/Packet+streaming+protocol+specification+draft)
* [Native communication protocol](https://blueberrydaq.atlassian.net/wiki/spaces/~640b55549cba7ca0287bc6e0/pages/544964610/openDAQ+native+communication+protocol+specification+draft)

The specifications are created separately from the user guide