### PR TITLE
Modify discovery capability merge

### DIFF
--- a/bindings/python/opendaq/generated/device/py_device_info.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_info.cpp
@@ -230,4 +230,20 @@ void defineIDeviceInfo(pybind11::module_ m, PyDaqIntf<daq::IDeviceInfo, daq::IPr
         },
         py::return_value_policy::take_ownership,
         "Retrieves the configuration connection information of the server to which the client is connected.");
+    cls.def("has_server_capability",
+        [](daq::IDeviceInfo *object, const std::string& protocolId)
+        {
+            const auto objectPtr = daq::DeviceInfoPtr::Borrow(object);
+            return objectPtr.hasServerCapability(protocolId);
+        },
+        py::arg("protocol_id"),
+        "Checks whether the server capability with a given ID is available.");
+    cls.def("get_server_capability",
+        [](daq::IDeviceInfo *object, const std::string& protocolId)
+        {
+            const auto objectPtr = daq::DeviceInfoPtr::Borrow(object);
+            return objectPtr.getServerCapability(protocolId).detach();
+        },
+        py::arg("protocol_id"),
+        "Gets the server capability with a given ID.");
 }

--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -1,4 +1,9 @@
 21.06.2024
+- [function] IDeviceInfoInternal::hasServerCapability(IString* protocolId, Bool* hasCapability)
++ [function] IDeviceInfo::hasServerCapability(IString* protocolId, Bool* hasCapability)
++ [function] IDeviceInfo::getServerCapability(IString* protocolId, IServerCapability** capability)
+
+21.06.2024
 -m [function] IInstanceBuilder::addDiscoveryService
 +m [function] IInstanceBuilder::addDiscoveryServer
 -m [function] IInstanceBuilder::getDiscoveryServices

--- a/core/opendaq/device/include/opendaq/device_info.h
+++ b/core/opendaq/device/include/opendaq/device_info.h
@@ -265,6 +265,21 @@ DECLARE_OPENDAQ_INTERFACE(IDeviceInfo, IPropertyObject)
      * If the connection to the server is not established, the fields of the server capability object are empty.
      */
     virtual ErrCode INTERFACE_FUNC getConfigurationConnectionInfo(IServerCapability** connectionInfo) = 0;
+
+     /*!
+     * @brief Checks whether the server capability with a given ID is available.
+     * @param protocolId The ID of the server capability protocol.
+     * @param[out] hasCapability True if the protocol is available; False otherwise.
+     */
+    virtual ErrCode INTERFACE_FUNC hasServerCapability(IString* protocolId, Bool* hasCapability) = 0;
+
+    /*!
+     * @brief Gets the server capability with a given ID.
+     * @param protocolId The ID of the server capability protocol.
+     * @param[out] serverCapability The server capability with the given ID.
+     * @retval OPENDAQ_ERR_NOTFOUND if the server capability is not available.
+     */
+    virtual ErrCode INTERFACE_FUNC getServerCapability(IString* protocolId, IServerCapability** serverCapability) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/device/include/opendaq/device_info_impl.h
+++ b/core/opendaq/device/include/opendaq/device_info_impl.h
@@ -103,6 +103,7 @@ public:
     ErrCode INTERFACE_FUNC getServerCapabilities(IList** serverCapabilities) override;
     ErrCode INTERFACE_FUNC clearServerStreamingCapabilities() override;
     ErrCode INTERFACE_FUNC hasServerCapability(IString* protocolId, Bool* hasCapability) override;
+    ErrCode INTERFACE_FUNC getServerCapability(IString* protocolId, IServerCapability** capability) override;
 
     ErrCode INTERFACE_FUNC getConfigurationConnectionInfo(IServerCapability** connectionInfo) override;
 

--- a/core/opendaq/device/include/opendaq/device_info_internal.h
+++ b/core/opendaq/device/include/opendaq/device_info_internal.h
@@ -51,8 +51,6 @@ DECLARE_OPENDAQ_INTERFACE(IDeviceInfoInternal, IBaseObject)
      * @brief Removes all server streaming capabilities from the list of supported capabilities.
      */
     virtual ErrCode INTERFACE_FUNC clearServerStreamingCapabilities() = 0;
-
-    virtual ErrCode INTERFACE_FUNC hasServerCapability(IString* protocolId, Bool* hasCapability) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/device/src/device_info_impl.cpp
+++ b/core/opendaq/device/src/device_info_impl.cpp
@@ -653,6 +653,31 @@ ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::hasServerCapability(ISt
 }
 
 template <typename TInterface, typename ... Interfaces>
+ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::getServerCapability(IString* protocolId, IServerCapability** capability)
+{
+    OPENDAQ_PARAM_NOT_NULL(protocolId);
+    OPENDAQ_PARAM_NOT_NULL(capability);
+
+    Bool hasCap;
+    ErrCode err = this->hasServerCapability(protocolId, &hasCap);
+    if (OPENDAQ_FAILED(err))
+        return err;
+
+    if (!hasCap)
+        return OPENDAQ_ERR_NOTFOUND;
+    
+    BaseObjectPtr obj;
+    StringPtr str = "serverCapabilities";
+    err = this->getPropertyValue(str, &obj);
+    if (OPENDAQ_FAILED(err))
+        return err;
+
+    const auto serverCapabilitiesPtr = obj.asPtr<IPropertyObject>();
+    *capability = serverCapabilitiesPtr.getPropertyValue(protocolId).asPtr<IServerCapability>().detach();
+    return OPENDAQ_SUCCESS;
+}
+
+template <typename TInterface, typename ... Interfaces>
 ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::getServerCapabilities(IList** serverCapabilities)
 {
     OPENDAQ_PARAM_NOT_NULL(serverCapabilities);

--- a/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
@@ -67,6 +67,8 @@ private:
 
     StreamingPtr onCreateStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config);
     StringPtr createConnectionString(const ServerCapabilityPtr& serverCapability);
+    static ServerCapabilityPtr mergeDiscoveryAndDeviceCap(const ServerCapabilityPtr& discoveryCap, const ServerCapabilityPtr& deviceCap);
+
 
     static bool isDefaultAddDeviceConfig(const PropertyObjectPtr& config);
     static PropertyObjectPtr createGeneralConfig();

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -532,7 +532,7 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
                 for (const auto& capability : devicePtr.getInfo().getServerCapabilities())
                 {
                     // assigns missing connection strings for server capabilities
-                    if (capability.getConnectionString() == "" && capability.getConnectionStrings().empty())
+                    if (capability.getConnectionStrings().empty())
                     {
                         auto capConnectionString = createConnectionString(capability);
                         if (capConnectionString.assigned())

--- a/modules/native_streaming_client_module/tests/test_native_streaming_client_module.cpp
+++ b/modules/native_streaming_client_module/tests/test_native_streaming_client_module.cpp
@@ -143,7 +143,7 @@ TEST_F(NativeStreamingClientModuleTest, CreateStreamingConnectionString)
     ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
 
     serverCapability.addAddress("123.123.123.123");
-    ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
+    ASSERT_EQ(module.createConnectionString(serverCapability), "daq.ns://123.123.123.123:7420");
 
     serverCapability.setPort(1234);
     ASSERT_NO_THROW(connectionString = module.createConnectionString(serverCapability));
@@ -165,7 +165,7 @@ TEST_F(NativeStreamingClientModuleTest, CreateDeviceConnectionString)
     ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
 
     serverCapability.addAddress("123.123.123.123");
-    ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
+    ASSERT_EQ(module.createConnectionString(serverCapability), "daq.nd://123.123.123.123:7420");
 
     serverCapability.setPort(1234);
     ASSERT_NO_THROW(connectionString = module.createConnectionString(serverCapability));

--- a/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
+++ b/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
@@ -59,11 +59,12 @@ NativeStreamingServerImpl::~NativeStreamingServerImpl()
     this->context.getOnCoreEvent() -= event(&NativeStreamingServerImpl::coreEventCallback);
     if (this->rootDevice.assigned())
     {
-        const auto info = this->rootDevice.getInfo().asPtr<IDeviceInfoInternal>();
+        const auto info = this->rootDevice.getInfo();
+        const auto infoInternal = info.asPtr<IDeviceInfoInternal>();
         if (info.hasServerCapability("opendaq_native_streaming"))
-            info.removeServerCapability("opendaq_native_streaming");
+            infoInternal.removeServerCapability("opendaq_native_streaming");
         if (info.hasServerCapability("opendaq_native_config"))
-            info.removeServerCapability("opendaq_native_config");
+            infoInternal.removeServerCapability("opendaq_native_config");
     }
 
     stopReading();
@@ -338,11 +339,12 @@ void NativeStreamingServerImpl::onStopServer()
 
     if (this->rootDevice.assigned())
     {
-        const auto info = this->rootDevice.getInfo().asPtr<IDeviceInfoInternal>();
+        const auto info = this->rootDevice.getInfo();
+        const auto infoInternal = info.asPtr<IDeviceInfoInternal>();
         if (info.hasServerCapability("opendaq_native_streaming"))
-            info.removeServerCapability("opendaq_native_streaming");
+            infoInternal.removeServerCapability("opendaq_native_streaming");
         if (info.hasServerCapability("opendaq_native_config"))
-            info.removeServerCapability("opendaq_native_config");
+            infoInternal.removeServerCapability("opendaq_native_config");
     }
 
 }

--- a/modules/opcua_client_module/include/opcua_client_module/opcua_client_module_impl.h
+++ b/modules/opcua_client_module/include/opcua_client_module/opcua_client_module_impl.h
@@ -39,7 +39,7 @@ private:
     StringPtr formConnectionString(const StringPtr& connectionString, const PropertyObjectPtr& config, std::string& host, int& port);
     static DeviceTypePtr createDeviceType();
     static PropertyObjectPtr createDefaultConfig();
-    static void completeDeviceServerCapabilities(const DevicePtr& device, const StringPtr& deviceAddress);
+    static void completeServerCapabilities(const DevicePtr& device, const StringPtr& deviceAddress);
     static PropertyObjectPtr populateDefaultConfig(const PropertyObjectPtr& config);
     discovery::DiscoveryClient discoveryClient;
 

--- a/modules/opcua_client_module/tests/test_opcua_client_module.cpp
+++ b/modules/opcua_client_module/tests/test_opcua_client_module.cpp
@@ -77,7 +77,7 @@ TEST_F(OpcUaClientModuleTest, CreateConnectionString)
     ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
 
     serverCapability.addAddress("123.123.123.123");
-    ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
+    ASSERT_EQ(module.createConnectionString(serverCapability), "daq.opcua://123.123.123.123:4840");
 
     serverCapability.setPort(1234);
     ASSERT_NO_THROW(connectionString = module.createConnectionString(serverCapability));

--- a/modules/opcua_server_module/src/opcua_server_impl.cpp
+++ b/modules/opcua_server_module/src/opcua_server_impl.cpp
@@ -84,9 +84,10 @@ void OpcUaServerImpl::onStopServer()
     server.stop();
     if (this->rootDevice.assigned())
     {
-        const auto info = this->rootDevice.getInfo().asPtr<IDeviceInfoInternal>();
+        const auto info = this->rootDevice.getInfo();
+        const auto infoInternal = info.asPtr<IDeviceInfoInternal>();
         if (info.hasServerCapability("opendaq_opcua_config"))
-            info.removeServerCapability("opendaq_opcua_config");
+            infoInternal.removeServerCapability("opendaq_opcua_config");
     }
 }
 

