### PR TITLE
opendaq_dependency: fix target checks and better target suport

### DIFF
--- a/external/opendaq_dependency.cmake
+++ b/external/opendaq_dependency.cmake
@@ -45,6 +45,8 @@ endmacro()
 #     [ FIND_PACKAGE_NAME depName ]           # overrides the name used in find_package() (default is NAME)
 #     [ LOG_LEVEL         WARNING ]           # sets CMAKE_MESSAGE_LOG_LEVEL when fetching
 #     [ PKGCONFIG_NAME    nameInPkgconfig ]   # if set, try pkgconfig with this name if find_package() fails
+#     [ SOURCE_SUBDIR     subdir ]            # add_subdirectory() this subdir in source instead of top level
+#     [ ADD_FETCH_ALIAS   Alias=Target ... ]  # add specified aliases if dep was fetched (not config mode)
 #     [ EXPECT_TARGET     depname::depname ]  # if set, asserts that the specified target is provided
 #     [ EXPECT_COMMNAD    some_command ]      # if set, asserts that the specified command is provided
 #     [ PATCH_FILES       ... ]               # if set, specified patches are applied before building
@@ -78,10 +80,11 @@ macro(opendaq_dependency)
 
     cmake_parse_arguments(OPENDAQ_DEP
         "OPTIONAL"
-        "NAME;REQUIRED_VERSION;EXPECT_TARGET;EXPECT_COMMAND;GIT_REPOSITORY;GIT_REF;GIT_SHALLOW;URL;URL_HASH;FETCH_LOG_LEVEL;PKGCONFIG_NAME;FIND_PACKAGE_NAME;GIT_SUBMODULES"
-        "PATCH_FILES"
+        "NAME;REQUIRED_VERSION;EXPECT_TARGET;EXPECT_COMMAND;GIT_REPOSITORY;GIT_REF;GIT_SHALLOW;URL;URL_HASH;FETCH_LOG_LEVEL;PKGCONFIG_NAME;FIND_PACKAGE_NAME;GIT_SUBMODULES;SOURCE_SUBDIR"
+        "PATCH_FILES;ADD_FETCH_ALIAS"
         ${ARGN})
 
+    string(TOLOWER "${OPENDAQ_DEP_NAME}" OPENDAQ_DEP_NAME_LOWER)
     string(TOUPPER "${OPENDAQ_DEP_NAME}" OPENDAQ_DEP_NAME_UPPER)
 
     set_cmake_folder_context(TARGET_FOLDER_NAME)
@@ -103,6 +106,7 @@ macro(opendaq_dependency)
     endif()
 
     if (NOT OPENDAQ_ALWAYS_FETCH_${OPENDAQ_DEP_NAME_UPPER})
+
         find_package(${OPENDAQ_DEP_FIND_PACKAGE_NAME} ${OPENDAQ_DEP_REQUIRED_VERSION} QUIET GLOBAL)
 
         if (${OPENDAQ_DEP_FIND_PACKAGE_NAME}_FOUND)
@@ -128,8 +132,8 @@ macro(opendaq_dependency)
             # make sure the thing found provides the expected targets/commands
             opendaq_check_dependency(
                 VAR OPENDAQ_DEP_TARGETS_OK
-                OPENDAQ_DEP_EXPECT_TARGET "${OPENDAQ_DEP_EXPECT_TARGET}"
-                OPENDAQ_DEP_EXPECT_COMMAND "${OPENDAQ_DEP_EXPECT_COMMAND}"
+                EXPECT_TARGET "${OPENDAQ_DEP_EXPECT_TARGET}"
+                EXPECT_COMMAND "${OPENDAQ_DEP_EXPECT_COMMAND}"
             )
 
             if (NOT OPENDAQ_DEP_TARGETS_OK)
@@ -189,6 +193,10 @@ macro(opendaq_dependency)
             message(FATAL_ERROR "No valid source given for opendaq_dependency()!")
         endif()
 
