### PR TITLE
Allow passing of device options via connection string as url options

### DIFF
--- a/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
@@ -31,8 +31,9 @@
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 
-BEGIN_NAMESPACE_OPENDAQ
+#include "tsl/ordered_map.h"
 
+BEGIN_NAMESPACE_OPENDAQ
 struct ModuleLibrary;
 
 class ModuleManagerImpl : public ImplementationOfWeak<IModuleManager, IModuleManagerUtils>
@@ -77,9 +78,13 @@ private:
     static PropertyObjectPtr createGeneralConfig();
 
     std::string getPrefixFromConnectionString(std::string connectionString) const;
+    static std::pair<std::string, tsl::ordered_map<std::string, BaseObjectPtr>> splitConnectionStringAndOptions(const std::string& connectionString);
 
     static StringPtr convertIfOldIdFB(const StringPtr& id);
     static StringPtr convertIfOldIdProtocol(const StringPtr& id);
+
+    static void populateDeviceConfigFromConnStrOptions(const PropertyObjectPtr& devConfig,
+                                                       const tsl::ordered_map<std::string, ObjectPtr<IBaseObject>>& options);
 
     bool modulesLoaded;
     std::vector<std::string> paths;

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -13,7 +13,7 @@
 #include <opendaq/device_private.h>
 #include <string>
 #include <future>
-#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string.hpp>
 #include <opendaq/search_filter_factory.h>
 #include <coretypes/validation.h>
 #include <opendaq/server_capability_config_ptr.h>
@@ -28,6 +28,7 @@
 #include <coreobjects/property_object_protected_ptr.h>
 #include <coreobjects/property_internal_ptr.h>
 #include <coreobjects/property_object_internal.h>
+#include <coreobjects/eval_value_factory.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 static OrphanedModules orphanedModules;
@@ -411,7 +412,9 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
     OPENDAQ_PARAM_NOT_NULL(device);
     *device = nullptr;
 
-    auto connectionStringPtr = StringPtr::Borrow(connectionString);
+    const auto [pureConnectionString, connectionStringOptions] = splitConnectionStringAndOptions(StringPtr::Borrow(connectionString));
+    auto connectionStringPtr = String(pureConnectionString);
+
     if (!connectionStringPtr.assigned() || connectionStringPtr.getLength() == 0)
         return this->makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Connection string is not set or empty");
 
@@ -510,11 +513,13 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
             continue;
 
         StringPtr id;
+        DeviceTypePtr deviceType;
         for (auto const& [typeId, type] : types)
         {
             if (type.getConnectionStringPrefix()== prefix)
             {
                 id = typeId;
+                deviceType = type;
                 break;
             }
         }
@@ -533,6 +538,14 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
             {
                 devConfig = nullptr;
             }
+        }
+
+        if (!connectionStringOptions.empty())
+        {
+            if (!devConfig.assigned())
+                devConfig = deviceType.createDefaultConfig();
+
+            populateDeviceConfigFromConnStrOptions(devConfig, connectionStringOptions);
         }
 
         auto errCode = module->createDevice(device, connectionStringPtr, parent, devConfig);
@@ -685,6 +698,16 @@ StringPtr ModuleManagerImpl::convertIfOldIdProtocol(const StringPtr& id)
     if (id == "opendaq_lt_streaming")
         return "OpenDAQLTStreaming";
     return id;
+}
+
+void ModuleManagerImpl::populateDeviceConfigFromConnStrOptions(const PropertyObjectPtr& devConfig,
+    const tsl::ordered_map<std::string, ObjectPtr<IBaseObject>>& options)
+{
+    for (const auto& item: options)
+    {
+        if (devConfig.hasProperty(item.first))
+            devConfig.setPropertyValue(item.first, item.second);
+    }
 }
 
 ErrCode ModuleManagerImpl::createFunctionBlock(IFunctionBlock** functionBlock, IString* id, IComponent* parent, IPropertyObject* config, IString* localId)
@@ -1171,6 +1194,36 @@ std::string ModuleManagerImpl::getPrefixFromConnectionString(std::string connect
     }
 
     return "";
