### PR TITLE
Bugfix: Property Objects has Numeric Id

### DIFF
--- a/shared/libraries/opcua/opcuaserver/include/opcuaserver/opcuaaddnodeparams.h
+++ b/shared/libraries/opcua/opcuaserver/include/opcuaserver/opcuaaddnodeparams.h
@@ -53,7 +53,8 @@ class AddObjectNodeParams : public GenericAddNodeParams<UA_ObjectAttributes>
 public:
     AddObjectNodeParams(const OpcUaNodeId& requestedNewNodeId);
     AddObjectNodeParams(const OpcUaNodeId& requestedNewNodeId, const OpcUaNodeId& parentNodeId);
-    
+    AddObjectNodeParams(const std::string& name, const OpcUaNodeId& parentNodeId);
+
     OpcUaNodeId typeDefinition = OpcUaNodeId(UA_NS0ID_BASEOBJECTTYPE);
 };
 

--- a/shared/libraries/opcua/opcuaserver/src/opcuaaddnodeparams.cpp
+++ b/shared/libraries/opcua/opcuaserver/src/opcuaaddnodeparams.cpp
@@ -54,13 +54,19 @@ AddObjectNodeParams::AddObjectNodeParams(const OpcUaNodeId& requestedNewNodeId, 
 {
 }
 
+AddObjectNodeParams::AddObjectNodeParams(const std::string& name, const OpcUaNodeId& parentNodeId)
+    : GenericAddNodeParams<UA_ObjectAttributes>(
+          RequestedNodeIdBaseOnName(name, parentNodeId), parentNodeId, OpcUaNodeId(UA_NS0ID_HASCOMPONENT), UA_ObjectAttributes_default)
+{
+}
+
+/*AddVariableNodeParams*/
+
 AddVariableNodeParams::AddVariableNodeParams(const std::string& name, const OpcUaNodeId& parentNodeId)
     : GenericAddNodeParams<UA_VariableAttributes>(
                   RequestedNodeIdBaseOnName(name, parentNodeId), parentNodeId, OpcUaNodeId(UA_NS0ID_HASPROPERTY), UA_VariableAttributes_default)
 {
 }
-
-/*AddVariableNodeParams*/
 
 AddVariableNodeParams::AddVariableNodeParams(const OpcUaNodeId& requestedNewNodeId)
     : AddVariableNodeParams(requestedNewNodeId, OpcUaNodeId())

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_object.cpp
@@ -133,7 +133,15 @@ OpcUaNodeId TmsServerObject::createNode(const OpcUaNodeId& parentNodeId)
             browseName = typeBrowseName;
     }
 
+    // Frist try to set via getRequestedNodeId, because NodeID will also be string
+    // if parent is numeric. However object needs to be GenericComponentPtr or child of it.
     auto params = AddObjectNodeParams(getRequestedNodeId(), parentNodeId);
+
+    // If object is not GenericComponentPtr or child the id should be set to string if possible.
+    // Possible means if parent has a string nodeId.
+    if (params.requestedNewNodeId.isNull())
+        params = AddObjectNodeParams(browseName, parentNodeId);
+        
     configureNodeAttributes(params.attr);
     params.referenceTypeId = getReferenceType();
     params.setBrowseName(browseName);


### PR DESCRIPTION
This bugfix fixes that property objects have a numeric NodeId if the parent has a string NodeId.
With this fix property objects have a String NodeId with this pattern <parentPath>/<browseName.>

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
