### PR TITLE
Add IProperty get/setValue

### DIFF
--- a/bindings/python/core_objects/generated/py_property.cpp
+++ b/bindings/python/core_objects/generated/py_property.cpp
@@ -259,4 +259,17 @@ void defineIProperty(pybind11::module_ m, PyDaqIntf<daq::IProperty, daq::IBaseOb
         py::return_value_policy::take_ownership,
         "Gets the event object that is triggered when the corresponding Property value is read.");
     */
+    cls.def_property("value",
+        [](daq::IProperty *object)
+        {
+            const auto objectPtr = daq::PropertyPtr::Borrow(object);
+            return baseObjectToPyObject(objectPtr.getValue());
+        },
+        [](daq::IProperty *object, const py::object& value)
+        {
+            const auto objectPtr = daq::PropertyPtr::Borrow(object);
+            objectPtr.setValue(pyObjectToBaseObject(value));
+        },
+        py::return_value_policy::take_ownership,
+        "Gets the value of the Property. Available only if the Property is bound to a Property object. / Sets the value of the Property. Available only if the Property is bound to a Property object.");
 }

--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -1,3 +1,11 @@
+08.08.2024
+Description:
+	- Add get/setValue method to IProperty
+	- Helpers allowing easier access to the property's value when iterating through an object's properties
+	
++ [function] IProperty::getValue(IBaseObject** value)
++ [function] IProperty::setValue(IBaseObject* value)
+
 26.07.2024
 Description:
   - Add method to IPropertyObject to detect begin/end update status  

--- a/core/coreobjects/include/coreobjects/eval_value_helpers.h
+++ b/core/coreobjects/include/coreobjects/eval_value_helpers.h
@@ -182,6 +182,8 @@ public:
     virtual ErrCode Property_GetStructType(IStructType** structType)  = 0;
     virtual ErrCode Property_GetOnPropertyValueWrite(IEvent** event)  = 0;
     virtual ErrCode Property_GetOnPropertyValueRead(IEvent** event)  = 0;
+    virtual ErrCode Property_GetValue(IBaseObject** value)  = 0;
+    virtual ErrCode Property_SetValue(IBaseObject* value)  = 0;
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override
     {
@@ -286,6 +288,16 @@ public:
     ErrCode INTERFACE_FUNC getOnPropertyValueRead(IEvent** event) override
     {
         return Property_GetOnPropertyValueRead(event);
+    }
+
+    ErrCode INTERFACE_FUNC getValue(IBaseObject** value) override
+    {
+        return Property_GetValue(value);
+    }
+
+    ErrCode INTERFACE_FUNC setValue(IBaseObject* value) override
+    {
+        return Property_SetValue(value);
     }
 };
 

--- a/core/coreobjects/include/coreobjects/eval_value_impl.h
+++ b/core/coreobjects/include/coreobjects/eval_value_impl.h
@@ -125,6 +125,8 @@ public:
     ErrCode Property_GetStructType(IStructType** structType) override;
     ErrCode Property_GetOnPropertyValueWrite(IEvent** event) override;
     ErrCode Property_GetOnPropertyValueRead(IEvent** event) override;
+    ErrCode Property_GetValue(IBaseObject** value) override;
+    ErrCode Property_SetValue(IBaseObject* value) override;
 
     // IUnit
 

--- a/core/coreobjects/include/coreobjects/property.h
+++ b/core/coreobjects/include/coreobjects/property.h
@@ -385,6 +385,26 @@ DECLARE_OPENDAQ_INTERFACE(IProperty, IBaseObject)
      * value to be overridden.
      */
     virtual ErrCode INTERFACE_FUNC getOnPropertyValueRead(IEvent** event) = 0;
