### PR TITLE
Bump version of `seanmiddleditch/gha-setup-ninja`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install ninja-build
         if: matrix.cmake_generator == 'Ninja'
-        uses: seanmiddleditch/gha-setup-ninja@v4
+        uses: seanmiddleditch/gha-setup-ninja@v5
 
       # https://github.com/actions/runner-images/issues/10001
       - name: Setup MSVC toolchain
@@ -559,7 +559,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install ninja-build
-        uses: seanmiddleditch/gha-setup-ninja@v4
+        uses: seanmiddleditch/gha-setup-ninja@v5
         with:
           version: 1.10.2
       - name: Set up Python
@@ -623,7 +623,7 @@ jobs:
 
       - name: Install ninja-build
         if: matrix.cmake_generator == 'Ninja'
-        uses: seanmiddleditch/gha-setup-ninja@v4
+        uses: seanmiddleditch/gha-setup-ninja@v5
         with:
           version: 1.10.2
 


### PR DESCRIPTION
Bump version of `seanmiddleditch/gha-setup-ninja` used in `ci.yml` from `@v4` to `@v5`, thereby fixing deprecation warnings (`Node.js 16 actions are deprecated`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes