### PR TITLE
Add method to detect the update status of property object

### DIFF
--- a/bindings/python/core_objects/generated/py_property_object.cpp
+++ b/bindings/python/core_objects/generated/py_property_object.cpp
@@ -173,6 +173,13 @@ void defineIPropertyObject(pybind11::module_ m, PyDaqIntf<daq::IPropertyObject, 
             objectPtr.endUpdate();
         },
         "Ends batch configuration of the object.");
+    cls.def_property_readonly("updating",
+        [](daq::IPropertyObject *object)
+        {
+            const auto objectPtr = daq::PropertyObjectPtr::Borrow(object);
+            return objectPtr.getUpdating();
+        },
+        "Returns the state of batch configuration.");
     /*
     cls.def_property_readonly("on_end_update",
         [](daq::IPropertyObject *object)

--- a/bindings/python/tests/test_begin_end_update.py
+++ b/bindings/python/tests/test_begin_end_update.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import opendaq_test
+import opendaq
+import unittest
+
+
+class TestBeginUpdateEndUpdate(opendaq_test.TestCase):
+
+    def test_props(self):
+        property_object = opendaq.PropertyObject()
+        property_object.add_property(opendaq.StringProperty(opendaq.String(
+            'property1'), opendaq.String('value1'), opendaq.Boolean(True)))
+        property_object.add_property(opendaq.IntProperty(opendaq.String(
+            'property2'), opendaq.Integer(2), opendaq.Boolean(True)))
+
+        self.assertEqual(property_object.get_property_value('property1'), 'value1')
+        self.assertEqual(property_object.get_property_value('property2'), 2)
+
+        property_object.begin_update()
+        property_object.set_property_value('property1', 'value')
+        property_object.set_property_value('property2', 3)
+        self.assertEqual(property_object.get_property_value('property1'), 'value1')
+        self.assertEqual(property_object.get_property_value('property2'), 2)
+        property_object.end_update()
+
+        self.assertEqual(property_object.get_property_value('property1'), 'value')
+        self.assertEqual(property_object.get_property_value('property2'), 3)
+
+    def test_updating(self):
+        property_object = opendaq.PropertyObject()
+
+        self.assertFalse(property_object.updating)
+
+        property_object.begin_update()
+        self.assertTrue(property_object.updating)
+        property_object.end_update()
+
+        self.assertFalse(property_object.updating)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -1,3 +1,11 @@
+26.07.2024
+Description:
+  - Add method to IPropertyObject to detect begin/end update status  
+Required integeration changes:
+  - Breaks binary compatibility
+
++ [function] IPropertyObject::getUpdating(Bool* updating)
+
 25.07.2024
 Description:
   - Add user context to json serializer

--- a/core/coreobjects/include/coreobjects/property_object.h
+++ b/core/coreobjects/include/coreobjects/property_object.h
@@ -320,6 +320,18 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObject, IBaseObject)
      */
     virtual ErrCode INTERFACE_FUNC endUpdate() = 0;
 
