### PR TITLE
Other/optimize begin end update config protocol

### DIFF
--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -47,7 +47,7 @@ public:
                                 std::thread::id reconnectionProcessingThreadId);
     ~NativeDeviceHelper();
 
-    DevicePtr connectAndGetDevice(const ComponentPtr& parent);
+    DevicePtr connectAndGetDevice(const ComponentPtr& parent, uint16_t protocolVersion);
 
     void subscribeToCoreEvent(const ContextPtr& context);
     void unsubscribeFromCoreEvent(const ContextPtr& context);
@@ -88,7 +88,7 @@ private:
 DECLARE_OPENDAQ_INTERFACE(INativeDevicePrivate, IBaseObject)
 {
     virtual void INTERFACE_FUNC attachDeviceHelper(std::unique_ptr<NativeDeviceHelper> deviceHelper) = 0;
-    virtual void INTERFACE_FUNC setConnectionString(const StringPtr& connectionString) = 0;
+    virtual void INTERFACE_FUNC updateDeviceInfo(const StringPtr& connectionString) = 0;
     virtual void INTERFACE_FUNC publishConnectionStatus(ConstCharPtr statusValue) = 0;
 };
 
@@ -107,8 +107,9 @@ public:
 
     // INativeDevicePrivate
     void INTERFACE_FUNC attachDeviceHelper(std::unique_ptr<NativeDeviceHelper> deviceHelper) override;
-    void INTERFACE_FUNC setConnectionString(const StringPtr& connectionString) override;
+    void INTERFACE_FUNC updateDeviceInfo(const StringPtr& connectionString) override;
     void INTERFACE_FUNC publishConnectionStatus(ConstCharPtr statusValue) override;
+
 
     // ISerializable
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_client_module_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_client_module_impl.h
@@ -25,6 +25,8 @@
 
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_CLIENT_MODULE
 
+enum class NativeType {config, streaming};
+
 class NativeStreamingClientModule final : public Module
 {
 public:
@@ -77,13 +79,15 @@ private:
                                  const PropertyObjectPtr& config,
                                  const StringPtr& host,
                                  const StringPtr& port,
-                                 const StringPtr& path);
-    PropertyObjectPtr createConnectionDefaultConfig();
+                                 const StringPtr& path,
+                                 uint16_t protocolVersion);
+
+    PropertyObjectPtr createConnectionDefaultConfig(NativeType nativeConfigType);
     bool acceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config);
     bool acceptsStreamingConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config);
     void populateDeviceConfigFromContext(PropertyObjectPtr deviceConfig);
     void populateTransportLayerConfigFromContext(PropertyObjectPtr transportLayerConfig);
-    PropertyObjectPtr populateDefaultConfig(const PropertyObjectPtr& config);
+    PropertyObjectPtr populateDefaultConfig(const PropertyObjectPtr& config, NativeType nativeType);
     void populateDefaultTransportLayerConfig(PropertyObjectPtr& defaultConfig, const PropertyObjectPtr& config);
     PropertyObjectPtr createTransportLayerDefaultConfig();
     bool validateDeviceConfig(const PropertyObjectPtr& config);

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -39,9 +39,9 @@ NativeDeviceHelper::~NativeDeviceHelper()
     closeConnectionOnRemoval();
 }
 
-DevicePtr NativeDeviceHelper::connectAndGetDevice(const ComponentPtr& parent)
+DevicePtr NativeDeviceHelper::connectAndGetDevice(const ComponentPtr& parent, uint16_t protocolVersion)
 {
-    auto device = configProtocolClient->connect(parent);
+    auto device = configProtocolClient->connect(parent, protocolVersion);
     deviceRef = device;
     return device;
 }
@@ -425,7 +425,7 @@ void NativeDeviceImpl::attachDeviceHelper(std::unique_ptr<NativeDeviceHelper> de
     this->deviceHelper = std::move(deviceHelper);
 }
 
-void NativeDeviceImpl::setConnectionString(const StringPtr& connectionString)
+void NativeDeviceImpl::updateDeviceInfo(const StringPtr& connectionString)
 {
     if (deviceInfoSet)
         return;
@@ -449,6 +449,11 @@ void NativeDeviceImpl::setConnectionString(const StringPtr& connectionString)
             if (propValue.assigned())
                 newDeviceInfo.asPtrOrNull<IPropertyObjectProtected>(true).setProtectedPropertyValue(propName, propValue);
         }
