### PR TITLE
Bump `ui-bundle.zip` version of `antora-ui-spring` from release 1.3 to 1.4

### DIFF
--- a/antora-playbook-dev.yml
+++ b/antora-playbook-dev.yml
@@ -22,5 +22,5 @@ content:
     start_path: docs/Antora
 ui:
   bundle:
-    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.3-opendaq/ui-bundle.zip
+    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.4-opendaq/ui-bundle.zip
     snapshot: true

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -22,5 +22,5 @@ content:
     start_path: docs/Antora
 ui:
   bundle:
-    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.3-opendaq/ui-bundle.zip
+    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.4-opendaq/ui-bundle.zip
     snapshot: true

--- a/antora-specs-playbook-dev.yml
+++ b/antora-specs-playbook-dev.yml
@@ -24,5 +24,5 @@ content:
     start_path: docs/Antora-specs
 ui:
   bundle:
-    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.3-opendaq/ui-bundle.zip
+    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.4-opendaq/ui-bundle.zip
     snapshot: true

--- a/antora-specs-playbook.yml
+++ b/antora-specs-playbook.yml
@@ -24,5 +24,5 @@ content:
     start_path: docs/Antora-specs
 ui:
   bundle:
-    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.3-opendaq/ui-bundle.zip
+    url: https://github.com/openDAQ/antora-ui-spring/releases/download/1.4-opendaq/ui-bundle.zip
     snapshot: true


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# Description:

Bump `ui-bundle.zip` version of `antora-ui-spring` from release 1.3 to 1.4 to deploy [fix for `href` in openDAQ/antora-ui-spring](https://github.com/openDAQ/antora-ui-spring/commit/1cdd1bb885104983c0232450f15ec861394c2e46), using non-hard-coded link in `header-content.hbs`, which is used to build `ui-bundle.zip`, thereby fixing links from header logo image for:

* https://docs-dev.opendaq.com/manual
* https://docs.opendaq.com/manual
* https://opendaq.github.io/

which no longer all point to https://docs.opendaq.com, but instead to the appropriate user guide docs/manual home page.

Also [tested locally](https://github.com/openDAQ/openDAQ/actions/runs/10061657977).