### PR TITLE
Fix CSV python writer formatting

### DIFF
--- a/examples/python/csv_writer.py
+++ b/examples/python/csv_writer.py
@@ -1,3 +1,4 @@
+import numpy as np
 import opendaq
 import time
 import argparse
@@ -57,9 +58,11 @@ class RecordedDevice:
     def write_sample(self, recorder, index):
         if index < recorder.read:
             if self.first_write:
-                tdata = recorder.domain_buffer[index].isoformat()
+                tdata = np.datetime_as_string(recorder.domain_buffer[index])
                 self.csv_file.write(f"{tdata};\n")
-            tdata = recorder.domain_buffer[index].isoformat()
+                self.first_write = False
+
+            tdata = np.datetime_as_string(recorder.domain_buffer[index])
             self.csv_file.write(
                 f"{tdata};{recorder.values_buffer[index]:.2f};")
             self.first_write = False


### PR DESCRIPTION
Fixed csv_writer python example:
-recorder.domain_buffer[index].isoformat() wasn't working, changed it to np.datetime_as_string(recorder.domain_buffer[index]).