### PR TITLE
Remove acceptsConnectionParameters from module

### DIFF
--- a/bindings/python/opendaq/generated/modulemanager/py_module.cpp
+++ b/bindings/python/opendaq/generated/modulemanager/py_module.cpp
@@ -75,14 +75,6 @@ void defineIModule(pybind11::module_ m, PyDaqIntf<daq::IModule, daq::IBaseObject
         },
         py::return_value_policy::take_ownership,
         "Returns a dictionary of known and available device types this module can create.");
-    cls.def("accepts_connection_parameters",
-        [](daq::IModule *object, const std::string& connectionString, daq::IPropertyObject* config)
-        {
-            const auto objectPtr = daq::ModulePtr::Borrow(object);
-            return objectPtr.acceptsConnectionParameters(connectionString, config);
-        },
-        py::arg("connection_string"), py::arg("config") = nullptr,
-        "Checks if connection string can be used to connect to devices supported by this module and if the configuration object provided to this module is valid.");
     cls.def("create_device",
         [](daq::IModule *object, const std::string& connectionString, daq::IComponent* parent, daq::IPropertyObject* config)
         {
@@ -123,14 +115,6 @@ void defineIModule(pybind11::module_ m, PyDaqIntf<daq::IModule, daq::IBaseObject
         },
         py::arg("server_type_id"), py::arg("root_device"), py::arg("config") = nullptr,
         "Creates and returns a server with the specified server type. To prevent cyclic reference, we should not use the Instance instead of rootDevice.");
-    cls.def("accepts_streaming_connection_parameters",
-        [](daq::IModule *object, const std::string& connectionString, daq::IPropertyObject* config)
-        {
-            const auto objectPtr = daq::ModulePtr::Borrow(object);
-            return objectPtr.acceptsStreamingConnectionParameters(connectionString, config);
-        },
-        py::arg("connection_string"), py::arg("config") = nullptr,
-        "Verifies whether the provided connection string and config object can be used to establish a streaming connection supported by this module.");
     cls.def("create_streaming",
         [](daq::IModule *object, const std::string& connectionString, daq::IPropertyObject* config)
         {

--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -1,3 +1,13 @@
+04.07.2024
+Description
+	- Make device connection string prefix mandatory
+	- Remove "accepts connection string" methods from module
+	
+-m [factory] inline DeviceTypePtr DeviceType(const StringPtr& id, const StringPtr& name, const StringPtr& description, const PropertyObjectPtr& defaultConfig = PropertyObject())
++m [factory] inline DeviceTypePtr DeviceType(const StringPtr& id, const StringPtr& name, const StringPtr& description, const StringPtr& prefix, const PropertyObjectPtr& defaultConfig = PropertyObject())
+- [function] IModule::acceptsConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config = nullptr)
+- [function] IModule::acceptsStreamingConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config = nullptr)
+
 21.06.2024
 - [function] IDeviceInfoInternal::hasServerCapability(IString* protocolId, Bool* hasCapability)
 + [function] IDeviceInfo::hasServerCapability(IString* protocolId, Bool* hasCapability)

--- a/core/opendaq/device/include/opendaq/device_type.h
+++ b/core/opendaq/device/include/opendaq/device_type.h
@@ -67,7 +67,8 @@ OPENDAQ_DECLARE_CLASS_FACTORY(
     IString*, id,
     IString*, name,
     IString*, description,
-    IPropertyObject*, defaultConfig
+    IPropertyObject*, defaultConfig,
+    IString*, prefix
 )
 
 /*!@}*/

--- a/core/opendaq/device/include/opendaq/device_type_factory.h
+++ b/core/opendaq/device/include/opendaq/device_type_factory.h
@@ -34,15 +34,17 @@ BEGIN_NAMESPACE_OPENDAQ
  * @param id The unique type ID of the device.
  * @param name The name of the device type.
  * @param description A short description of the device type.
+ * @param prefix The prefix of the connection string used when adding the device (the part before  the "://" delimiter in the connection string)
  * @param defaultConfig The property object, to be cloned and returned, each time user creates default
  * configuration object. This way each instance of the device has its own configuration object.
  */
 inline DeviceTypePtr DeviceType(const StringPtr& id,
                                 const StringPtr& name,
                                 const StringPtr& description,
+                                const StringPtr& prefix,
                                 const PropertyObjectPtr& defaultConfig = PropertyObject())
 {
-    DeviceTypePtr obj(DeviceType_Create(id, name, description, defaultConfig));
+    DeviceTypePtr obj(DeviceType_Create(id, name, description, defaultConfig, prefix));
     return obj;
 }
 

--- a/core/opendaq/device/include/opendaq/device_type_impl.h
+++ b/core/opendaq/device/include/opendaq/device_type_impl.h
@@ -30,7 +30,7 @@ public:
                             const StringPtr& name,
                             const StringPtr& description,
                             const PropertyObjectPtr& defaultConfig,
-                            const StringPtr& prefix = "");
+                            const StringPtr& prefix);
 
     explicit DeviceTypeImpl(const ComponentTypeBuilderPtr& builder);
 

--- a/core/opendaq/device/src/device_type_impl.cpp
+++ b/core/opendaq/device/src/device_type_impl.cpp
@@ -41,7 +41,9 @@ OPENDAQ_DEFINE_CLASS_FACTORY(
     IString*,
     description,
     IPropertyObject*,
-    defaultConfig
+    defaultConfig,
+    IString*,
+    prefix
     )
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -113,13 +113,13 @@ TEST_F(DeviceTest, DefaultProperties)
 TEST_F(DeviceTest, DeviceTypeStructType)
 {
     const auto structType = daq::DeviceTypeStructType();
-    const daq::StructPtr structPtr = daq::DeviceType("id", "name", "desc");
+    const daq::StructPtr structPtr = daq::DeviceType("id", "name", "desc", "prefix");
     ASSERT_EQ(structType, structPtr.getStructType());
 }
 
 TEST_F(DeviceTest, DeviceTypeStructFields)
 {
-    const daq::StructPtr structPtr = daq::DeviceType("id", "name", "desc");
+    const daq::StructPtr structPtr = daq::DeviceType("id", "name", "desc", "prefix");
     ASSERT_EQ(structPtr.get("id"), "id");
     ASSERT_EQ(structPtr.get("name"), "name");
     ASSERT_EQ(structPtr.get("description"), "desc");
@@ -128,7 +128,7 @@ TEST_F(DeviceTest, DeviceTypeStructFields)
 TEST_F(DeviceTest, DeviceTypeStructNames)
 {
     const auto structType = daq::DeviceTypeStructType();
-    const daq::StructPtr structPtr = daq::DeviceType("id", "name", "desc");
+    const daq::StructPtr structPtr = daq::DeviceType("id", "name", "desc", "prefix");
     ASSERT_EQ(structType.getFieldNames(), structPtr.getFieldNames());
 }
 

--- a/core/opendaq/device/tests/test_device_info.cpp
+++ b/core/opendaq/device/tests/test_device_info.cpp
@@ -144,7 +144,7 @@ TEST_F(DeviceInfoTest, SetGetDeviceType)
     DeviceInfoConfigPtr deviceInfoConfig = DeviceInfo("", "");
     DeviceInfoPtr deviceInfo = deviceInfoConfig;
 
-    auto deviceType = DeviceType("test", "", "");
+    auto deviceType = DeviceType("test", "", "", "prefix");
     deviceInfoConfig.setDeviceType(deviceType);
     ASSERT_EQ(deviceInfo.getDeviceType(), deviceType);
     ASSERT_EQ(deviceInfo.getDeviceType().getId(), "test");
@@ -174,7 +174,7 @@ TEST_F(DeviceInfoTest, Freezable)
 
     ASSERT_THROW(deviceInfoConfig.addProperty(StringProperty("test_key", "test_value")), FrozenException);
 
-    auto deviceType = DeviceType("test", "", "");
+    auto deviceType = DeviceType("test", "", "", "prefix");
     ASSERT_THROW(deviceInfoConfig.setDeviceType(deviceType), FrozenException);
 }
 

--- a/core/opendaq/modulemanager/include/opendaq/module.h
+++ b/core/opendaq/modulemanager/include/opendaq/module.h
@@ -78,17 +78,6 @@ DECLARE_OPENDAQ_INTERFACE(IModule, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getAvailableDeviceTypes(IDict** deviceTypes) = 0;
 
     /*!
-     * @brief Checks if connection string can be used to connect to devices supported by this module and if the
-     * configuration object provided to this module is valid.
-     * @param[out] accepted Whether this module supports the @p connectionString and @p config.
-     * @param connectionString Typically a connection string usually has a well known prefix, such as `opc.tcp//`.
-     * Connection strings could simply be devices such as `obsidian` when openDAQ SDK is running on DAQ device hardware.
-     * @param config A configuration object that contains connection parameters in the form of key-value pairs. The configuration
-     * is used and applied when connecting to a device. This method check if provided config object is valid.
-     */
-    virtual ErrCode INTERFACE_FUNC acceptsConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config = nullptr) = 0;
-
-    /*!
      * @brief Creates a device object that can communicate with the device described in the specified connection string.
      * The device object is not automatically added as a sub-device of the caller, but only returned by reference.
      * @param[out] device The device object created to communicate with and control the device.
@@ -133,16 +122,6 @@ DECLARE_OPENDAQ_INTERFACE(IModule, IBaseObject)
      */
     virtual ErrCode INTERFACE_FUNC createServer(IServer** server, IString* serverTypeId, IDevice* rootDevice, IPropertyObject* config = nullptr) = 0;
 
