### PR TITLE
Remove redundant fb config check

### DIFF
--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb.h
@@ -30,7 +30,7 @@ protected:
     void createFunctionBlocks();
     void createSignals();
     void createInputPorts();
-    void createTestConfigProperties();
+    void createTestConfigProperties(const daq::PropertyObjectPtr& config);
 };
 
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(

--- a/core/opendaq/opendaq/mocks/mock_fb.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb.cpp
@@ -12,14 +12,14 @@ MockFunctionBlockImpl::MockFunctionBlockImpl(daq::FunctionBlockTypePtr type,
                                              const daq::ComponentPtr& parent,
                                              const daq::StringPtr& localId,
                                              const daq::PropertyObjectPtr& config)
-    : FunctionBlockImpl<IFunctionBlock>(type, ctx, parent, localId, nullptr, config)
+    : FunctionBlockImpl<IFunctionBlock>(type, ctx, parent, localId)
 {
     this->tags.add("mock_fb");
 
     createFunctionBlocks();
     createSignals();
     createInputPorts();
-    createTestConfigProperties();
+    createTestConfigProperties(config);
 }
 
 void MockFunctionBlockImpl::createFunctionBlocks()
@@ -54,10 +54,13 @@ void MockFunctionBlockImpl::createSignals()
     createAndAddSignal("UniqueId_5", createDescriptor("Signal5"), true, false);
 }
 
-void MockFunctionBlockImpl::createTestConfigProperties()
+void MockFunctionBlockImpl::createTestConfigProperties(const PropertyObjectPtr& config)
 {
     addProperty(IntProperty("TestConfigInt", 0));
     addProperty(StringProperty("TestConfigString", ""));
+
+    if (!config.assigned())
+        return;
 
     if (config.hasProperty("TestConfigInt"))
         setPropertyValue((StringPtr) "TestConfigInt", config.getPropertyValue("TestConfigInt"));


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Description:

Removes unused config check in base FB implementation. Will later on be replaced in module manager and stored config for save/load.