### PR TITLE
<TBBAS-1425> Enable streaming for signals of FB added via OpcUa

### DIFF
--- a/examples/python/gui_demo/components/input_port_row_view.py
+++ b/examples/python/gui_demo/components/input_port_row_view.py
@@ -50,8 +50,8 @@ class InputPortRowView(tk.Frame):
         if self.device is not None:
             self.context.update_signals_for_device(self.device)
             self.fill_dropdown()
-        if self.input_port is not None and self.input_port.connection is not None:
-            short_id = self.context.short_id(self.input_port.connection.signal.global_id)
+        if self.input_port is not None and self.input_port.signal is not None:
+            short_id = self.context.short_id(self.input_port.signal.global_id)
             self.input_var.set(short_id)
             self.dropdown.set(short_id)
 

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
@@ -390,6 +390,7 @@ TmsServerFunctionBlockPtr TmsServerDevice::addFunctionBlock(const StringPtr& fbT
     auto functionBlock = object.addFunctionBlock(fbTypeId, config);
     auto tmsFunctionBlock = registerTmsObjectOrAddReference<TmsServerFunctionBlock<>>(fbFolderNodeId, functionBlock, functionBlocks.size());
     functionBlocks.push_back(tmsFunctionBlock);
+    tmsFunctionBlock->createNonhierarchicalReferences();
     return tmsFunctionBlock;
 }
 


### PR DESCRIPTION
# Description:

* link streaming sources available per the device with the signals from added function block
* fix - create non-hierarchical references for added function block
* Python gui app - input port view - retrieve the connected signal directly from input port instead of getting it from connection to bypass OpcUa implementation limitations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