-    /*!
-     * @brief Verifies whether the provided connection string and config object can be used to establish a streaming connection
-     * supported by this module.
-     * @param[out] accepted Whether this module supports the @p connectionString with provided @p config.
-     * @param connectionString Typically a connection string usually has a well known prefix, such as `daq.lt//`.
-     * @param config A config object that contains parameters used to configure a streaming connection.
-     * This object can contain properties like various connection timeouts or other streaming protocol specific settings.
-     * Can be created from its corresponding Streaming type object. In case of a null value, it will use the default configuration.
-     */
-    virtual ErrCode INTERFACE_FUNC acceptsStreamingConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config = nullptr) = 0;
 
     /*!
      * @brief Creates and returns a streaming object using the specified connection string and config object.

--- a/core/opendaq/modulemanager/include/opendaq/module_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_impl.h
@@ -106,24 +106,6 @@ public:
     }
 
     /*!
-     * @brief Checks if connection string can be used to connect to devices supported by this module.
-     * @param connectionString Typically a connection string usually has a well known prefix, such as `opc.tcp//`.
-     * Connection strings could simply be devices such as `obsidian` when openDAQ SDK is running on DAQ device hardware.
-     * @param accepted Whether this module supports the @p connectionString.
-     */
-    ErrCode INTERFACE_FUNC acceptsConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config) override
-    {
-        OPENDAQ_PARAM_NOT_NULL(accepted);
-        OPENDAQ_PARAM_NOT_NULL(connectionString);
-
-        bool accepts;
-        ErrCode errCode = wrapHandlerReturn(this, &Module::onAcceptsConnectionParameters, accepts, connectionString, config);
-
-        *accepted = accepts;
-        return errCode;
-    }
-
-    /*!
      * @brief Creates a device object that can communicate with the device described in the specified connection string.
      * The device object is not automatically added as a sub-device of the caller, but only returned by reference.
      * @param connectionString Describes the connection info of the device to connect to. 
@@ -216,27 +198,6 @@ public:
     }
 
     /*!
-     * @brief Verifies whether the provided connection string and config object can be used to establish a streaming connection
-     * supported by this module.
-     * @param[out] accepted Whether this module supports the @p connectionString with provided @p config.
-     * @param connectionString Typically a connection string usually has a well known prefix, such as `daq.lt//`.
-     * @param config A config object that contains parameters used to configure a streaming connection.
-     * This object can contain properties like various connection timeouts or other streaming protocol specific settings.
-     * Can be created from its corresponding Streaming type object. In case of a null value, it will use the default configuration.
-     */
-    ErrCode INTERFACE_FUNC acceptsStreamingConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config = nullptr) override
-    {
-        OPENDAQ_PARAM_NOT_NULL(accepted);
-        OPENDAQ_PARAM_NOT_NULL(connectionString);
-
-        bool accepts;
-        ErrCode errCode = wrapHandlerReturn(this, &Module::onAcceptsStreamingConnectionParameters, accepts, connectionString, config);
-
-        *accepted = accepts;
-        return errCode;
-    }
-
-    /*!
      * @brief Creates and returns a streaming object using the specified connection string and config object.
      * @param connectionString Typically a connection string usually has a well known prefix, such as `daq.lt//`.
      * @param config A config object that contains parameters used to configure a streaming connection.
@@ -308,19 +269,6 @@ public:
     }
 
     /*!
-     * @brief Checks if connection string can be used to connect to devices supported by this module.
-     * @param connectionString Typically a connection string usually has a well known prefix, such as `opc.tcp//`.
-     * Connection strings could simply be devices such as `obsidian` when openDAQ SDK is running on DAQ device hardware.
-     * @param config A configuration object that contains connection parameters in the form of key-value pairs. The configuration
-     * is used and applied when connecting to a device. This method check if provided config object is valid.
-     * @returns Whether this module supports the @p connectionString and @p config is valid.
-     */
-    virtual bool onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config)
-    {
-        return false;
-    }
-
-    /*!
      * @brief Creates a device object that can communicate with the device described in the specified connection string.
      * The device object is not automatically added as a sub-device of the caller, but only returned by reference.
      * @param connectionString Describes the connection info of the device to connect to.
@@ -371,11 +319,6 @@ public:
     virtual ServerPtr onCreateServer(StringPtr serverType, PropertyObjectPtr serverConfig, DevicePtr rootDevice)
     {
         return nullptr;
-    }
-
-    virtual bool onAcceptsStreamingConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config)
-    {
-        return false;
     }
 
     virtual StreamingPtr onCreateStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config)

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -427,133 +427,96 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
     for (const auto& library : libraries)
     {
         const auto module = library.module;
-        
-        bool accepted{false};
+        const std::string prefix = getPrefixFromConnectionString(connectionStringPtr);
+
+        DictPtr<IString, IDeviceType> types;
+        module->getAvailableDeviceTypes(&types);
+        if (!types.assigned())
+            continue;
+
+        StringPtr id;
+        for (auto const& [typeId, type] : types)
+        {
+            if (type.getConnectionStringPrefix()== prefix)
+            {
+                id = typeId;
+                break;
+            }
+        }
+
+        if (!id.assigned())
+            continue;
+            
         if (isDefaultAddDeviceConfigRes)
         {
-            const std::string prefix = getPrefixFromConnectionString(connectionStringPtr);
-            DictPtr<IString, IDeviceType> types;
-            module->getAvailableDeviceTypes(&types);
-            if (!types.assigned())
-                continue;
-            StringPtr id;
-            for (auto const& [typeId, type] : types)
-            {
-                if (type.getConnectionStringPrefix()== prefix)
-                {
-                    id = typeId;
-                    break;
-                }
-            }
-
-            if (!id.assigned())
-                continue;
-
-            PropertyObjectPtr typeConfig = devConfig.getPropertyValue(id);
-
-            try
-            {
-                accepted = module.acceptsConnectionParameters(connectionStringPtr, typeConfig);
-            }
-            catch (NotImplementedException&)
-            {
-                LOG_I("{}: AcceptsConnectionString not implemented", module.getName())
-                accepted = false;
-            }
-            catch ([[maybe_unused]] const std::exception& e)
-            {
-                LOG_W("{}: AcceptsConnectionString failed: {}", module.getName(), e.what())
-                accepted = false;
-            }
-
-            if (accepted)
-            {
-                devConfig = typeConfig;
-            }
-        }
-        else
-        {
-            try
-            {
-                accepted = module.acceptsConnectionParameters(connectionStringPtr, devConfig);
-            }
-            catch (NotImplementedException&)
-            {
-                LOG_I("{}: AcceptsConnectionString not implemented", module.getName())
-                accepted = false;
-            }
-            catch ([[maybe_unused]] const std::exception& e)
-            {
-                LOG_W("{}: AcceptsConnectionString failed: {}", module.getName(), e.what())
-                accepted = false;
-            }
+            if (devConfig.hasProperty(id))
+                devConfig = devConfig.getPropertyValue(id);
+            else
+                devConfig = nullptr;
         }
 
-        if (accepted)
+        auto errCode = module->createDevice(device, connectionStringPtr, parent, devConfig);
+
+        if (OPENDAQ_FAILED(errCode))
+            return errCode;
+
+        const auto devicePtr = DevicePtr::Borrow(*device);
+        if (devicePtr.assigned() && devicePtr.getInfo().assigned())
         {
-            auto errCode = module->createDevice(device, connectionStringPtr, parent, devConfig);
-
-            if (OPENDAQ_FAILED(errCode))
-                return errCode;
-
-            const auto devicePtr = DevicePtr::Borrow(*device);
-            if (devicePtr.assigned() && devicePtr.getInfo().assigned())
+            const auto connectedDeviceInfo = devicePtr.getInfo();
+            const auto connectedDeviceInfoInternal = connectedDeviceInfo.asPtr<IDeviceInfoInternal>();
+            if (discoveredDeviceInfo.assigned())
             {
-                const auto connectedDeviceInfo = devicePtr.getInfo();
-                const auto connectedDeviceInfoInternal = connectedDeviceInfo.asPtr<IDeviceInfoInternal>();
-                if (discoveredDeviceInfo.assigned())
+                // Replaces the default fields of capabilities retrieved from the config/structure protocol
+                // if a better alternative is available from the discovery results
+                for (const auto& capability : discoveredDeviceInfo.getServerCapabilities())
                 {
-                    // Replaces the default fields of capabilities retrieved from the config/structure protocol
-                    // if a better alternative is available from the discovery results
-                    for (const auto& capability : discoveredDeviceInfo.getServerCapabilities())
+                    const auto capId = capability.getProtocolId();
+                    ServerCapabilityPtr capPtr = capability;
+
+                    if (connectedDeviceInfo.hasServerCapability(capId))
                     {
-                        const auto capId = capability.getProtocolId();
-                        ServerCapabilityPtr capPtr = capability;
-
-                        if (connectedDeviceInfo.hasServerCapability(capId))
+                        try
                         {
-                            try
-                            {
-                                capPtr = mergeDiscoveryAndDeviceCap(capability, connectedDeviceInfo.getServerCapability(capId));
-                            }
-                            catch ([[maybe_unused]] const std::exception& e)
-                            {
-                                capPtr = capability;
-                                LOG_W("{}: Failed to merge discovery and device server capability with ID {}: {}", module.getName(), capId, e.what())
-                            }
-
-                            connectedDeviceInfoInternal.removeServerCapability(capability.getProtocolId());
+                            capPtr = mergeDiscoveryAndDeviceCap(capability, connectedDeviceInfo.getServerCapability(capId));
+                        }
+                        catch ([[maybe_unused]] const std::exception& e)
+                        {
+                            capPtr = capability;
+                            LOG_W("{}: Failed to merge discovery and device server capability with ID {}: {}", module.getName(), capId, e.what())
                         }
 
-                        connectedDeviceInfoInternal.addServerCapability(capPtr);
+                        connectedDeviceInfoInternal.removeServerCapability(capability.getProtocolId());
                     }
-                }
 
-                for (const auto& capability : devicePtr.getInfo().getServerCapabilities())
-                {
-                    // assigns missing connection strings for server capabilities
-                    if (capability.getConnectionStrings().empty())
-                    {
-                        auto capConnectionString = createConnectionString(capability);
-                        if (capConnectionString.assigned())
-                            capability.asPtr<IServerCapabilityConfig>().addConnectionString(capConnectionString);
-                    }
-                }
-
-                // automatically skips streaming connection for local and pseudo (streaming) devices
-                auto mirroredDeviceConfigPtr = devicePtr.asPtrOrNull<IMirroredDeviceConfig>(true);
-                if (mirroredDeviceConfigPtr.assigned())
-                {
-                    errCode = daqTry([this, &mirroredDeviceConfigPtr, &configPtr]
-                        {
-                            configureStreamings(mirroredDeviceConfigPtr, configPtr);
-                            return OPENDAQ_SUCCESS;
-                        });
+                    connectedDeviceInfoInternal.addServerCapability(capPtr);
                 }
             }
 
-            return errCode;
+            for (const auto& capability : devicePtr.getInfo().getServerCapabilities())
+            {
+                // assigns missing connection strings for server capabilities
+                if (capability.getConnectionStrings().empty())
+                {
+                    auto capConnectionString = createConnectionString(capability);
+                    if (capConnectionString.assigned())
+                        capability.asPtr<IServerCapabilityConfig>().addConnectionString(capConnectionString);
+                }
+            }
+
+            // automatically skips streaming connection for local and pseudo (streaming) devices
+            auto mirroredDeviceConfigPtr = devicePtr.asPtrOrNull<IMirroredDeviceConfig>(true);
+            if (mirroredDeviceConfigPtr.assigned())
+            {
+                errCode = daqTry([this, &mirroredDeviceConfigPtr, &configPtr]
+                    {
+                        configureStreamings(mirroredDeviceConfigPtr, configPtr);
+                        return OPENDAQ_SUCCESS;
+                    });
+            }
         }
+
+        return errCode;
     }
 
     return this->makeErrorInfo(
@@ -948,79 +911,42 @@ StreamingPtr ModuleManagerImpl::onCreateStreaming(const StringPtr& connectionStr
     for (const auto& library : libraries)
     {
         const auto module = library.module;
-        bool accepted{false};
+    
+        const std::string prefix = getPrefixFromConnectionString(connectionString);
+        DictPtr<IString, IStreamingType> types;
+        module->getAvailableStreamingTypes(&types);
+        if (!types.assigned())
+            continue;
+
+        StringPtr id;
+        for (auto const& [typeId, type] : types)
+        {
+            if (type.getConnectionStringPrefix()== prefix)
+            {
+                id = typeId;
+                break;
+            }
+        }
+
+        if (!id.assigned())
+            continue;
+
         if (isDefaultAddDeviceConfig(config))
         {
-            const std::string prefix = getPrefixFromConnectionString(connectionString);
-            DictPtr<IString, IStreamingType> types;
-            module->getAvailableStreamingTypes(&types);
-            if (!types.assigned())
-                continue;
-
-            StringPtr id;
-            for (auto const& [typeId, type] : types)
-            {
-                if (type.getConnectionStringPrefix()== prefix)
-                {
-                    id = typeId;
-                    break;
-                }
-            }
-
-            if (!id.assigned())
-                continue;
-
-            PropertyObjectPtr typeConfig = streamingConfig.getPropertyValue(id);
-
-            try
-            {
-                accepted = module.acceptsConnectionParameters(connectionString, typeConfig);
-            }
-            catch (NotImplementedException&)
-            {
-                LOG_I("{}: AcceptsConnectionString not implemented", module.getName())
-                accepted = false;
-            }
-            catch ([[maybe_unused]] const std::exception& e)
-            {
-                LOG_W("{}: AcceptsConnectionString failed: {}", module.getName(), e.what())
-                accepted = false;
-            }
-
-            if (accepted)
-            {
-                streamingConfig = typeConfig;
-            }
-        }
-        else
-        {
-            try
-            {
-                accepted = module.acceptsStreamingConnectionParameters(connectionString, streamingConfig);
-            }
-            catch (const NotImplementedException&)
-            {
-                LOG_D("{}: acceptsStreamingConnectionParameters not implemented", module.getName());
-                accepted = false;
-            }
-            catch (const std::exception& e)
-            {
-                LOG_W("{}: acceptsStreamingConnectionParameters failed: {}", module.getName(), e.what());
-                accepted = false;
-            }
+            if (streamingConfig.hasProperty(id))
+                streamingConfig = streamingConfig.getPropertyValue(id);
+            else
+                streamingConfig = nullptr;
         }
 
-        if (accepted)
+        try
         {
-            try
-            {
-                streaming = module.createStreaming(connectionString, streamingConfig);
-            }
-            catch ([[maybe_unused]] const std::exception& e)
-            {
-                LOG_E("{}: createStreaming failed: {}", module.getName(), e.what())
-                throw e;
-            }
+            streaming = module.createStreaming(connectionString, streamingConfig);
+        }
+        catch ([[maybe_unused]] const std::exception& e)
+        {
+            LOG_E("{}: createStreaming failed: {}", module.getName(), e.what())
+            throw;
         }
     }
 

--- a/core/opendaq/modulemanager/tests/mock/mock_module.cpp
+++ b/core/opendaq/modulemanager/tests/mock/mock_module.cpp
@@ -34,14 +34,6 @@ ErrCode MockModuleImpl::getAvailableDeviceTypes(IDict** deviceTypes)
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode MockModuleImpl::acceptsConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config)
-{
-    OPENDAQ_PARAM_NOT_NULL(accepted);
-
-    *accepted = false;
-    return OPENDAQ_SUCCESS;
-}
-
 ErrCode MockModuleImpl::createDevice(IDevice** device, IString* connectionString, IComponent* parent, IPropertyObject* config)
 {
     return OPENDAQ_ERR_NOTFOUND;
@@ -76,16 +68,6 @@ ErrCode MockModuleImpl::getVersionInfo(IVersionInfo** version)
         return OPENDAQ_ERR_ARGUMENT_NULL;
 
     *version = nullptr;
-    return OPENDAQ_SUCCESS;
-}
-
-ErrCode MockModuleImpl::acceptsStreamingConnectionParameters(Bool* accepted,
-                                                             IString* /*connectionString*/,
-                                                             IPropertyObject* /*config*/)
-{
-    OPENDAQ_PARAM_NOT_NULL(accepted);
-
-    *accepted = false;
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/opendaq/modulemanager/tests/mock/mock_module.h
+++ b/core/opendaq/modulemanager/tests/mock/mock_module.h
@@ -27,7 +27,6 @@ public:
 
     daq::ErrCode INTERFACE_FUNC getAvailableDevices(daq::IList** availableDevices) override;
     daq::ErrCode INTERFACE_FUNC getAvailableDeviceTypes(daq::IDict** deviceTypes) override;
-    daq::ErrCode INTERFACE_FUNC acceptsConnectionParameters(daq::Bool* accepted, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createDevice(daq::IDevice** device, daq::IString* connectionString, daq::IComponent* parent, daq::IPropertyObject* config) override;
 
     daq::ErrCode INTERFACE_FUNC getAvailableFunctionBlockTypes(daq::IDict** functionBlockTypes) override;
@@ -36,7 +35,6 @@ public:
     daq::ErrCode INTERFACE_FUNC getAvailableServerTypes(daq::IDict** serverTypes) override;
     daq::ErrCode INTERFACE_FUNC createServer(daq::IServer** server, daq::IString* serverType, daq::IDevice* rootDevice, daq::IPropertyObject* config) override;
 
-    daq::ErrCode INTERFACE_FUNC acceptsStreamingConnectionParameters(daq::Bool* accepted, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createStreaming(daq::IStreaming** streaming, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createConnectionString(daq::IString** connectionString, daq::IServerCapability* serverCapability) override;
     daq::ErrCode INTERFACE_FUNC getAvailableStreamingTypes(daq::IDict** streamingTypes) override;

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_device_module.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_device_module.h
@@ -30,7 +30,6 @@ public:
 
     daq::ErrCode INTERFACE_FUNC getAvailableDevices(daq::IList** availableDevices) override;
     daq::ErrCode INTERFACE_FUNC getAvailableDeviceTypes(daq::IDict** deviceTypes) override;
-    daq::ErrCode INTERFACE_FUNC acceptsConnectionParameters(daq::Bool* accepted, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createDevice(daq::IDevice** device, daq::IString* connectionString, daq::IComponent* parent, daq::IPropertyObject* config) override;
 
     daq::ErrCode INTERFACE_FUNC getAvailableFunctionBlockTypes(daq::IDict** functionBlockTypes) override;
@@ -39,7 +38,6 @@ public:
     daq::ErrCode INTERFACE_FUNC getAvailableServerTypes(daq::IDict** serverTypes) override;
     daq::ErrCode INTERFACE_FUNC createServer(daq::IServer** server, daq::IString* serverType, daq::IDevice* rootDevice, daq::IPropertyObject* config) override;
 
-    daq::ErrCode INTERFACE_FUNC acceptsStreamingConnectionParameters(daq::Bool* accepted, daq::IString* connectionString, daq::IPropertyObject* /*config*/) override;
     daq::ErrCode INTERFACE_FUNC createStreaming(daq::IStreaming** streaming, daq::IString* connectionString, daq::IPropertyObject* /*config*/) override;
     daq::ErrCode INTERFACE_FUNC getAvailableStreamingTypes(daq::IDict** streamingTypes) override;
 

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb_module.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb_module.h
@@ -31,7 +31,6 @@ public:
 
     daq::ErrCode INTERFACE_FUNC getAvailableDevices(daq::IList** availableDevices) override;
     daq::ErrCode INTERFACE_FUNC getAvailableDeviceTypes(daq::IDict** deviceTypes) override;
-    daq::ErrCode INTERFACE_FUNC acceptsConnectionParameters(daq::Bool* accepted, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createDevice(daq::IDevice** device, daq::IString* connectionString, daq::IComponent* parent, daq::IPropertyObject* config) override;
 
     daq::ErrCode INTERFACE_FUNC getAvailableFunctionBlockTypes(daq::IDict** functionBlockTypes) override;
@@ -40,7 +39,6 @@ public:
     daq::ErrCode INTERFACE_FUNC getAvailableServerTypes(daq::IDict** serverTypes) override;
     daq::ErrCode INTERFACE_FUNC createServer(daq::IServer** server, daq::IString* serverType, daq::IDevice* rootDevice, daq::IPropertyObject* config) override;
 
-    daq::ErrCode INTERFACE_FUNC acceptsStreamingConnectionParameters(daq::Bool* accepted, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createStreaming(daq::IStreaming** streaming, daq::IString* connectionString, daq::IPropertyObject* config) override;
 
     daq::ErrCode INTERFACE_FUNC createConnectionString(daq::IString** connectionString, daq::IServerCapability* serverCapability) override;

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_server_module.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_server_module.h
@@ -31,7 +31,6 @@ public:
 
     daq::ErrCode INTERFACE_FUNC getAvailableDevices(daq::IList** availableDevices) override;
     daq::ErrCode INTERFACE_FUNC getAvailableDeviceTypes(daq::IDict** deviceTypes) override;
-    daq::ErrCode INTERFACE_FUNC acceptsConnectionParameters(daq::Bool * accepted, daq::IString * connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createDevice(daq::IDevice** device, daq::IString* connectionString, daq::IComponent* parentGlobalId, daq::IPropertyObject* config) override;
 
     daq::ErrCode INTERFACE_FUNC getAvailableFunctionBlockTypes(daq::IDict** functionBlockTypes) override;
@@ -40,7 +39,6 @@ public:
     daq::ErrCode INTERFACE_FUNC getAvailableServerTypes(daq::IDict** serverTypes) override;
     daq::ErrCode INTERFACE_FUNC createServer(daq::IServer** server, daq::IString* serverType, daq::IDevice* rootDevice, daq::IPropertyObject* config) override;
 
-    daq::ErrCode INTERFACE_FUNC acceptsStreamingConnectionParameters(daq::Bool* accepted, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC createStreaming(daq::IStreaming** streaming, daq::IString* connectionString, daq::IPropertyObject* config) override;
     daq::ErrCode INTERFACE_FUNC getAvailableStreamingTypes(daq::IDict** streamingTypes) override;
 

--- a/core/opendaq/opendaq/mocks/mock_device_module.cpp
+++ b/core/opendaq/opendaq/mocks/mock_device_module.cpp
@@ -29,12 +29,12 @@ ErrCode MockDeviceModuleImpl::getAvailableDevices(IList** availableDevices)
 {
     ListPtr<IDeviceInfo> availableDevicesPtr = List<IDeviceInfo>();
 
-    auto daqClientDeviceInfo = DeviceInfo("daq_client_device");
-    daqClientDeviceInfo.setDeviceType(DeviceType("daq_client_device", "Client", "Client device"));
+    auto daqClientDeviceInfo = DeviceInfo("daqmock://client_device");
+    daqClientDeviceInfo.setDeviceType(DeviceType("mock_client_device", "Client", "Client device", "daqmock"));
     availableDevicesPtr.pushBack(daqClientDeviceInfo);
 
-    auto mockPhysDeviceInfo = DeviceInfo("mock_phys_device");
-    mockPhysDeviceInfo.setDeviceType(DeviceType("mock_phys_device", "Mock physical device", "Mock"));
+    auto mockPhysDeviceInfo = DeviceInfo("daqmock://phys_device");
+    mockPhysDeviceInfo.setDeviceType(DeviceType("mock_phys_device", "Mock physical device", "Mock", "daqmock"));
     availableDevicesPtr.pushBack(mockPhysDeviceInfo);
 
     *availableDevices = availableDevicesPtr.detach();
@@ -49,21 +49,10 @@ ErrCode MockDeviceModuleImpl::getAvailableDeviceTypes(IDict** deviceTypes)
     mockConfig.addProperty(StringProperty("message", ""));
 
     auto types = Dict<IString, IDeviceType>();
-    types.set("daq_client_device", DeviceType("daq_client_device", "Client", "Client device"));
-    types.set("mock_phys_device", DeviceType("mock_phys_device", "Mock physical device", "Mock", mockConfig));
+    types.set("mock_client_device", DeviceType("mock_client_device", "Client", "Client device", "daqmock"));
+    types.set("mock_phys_device", DeviceType("mock_phys_device", "Mock physical device", "Mock", "daqmock", mockConfig));
 
     *deviceTypes = types.detach();
-    return OPENDAQ_SUCCESS;
-}
-
-ErrCode MockDeviceModuleImpl::acceptsConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* /*config*/)
-{
-    const StringPtr connStr = connectionString;
-
-    *accepted = false;
-    if (connStr == "daq_client_device" || connStr == "mock_phys_device")
-        *accepted = true;
-
     return OPENDAQ_SUCCESS;
 }
 
@@ -73,7 +62,7 @@ ErrCode MockDeviceModuleImpl::createDevice(IDevice** device,
                                            IPropertyObject* config)
 {
     StringPtr connStr = connectionString;
-    if (connStr == "daq_client_device")
+    if (connStr == "daqmock://client_device")
     {
         const ModulePtr deviceModule(MockDeviceModule_Create(ctx));
         const ModulePtr fbModule(MockFunctionBlockModule_Create(ctx));
@@ -85,7 +74,7 @@ ErrCode MockDeviceModuleImpl::createDevice(IDevice** device,
         auto clientDevice = Client(ctx, "client", nullptr, parent);
         *device = clientDevice.detach();
     }
-    else if (connStr == "mock_phys_device")
+    else if (connStr == "daqmock://phys_device")
     {
         std::string id = "mockdev";
         if (cnt != 0)
@@ -133,16 +122,6 @@ ErrCode MockDeviceModuleImpl::getVersionInfo(IVersionInfo** version)
         return OPENDAQ_ERR_ARGUMENT_NULL;
 
     *version = nullptr;
-    return OPENDAQ_SUCCESS;
-}
-
-ErrCode MockDeviceModuleImpl::acceptsStreamingConnectionParameters(Bool* accepted,
-                                                                   IString* /*connectionString*/,
-                                                                   IPropertyObject* /*config*/)
-{
-    OPENDAQ_PARAM_NOT_NULL(accepted);
-
-    *accepted = false;
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/opendaq/opendaq/mocks/mock_fb_module.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb_module.cpp
@@ -40,12 +40,6 @@ ErrCode MockFunctionBlockModuleImpl::getAvailableDeviceTypes(IDict** deviceTypes
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode MockFunctionBlockModuleImpl::acceptsConnectionParameters(Bool* accepted, IString* /*connectionString*/, IPropertyObject* /*config*/)
-{
-    *accepted = false;
-    return OPENDAQ_SUCCESS;
-}
-
 ErrCode MockFunctionBlockModuleImpl::createDevice(IDevice** device,
                                                   IString* /*connectionString*/,
                                                   IComponent* /*parent*/,
@@ -110,16 +104,6 @@ ErrCode MockFunctionBlockModuleImpl::getVersionInfo(IVersionInfo** version)
         return OPENDAQ_ERR_ARGUMENT_NULL;
 
     *version = nullptr;
-    return OPENDAQ_SUCCESS;
-}
-
-ErrCode MockFunctionBlockModuleImpl::acceptsStreamingConnectionParameters(Bool* accepted,
-                                                                          IString* /*connectionString*/,
-                                                                          IPropertyObject* /*config*/)
-{
-    OPENDAQ_PARAM_NOT_NULL(accepted);
-
-    *accepted = false;
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/opendaq/opendaq/mocks/mock_server_module.cpp
+++ b/core/opendaq/opendaq/mocks/mock_server_module.cpp
@@ -41,12 +41,6 @@ ErrCode MockServerModuleImpl::getAvailableDeviceTypes(IDict** deviceTypes)
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode MockServerModuleImpl::acceptsConnectionParameters(Bool* accepted, IString* /*connectionString*/, IPropertyObject* /*config*/)
-{
-    *accepted = false;
-    return OPENDAQ_SUCCESS;
-}
-
 ErrCode MockServerModuleImpl::createDevice(IDevice** device,
                                            IString* /*connectionString*/,
                                            IComponent* /*parent*/,
@@ -108,16 +102,6 @@ ErrCode MockServerModuleImpl::getVersionInfo(IVersionInfo** version)
         return OPENDAQ_ERR_ARGUMENT_NULL;
 
     *version = nullptr;
-    return OPENDAQ_SUCCESS;
-}
-
-ErrCode MockServerModuleImpl::acceptsStreamingConnectionParameters(Bool* accepted,
-                                                                   IString* /*connectionString*/,
-                                                                   IPropertyObject* /*config*/)
-{
-    OPENDAQ_PARAM_NOT_NULL(accepted);
-
-    *accepted = false;
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/opendaq/opendaq/tests/test_access_control.cpp
+++ b/core/opendaq/opendaq/tests/test_access_control.cpp
@@ -36,7 +36,7 @@ public:
         moduleManager.addModule(fbModule);
 
         auto instance = InstanceCustom(context, "localInstance");
-        instance.addDevice("mock_phys_device");
+        instance.addDevice("daqmock://phys_device");
         instance.addFunctionBlock("mock_fb_uid");
 
         return instance;

--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -39,7 +39,7 @@ public:
         moduleManager.addModule(fbModule);
 
         instance = InstanceCustom(context, "test");
-        instance.addDevice("mock_phys_device");
+        instance.addDevice("daqmock://phys_device");
         instance.addFunctionBlock("mock_fb_uid");
     }
 
@@ -806,18 +806,18 @@ TEST_F(CoreEventTest, DeviceAdded)
             addCount++;
         };
 
-    instance.addDevice("mock_phys_device");
-    instance.addDevice("mock_phys_device");
-    instance.addDevice("mock_phys_device");
+    instance.addDevice("daqmock://phys_device");
+    instance.addDevice("daqmock://phys_device");
+    instance.addDevice("daqmock://phys_device");
 
     ASSERT_EQ(addCount, 3);
 }
 
 TEST_F(CoreEventTest, DeviceRemoved)
 {
-    const auto dev1 = instance.addDevice("mock_phys_device");
-    const auto dev2 = instance.addDevice("mock_phys_device");
-    const auto dev3 = instance.addDevice("mock_phys_device");
+    const auto dev1 = instance.addDevice("daqmock://phys_device");
+    const auto dev2 = instance.addDevice("daqmock://phys_device");
+    const auto dev3 = instance.addDevice("daqmock://phys_device");
 
     int removeCount = 0;
     getOnCoreEvent() +=
@@ -848,11 +848,11 @@ TEST_F(CoreEventTest, DeviceAddedRemovedMuted)
             callCount++;
         };
 
-    const auto dev1 = instance.addDevice("mock_phys_device");
-    const auto dev2 = instance.addDevice("mock_phys_device");
+    const auto dev1 = instance.addDevice("daqmock://phys_device");
+    const auto dev2 = instance.addDevice("daqmock://phys_device");
     
     instance.getRootDevice().asPtr<IPropertyObjectInternal>().enableCoreEventTrigger();
-    const auto dev3 = instance.addDevice("mock_phys_device");
+    const auto dev3 = instance.addDevice("daqmock://phys_device");
     instance.getRootDevice().asPtr<IPropertyObjectInternal>().disableCoreEventTrigger();
 
     instance.removeDevice(dev1);

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -49,7 +49,7 @@ TEST_F(InstanceTest, GetSetRootDevice)
 {
     auto instance = test_helpers::setupInstance();
     ASSERT_EQ(instance.getRootDevice().getInfo().getName(), String("openDAQ Client"));
-    instance.setRootDevice("daq_client_device");
+    instance.setRootDevice("daqmock://client_device");
 }
 
 TEST_F(InstanceTest, SetRootDeviceWithConfig)
@@ -60,7 +60,7 @@ TEST_F(InstanceTest, SetRootDeviceWithConfig)
     auto config = deviceTypes.get("mock_phys_device").createDefaultConfig();
     config.setPropertyValue("message", "Hello from config.");
 
-    ASSERT_NO_THROW(instance.setRootDevice("mock_phys_device", config));
+    ASSERT_NO_THROW(instance.setRootDevice("daqmock://phys_device", config));
 
     auto rootDevice = instance.getRootDevice();
     ASSERT_TRUE(rootDevice.hasProperty("message"));
@@ -71,7 +71,7 @@ TEST_F(InstanceTest, RootDeviceWithModuleFunctionBlocks)
 {
     auto instance = test_helpers::setupInstance();
     ASSERT_EQ(instance.getRootDevice().getInfo().getName(), String("openDAQ Client"));
-    instance.setRootDevice("mock_phys_device");
+    instance.setRootDevice("daqmock://phys_device");
 
     auto fbs = instance.getFunctionBlocks();
     ASSERT_EQ(fbs.getCount(), 0u);
@@ -95,7 +95,7 @@ TEST_F(InstanceTest, RootDeviceWithModuleFunctionBlocks)
     fbs = instance.getFunctionBlocks();
     ASSERT_EQ(fbs.getCount(), 0u);
 
-    ASSERT_THROW(instance.setRootDevice("mock_phys_device"), InvalidStateException);
+    ASSERT_THROW(instance.setRootDevice("daqmock://phys_device"), InvalidStateException);
 
 }
 
@@ -128,9 +128,9 @@ TEST_F(InstanceTest, EnumerateDeviceTypes)
     auto deviceTypes = instance.getAvailableDeviceTypes();
     ASSERT_EQ(deviceTypes.getCount(), 2u);
 
-    ASSERT_TRUE(deviceTypes.hasKey("daq_client_device"));
-    auto mockDevice = deviceTypes.get("daq_client_device");
-    ASSERT_EQ(mockDevice.getId(), "daq_client_device");
+    ASSERT_TRUE(deviceTypes.hasKey("mock_client_device"));
+    auto mockDevice = deviceTypes.get("mock_client_device");
+    ASSERT_EQ(mockDevice.getId(), "mock_client_device");
 
     ASSERT_TRUE(deviceTypes.hasKey("mock_phys_device"));
     mockDevice = deviceTypes.get("mock_phys_device");
@@ -144,7 +144,7 @@ TEST_F(InstanceTest, AddDevice)
     ASSERT_EQ(availableDevices.getCount(), 2u);
 
     for (const auto& deviceInfo : availableDevices)
-        if (deviceInfo.getConnectionString() != "daq_client_device")
+        if (deviceInfo.getConnectionString() != "daqmock://client_device")
             instance.addDevice(deviceInfo.getConnectionString());
 
     ASSERT_EQ(instance.getDevices().getCount(), 1u);
@@ -157,7 +157,7 @@ TEST_F(InstanceTest, RemoveDevice)
     ASSERT_EQ(availableDevices.getCount(), 2u);
 
     for (const auto& deviceInfo : availableDevices)
-        if (deviceInfo.getConnectionString() != "daq_client_device")
+        if (deviceInfo.getConnectionString() != "daqmock://client_device")
             instance.addDevice(deviceInfo.getConnectionString());
 
     const auto devices = instance.getDevices();
@@ -173,12 +173,12 @@ TEST_F(InstanceTest, AddNested)
 {
     auto instance = test_helpers::setupInstance();
     auto availableDevices = instance.getAvailableDevices();
-    ASSERT_EQ(availableDevices[0].getConnectionString(), "daq_client_device");
+    ASSERT_EQ(availableDevices[0].getConnectionString(), "daqmock://client_device");
 
     DevicePtr device1, device2, device3;
-    ASSERT_NO_THROW(device1 = instance.addDevice("mock_phys_device"));
-    ASSERT_NO_THROW(device2 = device1.addDevice("mock_phys_device"));
-    ASSERT_NO_THROW(device3 = device2.addDevice("mock_phys_device"));
+    ASSERT_NO_THROW(device1 = instance.addDevice("daqmock://phys_device"));
+    ASSERT_NO_THROW(device2 = device1.addDevice("daqmock://phys_device"));
+    ASSERT_NO_THROW(device3 = device2.addDevice("daqmock://phys_device"));
 }
 
 TEST_F(InstanceTest, AddFunctionBlock)
@@ -241,9 +241,9 @@ TEST_F(InstanceTest, GetChannels)
 {
     auto instance = test_helpers::setupInstance();
     auto availableDevices = instance.getAvailableDevices();
-    ASSERT_EQ(availableDevices[1].getConnectionString(), "mock_phys_device");
+    ASSERT_EQ(availableDevices[1].getConnectionString(), "daqmock://phys_device");
 
-    auto device = instance.addDevice("mock_phys_device");
+    auto device = instance.addDevice("daqmock://phys_device");
     ASSERT_EQ(device.getChannels().getCount(), 4u);
 }
 
@@ -340,7 +340,7 @@ TEST_F(InstanceTest, Serialize)
     ASSERT_EQ(availableDevices.getCount(), 2u);
 
     for (const auto& deviceInfo : availableDevices)
-        if (deviceInfo.getConnectionString() != "daq_client_device")
+        if (deviceInfo.getConnectionString() != "daqmock://client_device")
             instance.addDevice(deviceInfo.getConnectionString());
 
     auto serializer = JsonSerializer(True);
@@ -414,7 +414,7 @@ TEST_F(InstanceTest, InstanceBuilderSetContext)
     ASSERT_EQ(instance.getContext().getLogger(), logger);
     ASSERT_EQ(instance.getContext().getScheduler(), context.getScheduler());
     ASSERT_EQ(instance.getContext().getAuthenticationProvider(), authenticationProvider);
-    ASSERT_NO_THROW(instance.addDevice("mock_phys_device"));
+    ASSERT_NO_THROW(instance.addDevice("daqmock://phys_device"));
 }
 
 TEST_F(InstanceTest, InstanceBuilderRootDeviceConfig)
@@ -428,7 +428,7 @@ TEST_F(InstanceTest, InstanceBuilderRootDeviceConfig)
     const ModulePtr deviceModule(MockDeviceModule_Create(context));
     moduleManager.addModule(deviceModule);
 
-    auto instance = InstanceBuilder().setContext(context).setRootDevice("mock_phys_device", config).build();
+    auto instance = InstanceBuilder().setContext(context).setRootDevice("daqmock://phys_device", config).build();
 
     auto rootDevice = instance.getRootDevice();
     ASSERT_TRUE(rootDevice.hasProperty("message"));
@@ -499,7 +499,7 @@ TEST_F(InstanceTest, InstanceBuilderGetDefault)
     const ModulePtr deviceModule(MockDeviceModule_Create(instance.getContext()));
     moduleManager.addModule(deviceModule);
 
-    instance.setRootDevice("mock_phys_device");
+    instance.setRootDevice("daqmock://phys_device");
     ASSERT_TRUE(instance.getRootDevice().assigned());
     ASSERT_EQ(instance.getRootDevice().getName(), "MockPhysicalDevice");
 }

--- a/modules/audio_device_module/include/audio_device_module/audio_device_module_impl.h
+++ b/modules/audio_device_module/include/audio_device_module/audio_device_module_impl.h
@@ -30,7 +30,6 @@ public:
     ListPtr<IDeviceInfo> onGetAvailableDevices() override;
     DictPtr<IString, IDeviceType> onGetAvailableDeviceTypes() override;
     DevicePtr onCreateDevice(const StringPtr& connectionString, const ComponentPtr& parent, const PropertyObjectPtr& config) override;
-    bool onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
 
     DictPtr<IString, IFunctionBlockType> onGetAvailableFunctionBlockTypes() override;
     FunctionBlockPtr onCreateFunctionBlock(const StringPtr& id, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config) override;

--- a/modules/audio_device_module/src/audio_device_impl.cpp
+++ b/modules/audio_device_module/src/audio_device_impl.cpp
@@ -257,7 +257,7 @@ std::string AudioDeviceImpl::getConnectionStringFromId(ma_backend backend, ma_de
 
 DeviceTypePtr AudioDeviceImpl::createType()
 {
-    return DeviceType("miniaudio", "Audio device", "");
+    return DeviceType("miniaudio", "Audio device", "", "miniaudio");
 }
 
 ma_device_id AudioDeviceImpl::getIdFromConnectionString(std::string connectionString)

--- a/modules/audio_device_module/src/audio_device_module_impl.cpp
+++ b/modules/audio_device_module/src/audio_device_module_impl.cpp
@@ -80,14 +80,6 @@ DevicePtr AudioDeviceModule::onCreateDevice(const StringPtr& connectionString,
     return devicePtr;
 }
 
-bool AudioDeviceModule::onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& /*config*/)
-{
-    LOG_T("Connection string: {}", connectionString);
-    std::string connStr = connectionString;
-    auto found = connStr.find("miniaudio://");
-    return (found == 0);
-}
-
 DictPtr<IString, IFunctionBlockType> AudioDeviceModule::onGetAvailableFunctionBlockTypes()
 {
     auto types = Dict<IString, IFunctionBlockType>();

--- a/modules/audio_device_module/tests/test_audio_device_module.cpp
+++ b/modules/audio_device_module/tests/test_audio_device_module.cpp
@@ -58,37 +58,6 @@ TEST_F(AudioDeviceModuleTest, EnumerateDevices)
     ASSERT_NO_THROW(deviceInfo = module.getAvailableDevices());
 }
 
-TEST_F(AudioDeviceModuleTest, AcceptsConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(AudioDeviceModuleTest, AcceptsConnectionStringEmpty)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters(""));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(AudioDeviceModuleTest, AcceptsConnectionStringInvalid)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters("drfrfgt"));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(AudioDeviceModuleTest, AcceptsConnectionStringCorrect)
-{
-    auto module = CreateModule();
-
-    ASSERT_TRUE(module.acceptsConnectionParameters("miniaudio://wasapi/...."));
-}
-
 TEST_F(AudioDeviceModuleTest, CreateDeviceConnectionStringNull)
 {
     auto module = CreateModule();

--- a/modules/empty_module/tests/test_empty_module.cpp
+++ b/modules/empty_module/tests/test_empty_module.cpp
@@ -58,21 +58,6 @@ TEST_F(EmptyModuleTest, EnumerateDevices)
     ASSERT_EQ(deviceInfo.getCount(), static_cast<SizeT>(0));
 }
 
-TEST_F(EmptyModuleTest, AcceptsConnectionStringNull)
-{
-    auto module = createModule();
-    ASSERT_THROW(module.acceptsConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(EmptyModuleTest, AcceptsConnectionStringEmpty)
-{
-    auto module = createModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters(""));
-    ASSERT_FALSE(accepts);
-}
-
 TEST_F(EmptyModuleTest, CreateDeviceConnectionStringNull)
 {
     auto module = createModule();

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_client_module_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_client_module_impl.h
@@ -36,8 +36,6 @@ public:
     DevicePtr onCreateDevice(const StringPtr& deviceConnectionString,
                              const ComponentPtr& parent,
                              const PropertyObjectPtr& config) override;
-    bool onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
-    bool onAcceptsStreamingConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
     StreamingPtr onCreateStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
     StringPtr onCreateConnectionString(const ServerCapabilityPtr& serverCapability) override;
 
@@ -81,6 +79,8 @@ private:
                                  const StringPtr& port,
                                  const StringPtr& path);
     PropertyObjectPtr createConnectionDefaultConfig();
+    bool acceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config);
+    bool acceptsStreamingConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config);
     void populateTransportLayerConfigFromContext(PropertyObjectPtr transportLayerConfig);
     PropertyObjectPtr populateDefaultConfig(const PropertyObjectPtr& config);
     PropertyObjectPtr createTransportLayerDefaultConfig();

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -335,7 +335,7 @@ DevicePtr NativeStreamingClientModule::onCreateDevice(const StringPtr& connectio
     else
         deviceConfig = populateDefaultConfig(config);
 
-    if (!onAcceptsConnectionParameters(connectionString, deviceConfig))
+    if (!acceptsConnectionParameters(connectionString, deviceConfig))
         throw InvalidParameterException();
 
     if (!context.assigned())
@@ -428,7 +428,7 @@ PropertyObjectPtr NativeStreamingClientModule::createConnectionDefaultConfig()
     return defaultConfig;
 }
 
-bool NativeStreamingClientModule::onAcceptsConnectionParameters(const StringPtr& connectionString,
+bool NativeStreamingClientModule::acceptsConnectionParameters(const StringPtr& connectionString,
                                                                 const PropertyObjectPtr& config)
 {
     auto pseudoDevicePrefixFound = connectionStringHasPrefix(connectionString, NativeStreamingDevicePrefix);
@@ -450,8 +450,8 @@ bool NativeStreamingClientModule::onAcceptsConnectionParameters(const StringPtr&
     }
 }
 
-bool NativeStreamingClientModule::onAcceptsStreamingConnectionParameters(const StringPtr& connectionString,
-                                                                   const PropertyObjectPtr& config)
+bool NativeStreamingClientModule::acceptsStreamingConnectionParameters(const StringPtr& connectionString,
+                                                                       const PropertyObjectPtr& /*config*/)
 {
     if (connectionString.assigned() && connectionString != "")
     {
@@ -526,10 +526,10 @@ StreamingPtr NativeStreamingClientModule::createNativeStreaming(const StringPtr&
 StreamingPtr NativeStreamingClientModule::onCreateStreaming(const StringPtr& connectionString,
                                                             const PropertyObjectPtr& config)
 {
-    if (!onAcceptsStreamingConnectionParameters(connectionString, config))
+    if (!acceptsStreamingConnectionParameters(connectionString, config))
         throw InvalidParameterException();
-    PropertyObjectPtr transportLayerConfig;
 
+    PropertyObjectPtr transportLayerConfig;
     PropertyObjectPtr parsedConfig;
     if (config.assigned())
     {

--- a/modules/native_streaming_client_module/tests/test_native_streaming_client_module.cpp
+++ b/modules/native_streaming_client_module/tests/test_native_streaming_client_module.cpp
@@ -61,22 +61,6 @@ TEST_F(NativeStreamingClientModuleTest, EnumerateDevices)
     ASSERT_NO_THROW(deviceInfo = module.getAvailableDevices());
 }
 
-TEST_F(NativeStreamingClientModuleTest, AcceptsConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(NativeStreamingClientModuleTest, AcceptsConnectionStringCorrect)
-{
-    auto module = CreateModule();
-
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.ns://device8"));
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.nd://device8"));
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.nd://[::1]"));
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.nd://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"));
-}
-
 TEST_F(NativeStreamingClientModuleTest, CreateDeviceConnectionStringNull)
 {
     auto module = CreateModule();
@@ -91,25 +75,6 @@ TEST_F(NativeStreamingClientModuleTest, CreateDeviceConnectionFailed)
 
     ASSERT_THROW(module.createDevice("daq.ns://127.0.0.1", nullptr), NotFoundException);
     ASSERT_THROW(module.createDevice("daq.nd://127.0.0.1", nullptr), NotFoundException);
-}
-
-TEST_F(NativeStreamingClientModuleTest, AcceptsStreamingConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsStreamingConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(NativeStreamingClientModuleTest, AcceptsStreamingConnectionStringEmpty)
-{
-    auto module = CreateModule();
-    ASSERT_FALSE(module.acceptsStreamingConnectionParameters(""));
-}
-
-TEST_F(NativeStreamingClientModuleTest, AcceptsStreamingConnectionStringCorrect)
-{
-    auto module = CreateModule();
-
-    ASSERT_TRUE(module.acceptsStreamingConnectionParameters("daq.ns://host"));
 }
 
 TEST_F(NativeStreamingClientModuleTest, CreateStreamingWithNullArguments)
@@ -208,38 +173,16 @@ TEST_F(NativeStreamingClientModuleTest, DefaultDeviceConfig)
     ASSERT_TRUE(deviceTypes.hasKey("opendaq_native_config"));
     auto deviceConfig = deviceTypes.get("opendaq_native_config").createDefaultConfig();
     ASSERT_TRUE(deviceConfig.assigned());
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.nd://address", deviceConfig));
 
     ASSERT_TRUE(deviceTypes.hasKey("opendaq_native_streaming"));
     auto pseudoDeviceConfig = deviceTypes.get("opendaq_native_streaming").createDefaultConfig();
     ASSERT_TRUE(pseudoDeviceConfig.assigned());
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.ns://address", pseudoDeviceConfig));
-}
-
-TEST_F(NativeStreamingClientModuleTest, InvalidDeviceConfig)
-{
-    auto module = CreateModule();
-    auto config = PropertyObject();
-
-    ASSERT_FALSE(module.acceptsConnectionParameters("daq.nd://device8", config));
-    ASSERT_FALSE(module.acceptsConnectionParameters("daq.ns://device8", config));
 }
 
 class ConnectionStringTest : public NativeStreamingClientModuleTest,
                              public testing::WithParamInterface<StringPtr>
 {
 };
-
-TEST_P(ConnectionStringTest, ConnectionStringNotAccepted)
-{
-    auto module = CreateModule();
-
-    StringPtr connectionString = GetParam();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters(connectionString));
-    ASSERT_FALSE(accepts);
-}
 
 TEST_P(ConnectionStringTest, CreateDeviceWrongConnectionString)
 {
@@ -248,17 +191,6 @@ TEST_P(ConnectionStringTest, CreateDeviceWrongConnectionString)
     StringPtr connectionString = GetParam();
 
     ASSERT_THROW(module.createDevice(connectionString, nullptr), InvalidParameterException);
-}
-
-TEST_P(ConnectionStringTest, StreamingConnectionStringNotAccepted)
-{
-    auto module = CreateModule();
-
-    StringPtr connectionString = GetParam();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsStreamingConnectionParameters(connectionString));
-    ASSERT_FALSE(accepts);
 }
 
 TEST_P(ConnectionStringTest, CreateStreamingWrongConnectionString)

--- a/modules/opcua_client_module/include/opcua_client_module/opcua_client_module_impl.h
+++ b/modules/opcua_client_module/include/opcua_client_module/opcua_client_module_impl.h
@@ -32,7 +32,7 @@ public:
     DevicePtr onCreateDevice(const StringPtr& connectionString,
                              const ComponentPtr& parent,
                              const PropertyObjectPtr& config) override;
-    bool onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
+    bool acceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config);
     StringPtr onCreateConnectionString(const ServerCapabilityPtr& serverCapability) override;
 
 private:

--- a/modules/opcua_client_module/src/opcua_client_module_impl.cpp
+++ b/modules/opcua_client_module/src/opcua_client_module_impl.cpp
@@ -98,7 +98,7 @@ DevicePtr OpcUaClientModule::onCreateDevice(const StringPtr& connectionString,
     else
         config = populateDefaultConfig(config);
 
-    if (!onAcceptsConnectionParameters(connectionString, config))
+    if (!acceptsConnectionParameters(connectionString, config))
         throw InvalidParameterException();
 
     if (!context.assigned())
@@ -209,7 +209,7 @@ StringPtr OpcUaClientModule::formConnectionString(const StringPtr& connectionStr
     return OpcUaScheme + host + ":" + std::to_string(port) + "/" + path;
 }
 
-bool OpcUaClientModule::onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config)
+bool OpcUaClientModule::acceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config)
 {
     std::string connStr = connectionString;
     auto found = connStr.find(DaqOpcUaDevicePrefix);

--- a/modules/opcua_client_module/tests/test_opcua_client_module.cpp
+++ b/modules/opcua_client_module/tests/test_opcua_client_module.cpp
@@ -84,39 +84,6 @@ TEST_F(OpcUaClientModuleTest, CreateConnectionString)
     ASSERT_EQ(connectionString, "daq.opcua://123.123.123.123:1234");
 }
 
-TEST_F(OpcUaClientModuleTest, AcceptsConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(OpcUaClientModuleTest, AcceptsConnectionStringEmpty)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters(""));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(OpcUaClientModuleTest, AcceptsConnectionStringInvalid)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters("drfrfgt"));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(OpcUaClientModuleTest, AcceptsConnectionStringCorrect)
-{
-    auto module = CreateModule();
-
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.opcua://device8"));
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.opcua://[::1]"));
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.opcua://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"));
-}
-
 TEST_F(OpcUaClientModuleTest, CreateDeviceConnectionStringNull)
 {
     auto module = CreateModule();

--- a/modules/ref_device_module/include/ref_device_module/ref_device_module_impl.h
+++ b/modules/ref_device_module/include/ref_device_module/ref_device_module_impl.h
@@ -28,7 +28,6 @@ public:
     ListPtr<IDeviceInfo> onGetAvailableDevices() override;
     DictPtr<IString, IDeviceType> onGetAvailableDeviceTypes() override;
     DevicePtr onCreateDevice(const StringPtr& connectionString, const ComponentPtr& parent, const PropertyObjectPtr& config) override;
-    bool onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
 
 private:
     std::vector<WeakRefPtr<IDevice>> devices;

--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -75,7 +75,8 @@ DeviceTypePtr RefDeviceImpl::CreateType()
 {
     return DeviceType("daqref",
                       "Reference device",
-                      "Reference device");
+                      "Reference device",
+                      "daqref");
 }
 
 DeviceInfoPtr RefDeviceImpl::onGetInfo()

--- a/modules/ref_device_module/src/ref_device_module_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_module_impl.cpp
@@ -110,14 +110,6 @@ DevicePtr RefDeviceModule::onCreateDevice(const StringPtr& connectionString,
     return devicePtr;
 }
 
-bool RefDeviceModule::onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& /*config*/)
-{
-    LOG_T("Connection string: {}", connectionString);
-    std::string connStr = connectionString;
-    auto found = connStr.find("daqref://");
-    return (found == 0);
-}
-
 size_t RefDeviceModule::getIdFromConnectionString(const std::string& connectionString) const
 {
     std::string prefixWithDeviceStr = "daqref://device";

--- a/modules/ref_device_module/tests/test_ref_device_module.cpp
+++ b/modules/ref_device_module/tests/test_ref_device_module.cpp
@@ -75,37 +75,6 @@ TEST_F(RefDeviceModuleTest, EnumerateDevices)
     ASSERT_EQ(deviceInfo[1].getConnectionString(), "daqref://device1");
 }
 
-TEST_F(RefDeviceModuleTest, AcceptsConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(RefDeviceModuleTest, AcceptsConnectionStringEmpty)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters(""));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(RefDeviceModuleTest, AcceptsConnectionStringInvalid)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters("drfrfgt"));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(RefDeviceModuleTest, AcceptsConnectionStringCorrect)
-{
-    auto module = CreateModule();
-
-    ASSERT_TRUE(module.acceptsConnectionParameters("daqref://device8"));
-}
-
 TEST_F(RefDeviceModuleTest, CreateDeviceConnectionStringNull)
 {
     auto module = CreateModule();

--- a/modules/ref_fb_module/tests/test_ref_fb_module.cpp
+++ b/modules/ref_fb_module/tests/test_ref_fb_module.cpp
@@ -62,30 +62,6 @@ TEST_F(RefFbModuleTest, EnumerateDevices)
     ASSERT_EQ(deviceInfoDict.getCount(), 0u);
 }
 
-TEST_F(RefFbModuleTest, AcceptsConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(RefFbModuleTest, AcceptsConnectionStringEmpty)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters(""));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(RefFbModuleTest, AcceptsConnectionStringInvalid)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters("drfrfgt"));
-    ASSERT_FALSE(accepts);
-}
-
 TEST_F(RefFbModuleTest, GetAvailableComponentTypes)
 {
     const auto module = CreateModule();

--- a/modules/tests/test_opendaq_device_modules/test_helpers/mock_helper_module.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_helpers/mock_helper_module.cpp
@@ -49,12 +49,6 @@ ErrCode MockHelperModuleImpl::getAvailableDeviceTypes(IDict** deviceTypes)
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode MockHelperModuleImpl::acceptsConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* /*config*/)
-{
-    *accepted = false;
-    return OPENDAQ_SUCCESS;
-}
-
 ErrCode MockHelperModuleImpl::createDevice(IDevice** /*device*/,
                                            IString* /*connectionString*/,
                                            IComponent* /*parent*/,
@@ -98,16 +92,6 @@ ErrCode MockHelperModuleImpl::getVersionInfo(IVersionInfo** version)
     OPENDAQ_PARAM_NOT_NULL(version);
 
     *version = nullptr;
-    return OPENDAQ_SUCCESS;
-}
-
-ErrCode MockHelperModuleImpl::acceptsStreamingConnectionParameters(Bool* accepted,
-                                                                   IString* /*connectionString*/,
-                                                                   IPropertyObject* /*config*/)
-{
-    OPENDAQ_PARAM_NOT_NULL(accepted);
-
-    *accepted = false;
     return OPENDAQ_SUCCESS;
 }
 

--- a/modules/tests/test_opendaq_device_modules/test_helpers/mock_helper_module.h
+++ b/modules/tests/test_opendaq_device_modules/test_helpers/mock_helper_module.h
@@ -36,7 +36,6 @@ public:
 
     ErrCode INTERFACE_FUNC getAvailableDevices(IList** availableDevices) override;
     ErrCode INTERFACE_FUNC getAvailableDeviceTypes(IDict** deviceTypes) override;
-    ErrCode INTERFACE_FUNC acceptsConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config) override;
     ErrCode INTERFACE_FUNC createDevice(IDevice** device, IString* connectionString, IComponent* parent, IPropertyObject* config) override;
 
     ErrCode INTERFACE_FUNC getAvailableFunctionBlockTypes(IDict** functionBlockTypes) override;
@@ -45,7 +44,6 @@ public:
     ErrCode INTERFACE_FUNC getAvailableServerTypes(IDict** serverTypes) override;
     ErrCode INTERFACE_FUNC createServer(IServer** server, IString* serverType, IDevice* rootDevice, IPropertyObject* config) override;
 
-    ErrCode INTERFACE_FUNC acceptsStreamingConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* /*config*/) override;
     ErrCode INTERFACE_FUNC createStreaming(IStreaming** streaming, IString* connectionString, IPropertyObject* /*config*/) override;
 
     ErrCode INTERFACE_FUNC createConnectionString(IString** connectionString, IServerCapability* serverCapability) override;

--- a/modules/tests/test_opendaq_device_modules/test_streaming.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_streaming.cpp
@@ -181,7 +181,7 @@ protected:
 
         auto instance = InstanceCustom(context, "local");
 
-        const auto mockDevice = instance.addDevice("mock_phys_device");
+        const auto mockDevice = instance.addDevice("daqmock://phys_device");
 
         auto streamingServer = std::get<0>(GetParam());
         instance.addServer(streamingServer, nullptr);
@@ -491,7 +491,7 @@ protected:
 
         auto instance = InstanceCustom(context, "local");
 
-        const auto mockDevice = instance.addDevice("mock_phys_device");
+        const auto mockDevice = instance.addDevice("daqmock://phys_device");
 
         const auto statisticsFb = instance.addFunctionBlock("ref_fb_module_statistics");
         statisticsFb.setPropertyValue("DomainSignalType", 1);  // 1 - Explicit
@@ -558,7 +558,7 @@ protected:
 
         auto instance = InstanceCustom(context, "local");
 
-        const auto mockDevice = instance.addDevice("mock_phys_device");
+        const auto mockDevice = instance.addDevice("daqmock://phys_device");
 
         auto streamingServerName = std::get<0>(GetParam());
         streamingServer = instance.addServer(streamingServerName, nullptr);
@@ -647,7 +647,7 @@ TEST_F(NativeDeviceStreamingTest, ChangedDataDescriptorBeforeSubscribeNativeDevi
     auto serverInstance = InstanceBuilder().setModuleManager(moduleManager).build();
     const ModulePtr deviceModule(MockDeviceModule_Create(serverInstance.getContext()));
     moduleManager.addModule(deviceModule);
-    serverInstance.setRootDevice("mock_phys_device");
+    serverInstance.setRootDevice("daqmock://phys_device");
     serverInstance.addServer("openDAQ Native Streaming", nullptr);
 
     const auto channels = serverInstance.getChannelsRecursive();

--- a/modules/websocket_streaming_client_module/include/websocket_streaming_client_module/websocket_streaming_client_module_impl.h
+++ b/modules/websocket_streaming_client_module/include/websocket_streaming_client_module/websocket_streaming_client_module_impl.h
@@ -32,13 +32,13 @@ public:
     DevicePtr onCreateDevice(const StringPtr& connectionString,
                              const ComponentPtr& parent,
                              const PropertyObjectPtr& config) override;
-    bool onAcceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
-    bool onAcceptsStreamingConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
+    bool acceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config);
+    bool acceptsStreamingConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config);
     StreamingPtr onCreateStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config) override;
     StringPtr onCreateConnectionString(const ServerCapabilityPtr& serverCapability) override;
 
 private:
-    static DeviceTypePtr createWebsocketDeviceType();
+    static DeviceTypePtr createWebsocketDeviceType(bool useOldPrefix);
     static StringPtr createUrlConnectionString(const StringPtr& host,
                                                const IntegerPtr& port,
                                                const StringPtr& path);

--- a/modules/websocket_streaming_client_module/tests/test_websocket_streaming_client_module.cpp
+++ b/modules/websocket_streaming_client_module/tests/test_websocket_streaming_client_module.cpp
@@ -60,48 +60,6 @@ TEST_F(WebsocketStreamingClientModuleTest, EnumerateDevices)
     ASSERT_NO_THROW(deviceInfo = module.getAvailableDevices());
 }
 
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsConnectionStringEmpty)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters(""));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsConnectionStringInvalid)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters("drfrfgt"));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsConnectionStringWrongPrefix)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsConnectionParameters("daq.opcua://device8"));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsConnectionStringCorrect)
-{
-    auto module = CreateModule();
-
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.lt://device8"));
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.lt://[::1]"));
-    ASSERT_TRUE(module.acceptsConnectionParameters("daq.lt://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"));
-}
-
 TEST_F(WebsocketStreamingClientModuleTest, CreateDeviceConnectionStringNull)
 {
     auto module = CreateModule();
@@ -139,49 +97,6 @@ TEST_F(WebsocketStreamingClientModuleTest, CreateDeviceConnectionFailed)
     ASSERT_THROW(module.createDevice("daq.lt://127.0.0.1", nullptr), NotFoundException);
 }
 
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsStreamingConnectionStringNull)
-{
-    auto module = CreateModule();
-    ASSERT_THROW(module.acceptsStreamingConnectionParameters(nullptr), ArgumentNullException);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsStreamingConnectionStringEmpty)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsStreamingConnectionParameters(""));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsStreamingConnectionStringInvalid)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsStreamingConnectionParameters("drfrfgt"));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsStreamingConnectionStringWrongPrefix)
-{
-    auto module = CreateModule();
-
-    bool accepts = true;
-    ASSERT_NO_THROW(accepts = module.acceptsStreamingConnectionParameters("daq.opcua://device8"));
-    ASSERT_FALSE(accepts);
-}
-
-TEST_F(WebsocketStreamingClientModuleTest, AcceptsStreamingConnectionStringCorrect)
-{
-    auto module = CreateModule();
-
-    ASSERT_TRUE(module.acceptsStreamingConnectionParameters("daq.lt://device8"));
-    // check that old style conenction is also supported
-    ASSERT_TRUE(module.acceptsStreamingConnectionParameters("daq.ws://device8"));
-}
-
 TEST_F(WebsocketStreamingClientModuleTest, CreateConnectionString)
 {
     auto context = NullContext();
@@ -208,7 +123,6 @@ TEST_F(WebsocketStreamingClientModuleTest, CreateConnectionString)
     ASSERT_NO_THROW(connectionString = module.createConnectionString(serverCapability));
     ASSERT_EQ(connectionString, "daq.lt://123.123.123.123:1234/path");
 }
