### PR TITLE
Other/fix ci issues

### DIFF
--- a/core/opendaq/logger/include/opendaq/log.h
+++ b/core/opendaq/logger/include/opendaq/log.h
@@ -33,7 +33,7 @@
 /// Plain
 
 #define DAQLOG_PLAIN(loggerComponent, message, level) loggerComponent.logMessage(\
-    daq::SourceLocation{__FILE__, __LINE__, OPENDAQ_CURRENT_FUNCTION}, message, level);
+    daq::SourceLocation{nullptr, 0, nullptr}, message, level);
 
 #if (OPENDAQ_LOG_LEVEL <= OPENDAQ_LOG_LEVEL_TRACE)
     #define DAQLOG_T(loggerComponent, message) DAQLOG_PLAIN(loggerComponent, message, daq::LogLevel::Trace);
@@ -74,7 +74,7 @@
 /// Format
 
 #define DAQLOG_FORMATTED(loggerComponent, message, logLevel, ...)                                    \
-    loggerComponent.logMessage(daq::SourceLocation{__FILE__, __LINE__, OPENDAQ_CURRENT_FUNCTION},    \
+    loggerComponent.logMessage(daq::SourceLocation{nullptr, 0, nullptr},    \
                                fmt::format(FMT_STRING(message), ##__VA_ARGS__).data(),               \
                                logLevel);
 

--- a/docs/tests/test_streaming_config.cpp
+++ b/docs/tests/test_streaming_config.cpp
@@ -132,10 +132,9 @@ TEST_F(StreamingConfigTest, WebsocketStreamingRead)
     double samples[100];
     for (int i = 0; i < 5; ++i)
     {
-        docs_test_helpers::waitForSamplesReady();
         SizeT count = 100;
-        reader.read(samples, &count);
-        ASSERT_GT(count, 0u);
+        reader.read(samples, &count, 10000);
+        ASSERT_EQ(count, 100u);
     }
 }
 
@@ -159,10 +158,9 @@ TEST_F(StreamingConfigTest, NativeStreamingRead)
     double samples[100];
     for (int i = 0; i < 5; ++i)
     {
-        docs_test_helpers::waitForSamplesReady();
         SizeT count = 100;
-        reader.read(samples, &count);
-        ASSERT_GT(count, 0u);
+        reader.read(samples, &count, 10000);
+        ASSERT_EQ(count, 100u);
     }
 }
 

--- a/external/streaming_protocol/CMakeLists.txt
+++ b/external/streaming_protocol/CMakeLists.txt
@@ -8,6 +8,7 @@ opendaq_dependency(
     NAME                streaming_protocol
     REQUIRED_VERSION    1.2.0
     GIT_REPOSITORY      https://github.com/openDAQ/streaming-protocol-lt.git
-    GIT_REF             v1.2.0
+#    GIT_REF             v1.2.0
+    GIT_REF             df10ffc00528b9f3f2a6de84cfda202e8d109087
     EXPECT_TARGET       daq::streaming_protocol
 )

--- a/external/streaming_protocol/CMakeLists.txt
+++ b/external/streaming_protocol/CMakeLists.txt
@@ -6,9 +6,8 @@ endif()
 
 opendaq_dependency(
     NAME                streaming_protocol
-    REQUIRED_VERSION    1.2.0
+    REQUIRED_VERSION    1.2.1
     GIT_REPOSITORY      https://github.com/openDAQ/streaming-protocol-lt.git
-#    GIT_REF             v1.2.0
-    GIT_REF             df10ffc00528b9f3f2a6de84cfda202e8d109087
+    GIT_REF             v1.2.1
     EXPECT_TARGET       daq::streaming_protocol
 )


### PR DESCRIPTION
This PR fixes some of the CI issues:

1.) Logger crashing
---------------------------------
Logger is crashing because when LOG macro is called, it makes a copy of log message and puts into intermediary buffer which is then picked up by a worker thread. However, it also takes a pointer to function name in file name. These are pointers to strings which have global/static lifetime, but only until a module is unloaded. So the scenario for crash is something like something like this: module logs a message -> module unloads -> worker thread tries to log a message -> crash because it accesses a pointer to function name/file name from unloaded module.

The workaround for this is not to take a function name / file name when logging. We anyway do not print those in the logs, or do we?

2.) Flaky tests with thread::sleep
Here we can use our blocking readers. The solution executes faster because it unblocks as soon it has enough data available, on the other hand it waits for a lot more time.

3.) Streaming LT race condition
Fixed in streaming protocol LT repo.

4.) There are more issues :(