### PR TITLE
Update onPropertyRead/Write calling logic on owned properties

### DIFF
--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -1,4 +1,14 @@
 12.08.2024
+Description:
+	- Changed logic of IProperty::getOnPropertyValue events.
+	- Now returns the owner's event when called, if the owner is assigned.
+	- A new function is available to get the class's event. That function is used internally to trigger class value change events.
+	
++ [function] IEvent::getSubscribers(IList** subscribers)
++ [function] IPropertyInternal::getClassOnPropertyValueWriteEvent(IEvent** event)
++ [function] IPropertyInternal::getClassOnPropertyValueReadEvent(IEvent** event)
+
+12.08.2024
 Description
   - Intergration the Sync Component
   - Populating eval expression with %ChildProperty:PropertyNames to get the list of child properties names where the ChildProperty is an Object-type property

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -748,7 +748,7 @@ public:
             });
     }
 
-    ErrCode INTERFACE_FUNC getOnPropertyValueWrite(IEvent** event) override
+    ErrCode INTERFACE_FUNC getClassOnPropertyValueWrite(IEvent** event) override
     {
         if (event == nullptr)
         {
@@ -759,11 +759,44 @@ public:
         return OPENDAQ_SUCCESS;
     }
 
+    ErrCode INTERFACE_FUNC getOnPropertyValueWrite(IEvent** event) override
+    {
+        if (event == nullptr)
+        {
+            return makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Cannot return the event via a null pointer.");
+        }
+        const auto ownerPtr = owner.assigned() ? owner.getRef() : nullptr;
+        if (ownerPtr.assigned())
+        {
+            return ownerPtr->getOnPropertyValueWrite(this->name, event);
+        }
+
+        *event = onValueWrite.addRefAndReturn();
+        return OPENDAQ_SUCCESS;
+    }
+
+    ErrCode INTERFACE_FUNC getClassOnPropertyValueRead(IEvent** event) override
+    {
+        if (event == nullptr)
+        {
+            return makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Cannot return the event via a null pointer.");
+        }
+
+        *event = onValueRead.addRefAndReturn();
+        return OPENDAQ_SUCCESS;
+    }
+
     ErrCode INTERFACE_FUNC getOnPropertyValueRead(IEvent** event) override
     {
         if (event == nullptr)
         {
             return makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Cannot return the event via a null pointer.");
+        }
+
+        const auto ownerPtr = owner.assigned() ? owner.getRef() : nullptr;
+        if (ownerPtr.assigned())
+        {
+            return ownerPtr->getOnPropertyValueRead(this->name, event);
         }
 
         *event = onValueRead.addRefAndReturn();

--- a/core/coreobjects/include/coreobjects/property_internal.h
+++ b/core/coreobjects/include/coreobjects/property_internal.h
@@ -111,6 +111,11 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyInternal, IBaseObject)
      * @brief Gets the unresolved type of the Property 
      */
     virtual ErrCode INTERFACE_FUNC getValueTypeUnresolved(CoreType* coreType) = 0;
+    
+    // [templateType(event, IPropertyObject, IPropertyValueEventArgs)]
+    virtual ErrCode INTERFACE_FUNC getClassOnPropertyValueRead(IEvent** event) = 0;
+    // [templateType(event, IPropertyObject, IPropertyValueEventArgs)]
+    virtual ErrCode INTERFACE_FUNC getClassOnPropertyValueWrite(IEvent** event) = 0;
 };
 /*!@}*/
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -460,9 +460,9 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getChildProp
 
 template <class PropObjInterface, class... Interfaces>
 BaseObjectPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::callPropertyValueWrite(const PropertyPtr& prop,
-                                                                                        const BaseObjectPtr& newValue,
-                                                                                        PropertyEventType changeType,
-                                                                                        bool isUpdating)
+                                                                                                 const BaseObjectPtr& newValue,
+                                                                                                 PropertyEventType changeType,
+                                                                                                 bool isUpdating)
 {
     if (!prop.assigned())
     {
@@ -471,9 +471,9 @@ BaseObjectPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::callPr
 
     auto args = PropertyValueEventArgs(prop, newValue, changeType, isUpdating);
 
-    if (prop.assigned())
+    if (!localProperties.count(prop.getName()))
     {
-        PropertyValueEventEmitter propEvent{prop.getOnPropertyValueWrite()};
+        const PropertyValueEventEmitter propEvent{prop.asPtr<IPropertyInternal>().getClassOnPropertyValueWrite()};
         if (propEvent.hasListeners())
         {
             propEvent(objPtr, args);
@@ -513,10 +513,14 @@ BaseObjectPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::callPr
     }
 
     auto args = PropertyValueEventArgs(prop, readValue, PropertyEventType::Read, False);
-    PropertyValueEventEmitter propEvent{prop.getOnPropertyValueRead()};
-    if (propEvent.hasListeners())
+
+    if (!localProperties.count(prop.getName()))
     {
-        propEvent(objPtr, args);
+        const PropertyValueEventEmitter propEvent{prop.asPtr<IPropertyInternal>().getClassOnPropertyValueRead()};
+        if (propEvent.hasListeners())
+        {
+            propEvent(objPtr, args);
+        }
     }
 
     const auto name = prop.getName();
@@ -1636,13 +1640,31 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::addProperty(
 
         if (hasDuplicateReferences(propPtr))
             return this->makeErrorInfo(OPENDAQ_ERR_INVALIDVALUE, "Reference property references a property that is already referenced by another.");
-
+        
         propPtr.asPtr<IOwnable>().setOwner(objPtr);
 
         const auto res = localProperties.insert(std::make_pair(propName, propPtr));
         if (!res.second)
             return this->makeErrorInfo(OPENDAQ_ERR_ALREADYEXISTS, fmt::format(R"(Property with name {} already exists.)", propName));
         
+        auto readEvent = propPtr.asPtr<IPropertyInternal>().getClassOnPropertyValueRead();
+        if (readEvent.getListenerCount())
+        {
+            PropertyValueEventEmitter emitter;
+            valueReadEvents.emplace(propName, emitter);
+            for (const auto& listener : readEvent.getListeners())
+                emitter.addHandler(listener);
+        }
+
+        auto writeEvent = propPtr.asPtr<IPropertyInternal>().getClassOnPropertyValueWrite();
+        if (writeEvent.getListenerCount())
+        {
+            PropertyValueEventEmitter emitter;
+            valueWriteEvents.emplace(propName, emitter);
+            for (const auto& listener : writeEvent.getListeners())
+                emitter.addHandler(listener);
+        }
+
         cloneAndSetChildPropertyObject(propPtr);
 
         if (!coreEventMuted && triggerCoreEvent.assigned())

--- a/core/coretypes/include/coretypes/event.h
+++ b/core/coretypes/include/coretypes/event.h
@@ -38,6 +38,7 @@ DECLARE_OPENDAQ_INTERFACE(IEvent, IBaseObject)
 
     virtual ErrCode INTERFACE_FUNC clear() = 0;
     virtual ErrCode INTERFACE_FUNC getSubscriberCount(SizeT* count) = 0;
+    virtual ErrCode INTERFACE_FUNC getSubscribers(IList** subscribers) = 0;
 
     virtual ErrCode INTERFACE_FUNC mute() = 0;
     virtual ErrCode INTERFACE_FUNC unmute() = 0;

--- a/core/coretypes/include/coretypes/event_impl.h
+++ b/core/coretypes/include/coretypes/event_impl.h
@@ -70,6 +70,7 @@ public:
 
     ErrCode INTERFACE_FUNC clear() override;
     ErrCode INTERFACE_FUNC getSubscriberCount(SizeT* count) override;
+    ErrCode INTERFACE_FUNC getSubscribers(IList** subscribers) override;
 
     ErrCode INTERFACE_FUNC trigger(IBaseObject* sender, IEventArgs* args) override;
 

--- a/core/coretypes/include/coretypes/event_ptr.h
+++ b/core/coretypes/include/coretypes/event_ptr.h
@@ -150,6 +150,18 @@ public:
         return count;
     }
 
+    ListPtr<IEventHandler> getListeners() const
+    {
+        if (this->object == nullptr)
+            throw InvalidParameterException();
+
+        ListPtr<IEventHandler> listeners;
+        auto errCode = this->object->getSubscribers(&listeners);
+        checkErrorInfo(errCode);
+
+        return listeners;
+    }
+
     void mute() const
     {
         if (this->object == nullptr)

--- a/core/coretypes/include/coretypes/event_wrapper.h
+++ b/core/coretypes/include/coretypes/event_wrapper.h
@@ -130,6 +130,16 @@ public:
         return eventPtr.getListenerCount();
     }
 
+    ListPtr<IEventHandler> getListeners()
+    {
+        if (!eventPtr.assigned())
+        {
+            throw InvalidParameterException("Invalid or uninitialized event.");
+        }
+
+        return eventPtr.getListeners();
+    }
+
     void mute() const
     {
         if (!eventPtr.assigned())

--- a/core/coretypes/src/event_impl.cpp
+++ b/core/coretypes/src/event_impl.cpp
@@ -81,6 +81,22 @@ ErrCode EventImpl::getSubscriberCount(SizeT* count)
     return OPENDAQ_SUCCESS;
 }
 
+ErrCode EventImpl::getSubscribers(IList** subscribers)
+{
+    if (!subscribers)
+        return OPENDAQ_ERR_ARGUMENT_NULL;
+
+	std::scoped_lock lock(sync);
+
+    auto list = List<IEventHandler>();
+
+    for (const auto& handler : handlers)
+        list.pushBack(handler.eventHandler);
+
+	*subscribers = list.detach();
+	return OPENDAQ_SUCCESS;
+}
+
 ErrCode EventImpl::trigger(IBaseObject* sender, IEventArgs* args)
 {
     std::scoped_lock lock(sync);


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

- Changed logic of `IProperty::getOnPropertyValueRead/Write` events.
- Now returns the owner's event when called, if the owner is assigned.
- A new function is available to get the class's event. That function is used internally to trigger class value change events.