### PR TITLE
[TBBAS-1725] Python GUI App fix displaying values with spaces

### DIFF
--- a/examples/python/gui_demo.py
+++ b/examples/python/gui_demo.py
@@ -310,7 +310,7 @@ class App(tk.Tk):
 
         if not skip:
             self.tree.insert(parent_node_id, tk.END, iid=component_node_id, image=icon,
-                             text=component_name, open=True, values=(component_node_id))
+                             text=component_name, open=True, values=(component_node_id,))
 
     def tree_restore_selection(self, old_node=None):
         desired_iid = old_node.global_id if old_node else ''

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -308,7 +308,7 @@ class AttributesDialog(Dialog):
                     value) is not daq.IDict else ''
                 iid = parent_node_name + '.' + name
                 self.additional_tree.insert(
-                    parent_node_name, tk.END, iid=iid, text=name, values=(display_value))
+                    parent_node_name, tk.END, iid=iid, text=name, values=(display_value,))
                 if type(value) is dict or type(value) is daq.IDict:
                     self.fill_additional_tree(iid, value)
         elif type(attributes) is daq.IDeviceInfo:
@@ -316,4 +316,4 @@ class AttributesDialog(Dialog):
                 iid = parent_node_name + '.' + property.name
                 value = attributes.get_property_value(property.name)
                 self.additional_tree.insert(
-                    parent_node_name, tk.END, iid=iid, text=property.name, values=(value))
+                    parent_node_name, tk.END, iid=iid, text=property.name, values=(value,))

--- a/examples/python/gui_demo/components/properties_view.py
+++ b/examples/python/gui_demo/components/properties_view.py
@@ -74,7 +74,7 @@ class PropertiesView(tk.Frame):
                     property_info.item_type, node.get_property_value(property_info.name))
 
             self.tree.insert('' if not parent_iid else parent_iid, tk.END, iid=iid, text=property_info.name, values=(
-                property_value))
+                property_value,))
 
             if property_info.value_type == daq.CoreType.ctObject:
                 self.fillProperties(


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
Python GUI App was displaying only that part of value before space character in TreeView widgets