### PR TITLE
Fix race condition within LT-streaming on signal unsubscribe:

### DIFF
--- a/shared/libraries/websocket_streaming/include/websocket_streaming/output_signal.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/output_signal.h
@@ -68,7 +68,6 @@ protected:
     bool doSetStartTime{false};
     std::mutex subscribedSync;
     daq::streaming_protocol::BaseSignalPtr stream;
-    bool dataWritingAllowed{false};
 
 private:
     void processAttributeChangedCoreEvent(ComponentPtr& component, CoreEventArgsPtr& args);

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_server.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_server.h
@@ -56,7 +56,6 @@ public:
     void onUnsubscribe(const OnUnsubscribeCallback& callback);
     void unicastPacket(const std::string& streamId, const std::string& signalId, const PacketPtr& packet);
     void broadcastPacket(const std::string& signalId, const PacketPtr &packet);
-    void sendPacketToSubscribers(const std::string& signalId, const PacketPtr& packet);
 
 protected:
     using SignalMap = std::unordered_map<std::string, OutputSignalBasePtr>;

--- a/shared/libraries/websocket_streaming/src/streaming_server.cpp
+++ b/shared/libraries/websocket_streaming/src/streaming_server.cpp
@@ -141,19 +141,6 @@ void StreamingServer::broadcastPacket(const std::string& signalId, const PacketP
     }
 }
 
-void StreamingServer::sendPacketToSubscribers(const std::string& signalId, const PacketPtr& packet)
-{
-    for (auto& [_, client] : clients)
-    {
-        auto signals = client.second;
-        if (auto signalIter = signals.find(signalId); signalIter != signals.end())
-        {
-            if (signalIter->second->isSubscribed())
-                signalIter->second->writeDaqPacket(packet);
-        }
-    }
-}
-
 DataRuleType StreamingServer::getSignalRuleType(const SignalPtr& signal)
 {
     auto descriptor = signal.getDescriptor();

--- a/shared/libraries/websocket_streaming/src/websocket_streaming_server.cpp
+++ b/shared/libraries/websocket_streaming/src/websocket_streaming_server.cpp
@@ -56,7 +56,7 @@ void WebsocketStreamingServer::start()
     packetReader.onPacket([this](const SignalPtr& signal, const ListPtr<IPacket>& packets) {
         const auto signalId = signal.getGlobalId();
         for (const auto& packet : packets)
-            streamingServer.sendPacketToSubscribers(signalId, packet);
+            streamingServer.broadcastPacket(signalId, packet);
     });
     packetReader.start();
 

--- a/shared/libraries/websocket_streaming/tests/test_streaming.cpp
+++ b/shared/libraries/websocket_streaming/tests/test_streaming.cpp
@@ -215,14 +215,14 @@ TEST_F(StreamingTest, PacketsCorrectSequence)
                                                                        1,
                                                                        {{2, 2}, {4, 4}, {6, 5}});
 
-    server->sendPacketToSubscribers(testConstantSignal.getGlobalId(), constantValuePacket1);
-    server->sendPacketToSubscribers(testDoubleSignal.getGlobalId(), explicitValuePacket1);
+    server->broadcastPacket(testConstantSignal.getGlobalId(), constantValuePacket1);
+    server->broadcastPacket(testDoubleSignal.getGlobalId(), explicitValuePacket1);
 
     auto domainPacket2 = getNextDomainPacket(sampleCount);
     auto explicitValuePacket2 = DataPacketWithDomain(domainPacket2, testDoubleSignal.getDescriptor(), sampleCount);
     std::memcpy(explicitValuePacket2.getRawData(), data.data(), explicitValuePacket2.getRawDataSize());
 
-    server->sendPacketToSubscribers(testDoubleSignal.getGlobalId(), explicitValuePacket2);
+    server->broadcastPacket(testDoubleSignal.getGlobalId(), explicitValuePacket2);
 
     auto domainPacket3 = getNextDomainPacket(sampleCount);
     auto explicitValuePacket3 = DataPacketWithDomain(domainPacket3, testDoubleSignal.getDescriptor(), sampleCount);
@@ -232,8 +232,8 @@ TEST_F(StreamingTest, PacketsCorrectSequence)
                                                                        sampleCount,
                                                                        1);
 
-    server->sendPacketToSubscribers(testConstantSignal.getGlobalId(), constantValuePacket3);
-    server->sendPacketToSubscribers(testDoubleSignal.getGlobalId(), explicitValuePacket3);
+    server->broadcastPacket(testConstantSignal.getGlobalId(), constantValuePacket3);
+    server->broadcastPacket(testDoubleSignal.getGlobalId(), explicitValuePacket3);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
@@ -321,14 +321,14 @@ TEST_F(StreamingTest, PacketsIncorrectSequence)
                                                                        1,
                                                                        {{2, 2}, {4, 4}, {6, 5}});
 
-    server->sendPacketToSubscribers(testDoubleSignal.getGlobalId(), explicitValuePacket1);
-    server->sendPacketToSubscribers(testConstantSignal.getGlobalId(), constantValuePacket1);
+    server->broadcastPacket(testDoubleSignal.getGlobalId(), explicitValuePacket1);
+    server->broadcastPacket(testConstantSignal.getGlobalId(), constantValuePacket1);
 
     auto domainPacket2 = getNextDomainPacket(sampleCount);
     auto explicitValuePacket2 = DataPacketWithDomain(domainPacket2, testDoubleSignal.getDescriptor(), sampleCount);
     std::memcpy(explicitValuePacket2.getRawData(), data.data(), explicitValuePacket2.getRawDataSize());
 
-    server->sendPacketToSubscribers(testDoubleSignal.getGlobalId(), explicitValuePacket2);
+    server->broadcastPacket(testDoubleSignal.getGlobalId(), explicitValuePacket2);
 
     auto domainPacket3 = getNextDomainPacket(sampleCount);
     auto explicitValuePacket3 = DataPacketWithDomain(domainPacket3, testDoubleSignal.getDescriptor(), sampleCount);
@@ -338,8 +338,8 @@ TEST_F(StreamingTest, PacketsIncorrectSequence)
                                                                        sampleCount,
                                                                        1);
 
-    server->sendPacketToSubscribers(testDoubleSignal.getGlobalId(), explicitValuePacket3);
-    server->sendPacketToSubscribers(testConstantSignal.getGlobalId(), constantValuePacket3);
+    server->broadcastPacket(testDoubleSignal.getGlobalId(), explicitValuePacket3);
+    server->broadcastPacket(testConstantSignal.getGlobalId(), constantValuePacket3);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(250));
 

--- a/shared/libraries/websocket_streaming/tests/test_websocket_client_device.cpp
+++ b/shared/libraries/websocket_streaming/tests/test_websocket_client_device.cpp
@@ -121,7 +121,7 @@ TEST_F(WebsocketClientDeviceTest, SignalWithDomain)
     // Publish signal changes
     auto descriptor = DataDescriptorBuilderCopy(testValueSignal.getDescriptor()).build();
     std::string signalId = testValueSignal.getGlobalId();
-    server->sendPacketToSubscribers(signalId, DataDescriptorChangedEventPacket(descriptor, testValueSignal.getDomainSignal().getDescriptor()));
+    server->broadcastPacket(signalId, DataDescriptorChangedEventPacket(descriptor, testValueSignal.getDomainSignal().getDescriptor()));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(250));
 


### PR DESCRIPTION
* protect concurrent data / meta-data writes vs signal subscribe / unsubscribe operations by the mutex lock

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