+    }
+
+    if (!newDeviceInfo.hasProperty("NativeConfigProtocolVersion"))
+    {
+        newDeviceInfo.addProperty(IntProperty("NativeConfigProtocolVersion", clientComm->getProtocolVersion()));
     }
 
     newDeviceInfo.freeze();

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_object.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_object.h
@@ -30,6 +30,7 @@ DECLARE_OPENDAQ_INTERFACE(IConfigClientObject, IBaseObject)
     virtual ErrCode INTERFACE_FUNC setRemoteGlobalId(IString* remoteGlobalId) = 0;
     virtual ErrCode INTERFACE_FUNC handleRemoteCoreEvent(IComponent* sender, ICoreEventArgs* args) = 0;
     virtual ErrCode INTERFACE_FUNC remoteUpdate(ISerializedObject* serialized) = 0;
+    virtual ErrCode INTERFACE_FUNC setRemoteUpdating(Bool remoteUpdating) = 0;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
@@ -23,6 +23,8 @@
 #include <coretypes/dictobject_factory.h>
 #include <coretypes/baseobject_factory.h>
 
+#include <set>
+
 namespace daq::config_protocol
 {
 
@@ -105,8 +107,8 @@ public:
     static PacketBuffer createGetProtocolInfoRequest(uint64_t id);
     void parseProtocolInfoRequest() const;
 
-    static PacketBuffer createGetProtocolInfoReply(uint64_t id, uint16_t currentVersion, const std::vector<uint16_t>& supportedVersions);
-    void parseProtocolInfoReply(uint16_t& currentVersion, std::vector<uint16_t>& supportedVersions) const;
+    static PacketBuffer createGetProtocolInfoReply(uint64_t id, uint16_t currentVersion, const std::set<uint16_t>& supportedVersions);
+    void parseProtocolInfoReply(uint16_t& currentVersion, std::set<uint16_t>& supportedVersions) const;
 
     static PacketBuffer createUpgradeProtocolRequest(uint64_t id, uint16_t version);
     void parseProtocolUpgradeRequest(uint16_t& version) const;

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -23,12 +23,11 @@
 #include <opendaq/ids_parser.h>
 #include <opendaq/deserialize_component_ptr.h>
 #include <opendaq/mirrored_signal_private_ptr.h>
-
 #include <config_protocol/config_client_object.h>
 #include <coretypes/cloneable.h>
 #include <coreobjects/core_event_args_factory.h>
-
-#include "opendaq/custom_log.h"
+#include <set>
+#include <opendaq/custom_log.h>
 
 namespace daq::config_protocol
 {
@@ -56,7 +55,7 @@ public:
     BaseObjectPtr getLastValue(const std::string& globalId);
 
     void beginUpdate(const std::string& globalId, const std::string& path);
-    void endUpdate(const std::string& globalId, const std::string& path);
+    void endUpdate(const std::string& globalId, const std::string& path, const ListPtr<IDict>& props = nullptr);
 
     bool getConnected() const;
     ContextPtr getDaqContext();
@@ -82,6 +81,8 @@ public:
                                              const FunctionPtr& factoryCallback,
                                              ComponentDeserializeCallback deviceDeserialzeCallback);
 
+    uint16_t getProtocolVersion() const;
+
 private:
     ContextPtr daqContext;
     uint64_t id;
@@ -90,6 +91,7 @@ private:
     DeserializerPtr deserializer;
     bool connected;
     WeakRefPtr<IDevice> rootDeviceRef;
+    uint16_t protocolVersion;
 
     ComponentDeserializeContextPtr createDeserializeContext(const std::string& remoteGlobalId,
                                                             const ContextPtr& context,
@@ -119,6 +121,8 @@ private:
     void forEachComponent(const ComponentPtr& component, const F& f);
     [[maybe_unused]]
     void setRemoteGlobalIds(const ComponentPtr& component, const StringPtr& parentRemoteId);
+
+    void setProtocolVersion(uint16_t protocolVersion);
 };
 
 using ConfigProtocolClientCommPtr = std::shared_ptr<ConfigProtocolClientComm>;
@@ -138,7 +142,7 @@ public:
                                   const ServerNotificationReceivedCallback& serverNotificationReceivedCallback);
 
     // called from client module
