### PR TITLE
Force Node 16 usage in Manylinux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
   windows_x64_artifact: SdkWindows64
   linux_x64_artifact: SdkLinux64
   nuget_artifact: Packages (openDAQ.Net NuGet)
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true # Workaround for: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
 jobs:
   build_windows:
@@ -461,7 +462,7 @@ jobs:
         run : git config --global --add safe.directory '*'
 
       - name: Checkout
-        uses: actions/checkout@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
+        uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -406,13 +406,6 @@ jobs:
         CXX: ${{ matrix.cxx }}
 
     steps:
-      # Addresses CentOS 7 EoL issue https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
-      - name: Update yum .repo files
-        run: |
-          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-          
       - name: Install basic dependencies
         run: |
           yum update -y

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ env:
   python_versions: 3.8 3.9 3.10 3.11 3.12
   windows_x64_artifact: SdkWindows64
   linux_x64_artifact: SdkLinux64
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true # Workaround for: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
 jobs:
   deploy_windows:
@@ -412,7 +413,7 @@ jobs:
           yum install -y git awscli
 
       - name: Checkout
-        uses: actions/checkout@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
+        uses: actions/checkout@v3
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,7 @@ env:
   python_versions: 3.8 3.9 3.10 3.11 3.12
   windows_x64_artifact: SdkWindows64
   linux_x64_artifact: SdkLinux64
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true # Workaround for: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
 jobs:
   package_windows:
@@ -313,7 +314,7 @@ jobs:
           yum install -y git
 
       - name: Checkout
-        uses: actions/checkout@v3 # TODO https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
+        uses: actions/checkout@v3 
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
# Description:

Due to [GitHub actions transitioning to Node20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), the manylinux CI jobs are failing. This fix enforces the usage of Node16 in those actions.