+
+    /*!
+     * @brief Gets the value of the Property. Available only if the Property is bound to a Property object.
+     * @param value The Property value.
+     * @return OPENDAQ_ERR_NO_OWNER if the Property is not bound to a Property object.
+     *
+     * The call is equivalent to calling `getPropertyValue` on the Property object and all the limitations
+     * and implications of that call still apply.
+     */
+    virtual ErrCode INTERFACE_FUNC getValue(IBaseObject** value) = 0;
+    
+    /*!
+     * @brief Sets the value of the Property. Available only if the Property is bound to a Property object.
+     * @param value The Property value.
+     * @return OPENDAQ_ERR_NO_OWNER if the Property is not bound to a Property object.
+     *
+     * The call is equivalent to calling `getPropertyValue` on the Property object and all the limitations
+     * and implications of that call still apply.
+     */
+    virtual ErrCode INTERFACE_FUNC setValue(IBaseObject* value) = 0;
 };
 /*!@}*/
 

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -35,6 +35,7 @@
 #include <coreobjects/permission_manager_factory.h>
 #include <coreobjects/permissions_builder_factory.h>
 #include <coreobjects/permission_manager_internal_ptr.h>
+#include <coreobjects/errors.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -767,6 +768,22 @@ public:
 
         *event = onValueRead.addRefAndReturn();
         return OPENDAQ_SUCCESS;
+    }
+
+    ErrCode INTERFACE_FUNC getValue(IBaseObject** value) override
+    {
+        if (!owner.assigned() || !owner.getRef().assigned())
+            return OPENDAQ_ERR_NO_OWNER;
+
+        return owner.getRef()->getPropertyValue(this->name, value);
+    }
+
+    ErrCode INTERFACE_FUNC setValue(IBaseObject* value) override
+    {
+        if (!owner.assigned() || !owner.getRef().assigned())
+            return OPENDAQ_ERR_NO_OWNER;
+
+        return owner.getRef()->setPropertyValue(this->name, value);
     }
 
     ErrCode INTERFACE_FUNC validate()

--- a/core/coreobjects/src/eval_value_impl.cpp
+++ b/core/coreobjects/src/eval_value_impl.cpp
@@ -683,6 +683,16 @@ ErrCode EvalValueImpl::Property_GetOnPropertyValueRead(IEvent** /*event*/)
     return OPENDAQ_ERR_ACCESSDENIED;
 }
 
+ErrCode EvalValueImpl::Property_GetValue(IBaseObject** /*value*/)
+{
+    return OPENDAQ_ERR_ACCESSDENIED;
+}
+
+ErrCode EvalValueImpl::Property_SetValue(IBaseObject* /*value*/)
+{
+    return OPENDAQ_ERR_ACCESSDENIED;
+}
+
 ErrCode EvalValueImpl::UnitObject_GetId(Int* id)
 {
     if (id == nullptr)

--- a/core/coreobjects/tests/amplifier_test.cpp
+++ b/core/coreobjects/tests/amplifier_test.cpp
@@ -346,6 +346,26 @@ TEST_F(STGAmplifierTest, Measurement0)
     ASSERT_EQ(rangeValues[0], rangeValue);
 }
 