-    DevicePtr connect(const ComponentPtr& parent = nullptr);
+    DevicePtr connect(const ComponentPtr& parent = nullptr, uint16_t protocolVersion = std::numeric_limits<uint16_t>::max());
     void reconnect();
 
     DevicePtr getDevice();
@@ -158,7 +162,7 @@ private:
     
     ComponentPtr findComponent(std::string globalId);
 
-    void protocolHandshake();
+    void protocolHandshake(uint16_t protocolVersion);
     void enumerateTypes();
 
     // this should handle server component updates
@@ -185,22 +189,41 @@ ConfigProtocolClient<TRootDeviceImpl>::ConfigProtocolClient(const ContextPtr& da
 }
 
 template<class TRootDeviceImpl>
-void ConfigProtocolClient<TRootDeviceImpl>::protocolHandshake()
+void ConfigProtocolClient<TRootDeviceImpl>::protocolHandshake(uint16_t protocolVersion)
 {
     auto getProtocolInfoRequestPacketBuffer = PacketBuffer::createGetProtocolInfoRequest(clientComm->generateId());
     const auto getProtocolInfoReplyPacketBuffer = sendRequestCallback(getProtocolInfoRequestPacketBuffer);
 
+    const std::set<uint16_t> supportedClientVersions {0, 1};
+
     uint16_t currentVersion;
-    std::vector<uint16_t> supportedVersions;
-    getProtocolInfoReplyPacketBuffer.parseProtocolInfoReply(currentVersion, supportedVersions);
+    std::set<uint16_t> supportedServerVersions;
+    getProtocolInfoReplyPacketBuffer.parseProtocolInfoReply(currentVersion, supportedServerVersions);
 
-    if (currentVersion != 0)
-        throw ConfigProtocolException("Invalid server protocol version");
+    if (protocolVersion != std::numeric_limits<uint16_t>::max())
+    {
+        if (std::find(supportedClientVersions.begin(), supportedClientVersions.end(), protocolVersion) == supportedClientVersions.end())
+            throw ConfigProtocolException("Protocol not supported on client");
 
-    if (std::find(supportedVersions.begin(), supportedVersions.end(), 0) == supportedVersions.end())
-        throw ConfigProtocolException("Protocol not supported on server");
+        if (std::find(supportedServerVersions.begin(), supportedServerVersions.end(), protocolVersion) == supportedServerVersions.end())
+            throw ConfigProtocolException("Protocol not supported on server");
+    }
+    else
+    {
+        std::set<uint16_t> commonVersions;
+        std::set_intersection(supportedClientVersions.begin(),
+                              supportedClientVersions.end(),
+                              supportedServerVersions.begin(),
+                              supportedServerVersions.end(),
+                              std::inserter(commonVersions, commonVersions.begin()));
 
-    auto upgradeProtocolRequestPacketBuffer = PacketBuffer::createUpgradeProtocolRequest(clientComm->generateId(), 0);
+        if (commonVersions.empty())
+            throw ConfigProtocolException("Cannot handshake a common protocol version");
+
+        protocolVersion = *commonVersions.rbegin();
+    }
+
+    auto upgradeProtocolRequestPacketBuffer = PacketBuffer::createUpgradeProtocolRequest(clientComm->generateId(), protocolVersion);
     const auto upgradeProtocolReplyPacketBuffer = sendRequestCallback(upgradeProtocolRequestPacketBuffer);
 
     bool success;
@@ -208,6 +231,10 @@ void ConfigProtocolClient<TRootDeviceImpl>::protocolHandshake()
 
     if (!success)
         throw ConfigProtocolException("Protocol upgrade failed");
+
+    clientComm->setProtocolVersion(protocolVersion);
+    const auto loggerComponent = daqContext.getLogger().getOrAddComponent("ConfigProtocolClient");
+    LOG_I("Config protocol version {} used", protocolVersion);
 }
 
 template<class TRootDeviceImpl>
@@ -257,7 +284,7 @@ void ConfigProtocolClient<TRootDeviceImpl>::reconnect()
     if (!rootDevice.assigned())
         throw NotAssignedException("Root device is not assigned.");
 