-
 
 TEST_F(WebsocketStreamingClientModuleTest, CreateStreamingWithNullArguments)
 {
@@ -251,9 +165,11 @@ TEST_F(WebsocketStreamingClientModuleTest, GetAvailableComponentTypes)
 
     DictPtr<IString, IDeviceType> deviceTypes;
     ASSERT_NO_THROW(deviceTypes = module.getAvailableDeviceTypes());
-    ASSERT_EQ(deviceTypes.getCount(), 1u);
+    ASSERT_EQ(deviceTypes.getCount(), 2u);
     ASSERT_TRUE(deviceTypes.hasKey("opendaq_lt_streaming"));
     ASSERT_EQ(deviceTypes.get("opendaq_lt_streaming").getId(), "opendaq_lt_streaming");
+    ASSERT_TRUE(deviceTypes.hasKey("opendaq_lt_streaming_old"));
+    ASSERT_EQ(deviceTypes.get("opendaq_lt_streaming_old").getId(), "opendaq_lt_streaming_old");
 
     DictPtr<IString, IServerType> serverTypes;
     ASSERT_NO_THROW(serverTypes = module.getAvailableServerTypes());

--- a/shared/libraries/opcuatms/opcuatms_server/tests/test_helpers.h
+++ b/shared/libraries/opcuatms/opcuatms_server/tests/test_helpers.h
@@ -44,8 +44,8 @@ namespace test_helpers
         moduleManager.addModule(fbModule);
 
         auto instance = InstanceCustom(context, "localInstance");
-        instance.addDevice("daq_client_device");
-        instance.addDevice("mock_phys_device");
+        instance.addDevice("daqmock://client_device");
+        instance.addDevice("daqmock://phys_device");
         instance.addFunctionBlock("mock_fb_uid");
 
         return instance;

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_streaming_integration.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_streaming_integration.cpp
@@ -174,7 +174,7 @@ protected:
 
         auto instance = InstanceCustom(context, "localInstance");
 
-        instance.addDevice("mock_phys_device");
+        instance.addDevice("daqmock://phys_device");
 
         return instance;
     }

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
@@ -33,8 +33,8 @@ public:
         moduleManager.addModule(fbModule);
 
         auto instance = InstanceCustom(context, "localInstance");
