### PR TITLE
Fix property object invalid cast on clone

### DIFF
--- a/core/opendaq/device/include/opendaq/address_info_impl.h
+++ b/core/opendaq/device/include/opendaq/address_info_impl.h
@@ -43,8 +43,7 @@ public:
     static ConstCharPtr SerializeId();
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 
-protected:
-    PropertyObjectPtr createCloneBase() override;
+    ErrCode INTERFACE_FUNC clone(IPropertyObject** cloned) override;
 
 private:
     template <typename T>

--- a/core/opendaq/device/include/opendaq/server_capability_impl.h
+++ b/core/opendaq/device/include/opendaq/server_capability_impl.h
@@ -70,12 +70,11 @@ public:
 
     ErrCode INTERFACE_FUNC getAddressInfo(IList** addressesInfo) override;
     ErrCode INTERFACE_FUNC addAddressInfo(IAddressInfo* addressInfo) override;
-    
+
+    ErrCode INTERFACE_FUNC clone(IPropertyObject** cloned) override;
+
     static ConstCharPtr SerializeId();
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
-
-protected:
-    PropertyObjectPtr createCloneBase() override;
 
 private:
     template <typename T>

--- a/core/opendaq/device/src/address_info_impl.cpp
+++ b/core/opendaq/device/src/address_info_impl.cpp
@@ -137,10 +137,27 @@ ErrCode AddressInfoImpl::Deserialize(ISerializedObject* serialized,
         });
 }
 
-PropertyObjectPtr AddressInfoImpl::createCloneBase()
+ErrCode AddressInfoImpl::clone(IPropertyObject** cloned)
 {
-    const auto obj = createWithImplementation<IAddressInfo, AddressInfoImpl>();
-    return obj;
+    OPENDAQ_PARAM_NOT_NULL(cloned);
+        
+    auto obj = createWithImplementation<IAddressInfo, AddressInfoImpl>();
+
+    return daqTry([this, &obj, &cloned]()
+    {
+        auto implPtr = static_cast<AddressInfoImpl*>(obj.getObject());
+        implPtr->configureClonedMembers(valueWriteEvents,
+                                        valueReadEvents,
+                                        endUpdateEvent,
+                                        triggerCoreEvent,
+                                        localProperties,
+                                        propValues,
+                                        customOrder,
+                                        permissionManager);
+
+        *cloned = obj.detach();
+        return OPENDAQ_SUCCESS;
+    });
 }
 
 #if !defined(BUILDING_STATIC_LIBRARY)

--- a/core/opendaq/device/src/server_capability_impl.cpp
+++ b/core/opendaq/device/src/server_capability_impl.cpp
@@ -262,12 +262,6 @@ ErrCode ServerCapabilityConfigImpl::Deserialize(ISerializedObject* serialized,
         });
 }
 
-PropertyObjectPtr ServerCapabilityConfigImpl::createCloneBase()
-{
-    const auto obj = createWithImplementation<IServerCapability, ServerCapabilityConfigImpl>("", "", ProtocolType::Unknown);
-    return obj;
-}
-
 ErrCode ServerCapabilityConfigImpl::getPort(IInteger** port)
 {
     OPENDAQ_PARAM_NOT_NULL(port);
@@ -345,6 +339,29 @@ ErrCode ServerCapabilityConfigImpl::addAddressInfo(IAddressInfo* addressInfo)
             addressStr.end());
     addressInfoPtr.addProperty(ObjectProperty(addressStr, addressInfo));
     return OPENDAQ_SUCCESS;
+}
+
+ErrCode ServerCapabilityConfigImpl::clone(IPropertyObject** cloned)
+{
+    OPENDAQ_PARAM_NOT_NULL(cloned);
+
+    auto obj = createWithImplementation<IServerCapability, ServerCapabilityConfigImpl>("", "", ProtocolType::Unknown);
+
+    return daqTry([this, &obj, &cloned]()
+    {
+        auto implPtr = static_cast<ServerCapabilityConfigImpl*>(obj.getObject());
+        implPtr->configureClonedMembers(valueWriteEvents,
+                                        valueReadEvents,
+                                        endUpdateEvent,
+                                        triggerCoreEvent,
+                                        localProperties,
+                                        propValues,
+                                        customOrder,
+                                        permissionManager);
+
+        *cloned = obj.detach();
+        return OPENDAQ_SUCCESS;
+    });
 }
 
 #if !defined(BUILDING_STATIC_LIBRARY)


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

Property object cloning requires access to a protected object implementation method. Thus the objects are statically cast to the PropertyObjectImpl. This was implemented incorrectly when the Property object implementation is not the standard, base implementation, but is instead an implementation that makes use of the GenericPropertyObjectImpl class.