-    protocolHandshake();
+    protocolHandshake(clientComm->getProtocolVersion());
     enumerateTypes();
 
     const StringPtr serializedDevice = clientComm->requestSerializedRootDevice();
@@ -270,9 +297,9 @@ void ConfigProtocolClient<TRootDeviceImpl>::reconnect()
 }
 
 template<class TRootDeviceImpl>
-DevicePtr ConfigProtocolClient<TRootDeviceImpl>::connect(const ComponentPtr& parent)
+DevicePtr ConfigProtocolClient<TRootDeviceImpl>::connect(const ComponentPtr& parent, uint16_t protocolVersion)
 {
-    protocolHandshake();
+    protocolHandshake(protocolVersion);
     enumerateTypes();
 
     const ComponentHolderPtr deviceHolder = clientComm->requestRootDevice(parent);

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_server.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_server.h
@@ -67,6 +67,9 @@ public:
 
     void processClientToDeviceStreamingPacket(uint32_t signalNumericId, const PacketPtr& packet);
 
+    uint16_t getProtocolVersion() const;
+    void setProtocolVersion(uint16_t protocolVersion);
+
 private:
     using DispatchFunction = std::function<BaseObjectPtr(const ParamsDictPtr&)>;
 
@@ -80,6 +83,8 @@ private:
     std::mutex notificationSerializerLock;
     std::unique_ptr<IComponentFinder> componentFinder;
     UserPtr user;
+    uint16_t protocolVersion;
+    const std::set<uint16_t> supportedServerVersions;
 
     PacketBuffer processPacket(const PacketBuffer& packetBuffer);
     StringPtr processRpc(const StringPtr& jsonStr);
@@ -90,7 +95,7 @@ private:
     BaseObjectPtr getComponent(const ParamsDictPtr& params) const;
     BaseObjectPtr getTypeManager(const ParamsDictPtr& params) const;
     BaseObjectPtr getSerializedRootDevice(const ParamsDictPtr& params);
-    BaseObjectPtr connectSignal(const InputPortPtr& inputPort, const ParamsDictPtr& params);
+    BaseObjectPtr connectSignal(uint16_t protocolVersion, const InputPortPtr& inputPort, const ParamsDictPtr& params);
 
     template <class SmartPtr, class F>
     BaseObjectPtr bindComponentWrapper(const F& f, const ParamsDictPtr& params);

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_device.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_device.h
@@ -26,14 +26,15 @@ namespace daq::config_protocol
 class ConfigServerDevice
 {
 public:
-    static BaseObjectPtr getAvailableFunctionBlockTypes(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
-    static BaseObjectPtr addFunctionBlock(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
-    static BaseObjectPtr removeFunctionBlock(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
-    static BaseObjectPtr getInfo(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
-    static BaseObjectPtr getTicksSinceOrigin(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
+    static BaseObjectPtr getAvailableFunctionBlockTypes(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
+    static BaseObjectPtr addFunctionBlock(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
+    static BaseObjectPtr removeFunctionBlock(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
+    static BaseObjectPtr getInfo(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
+    static BaseObjectPtr getTicksSinceOrigin(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user);
 };
 
-inline BaseObjectPtr ConfigServerDevice::getAvailableFunctionBlockTypes(const DevicePtr& device,
+inline BaseObjectPtr ConfigServerDevice::getAvailableFunctionBlockTypes(uint16_t protocolVersion,
+                                                                        const DevicePtr& device,
                                                                         const ParamsDictPtr& params,
                                                                         const UserPtr& user)
 {
@@ -43,7 +44,7 @@ inline BaseObjectPtr ConfigServerDevice::getAvailableFunctionBlockTypes(const De
     return fbTypes;
 }
 
-inline BaseObjectPtr ConfigServerDevice::addFunctionBlock(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
+inline BaseObjectPtr ConfigServerDevice::addFunctionBlock(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
 {
     ConfigServerAccessControl::protectObject(device, user, {Permission::Read, Permission::Write});
 
@@ -56,7 +57,7 @@ inline BaseObjectPtr ConfigServerDevice::addFunctionBlock(const DevicePtr& devic
     return ComponentHolder(fb);
 }
 
-inline BaseObjectPtr ConfigServerDevice::removeFunctionBlock(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
+inline BaseObjectPtr ConfigServerDevice::removeFunctionBlock(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
 {
     ConfigServerAccessControl::protectObject(device, user, {Permission::Read, Permission::Write});
 
@@ -73,14 +74,14 @@ inline BaseObjectPtr ConfigServerDevice::removeFunctionBlock(const DevicePtr& de
     return nullptr;
 }
 
-inline BaseObjectPtr ConfigServerDevice::getInfo(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
+inline BaseObjectPtr ConfigServerDevice::getInfo(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
 {
     ConfigServerAccessControl::protectObject(device, user, Permission::Read);
 
     return device.getInfo();
 }
 
-inline BaseObjectPtr ConfigServerDevice::getTicksSinceOrigin(const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
+inline BaseObjectPtr ConfigServerDevice::getTicksSinceOrigin(uint16_t protocolVersion, const DevicePtr& device, const ParamsDictPtr& params, const UserPtr& user)
 {
     ConfigServerAccessControl::protectObject(device, user, Permission::Read);
 

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_input_port.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_input_port.h
@@ -23,11 +23,11 @@ namespace daq::config_protocol
 class ConfigServerInputPort
 {
 public:
-    static BaseObjectPtr connect(const InputPortPtr& inputPort, const SignalPtr& signal, const UserPtr& user);
-    static BaseObjectPtr disconnect(const InputPortPtr& inputPort, const ParamsDictPtr& params, const UserPtr& user);
+    static BaseObjectPtr connect(uint16_t protocolVersion, const InputPortPtr& inputPort, const SignalPtr& signal, const UserPtr& user);
+    static BaseObjectPtr disconnect(uint16_t protocolVersion, const InputPortPtr& inputPort, const ParamsDictPtr& params, const UserPtr& user);
 };
 
-inline BaseObjectPtr ConfigServerInputPort::connect(const InputPortPtr& inputPort, const SignalPtr& signal, const UserPtr& user)
+inline BaseObjectPtr ConfigServerInputPort::connect(uint16_t protocolVersion, const InputPortPtr& inputPort, const SignalPtr& signal, const UserPtr& user)
 {
     ConfigServerAccessControl::protectObject(inputPort, user, {Permission::Read, Permission::Write});
     ConfigServerAccessControl::protectObject(signal, user, Permission::Read);
@@ -39,7 +39,7 @@ inline BaseObjectPtr ConfigServerInputPort::connect(const InputPortPtr& inputPor
     return nullptr;
 }
 
-inline BaseObjectPtr ConfigServerInputPort::disconnect(const InputPortPtr& inputPort, const ParamsDictPtr& params, const UserPtr& user)
+inline BaseObjectPtr ConfigServerInputPort::disconnect(uint16_t protocolVersion, const InputPortPtr& inputPort, const ParamsDictPtr& params, const UserPtr& user)
 {
     ConfigServerAccessControl::protectObject(inputPort, user, {Permission::Read, Permission::Write});
 

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_signal.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_signal.h
@@ -24,10 +24,10 @@ namespace daq::config_protocol
 class ConfigServerSignal
 {
 public:
-    static BaseObjectPtr getLastValue(const SignalPtr& signal, const ParamsDictPtr& params, const UserPtr& user);
+    static BaseObjectPtr getLastValue(uint16_t protocolVersion, const SignalPtr& signal, const ParamsDictPtr& params, const UserPtr& user);
 };
 
-inline BaseObjectPtr ConfigServerSignal::getLastValue(const SignalPtr& signal, const ParamsDictPtr& /*params*/, const UserPtr& user)
+inline BaseObjectPtr ConfigServerSignal::getLastValue(uint16_t protocolVersion, const SignalPtr& signal, const ParamsDictPtr& /*params*/, const UserPtr& user)
 {
     ConfigServerAccessControl::protectObject(signal, user, Permission::Read);
 

--- a/shared/libraries/config_protocol/src/config_protocol.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol.cpp
@@ -179,7 +179,7 @@ PacketBuffer PacketBuffer::createGetProtocolInfoRequest(uint64_t id)
     return packetBuffer;
 }
 
-PacketBuffer PacketBuffer::createGetProtocolInfoReply(uint64_t id, uint16_t currentVersion, const std::vector<uint16_t>& supportedVersions)
+PacketBuffer PacketBuffer::createGetProtocolInfoReply(uint64_t id, uint16_t currentVersion, const std::set<uint16_t>& supportedVersions)
 {
     const auto payloadSize = sizeof(uint16_t) + sizeof(uint16_t) +
                              supportedVersions.size() * sizeof(uint16_t);
@@ -205,7 +205,7 @@ void PacketBuffer::parseProtocolInfoRequest() const
         throw ConfigProtocolException("Invalid payload");
 }
 
-void PacketBuffer::parseProtocolInfoReply(uint16_t& currentVersion, std::vector<uint16_t>& supportedVersions) const
+void PacketBuffer::parseProtocolInfoReply(uint16_t& currentVersion, std::set<uint16_t>& supportedVersions) const
 {
     if (getPacketType() != PacketType::GetProtocolInfo)
         throw ConfigProtocolException("Invalid packet type");
@@ -215,8 +215,9 @@ void PacketBuffer::parseProtocolInfoReply(uint16_t& currentVersion, std::vector<
 
     auto payload = static_cast<uint16_t*>(getPayload());
     currentVersion = *payload++;
-    supportedVersions.resize(*payload++);
-    std::memcpy(supportedVersions.data(), payload, supportedVersions.size() * sizeof(uint16_t));
+    const size_t verCount = *payload++;
+    for (size_t i = 0; i < verCount; i++)
+        supportedVersions.insert(*payload++);
 }
 
 PacketBuffer PacketBuffer::createUpgradeProtocolRequest(uint64_t id, uint16_t version)

--- a/shared/libraries/config_protocol/tests/test_config_client_server.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_client_server.cpp
@@ -375,6 +375,24 @@ TEST_F(ConfigProtocolTest, BeginEndUpdate)
     ASSERT_EQ(device->getPropertyValue("PropName"), "val");
 }
 
+TEST_F(ConfigProtocolTest, BeginEndUpdateWithProps)
+{
+    device->addProperty(StringPropertyBuilder("PropName", "-").build());
+    ASSERT_EQ(device->getPropertyValue("PropName"), "-");
+
+    client->getClientComm()->sendComponentCommand("//root", "BeginUpdate");
+
+    auto prop = Dict<IString, IBaseObject>({{"Name", "PropName"}, {"ProtectedAccess", False}, {"SetValue", True}, {"Value", "val"}});
+    auto props = List<IDict>(prop);
+    auto params = Dict<IString, IBaseObject>({{"Props", props}});
+
+    ASSERT_THROW(client->getClientComm()->sendComponentCommand("//root", "EndUpdate", params), NotSupportedException);
+    server->setProtocolVersion(1);
+    client->getClientComm()->sendComponentCommand("//root", "EndUpdate", params);
+
+    ASSERT_EQ(device->getPropertyValue("PropName"), "val");
+}
+
 TEST_F(ConfigProtocolTest, SetNameAndDescriptionAttribute)
 {
     StringPtr deviceName;

--- a/shared/libraries/config_protocol/tests/test_config_packet.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_packet.cpp
@@ -102,7 +102,7 @@ TEST_F(ConfigPacketTest, GetProtocolInfoReply)
 
     ASSERT_EQ(packetBuffer.getId(), 1u);
     uint16_t curVer;
-    std::vector<uint16_t> supVer;
+    std::set<uint16_t> supVer;
     packetBuffer.parseProtocolInfoReply(curVer, supVer);
 
     ASSERT_EQ(curVer, 2);

--- a/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
@@ -249,7 +249,7 @@ TEST_F(ConfigProtocolAccessControlTest, BeginEndUpdate)
 
     setupServerAndClient(device, UserRegular);
 
-    ASSERT_THROW(clientDevice.beginUpdate(), AccessDeniedException);
+    clientDevice.beginUpdate();
     ASSERT_THROW(clientDevice.endUpdate(), AccessDeniedException);
 
     setupServerAndClient(device, UserAdmin);


### PR DESCRIPTION
Updates native configuration protocol implementation on the client side to send all updates on the `endUpdate` call. It also implements version 1 of the protocol, where property updates can be sent with the `endUpdate` call.