### PR TITLE
Re-add check for signal parent component

### DIFF
--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb.h
@@ -30,7 +30,6 @@ protected:
     void createFunctionBlocks();
     void createSignals();
     void createInputPorts();
-    void createReferencedSignals();
     void createTestConfigProperties();
 };
 

--- a/core/opendaq/opendaq/mocks/mock_fb.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb.cpp
@@ -19,7 +19,6 @@ MockFunctionBlockImpl::MockFunctionBlockImpl(daq::FunctionBlockTypePtr type,
     createFunctionBlocks();
     createSignals();
     createInputPorts();
-    createReferencedSignals();
     createTestConfigProperties();
 }
 
@@ -53,15 +52,6 @@ void MockFunctionBlockImpl::createSignals()
     createAndAddSignal("UniqueId_3", createDescriptor("Signal3"));
     createAndAddSignal("UniqueId_4", createDescriptor("Signal4"));
     createAndAddSignal("UniqueId_5", createDescriptor("Signal5"), true, false);
-}
-
-void MockFunctionBlockImpl::createReferencedSignals()
-{
-    auto thisPtr = this->borrowPtr<FunctionBlockPtr>();
-    assert(thisPtr.getFunctionBlocks().getCount() > 0);
-    assert(thisPtr.getFunctionBlocks()[0].getSignals().getCount() > 0);
-
-    addSignal(thisPtr.getFunctionBlocks()[0].getSignals()[0]); // add first signal from nested function block
 }
 
 void MockFunctionBlockImpl::createTestConfigProperties()

--- a/core/opendaq/signal/include/opendaq/signal_container_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_container_impl.h
@@ -302,6 +302,9 @@ SignalConfigPtr GenericSignalContainerImpl<Intf, Intfs ...>::createAndAddSignal(
 template <class Intf, class... Intfs>
 void GenericSignalContainerImpl<Intf, Intfs...>::addSignal(const SignalPtr& signal)
 {
+    if (signal.getParent() != this->signals)
+        throw InvalidParameterException("Invalid parent of signal");
+
     try
     {
         this->signals.addItem(signal);

--- a/shared/libraries/opcuatms/opcuatms_server/tests/test_tms_function_block.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/tests/test_tms_function_block.cpp
@@ -72,7 +72,7 @@ TEST_F(TmsFunctionBlockTest, BrowseSignals)
     OpcUaServerNode serverNodeFB(*this->getServer(), nodeId);
     auto signalServerNode = serverNodeFB.getChildNode(UA_QUALIFIEDNAME_ALLOC(NAMESPACE_DAQBSP, "Sig"));
     auto signalReferences = signalServerNode->browse(OpcUaNodeId(NAMESPACE_DAQBSP, UA_DAQBSPID_HASVALUESIGNAL));
-    ASSERT_EQ(signalReferences.size(), 5u);
+    ASSERT_EQ(signalReferences.size(), 4u);
 }
 
 // TODO: Enable once name and description are no longer props

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_function_block.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_function_block.cpp
@@ -124,12 +124,11 @@ TEST_F(TmsFunctionBlockTest, MethodGetSignals)
     ASSERT_NO_THROW(signals = clientFunctionBlock.getSignals());
     ASSERT_TRUE(signals.assigned());
 
-    ASSERT_EQ(signals.getCount(), 5u);
+    ASSERT_EQ(signals.getCount(), 4u);
     ASSERT_EQ(signals[0].getDescriptor().getName(), "Signal1");
     ASSERT_EQ(signals[1].getDescriptor().getName(), "Signal2");
     ASSERT_EQ(signals[2].getDescriptor().getName(), "Signal3");
     ASSERT_EQ(signals[3].getDescriptor().getName(), "Signal4");
-    ASSERT_EQ(signals[4].getDescriptor().getName(), "NestedSignal1");
 }
 
 TEST_F(TmsFunctionBlockTest, SignalCheckGlobalId)


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

- Add check to prevent duplicate signals in openDAQ component tree