+TEST_F(STGAmplifierTest, Measurement0PropertySetValue)
+{
+    auto lvAmpl = PropertyObject(objManager, "LvAmp");
+    lvAmpl.getProperty("Measurement").setValue(0);
+
+    lvAmpl.getProperty("Range").setValue(0);
+    Float rangeValue = lvAmpl.getPropertySelectionValue("Range");
+    auto rangeProp = lvAmpl.getProperty("Range");
+    ListPtr<Float> rangeValues = rangeProp.getSelectionValues();
+
+    ASSERT_EQ(rangeValues[0], rangeValue);
+    
+    lvAmpl.setPropertyValue("Measurement", 1);
+    rangeValue = lvAmpl.getPropertySelectionValue("Range");
+    rangeProp = lvAmpl.getProperty("Range");
+    rangeValues = rangeProp.getSelectionValues();
+
+    ASSERT_EQ(rangeValues[0], rangeValue);
+}
+
 TEST_F(STGAmplifierTest, Measurement1)
 {
     auto stgAmpl = PropertyObject(objManager, "LvAmp");
@@ -414,6 +434,34 @@ TEST_F(STGAmplifierTest, SetAndGetRefProperty)
 
     stgAmpl.setPropertyValue("Range", 2);
     stgAmpl.setPropertyValue("Measurement", 0);
+
+    ASSERT_EQ(stgAmpl.getPropertyValue("Range"), 1);
+}
+
+TEST_F(STGAmplifierTest, SetAndGetRefPropertyPropertySetValue)
+{
+    // create instance
+    auto stgAmpl = PropertyObject(objManager, "StgAmp");
+
+    stgAmpl.getProperty("Measurement").setValue(0);
+
+    auto rangeProp = stgAmpl.getProperty("Range");
+    ListPtr<Float> rangeValues = rangeProp.getSelectionValues();
+
+    ASSERT_EQ(rangeValues.getCount(), 4u);
+    ASSERT_EQ(rangeValues.getItemAt(0), 50.0);
+
+    stgAmpl.getProperty("Range").setValue(1);
+    stgAmpl.getProperty("Measurement").setValue(1);
+
+    rangeProp = stgAmpl.getProperty("Range");
+    rangeValues = rangeProp.getSelectionValues();
+
+    ASSERT_EQ(rangeValues.getCount(), 4u);
+    ASSERT_EQ(rangeValues.getItemAt(0), 1000.0);
+
+    stgAmpl.getProperty("Range").setValue(2);
+    stgAmpl.getProperty("Measurement").setValue(0);
 
     ASSERT_EQ(stgAmpl.getPropertyValue("Range"), 1);
 }
@@ -775,4 +823,12 @@ TEST_F(STGAmplifierTest, TestBeginEndUpdateOrder)
     ASSERT_EQ(ampl.getPropertyValue("ResistanceRange"), 2);
     ASSERT_EQ(ampl.getPropertyValue("BridgeRange"), 1);
     ASSERT_EQ(ampl.getPropertyValue("VoltageInputType"), 0);
+}
+
+TEST_F(STGAmplifierTest, TestPropertyGetValue)
+{
+    auto ampl = PropertyObject(objManager, "StgAmp");
+
+    for (const auto& prop : ampl.getAllProperties())
+        ASSERT_EQ(ampl.getPropertyValue(prop.getName()), prop.getValue());
 }

--- a/core/opendaq/functionblock/include/opendaq/property_wrapper_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/property_wrapper_impl.h
@@ -52,6 +52,8 @@ public:
     virtual ErrCode INTERFACE_FUNC getOnPropertyValueWrite(IEvent** event);
     // [ignore(Wrapper)]
     virtual ErrCode INTERFACE_FUNC getOnPropertyValueRead(IEvent** event);
+    virtual ErrCode INTERFACE_FUNC getValue(IBaseObject** value);
+    virtual ErrCode INTERFACE_FUNC setValue(IBaseObject* value);
 
 private:
     PropertyPtr property;

--- a/core/opendaq/functionblock/src/property_wrapper_impl.cpp
+++ b/core/opendaq/functionblock/src/property_wrapper_impl.cpp
@@ -159,4 +159,14 @@ ErrCode PropertyWrapperImpl::getOnPropertyValueRead(IEvent** event)
     return property->getOnPropertyValueRead(event);
 }
 
