### PR TITLE
Fix `nullptr` not equals (`!=`) comparator

### DIFF
--- a/core/coretypes/include/coretypes/objectptr.h
+++ b/core/coretypes/include/coretypes/objectptr.h
@@ -1145,7 +1145,7 @@ bool operator==(std::nullptr_t lhs, const ObjectPtr<T>& rhs)
 template <class T>
 bool operator!=(std::nullptr_t lhs, const ObjectPtr<T>& rhs)
 {
-    return rhs == lhs;
+    return rhs != lhs;
 }
 
 template <class T>

--- a/core/coretypes/tests/test_objectptr.cpp
+++ b/core/coretypes/tests/test_objectptr.cpp
@@ -137,11 +137,15 @@ TEST_F(ObjectPtrTest, Equality)
     ASSERT_TRUE(ptr1 != ptr2);
     ASSERT_TRUE(ptr1 != nullptr);
     ASSERT_FALSE(ptr1 == nullptr);
+    ASSERT_TRUE(nullptr != ptr1);
+    ASSERT_FALSE(nullptr == ptr1);
     ASSERT_FALSE(ptr1 == ptr2);
     ASSERT_TRUE(ptr1 != ptr3);
     ASSERT_FALSE(ptr1 == ptr3);
     ASSERT_TRUE(ptr3 != ptr1);
     ASSERT_FALSE(ptr3 == ptr1);
+    ASSERT_TRUE(nullptr == ptr3);
+    ASSERT_FALSE(nullptr != ptr3);
 }
 
 TEST_F(ObjectPtrTest, EmptyEqual)


### PR DESCRIPTION
Fix `nullptr` not equals (`!=`) comparator and add some test cases that would fail otherwise

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:

```cpp
auto obj = new NumberPtr(42);
auto a4 = (obj != nullptr);  // true
auto a5 = (obj == nullptr);  // false
auto a6 = (nullptr == obj);  // false
auto a7 = (nullptr != obj);  // true
delete obj;

auto num = NumberPtr(42);
auto a0 = (num != nullptr);  // true
auto a1 = (num == nullptr);  // false
auto a2 = (nullptr == num);  // false
auto a3 = (nullptr != num);  // before: false, after: true
```