-        instance.addDevice("daq_client_device");
-        const auto device = instance.addDevice("mock_phys_device");
+        instance.addDevice("daqmock://client_device");
+        const auto device = instance.addDevice("daqmock://phys_device");
         const auto infoInternal = device.getInfo().asPtr<IDeviceInfoInternal>();
         infoInternal.addServerCapability(ServerCapability("protocol_1", "protocol 1", ProtocolType::Streaming));
         infoInternal.addServerCapability(ServerCapability("protocol_2", "protocol 2", ProtocolType::Configuration));

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_integration.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_integration.cpp
@@ -32,8 +32,8 @@ public:
         moduleManager.addModule(fbModule);
 
         auto instance = InstanceCustom(context, localId);
-        instance.addDevice("daq_client_device");
-        instance.addDevice("mock_phys_device");
+        instance.addDevice("daqmock://client_device");
+        instance.addDevice("daqmock://phys_device");
         instance.addFunctionBlock("mock_fb_uid");
 
         return instance;

--- a/shared/libraries/websocket_streaming/tests/streaming_test_helpers.h
+++ b/shared/libraries/websocket_streaming/tests/streaming_test_helpers.h
@@ -45,8 +45,8 @@ namespace streaming_test_helpers
         moduleManager.addModule(fbModule);
 
         auto instance = InstanceCustom(context, "localInstance");
-        instance.addDevice("daq_client_device");
-        instance.addDevice("mock_phys_device");
+        instance.addDevice("daqmock://client_device");
+        instance.addDevice("daqmock://phys_device");
         instance.addFunctionBlock("mock_fb_uid");
 
         return instance;


### PR DESCRIPTION
## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Description:

- Make device connection string prefix mandatory
- Remove "accepts connection string" methods from module
- Requires any device modules to update their "DeviceType" to contain a prefix
- Requires any device modules to update their connection strings to start with a prefix, followed by ://