+ErrCode PropertyWrapperImpl::getValue(IBaseObject** value)
+{
+    return property->getValue(value);
+}
+
+ErrCode PropertyWrapperImpl::setValue(IBaseObject* value)
+{
+    return property->setValue(value);
+}
+
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/include/opendaq/reader_status.h
+++ b/core/opendaq/reader/include/opendaq/reader_status.h
@@ -62,7 +62,7 @@ DECLARE_OPENDAQ_INTERFACE(IReaderStatus, IBaseObject)
 
     /*!
      * @brief Checks the validity of the reader.
-     * @param[out] status Boolean value indicating the validity of the reader
+     * @param[out] valid Boolean value indicating the validity of the reader
      */
     virtual ErrCode INTERFACE_FUNC getValid(Bool* valid) = 0;
 

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -167,9 +167,28 @@ TEST_F(ConfigProtocolIntegrationTest, GetInitialPropertyValue)
     ASSERT_EQ(serverDeviceSerialized, clientDeviceSerialized);
 }
 
+TEST_F(ConfigProtocolIntegrationTest, GetInitialPropertyValuePropertySetter)
+{
+    serverDevice.getChannels()[0].getProperty("StrProp").setValue("SomeValue");
+
+    const auto serverDeviceSerialized = serializeComponent(serverDevice);
+    ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), clientDevice.getChannels()[0].getPropertyValue("StrProp"));
+
+    const auto clientDeviceSerialized = serializeComponent(clientDevice);
+    ASSERT_EQ(serverDeviceSerialized, clientDeviceSerialized);
+}
+
 TEST_F(ConfigProtocolIntegrationTest, SetPropertyValue)
 {
     clientDevice.getChannels()[0].setPropertyValue("StrProp", "SomeValue");
+
+    ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");
+    ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), clientDevice.getChannels()[0].getPropertyValue("StrProp"));
+}
+
+TEST_F(ConfigProtocolIntegrationTest, SetPropertyValuePropertySetter)
+{
+    clientDevice.getChannels()[0].getProperty("StrProp").setValue("SomeValue");
 
     ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");
     ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), clientDevice.getChannels()[0].getPropertyValue("StrProp"));

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_amplifier.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_amplifier.cpp
@@ -356,6 +356,28 @@ TEST_F(TMSAmplifierTest, Measurement0)
     ASSERT_EQ(rangeValues[0], rangeValue);
 }
 
+TEST_F(TMSAmplifierTest, Measurement0PropertySEtter)
+{
+    const auto obj = PropertyObject(objManager, "LvAmp");
+    auto [serverObj, lvAmpl] = registerPropertyObject(obj);
+
+    lvAmpl.getProperty("Measurement").setValue(0);
+
+    lvAmpl.getProperty("Range").setValue(0);
+    Float rangeValue = lvAmpl.getPropertySelectionValue("Range");
+    auto rangeProp = lvAmpl.getProperty("Range");
+    ListPtr<Float> rangeValues = rangeProp.getSelectionValues();
+
+    ASSERT_EQ(rangeValues[0], rangeValue);
+    
+    lvAmpl.getProperty("Measurement").setValue(1);
+    rangeValue = lvAmpl.getPropertySelectionValue("Range");
+    rangeProp = lvAmpl.getProperty("Range");
+    rangeValues = rangeProp.getSelectionValues();
+
+    ASSERT_EQ(rangeValues[0], rangeValue);
+}
+
 TEST_F(TMSAmplifierTest, Measurement1)
 {
     const auto obj = PropertyObject(objManager, "LvAmp");
@@ -772,4 +794,12 @@ TEST_F(TMSAmplifierTest, PropertyOrder2)
 
     for (SizeT i = 0; i < serverProps.getCount(); ++i)
         ASSERT_EQ(serverProps[i].getName(), clientProps[i].getName());
+}
+
+TEST_F(TMSAmplifierTest, PropertyGetValue)
+{
+    const auto obj = PropertyObject(objManager, "LvAmp");
+    auto [serverObj, lvAmpl] = registerPropertyObject(obj);
+    for (const auto& prop : lvAmpl.getAllProperties())
+        ASSERT_EQ(lvAmpl.getPropertyValue(prop.getName()), prop.getValue());
 }


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:

- Add `get/setValue` method to `IProperty`
- Allows easier access to the property's value when iterating through an object's properties