+}
+
+std::pair<std::string, tsl::ordered_map<std::string, BaseObjectPtr>> ModuleManagerImpl::splitConnectionStringAndOptions(
+    const std::string& connectionString)
+{
+    std::vector<std::string> strs1;
+    boost::split(strs1, connectionString, boost::is_any_of("?"));
+
+    if (strs1.size() == 1)
+        return std::make_pair(strs1[0], tsl::ordered_map<std::string, BaseObjectPtr> {});
+
+    if (strs1.size() != 2)
+        throw InvalidParameterException("Invalid connection string");
+
+    std::vector<std::string> options;
+    boost::split(options, strs1[1], boost::is_any_of("&"));
+
+    tsl::ordered_map<std::string, BaseObjectPtr> optionsMap;
+    for (const auto& option: options)
+    {
+        std::vector<std::string> keyAndValue;
+        boost::split(keyAndValue, option, boost::is_any_of("="));
+        if (keyAndValue.size() != 2)
+            throw InvalidParameterException("Invalid connection string");
+
+        BaseObjectPtr value = EvalValue(keyAndValue[1]);
+        optionsMap.insert({keyAndValue[0], value});
+    }
+
+    return std::make_pair(strs1[0], optionsMap);
 }
 
 ServerCapabilityPtr ModuleManagerImpl::replaceOldProtocolIds(const ServerCapabilityPtr& cap)

--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -34,7 +34,7 @@ RefDeviceImpl::RefDeviceImpl(size_t id, const PropertyObjectPtr& config, const C
 
     if (config.assigned())
     {
-        if (config.hasProperty("LocalId"))
+        if (config.hasProperty("SerialNumber"))
             serialNumber = config.getPropertyValue("SerialNumber");
     }
     
@@ -65,7 +65,7 @@ DeviceInfoPtr RefDeviceImpl::CreateDeviceInfo(size_t id, const StringPtr& serial
     devInfo.setName(fmt::format("Device {}", id));
     devInfo.setManufacturer("openDAQ");
     devInfo.setModel("Reference device");
-    devInfo.setSerialNumber(serialNumber.assigned() ? serialNumber : String(fmt::format("dev_ser_{}", id)));
+    devInfo.setSerialNumber(serialNumber.assigned() && serialNumber.getLength() != 0 ? serialNumber : String(fmt::format("dev_ser_{}", id)));
     devInfo.setDeviceType(CreateType());
 
     return devInfo;
@@ -73,10 +73,16 @@ DeviceInfoPtr RefDeviceImpl::CreateDeviceInfo(size_t id, const StringPtr& serial
 
 DeviceTypePtr RefDeviceImpl::CreateType()
 {
+    const auto defaultConfig = PropertyObject();
+    defaultConfig.addProperty(IntProperty("NumberOfChannels", 2));
+    defaultConfig.addProperty(BoolProperty("EnableCANChannel", False));
+    defaultConfig.addProperty(StringProperty("SerialNumber", ""));
+
     return DeviceType("daqref",
                       "Reference device",
                       "Reference device",
-                      "daqref");
+                      "daqref",
+                      defaultConfig);
 }
 
 DeviceInfoPtr RefDeviceImpl::onGetInfo()

--- a/modules/tests/test_ref_modules/test_ref_modules.cpp
+++ b/modules/tests/test_ref_modules/test_ref_modules.cpp
@@ -350,6 +350,16 @@ TEST_F(RefModulesTest, FindComponentChannel)
     ASSERT_TRUE(comp.supportsInterface<IChannel>());
 }
 
+TEST_F(RefModulesTest, OptionViaConnectionString)
+{
+    auto instance = Instance("", "localInstance");
+    auto device = instance.addDevice("daqref://device0?NumberOfChannels=3&EnableCANChannel=True");
+
+    const auto numOfChannels = device.getChannelsRecursive().getCount();
+
+    ASSERT_EQ(numOfChannels, 4);
+}
+
 TEST_F(RefModulesTest, FindComponentDevice)
 {
     auto instance = Instance("", "localInstance");


### PR DESCRIPTION
Allows to pass options as a part of a connection string.

This only works for device only config options for now.