+    /*!
+     * @brief Returns the state of batch configuration.
+     * @param[out] updating True if the object is performing batch update of its properties.
+     *
+     * Batched configuration is used to apply several settings at once. To begin batch configuration, call `beginUpdate`.
+     * When the `setPropertyValue` is called on the object, the changes are not immediately applied. When `endUpdate`
+     * is called, the property values set between the `beginUpdate` and `endUpdate` method calls are
+     * applied. This method returns True if `beginUpdate` method has been called on the object` and `endUpdate` has not
+     * been called yet.
+     */
+    virtual ErrCode INTERFACE_FUNC getUpdating(Bool* updating) = 0;
+
     // [templateType(event, IPropertyObject, IEndUpdateEventArgs)]
     /*!
      * @brief Gets the Event that is triggered whenever the batch configuration is applied.

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -91,6 +91,7 @@ public:
 
     virtual ErrCode INTERFACE_FUNC beginUpdate() override;
     virtual ErrCode INTERFACE_FUNC endUpdate() override;
+    virtual ErrCode INTERFACE_FUNC getUpdating(Bool* updating) override;
 
     virtual ErrCode INTERFACE_FUNC getOnEndUpdate(IEvent** event) override;
     virtual ErrCode INTERFACE_FUNC getPermissionManager(IPermissionManager** permissionManager) override;
@@ -2047,6 +2048,15 @@ template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::endUpdate()
 {
     return endUpdateInternal(true);
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getUpdating(Bool* updating)
+{
+    OPENDAQ_PARAM_NOT_NULL(updating);
+
+    *updating = updateCount > 0 ? True : False;
+    return OPENDAQ_SUCCESS;
 }
 
 template <typename PropObjInterface, typename ... Interfaces>

--- a/core/opendaq/opendaq/include/opendaq/instance_impl.h
+++ b/core/opendaq/opendaq/include/opendaq/instance_impl.h
@@ -128,6 +128,8 @@ public:
 
     ErrCode INTERFACE_FUNC beginUpdate() override;
     ErrCode INTERFACE_FUNC endUpdate() override;
+    ErrCode INTERFACE_FUNC getUpdating(Bool* updating) override;
+
     ErrCode INTERFACE_FUNC getOnEndUpdate(IEvent** event) override;
     ErrCode INTERFACE_FUNC getPermissionManager(IPermissionManager** permissionManager) override;
 

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -697,6 +697,11 @@ ErrCode InstanceImpl::endUpdate()
     return rootDevice->endUpdate();
 }
 
+ErrCode InstanceImpl::getUpdating(Bool* updating)
+{
+    return rootDevice->getUpdating(updating);
+}
+
 ErrCode InstanceImpl::getOnEndUpdate(IEvent** event)
 {
     return rootDevice->endUpdate();

--- a/examples/python/gui_demo.py
+++ b/examples/python/gui_demo.py
@@ -206,8 +206,8 @@ class App(tk.Tk):
         popup = tk.Menu(tree, tearoff=0)
         popup.add_command(label="Remove")
         popup.add_command(label="Close")
-        popup.add_command(label="Begin update", command=self.handle_start_update)
-        popup.add_command(label="End update", command=self.handle_stop_update)
+        popup.add_command(label="Begin update", command=self.handle_begin_update)
+        popup.add_command(label="End update", command=self.handle_end_update)
         self.tree_popup = popup
 
     def tree_update(self, new_selected_node=None):
@@ -220,7 +220,7 @@ class App(tk.Tk):
             self.context.instance, self.current_tab())
         self.tree_restore_selection(
             self.context.selected_node)  # reset in case the selected node outdates
-        self.change_node(None)
+        self.set_node_update_status()
 
     def tree_traverse_components_recursive(self, component, display_type=DisplayType.UNSPECIFIED):
         if component is None:
@@ -298,7 +298,7 @@ class App(tk.Tk):
             icon = self.context.icons['device']
         elif daq.IFolder.can_cast_from(component):
             icon = self.context.icons['folder']
-            component_name = self.get_string_from_component(component_name)
+            component_name = self.get_standard_folder_name(component_name)
         else:  # skipping unknown type components
             skip = not show_unknown
 
@@ -306,8 +306,7 @@ class App(tk.Tk):
             self.tree.insert(parent_node_id, tk.END, iid=component_node_id, image=icon,
                              text=component_name, open=True, values=(component_node_id))
 
-
-    def get_string_from_component(self, component):
+    def get_standard_folder_name(self, component):
         if component == 'Sig':
             component = 'Signals'
         elif component == 'FB':
@@ -582,48 +581,48 @@ class App(tk.Tk):
     def current_tab(self):
         return DisplayType.from_tab_index(self.nb.index('current')) if self.nb is not None else DisplayType.UNSPECIFIED
 
-    def handle_start_update(self):
+    def handle_begin_update(self):
         selected_item = treeview_get_first_selection(self.tree)
         if selected_item:
-            self.begin_update_on_node_and_children(selected_item)
-            self.change_node('red')
+            self.begin_update_on_node(selected_item)
+            self.set_node_update_status()
             self.tree_update(self.context.selected_node)
 
-    def handle_stop_update(self):
+    def handle_end_update(self):
         selected_item = treeview_get_first_selection(self.tree)
         if selected_item:
-            self.end_update_on_node_and_children(selected_item)
-            self.change_node('red')
+            self.end_update_on_node(selected_item)
+            self.set_node_update_status()
             self.tree_update(self.context.selected_node)
 
-    def begin_update_on_node_and_children(self, node):
+    def begin_update_on_node(self, node):
         node_obj = find_component(node, self.context.instance)
         node_obj = daq.IPropertyObject.cast_from(node_obj)
         node_obj.begin_update()
 
-    def end_update_on_node_and_children(self, node):
+    def end_update_on_node(self, node):
         node_obj = find_component(node, self.context.instance)
         node_obj = daq.IPropertyObject.cast_from(node_obj)
         node_obj.end_update()
 
-    def change_node(self, color):
+    def set_node_update_status(self):
         for node in self.tree.get_children():
-            self._change_node_recursive(node, color)
+            self._set_node_update_status_recursive(node)
 
-    def _change_node_recursive(self, node, color):
+    def _set_node_update_status_recursive(self, node):
+        color = 'red'
         node_obj = find_component(node, self.context.instance)
-        node_text = self.get_string_from_component(node_obj.name)
-        if daq.IPropertyObject.can_cast_from(node_obj):
-            node_obj = daq.IPropertyObject.cast_from(node_obj)
-            if node_obj.updating:
-                self.tree.item(node, tags=('selected',),
-                               text=node_text + " [*]")
-                self.tree.tag_configure('selected', foreground=color)
-            else:
-                self.tree.item(node, tags=())
+        node_text = self.get_standard_folder_name(node_obj.name)
+        if node_obj.updating:
+            self.tree.item(node, tags=('selected',),
+                           text=node_text + " [*]")
+            self.tree.tag_configure('selected', foreground=color)
+        else:
+            self.tree.item(node, tags=())
         children = self.tree.get_children(node)
         for child in children:
-            self._change_node_recursive(child, color)
+            self._set_node_update_status_recursive(child)
+
 
 # MARK: - Entry point
 if __name__ == '__main__':

--- a/examples/python/gui_demo.py
+++ b/examples/python/gui_demo.py
@@ -206,6 +206,8 @@ class App(tk.Tk):
         popup = tk.Menu(tree, tearoff=0)
         popup.add_command(label="Remove")
         popup.add_command(label="Close")
+        popup.add_command(label="Begin update", command=self.handle_start_update)
+        popup.add_command(label="End update", command=self.handle_stop_update)
         self.tree_popup = popup
 
     def tree_update(self, new_selected_node=None):
@@ -218,6 +220,7 @@ class App(tk.Tk):
             self.context.instance, self.current_tab())
         self.tree_restore_selection(
             self.context.selected_node)  # reset in case the selected node outdates
+        self.change_node(None)
 
     def tree_traverse_components_recursive(self, component, display_type=DisplayType.UNSPECIFIED):
         if component is None:
@@ -295,22 +298,27 @@ class App(tk.Tk):
             icon = self.context.icons['device']
         elif daq.IFolder.can_cast_from(component):
             icon = self.context.icons['folder']
-            if component_name == 'Sig':
-                component_name = 'Signals'
-            elif component_name == 'FB':
-                component_name = 'Function blocks'
-            elif component_name == 'Dev':
-                component_name = 'Devices'
-            elif component_name == 'IP':
-                component_name = 'Input ports'
-            elif component_name == 'IO':
-                component_name = 'Inputs/Outputs'
+            component_name = self.get_string_from_component(component_name)
         else:  # skipping unknown type components
             skip = not show_unknown
 
         if not skip:
             self.tree.insert(parent_node_id, tk.END, iid=component_node_id, image=icon,
                              text=component_name, open=True, values=(component_node_id))
+
+
+    def get_string_from_component(self, component):
+        if component == 'Sig':
+            component = 'Signals'
+        elif component == 'FB':
+            component = 'Function blocks'
+        elif component == 'Dev':
+            component = 'Devices'
+        elif component == 'IP':
+            component = 'Input ports'
+        elif component == 'IO':
+            component = 'Inputs/Outputs'
+        return component
 
     def tree_restore_selection(self, old_node=None):
         desired_iid = old_node.global_id if old_node else ''
@@ -574,6 +582,48 @@ class App(tk.Tk):
     def current_tab(self):
         return DisplayType.from_tab_index(self.nb.index('current')) if self.nb is not None else DisplayType.UNSPECIFIED
 
+    def handle_start_update(self):
+        selected_item = treeview_get_first_selection(self.tree)
+        if selected_item:
+            self.begin_update_on_node_and_children(selected_item)
+            self.change_node('red')
+            self.tree_update(self.context.selected_node)
+
+    def handle_stop_update(self):
+        selected_item = treeview_get_first_selection(self.tree)
+        if selected_item:
+            self.end_update_on_node_and_children(selected_item)
+            self.change_node('red')
+            self.tree_update(self.context.selected_node)
+
+    def begin_update_on_node_and_children(self, node):
+        node_obj = find_component(node, self.context.instance)
+        node_obj = daq.IPropertyObject.cast_from(node_obj)
+        node_obj.begin_update()
+
+    def end_update_on_node_and_children(self, node):
+        node_obj = find_component(node, self.context.instance)
+        node_obj = daq.IPropertyObject.cast_from(node_obj)
+        node_obj.end_update()
+
+    def change_node(self, color):
+        for node in self.tree.get_children():
+            self._change_node_recursive(node, color)
+
+    def _change_node_recursive(self, node, color):
+        node_obj = find_component(node, self.context.instance)
+        node_text = self.get_string_from_component(node_obj.name)
+        if daq.IPropertyObject.can_cast_from(node_obj):
+            node_obj = daq.IPropertyObject.cast_from(node_obj)
+            if node_obj.updating:
+                self.tree.item(node, tags=('selected',),
+                               text=node_text + " [*]")
+                self.tree.tag_configure('selected', foreground=color)
+            else:
+                self.tree.item(node, tags=())
+        children = self.tree.get_children(node)
+        for child in children:
+            self._change_node_recursive(child, color)
 
 # MARK: - Entry point
 if __name__ == '__main__':


### PR DESCRIPTION
Adds `IPropertyObject.getUpdating(Bool* updating)` method to detect the begin/end update status on the property object.

The idea is to add begin/endUpdate support to the Python GUI demo app, and the new method is required to show the begin/endUpdate status.