+        if (OPENDAQ_DEP_SOURCE_SUBDIR)
+            list(APPEND SOURCE_PARAMS SOURCE_SUBDIR ${OPENDAQ_DEP_SOURCE_SUBDIR})
+        endif()
+
         FetchContent_Declare(${OPENDAQ_DEP_NAME}
             ${SOURCE_PARAMS}
             ${OPENDAQ_DEP_GIT_SUBMODULES}
@@ -201,11 +209,24 @@ macro(opendaq_dependency)
         # pop CMAKE_MESSAGE_LOG_LEVEL
         set(CMAKE_MESSAGE_LOG_LEVEL ${OPENDAQ_DEP_OLD_LOG_LEVEL})
 
+        # in fetched (add_subdirectory) mode, some packages do not create target aliases
+        # normally expected in config mode (find_package) as these are only in its *Config.cmake
+        # files; we will add these aliases ourselves now if requested by the caller
+        foreach(alias ${OPENDAQ_DEP_ADD_FETCH_ALIAS})
+            if(alias MATCHES "^([^=]+)=([^=]+)$")
+                set(alias_from "${CMAKE_MATCH_1}")
+                set(alias_to "${CMAKE_MATCH_2}")
+                add_library(${alias_from} ALIAS ${alias_to})
+            else()
+                message(FATAL_ERROR "opendaq_dependency ADD_FETCH_ALIAS must be of the form Alias=RealTarget")
+            endif()
+        endforeach()
+
         # make sure the thing fetched provides the expected targets/commands
         opendaq_check_dependency(
             VAR ${OPENDAQ_DEP_NAME}_FETCHED
-            OPENDAQ_DEP_EXPECT_TARGET "${OPENDAQ_DEP_EXPECT_TARGET}"
-            OPENDAQ_DEP_EXPECT_COMMAND "${OPENDAQ_DEP_EXPECT_COMMAND}"
+            EXPECT_TARGET "${OPENDAQ_DEP_EXPECT_TARGET}"
+            EXPECT_COMMAND "${OPENDAQ_DEP_EXPECT_COMMAND}"
         )
 
         if (NOT OPENDAQ_DEP_OPTIONAL AND NOT ${OPENDAQ_DEP_NAME}_FETCHED)
@@ -214,4 +235,3 @@ macro(opendaq_dependency)
     endif()
 
 endmacro()
-#endfunction()

--- a/external/taskflow/CMakeLists.txt
+++ b/external/taskflow/CMakeLists.txt
@@ -7,15 +7,10 @@ opendaq_dependency(
     REQUIRED_VERSION    3.4.0
     GIT_REPOSITORY      https://github.com/taskflow/taskflow.git
     GIT_REF             v3.4.0
+    ADD_FETCH_ALIAS     Taskflow::Taskflow=Taskflow
     EXPECT_TARGET       Taskflow::Taskflow
     PATCH_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-TBBAS-280-Fix-Executor-async-functions-to-set-except.patch
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0002-Implement-fallback-uncaught-exception-handler.patch
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0003-Ignore-False-Positive-Mem-Leak.patch
 )
-
-# Taskflow incorrectly only exposes namespaced target Taskflow::Taskflow in interface
-# (imported) mode and we must manually create the alias in build mode
-if (TARGET Taskflow AND NOT TARGET Taskflow::Taskflow)
-    add_library(Taskflow::Taskflow ALIAS Taskflow)
-endif()

--- a/external/xxHash/CMakeLists.txt
+++ b/external/xxHash/CMakeLists.txt
@@ -13,13 +13,12 @@ opendaq_dependency(
     REQUIRED_VERSION    0.8.1
     GIT_REPOSITORY      https://github.com/Cyan4973/xxHash.git
     GIT_REF             v0.8.1
+    SOURCE_SUBDIR       cmake_unofficial
     EXPECT_TARGET       xxHash::xxhash
     PATCH_FILES         "${PATCH_FILES}"
 )
 
 if (xxHash_FETCHED)
-
-    add_subdirectory(${xxhash_SOURCE_DIR}/cmake_unofficial ${xxhash_BINARY_DIR})
 
     install(TARGETS xxhash
         EXPORT ${SDK_NAME}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

This commit fixes the target-presence checks in opendaq_dependency(). Due to a bug, the checks were not previously being done at all. Now that they are, some libraries - like xxHash and Taskflow - needed some special handling, because they do not create their prefixed aliases (e.g. xxHash::xxhash) when used in FetchContent/add_subdirectory mode; these aliases are only created by the *Config.cmake files in config mode. So a new option ADD_FETCH_ALIAS is added to opendaq_dependency to create such aliases when a dependency is fetched with FetchContent. An additional pass-through option SOURCE_SUBDIR was added, which is passed through directly to FetchContent, to handle cases where the top-level CMake file is not in the repository's top directory (e.g. Arrow and xxHash).