--- a/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
+++ b/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
@@ -53,6 +53,8 @@ WebsocketStreamingClientModule::WebsocketStreamingClientModule(ContextPtr contex
 
                 cap.setConnectionType("TCP/IP");
                 cap.setPrefix("daq.lt");
+                if (discoveredDevice.servicePort > 0)
+                    cap.setPort(discoveredDevice.servicePort);
                 return cap;
             }
         }, 
@@ -60,6 +62,7 @@ WebsocketStreamingClientModule::WebsocketStreamingClientModule(ContextPtr contex
     )
 {
     discoveryClient.initMdnsClient(List<IString>("_streaming-lt._tcp.local.", "_streaming-ws._tcp.local."));
+    loggerComponent = this->context.getLogger().getOrAddComponent("StreamingLTClient");
 }
 
 ListPtr<IDeviceInfo> WebsocketStreamingClientModule::onGetAvailableDevices()
@@ -194,7 +197,10 @@ StringPtr WebsocketStreamingClientModule::onCreateConnectionString(const ServerC
 
     auto port = serverCapability.getPort();
     if (port == -1)
-        throw InvalidParameterException("Port is not set");
+    {
+        port = 7414;
+        LOG_W("LT Streaming server capability is missing port. Defaulting to 7414.")
+    }
 
     return WebsocketStreamingClientModule::createUrlConnectionString(
         address,

--- a/modules/websocket_streaming_client_module/tests/test_websocket_streaming_client_module.cpp
+++ b/modules/websocket_streaming_client_module/tests/test_websocket_streaming_client_module.cpp
@@ -198,7 +198,7 @@ TEST_F(WebsocketStreamingClientModuleTest, CreateConnectionString)
     ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
 
     serverCapability.addAddress("123.123.123.123");
-    ASSERT_THROW(module.createConnectionString(serverCapability), InvalidParameterException);
+    ASSERT_EQ(module.createConnectionString(serverCapability), "daq.lt://123.123.123.123:7414");
 
     serverCapability.setPort(1234);
     ASSERT_NO_THROW(connectionString = module.createConnectionString(serverCapability));

--- a/shared/libraries/websocket_streaming/src/websocket_streaming_server.cpp
+++ b/shared/libraries/websocket_streaming/src/websocket_streaming_server.cpp
@@ -71,9 +71,10 @@ void WebsocketStreamingServer::stop()
 {
     if (this->device.assigned())
     {
-         const auto info = this->device.getInfo().asPtr<IDeviceInfoInternal>();
+         const auto info = this->device.getInfo();
+         const auto infoInternal = info.asPtr<IDeviceInfoInternal>();
          if (info.hasServerCapability("opendaq_lt_streaming"))
-             info.removeServerCapability("opendaq_lt_streaming");
+             infoInternal.removeServerCapability("opendaq_lt_streaming");
     }
 
     stopInternal();


### PR DESCRIPTION
- Take device caps as source of truth
- Add port to discovery caps
- Fall back to default port if not specified in cap
