### PR TITLE
[TBBAS-1741] .NET Bindings - GUI demo displays inputs/outputs and can configure

### DIFF
--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/AttributeItem.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/AttributeItem.cs
@@ -16,6 +16,7 @@
 
 
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 using Daq.Core.Objects;
 using Daq.Core.Types;

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/AttributeItem.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/AttributeItem.cs
@@ -1,0 +1,103 @@
+﻿/*
+ * Copyright 2022-2024 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+using System.ComponentModel;
+
+using Daq.Core.Objects;
+using Daq.Core.Types;
+
+using GlblRes = global::openDAQDemoNet.Properties.Resources;
+
+
+namespace openDAQDemoNet;
+
+
+/// <summary>
+/// Class describing <see cref="Daq.Core.OpenDAQ.Component"/> attributes.
+/// </summary>
+public class AttributeItem
+{
+    private readonly Image _editableImage = new Bitmap(16, 16); //empty image
+    private readonly Image _lockedImage   = (Image)GlblRes.locked16.Clone();
+
+    private readonly bool       _isLocked;
+    private readonly string     _name;
+    private readonly CoreType   _valueType;
+    private readonly BaseObject _openDaqObject;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AttributeItem"/> class.
+    /// </summary>
+    /// <param name="isLocked">If set to <c>true</c>, the attribute is locked; otherwise <c>false</c>.</param>
+    /// <param name="name">The attribute's name.</param>
+    /// <param name="displayName">The attribute's display name.</param>
+    /// <param name="value">The attribute value's text representation.</param>
+    /// <param name="valueType">The attribute's value type.</param>
+    /// <param name="openDaqObject">The owner of this attribute.</param>
+    public AttributeItem(bool isLocked, string name, string displayName, string? value, CoreType valueType, BaseObject openDaqObject)
+    {
+        _isLocked    = isLocked;
+        _name          = name;
+        _valueType     = valueType;
+        _openDaqObject = openDaqObject;
+
+        this.DisplayName = displayName;
+        this.Value       = value ?? string.Empty;
+    }
+
+    #region fields to show in table
+
+    /// <summary>
+    /// Gets an image indicating whether this <see cref="AttributeItem"/> is locked.
+    /// </summary>
+    [DisplayName("Locked")]
+    public Image LockedImage => _isLocked ? _lockedImage : _editableImage;
+
+    /// <summary>
+    /// Gets the attribute's human readable name.
+    /// </summary>
+    [DisplayName("Attribute name")]
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the attribute value.
+    /// </summary>
+    [DisplayName("Value")]
+    public string Value { get; }
+
+    #endregion
+
+    /// <summary>
+    /// Gets the locked state of the attribute.
+    /// </summary>
+    internal bool IsLocked => _isLocked;
+
+    /// <summary>
+    /// Gets the attribute's name.
+    /// </summary>
+    internal string Name => _name;
+
+    /// <summary>
+    /// Gets the attribute's value type.
+    /// </summary>
+    internal CoreType ValueType => _valueType;
+
+    /// <summary>
+    /// Gets the openDAQ object that owns this attribute.
+    /// </summary>
+    internal BaseObject OpenDaqObject => _openDaqObject;
+}

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/PropertyItem.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/PropertyItem.cs
@@ -16,8 +16,10 @@
 
 
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 using Daq.Core.Objects;
+using Daq.Core.Types;
 
 using GlblRes = global::openDAQDemoNet.Properties.Resources;
 
@@ -26,15 +28,11 @@ namespace openDAQDemoNet;
 
 
 /// <summary>
-/// Class describing property items from <see cref="Daq.Core.OpenDAQ.Component"/>s.
+/// Class describing property items from <see cref="Daq.Core.OpenDAQ.Component"/>s (inherits from <see cref="AttributeItem"/>).
 /// </summary>
-public class PropertyItem
+/// <seealso cref="AttributeItem" />
+public class PropertyItem : AttributeItem
 {
-    private readonly Image _editableImage = new Bitmap(16, 16); //empty image
-    private readonly Image _lockedImage   = (Image)GlblRes.locked16.Clone();
-
-    private bool _isLocked;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="PropertyItem"/> class.
     /// </summary>
@@ -42,35 +40,36 @@ public class PropertyItem
     /// <param name="name">The property name.</param>
     /// <param name="value">The property value's text representation.</param>
     /// <param name="unit">The property value's unit.</param>
-    public PropertyItem(bool isLocked, string name, string? value, string unit, string description)
+    /// <param name="description">The description of the property.</param>
+    /// <param name="openDaqObject">The property object.</param>
+    public PropertyItem(bool isLocked, string name, string? value, string unit, string description, BaseObject openDaqObject)
+        : base(isLocked, name, name, value, CoreType.ctUndefined, openDaqObject)
     {
-        _isLocked = isLocked;
-
-        this.Name        = name;
-        this.Value       = value ?? string.Empty;
         this.Unit        = unit;
         this.Description = description;
     }
 
     #region fields to show in table
 
+    //Hack: declaring base properties as `new` to display the inherited properties first in grid (DisplayAttribute.Order not working)
+
     /// <summary>
     /// Gets an image indicating whether this <see cref="PropertyItem"/> is locked.
     /// </summary>
     [DisplayName("Locked")]
-    public Image LockedImage => _isLocked ? _lockedImage : _editableImage;
+    public new Image LockedImage => base.LockedImage;
 
     /// <summary>
     /// Gets the property name.
     /// </summary>
     [DisplayName("Property name")]
-    public string Name { get; }
+    public new string DisplayName => base.DisplayName; //for a `Property` the `DisplayName` always equals `Name`
 
     /// <summary>
     /// Gets the property value.
     /// </summary>
     [DisplayName("Value")]
-    public string Value { get; }
+    public new string Value => base.Value;
 
     /// <summary>
     /// Gets the property value's unit.
@@ -85,9 +84,4 @@ public class PropertyItem
     public string Description { get; }
 
     #endregion
-
-    /// <summary>
-    /// Gets the locked state (private property).
-    /// </summary>
-    internal bool IsLocked => _isLocked;
 }

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.Designer.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.Designer.cs
@@ -1,0 +1,93 @@
+﻿namespace openDAQDemoNet
+{
+    partial class frmEditComponent
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            gridAttributes = new DataGridView();
+            contextMenuStripGridAttributes = new ContextMenuStrip(components);
+            conetxtMenuItemGridAttributesEdit = new ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)gridAttributes).BeginInit();
+            contextMenuStripGridAttributes.SuspendLayout();
+            SuspendLayout();
+            // 
+            // gridAttributes
+            // 
+            gridAttributes.AllowUserToAddRows = false;
+            gridAttributes.AllowUserToDeleteRows = false;
+            gridAttributes.BackgroundColor = SystemColors.Window;
+            gridAttributes.ContextMenuStrip = contextMenuStripGridAttributes;
+            gridAttributes.Dock = DockStyle.Fill;
+            gridAttributes.Location = new Point(0, 0);
+            gridAttributes.Name = "gridAttributes";
+            gridAttributes.ReadOnly = true;
+            gridAttributes.RowTemplate.Height = 25;
+            gridAttributes.Size = new Size(684, 561);
+            gridAttributes.TabIndex = 6;
+            gridAttributes.CellContextMenuStripNeeded += gridAttributes_CellContextMenuStripNeeded;
+            gridAttributes.CellDoubleClick += gridAttributes_CellDoubleClick;
+            // 
+            // contextMenuStripGridAttributes
+            // 
+            contextMenuStripGridAttributes.Items.AddRange(new ToolStripItem[] { conetxtMenuItemGridAttributesEdit });
+            contextMenuStripGridAttributes.Name = "contextMenuStrip1";
+            contextMenuStripGridAttributes.Size = new Size(193, 26);
+            contextMenuStripGridAttributes.Opening += contextMenuStripGridAttributes_Opening;
+            // 
+            // conetxtMenuItemGridAttributesEdit
+            // 
+            conetxtMenuItemGridAttributesEdit.Name = "conetxtMenuItemGridAttributesEdit";
+            conetxtMenuItemGridAttributesEdit.ShortcutKeyDisplayString = "<double-click>";
+            conetxtMenuItemGridAttributesEdit.Size = new Size(192, 22);
+            conetxtMenuItemGridAttributesEdit.Text = "Edit...";
+            conetxtMenuItemGridAttributesEdit.Click += conetxtMenuItemGridAttributesEdit_Click;
+            // 
+            // frmEditComponent
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(684, 561);
+            Controls.Add(gridAttributes);
+            FormBorderStyle = FormBorderStyle.SizableToolWindow;
+            Name = "frmEditComponent";
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Attributes";
+            FormClosing += frmEditComponent_FormClosing;
+            Shown += frmEditComponent_Shown;
+            ((System.ComponentModel.ISupportInitialize)gridAttributes).EndInit();
+            contextMenuStripGridAttributes.ResumeLayout(false);
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private DataGridView gridAttributes;
+        private ContextMenuStrip contextMenuStripGridAttributes;
+        private ToolStripMenuItem conetxtMenuItemGridAttributesEdit;
+    }
+}

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.Designer.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.Designer.cs
@@ -44,6 +44,7 @@
             gridAttributes.ContextMenuStrip = contextMenuStripGridAttributes;
             gridAttributes.Dock = DockStyle.Fill;
             gridAttributes.Location = new Point(0, 0);
+            gridAttributes.MultiSelect = false;
             gridAttributes.Name = "gridAttributes";
             gridAttributes.ReadOnly = true;
             gridAttributes.RowTemplate.Height = 25;

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+using Daq.Core.OpenDAQ;
+
+using Component = Daq.Core.OpenDAQ.Component;
+
+
+namespace openDAQDemoNet;
+
+
+public partial class frmEditComponent : Form
+{
+    private readonly Component                  _component;
+    private readonly BindingList<AttributeItem> _attributeItems = new();
+
+    public frmEditComponent(Component component)
+    {
+        InitializeComponent();
+
+        _component = component;
+
+        frmMain.InitializeDataGridView(this.gridAttributes);
+    }
+
+    private void frmEditComponent_Shown(object sender, EventArgs e)
+    {
+        SetWaitCursor();
+        this.Update();
+
+        frmMain.UpdateAttributes(_component, _attributeItems);
+
+        //binding data late to not to "trash" GUI display beforehand
+        this.gridAttributes.DataSource = _attributeItems;
+        this.gridAttributes.Columns[nameof(PropertyItem.LockedImage)].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
+        this.gridAttributes.Refresh();
+        this.gridAttributes.ClearSelection();
+        this.gridAttributes.AutoResizeColumns();
+
+        ResetWaitCursor();
+    }
+
+    private void frmEditComponent_FormClosing(object sender, FormClosingEventArgs e)
+    {
+        _attributeItems.Clear();
+    }
+
+    #region gridAttributes
+
+    private void gridAttributes_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
+    {
+        if (e.RowIndex < 0)
+        {
+            MessageBox.Show("No attribute selected", "Edit", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            return;
+        }
+
+        var attributeItem = (AttributeItem)((DataGridView)sender).Rows[e.RowIndex].DataBoundItem;
+
+        if (attributeItem.IsLocked)
+        {
+            MessageBox.Show("Attribute is locked", $"Edit attribute \"{attributeItem.DisplayName}\"", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            return;
+        }
+
+        AttributeItem selectedAttributeObject = (AttributeItem)this.gridAttributes.SelectedRows[0].DataBoundItem;
+
+        frmMain.EditSelectedAttribute(this, selectedAttributeObject);
+        frmMain.UpdateAttributes((Component)selectedAttributeObject.OpenDaqObject, _attributeItems);
+    }
+
+    #region conetxtMenuItemGridAttributesEdit
+
+    private void gridAttributes_CellContextMenuStripNeeded(object sender, DataGridViewCellContextMenuStripNeededEventArgs e)
+    {
+        if ((e.RowIndex < 0) || (e.ColumnIndex < 0))
+            return;
+
+        DataGridView dataGridView = ((DataGridView)sender);
+
+        //select the clicked cell/row for context menu (which opens automatically after this)
+        dataGridView.CurrentCell = dataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex];
+    }
+
+    private void contextMenuStripGridAttributes_Opening(object sender, CancelEventArgs e)
+    {
+        //init
+        this.conetxtMenuItemGridAttributesEdit.Enabled = false;
+
+        //get the DataGridView on which the context menu has been triggered
+        var grid = (DataGridView)((ContextMenuStrip)sender).SourceControl;
+
+        if (grid.SelectedRows.Count == 0)
+        {
+            e.Cancel = true;
+            return;
+        }
+
+        Point cursor = grid.PointToClient(Cursor.Position);
+        var info = grid.HitTest(cursor.X, cursor.Y);
+        if (info.Type != DataGridViewHitTestType.Cell)
+        {
+            //no node clicked
+            e.Cancel = true;
+            return;
+        }
+
+        var selectedProperty = (AttributeItem)grid.SelectedRows[0].DataBoundItem;
+
+        this.conetxtMenuItemGridAttributesEdit.Enabled = !selectedProperty.IsLocked;
+    }
+
+    private void conetxtMenuItemGridAttributesEdit_Click(object sender, EventArgs e)
+    {
+        var toolStripMenuItem = (ToolStripMenuItem)sender;
+        var sourceControl = ((ContextMenuStrip)toolStripMenuItem.Owner).SourceControl;
+
+        if (sourceControl == this.gridAttributes)
+        {
+            frmMain.EditSelectedAttribute(this, (AttributeItem)this.gridAttributes.SelectedRows[0].DataBoundItem);
+            frmMain.UpdateAttributes(_component, _attributeItems);
+        }
+    }
+
+    #endregion conetxtMenuItemGridAttributesEdit
+
+    #endregion gridAttributes
+
+
+    #region Common GUI methods
+
+    /// <summary>
+    /// Sets the wait cursor.
+    /// </summary>
+    private void SetWaitCursor()
+    {
+        Cursor.Current     = Cursors.WaitCursor;
+        this.Cursor        = Cursors.WaitCursor;
+        this.UseWaitCursor = true;
+    }
+
+    /// <summary>
+    /// Resets to the default cursor.
+    /// </summary>
+    private void ResetWaitCursor()
+    {
+        this.UseWaitCursor = false;
+        this.Cursor        = Cursors.Default;
+        Cursor.Current     = Cursors.Default;
+        base.ResetCursor();
+    }
+
+    #endregion Common GUI methods
+}

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.cs
@@ -71,10 +71,7 @@ public partial class frmEditComponent : Form
             return;
         }
 
-        AttributeItem selectedAttributeObject = (AttributeItem)this.gridAttributes.SelectedRows[0].DataBoundItem;
-
-        frmMain.EditSelectedAttribute(this, selectedAttributeObject);
-        frmMain.UpdateAttributes((Component)selectedAttributeObject.OpenDaqObject, _attributeItems);
+        EditSelectedAttribute();
     }
 
     #region conetxtMenuItemGridAttributesEdit
@@ -121,16 +118,26 @@ public partial class frmEditComponent : Form
     private void conetxtMenuItemGridAttributesEdit_Click(object sender, EventArgs e)
     {
         var toolStripMenuItem = (ToolStripMenuItem)sender;
-        var sourceControl = ((ContextMenuStrip)toolStripMenuItem.Owner).SourceControl;
+        var gridControl = ((ContextMenuStrip)toolStripMenuItem.Owner).SourceControl as DataGridView;
 
-        if (sourceControl == this.gridAttributes)
-        {
-            frmMain.EditSelectedAttribute(this, (AttributeItem)this.gridAttributes.SelectedRows[0].DataBoundItem);
-            frmMain.UpdateAttributes(_component, _attributeItems);
-        }
+        if (gridControl != this.gridAttributes)
+            return;
+
+        EditSelectedAttribute();
     }
 
     #endregion conetxtMenuItemGridAttributesEdit
+
+    private void EditSelectedAttribute()
+    {
+        var selectedAttributeItem = (AttributeItem)this.gridAttributes.SelectedRows[0].DataBoundItem;
+
+        frmMain.EditSelectedAttribute(this, selectedAttributeItem);
+        frmMain.UpdateAttributes((Component)selectedAttributeItem.OpenDaqObject, _attributeItems);
+
+        this.gridAttributes.ClearSelection();
+        this.gridAttributes.AutoResizeColumns();
+    }
 
     #endregion gridAttributes
 

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.resx
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmEditComponent.resx
@@ -117,19 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStripTreeComponents.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>235, 15</value>
-  </metadata>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>15, 15</value>
-  </metadata>
-  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>130, 15</value>
-  </metadata>
-  <metadata name="contextMenuStripGridProperties.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>474, 15</value>
-  </metadata>
-  <metadata name="imglTreeImages.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>698, 15</value>
+  <metadata name="contextMenuStripGridAttributes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmInputDialog.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmInputDialog.cs
@@ -125,7 +125,7 @@ public partial class frmInputDialog : Form
 
         if ((_minValue is double minValue) && (_maxValue is double maxValue))
         {
-            if ((_integerValue < minValue) || (_integerValue > maxValue))
+            if ((_floatValue < minValue) || (_floatValue > maxValue))
             {
                 MessageBox.Show(this, $"The input is not within min/max range.\nPlease try again.",
                                 this.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.Designer.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.Designer.cs
@@ -56,7 +56,9 @@
             gridProperties = new DataGridView();
             contextMenuStripGridProperties = new ContextMenuStrip(components);
             conetxtMenuItemGridPropertiesEdit = new ToolStripMenuItem();
+            gridAttributes = new DataGridView();
             imglTreeImages = new ImageList(components);
+            splitContainer2 = new SplitContainer();
             contextMenuStripTreeComponents.SuspendLayout();
             menuStrip1.SuspendLayout();
             toolStrip1.SuspendLayout();
@@ -67,6 +69,11 @@
             splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)gridProperties).BeginInit();
             contextMenuStripGridProperties.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)gridAttributes).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)splitContainer2).BeginInit();
+            splitContainer2.Panel1.SuspendLayout();
+            splitContainer2.Panel2.SuspendLayout();
+            splitContainer2.SuspendLayout();
             SuspendLayout();
             // 
             // treeComponents
@@ -78,7 +85,7 @@
             treeNode1.Name = "Node0";
             treeNode1.Text = "treeComponents";
             treeComponents.Nodes.AddRange(new TreeNode[] { treeNode1 });
-            treeComponents.Size = new Size(297, 542);
+            treeComponents.Size = new Size(397, 683);
             treeComponents.TabIndex = 2;
             treeComponents.AfterSelect += treeComponents_AfterSelect;
             treeComponents.NodeMouseClick += treeComponents_NodeMouseClick;
@@ -102,7 +109,7 @@
             menuStrip1.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem, viewToolStripMenuItem });
             menuStrip1.Location = new Point(0, 0);
             menuStrip1.Name = "menuStrip1";
-            menuStrip1.Size = new Size(784, 24);
+            menuStrip1.Size = new Size(984, 24);
             menuStrip1.TabIndex = 4;
             menuStrip1.Text = "menuStrip1";
             // 
@@ -167,7 +174,7 @@
             toolStrip1.Items.AddRange(new ToolStripItem[] { btnAddDevice, btnAddFunctionBlock, btnRefresh });
             toolStrip1.Location = new Point(0, 24);
             toolStrip1.Name = "toolStrip1";
-            toolStrip1.Size = new Size(784, 25);
+            toolStrip1.Size = new Size(984, 25);
             toolStrip1.TabIndex = 5;
             toolStrip1.Text = "toolStrip1";
             // 
@@ -206,7 +213,7 @@
             tabControl1.Location = new Point(0, 49);
             tabControl1.Name = "tabControl1";
             tabControl1.SelectedIndex = 0;
-            tabControl1.Size = new Size(784, 23);
+            tabControl1.Size = new Size(984, 23);
             tabControl1.TabIndex = 6;
             tabControl1.Selected += tabControl1_Selected;
             // 
@@ -215,7 +222,7 @@
             tabSystemOverview.Location = new Point(4, 24);
             tabSystemOverview.Name = "tabSystemOverview";
             tabSystemOverview.Padding = new Padding(3);
-            tabSystemOverview.Size = new Size(776, 0);
+            tabSystemOverview.Size = new Size(976, 0);
             tabSystemOverview.TabIndex = 0;
             tabSystemOverview.Text = "System overview";
             tabSystemOverview.UseVisualStyleBackColor = true;
@@ -225,7 +232,7 @@
             tabSignals.Location = new Point(4, 24);
             tabSignals.Name = "tabSignals";
             tabSignals.Padding = new Padding(3);
-            tabSignals.Size = new Size(776, 0);
+            tabSignals.Size = new Size(976, 0);
             tabSignals.TabIndex = 1;
             tabSignals.Text = "Signals";
             tabSignals.UseVisualStyleBackColor = true;
@@ -234,7 +241,7 @@
             // 
             tabChannels.Location = new Point(4, 24);
             tabChannels.Name = "tabChannels";
-            tabChannels.Size = new Size(776, 0);
+            tabChannels.Size = new Size(976, 0);
             tabChannels.TabIndex = 2;
             tabChannels.Text = "Channels";
             tabChannels.UseVisualStyleBackColor = true;
@@ -243,7 +250,7 @@
             // 
             tabFunctionBlocks.Location = new Point(4, 24);
             tabFunctionBlocks.Name = "tabFunctionBlocks";
-            tabFunctionBlocks.Size = new Size(776, 0);
+            tabFunctionBlocks.Size = new Size(976, 0);
             tabFunctionBlocks.TabIndex = 3;
             tabFunctionBlocks.Text = "Function blocks";
             tabFunctionBlocks.UseVisualStyleBackColor = true;
@@ -252,7 +259,7 @@
             // 
             tabFullTopology.Location = new Point(4, 24);
             tabFullTopology.Name = "tabFullTopology";
-            tabFullTopology.Size = new Size(776, 0);
+            tabFullTopology.Size = new Size(976, 0);
             tabFullTopology.TabIndex = 4;
             tabFullTopology.Text = "Full topology";
             tabFullTopology.UseVisualStyleBackColor = true;
@@ -260,6 +267,7 @@
             // splitContainer1
             // 
             splitContainer1.Dock = DockStyle.Fill;
+            splitContainer1.FixedPanel = FixedPanel.Panel1;
             splitContainer1.Location = new Point(0, 72);
             splitContainer1.Name = "splitContainer1";
             // 
@@ -270,10 +278,10 @@
             // 
             // splitContainer1.Panel2
             // 
-            splitContainer1.Panel2.Controls.Add(gridProperties);
+            splitContainer1.Panel2.Controls.Add(splitContainer2);
             splitContainer1.Panel2.Padding = new Padding(0, 3, 3, 3);
-            splitContainer1.Size = new Size(784, 548);
-            splitContainer1.SplitterDistance = 300;
+            splitContainer1.Size = new Size(984, 689);
+            splitContainer1.SplitterDistance = 400;
             splitContainer1.TabIndex = 0;
             // 
             // gridProperties
@@ -283,11 +291,11 @@
             gridProperties.BackgroundColor = SystemColors.Window;
             gridProperties.ContextMenuStrip = contextMenuStripGridProperties;
             gridProperties.Dock = DockStyle.Fill;
-            gridProperties.Location = new Point(0, 3);
+            gridProperties.Location = new Point(0, 0);
             gridProperties.Name = "gridProperties";
             gridProperties.ReadOnly = true;
             gridProperties.RowTemplate.Height = 25;
-            gridProperties.Size = new Size(477, 542);
+            gridProperties.Size = new Size(577, 400);
             gridProperties.TabIndex = 4;
             gridProperties.CellContextMenuStripNeeded += gridProperties_CellContextMenuStripNeeded;
             gridProperties.CellDoubleClick += gridProperties_CellDoubleClick;
@@ -307,17 +315,52 @@
             conetxtMenuItemGridPropertiesEdit.Text = "Edit...";
             conetxtMenuItemGridPropertiesEdit.Click += conetxtMenuItemGridPropertiesEdit_Click;
             // 
+            // gridAttributes
+            // 
+            gridAttributes.AllowUserToAddRows = false;
+            gridAttributes.AllowUserToDeleteRows = false;
+            gridAttributes.BackgroundColor = SystemColors.Window;
+            gridAttributes.ContextMenuStrip = contextMenuStripGridProperties;
+            gridAttributes.Dock = DockStyle.Fill;
+            gridAttributes.Location = new Point(0, 0);
+            gridAttributes.Name = "gridAttributes";
+            gridAttributes.ReadOnly = true;
+            gridAttributes.RowTemplate.Height = 25;
+            gridAttributes.Size = new Size(577, 279);
+            gridAttributes.TabIndex = 5;
+            gridAttributes.CellContextMenuStripNeeded += gridAttributes_CellContextMenuStripNeeded;
+            gridAttributes.CellDoubleClick += gridAttributes_CellDoubleClick;
+            // 
             // imglTreeImages
             // 
             imglTreeImages.ColorDepth = ColorDepth.Depth8Bit;
             imglTreeImages.ImageSize = new Size(16, 16);
             imglTreeImages.TransparentColor = Color.Transparent;
             // 
+            // splitContainer2
+            // 
+            splitContainer2.Dock = DockStyle.Fill;
+            splitContainer2.FixedPanel = FixedPanel.Panel2;
+            splitContainer2.Location = new Point(0, 3);
+            splitContainer2.Name = "splitContainer2";
+            splitContainer2.Orientation = Orientation.Horizontal;
+            // 
+            // splitContainer2.Panel1
+            // 
+            splitContainer2.Panel1.Controls.Add(gridProperties);
+            // 
+            // splitContainer2.Panel2
+            // 
+            splitContainer2.Panel2.Controls.Add(gridAttributes);
+            splitContainer2.Size = new Size(577, 683);
+            splitContainer2.SplitterDistance = 400;
+            splitContainer2.TabIndex = 6;
+            // 
             // frmMain
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(784, 620);
+            ClientSize = new Size(984, 761);
             Controls.Add(splitContainer1);
             Controls.Add(tabControl1);
             Controls.Add(toolStrip1);
@@ -341,6 +384,11 @@
             splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)gridProperties).EndInit();
             contextMenuStripGridProperties.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)gridAttributes).EndInit();
+            splitContainer2.Panel1.ResumeLayout(false);
+            splitContainer2.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainer2).EndInit();
+            splitContainer2.ResumeLayout(false);
             ResumeLayout(false);
             PerformLayout();
         }
@@ -373,5 +421,7 @@
         private DataGridView gridProperties;
         private ContextMenuStrip contextMenuStripGridProperties;
         private ToolStripMenuItem conetxtMenuItemGridPropertiesEdit;
+        private DataGridView gridAttributes;
+        private SplitContainer splitContainer2;
     }
 }

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.Designer.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.Designer.cs
@@ -52,28 +52,40 @@
             tabChannels = new TabPage();
             tabFunctionBlocks = new TabPage();
             tabFullTopology = new TabPage();
-            splitContainer1 = new SplitContainer();
+            splitContainerMain = new SplitContainer();
+            splitContainerPropertiesAttributes = new SplitContainer();
+            splitContainerPropertiesInputs = new SplitContainer();
             gridProperties = new DataGridView();
             contextMenuStripGridProperties = new ContextMenuStrip(components);
             conetxtMenuItemGridPropertiesEdit = new ToolStripMenuItem();
+            groupInputPorts = new GroupBox();
+            tableInputPorts = new TableLayoutPanel();
+            label1 = new Label();
+            comboBox1 = new ComboBox();
+            button1 = new Button();
             gridAttributes = new DataGridView();
             imglTreeImages = new ImageList(components);
-            splitContainer2 = new SplitContainer();
             contextMenuStripTreeComponents.SuspendLayout();
             menuStrip1.SuspendLayout();
             toolStrip1.SuspendLayout();
             tabControl1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
-            splitContainer1.Panel1.SuspendLayout();
-            splitContainer1.Panel2.SuspendLayout();
-            splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainerMain).BeginInit();
+            splitContainerMain.Panel1.SuspendLayout();
+            splitContainerMain.Panel2.SuspendLayout();
+            splitContainerMain.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainerPropertiesAttributes).BeginInit();
+            splitContainerPropertiesAttributes.Panel1.SuspendLayout();
+            splitContainerPropertiesAttributes.Panel2.SuspendLayout();
+            splitContainerPropertiesAttributes.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainerPropertiesInputs).BeginInit();
+            splitContainerPropertiesInputs.Panel1.SuspendLayout();
+            splitContainerPropertiesInputs.Panel2.SuspendLayout();
+            splitContainerPropertiesInputs.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)gridProperties).BeginInit();
             contextMenuStripGridProperties.SuspendLayout();
+            groupInputPorts.SuspendLayout();
+            tableInputPorts.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)gridAttributes).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)splitContainer2).BeginInit();
-            splitContainer2.Panel1.SuspendLayout();
-            splitContainer2.Panel2.SuspendLayout();
-            splitContainer2.SuspendLayout();
             SuspendLayout();
             // 
             // treeComponents
@@ -264,25 +276,62 @@
             tabFullTopology.Text = "Full topology";
             tabFullTopology.UseVisualStyleBackColor = true;
             // 
-            // splitContainer1
+            // splitContainerMain
             // 
-            splitContainer1.Dock = DockStyle.Fill;
-            splitContainer1.FixedPanel = FixedPanel.Panel1;
-            splitContainer1.Location = new Point(0, 72);
-            splitContainer1.Name = "splitContainer1";
+            splitContainerMain.Dock = DockStyle.Fill;
+            splitContainerMain.FixedPanel = FixedPanel.Panel1;
+            splitContainerMain.Location = new Point(0, 72);
+            splitContainerMain.Name = "splitContainerMain";
             // 
-            // splitContainer1.Panel1
+            // splitContainerMain.Panel1
             // 
-            splitContainer1.Panel1.Controls.Add(treeComponents);
-            splitContainer1.Panel1.Padding = new Padding(3, 3, 0, 3);
+            splitContainerMain.Panel1.Controls.Add(treeComponents);
+            splitContainerMain.Panel1.Padding = new Padding(3, 3, 0, 3);
             // 
-            // splitContainer1.Panel2
+            // splitContainerMain.Panel2
             // 
-            splitContainer1.Panel2.Controls.Add(splitContainer2);
-            splitContainer1.Panel2.Padding = new Padding(0, 3, 3, 3);
-            splitContainer1.Size = new Size(984, 689);
-            splitContainer1.SplitterDistance = 400;
-            splitContainer1.TabIndex = 0;
+            splitContainerMain.Panel2.Controls.Add(splitContainerPropertiesAttributes);
+            splitContainerMain.Panel2.Padding = new Padding(0, 3, 3, 3);
+            splitContainerMain.Size = new Size(984, 689);
+            splitContainerMain.SplitterDistance = 400;
+            splitContainerMain.TabIndex = 0;
+            // 
+            // splitContainerPropertiesAttributes
+            // 
+            splitContainerPropertiesAttributes.Dock = DockStyle.Fill;
+            splitContainerPropertiesAttributes.FixedPanel = FixedPanel.Panel2;
+            splitContainerPropertiesAttributes.Location = new Point(0, 3);
+            splitContainerPropertiesAttributes.Name = "splitContainerPropertiesAttributes";
+            splitContainerPropertiesAttributes.Orientation = Orientation.Horizontal;
+            // 
+            // splitContainerPropertiesAttributes.Panel1
+            // 
+            splitContainerPropertiesAttributes.Panel1.Controls.Add(splitContainerPropertiesInputs);
+            // 
+            // splitContainerPropertiesAttributes.Panel2
+            // 
+            splitContainerPropertiesAttributes.Panel2.Controls.Add(gridAttributes);
+            splitContainerPropertiesAttributes.Size = new Size(577, 683);
+            splitContainerPropertiesAttributes.SplitterDistance = 400;
+            splitContainerPropertiesAttributes.TabIndex = 6;
+            // 
+            // splitContainerPropertiesInputs
+            // 
+            splitContainerPropertiesInputs.Dock = DockStyle.Fill;
+            splitContainerPropertiesInputs.FixedPanel = FixedPanel.Panel1;
+            splitContainerPropertiesInputs.Location = new Point(0, 0);
+            splitContainerPropertiesInputs.Name = "splitContainerPropertiesInputs";
+            // 
+            // splitContainerPropertiesInputs.Panel1
+            // 
+            splitContainerPropertiesInputs.Panel1.Controls.Add(gridProperties);
+            // 
+            // splitContainerPropertiesInputs.Panel2
+            // 
+            splitContainerPropertiesInputs.Panel2.Controls.Add(groupInputPorts);
+            splitContainerPropertiesInputs.Size = new Size(577, 400);
+            splitContainerPropertiesInputs.SplitterDistance = 300;
+            splitContainerPropertiesInputs.TabIndex = 8;
             // 
             // gridProperties
             // 
@@ -295,7 +344,7 @@
             gridProperties.Name = "gridProperties";
             gridProperties.ReadOnly = true;
             gridProperties.RowTemplate.Height = 25;
-            gridProperties.Size = new Size(577, 400);
+            gridProperties.Size = new Size(300, 400);
             gridProperties.TabIndex = 4;
             gridProperties.CellContextMenuStripNeeded += gridProperties_CellContextMenuStripNeeded;
             gridProperties.CellDoubleClick += gridProperties_CellDoubleClick;
@@ -315,6 +364,64 @@
             conetxtMenuItemGridPropertiesEdit.Text = "Edit...";
             conetxtMenuItemGridPropertiesEdit.Click += conetxtMenuItemGridPropertiesEdit_Click;
             // 
+            // groupInputPorts
+            // 
+            groupInputPorts.Controls.Add(tableInputPorts);
+            groupInputPorts.Dock = DockStyle.Fill;
+            groupInputPorts.Location = new Point(0, 0);
+            groupInputPorts.Name = "groupInputPorts";
+            groupInputPorts.Size = new Size(273, 400);
+            groupInputPorts.TabIndex = 6;
+            groupInputPorts.TabStop = false;
+            groupInputPorts.Text = "Input ports";
+            // 
+            // tableInputPorts
+            // 
+            tableInputPorts.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            tableInputPorts.AutoSize = true;
+            tableInputPorts.ColumnCount = 3;
+            tableInputPorts.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 75F));
+            tableInputPorts.ColumnStyles.Add(new ColumnStyle());
+            tableInputPorts.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tableInputPorts.Controls.Add(label1, 0, 0);
+            tableInputPorts.Controls.Add(comboBox1, 1, 0);
+            tableInputPorts.Controls.Add(button1, 2, 0);
+            tableInputPorts.Location = new Point(3, 22);
+            tableInputPorts.Name = "tableInputPorts";
+            tableInputPorts.RowCount = 1;
+            tableInputPorts.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
+            tableInputPorts.Size = new Size(262, 29);
+            tableInputPorts.TabIndex = 0;
+            // 
+            // label1
+            // 
+            label1.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            label1.AutoSize = true;
+            label1.Location = new Point(3, 7);
+            label1.Name = "label1";
+            label1.Size = new Size(69, 15);
+            label1.TabIndex = 0;
+            label1.Text = "label1";
+            label1.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // comboBox1
+            // 
+            comboBox1.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            comboBox1.FormattingEnabled = true;
+            comboBox1.Location = new Point(78, 3);
+            comboBox1.Name = "comboBox1";
+            comboBox1.Size = new Size(121, 23);
+            comboBox1.TabIndex = 1;
+            // 
+            // button1
+            // 
+            button1.Anchor = AnchorStyles.Left;
+            button1.Location = new Point(205, 3);
+            button1.Name = "button1";
+            button1.Size = new Size(54, 23);
+            button1.TabIndex = 2;
+            button1.UseVisualStyleBackColor = true;
+            // 
             // gridAttributes
             // 
             gridAttributes.AllowUserToAddRows = false;
@@ -328,7 +435,7 @@
             gridAttributes.RowTemplate.Height = 25;
             gridAttributes.Size = new Size(577, 279);
             gridAttributes.TabIndex = 5;
-            gridAttributes.CellContextMenuStripNeeded += gridAttributes_CellContextMenuStripNeeded;
+            gridAttributes.CellContextMenuStripNeeded += gridProperties_CellContextMenuStripNeeded;
             gridAttributes.CellDoubleClick += gridAttributes_CellDoubleClick;
             // 
             // imglTreeImages
@@ -337,31 +444,12 @@
             imglTreeImages.ImageSize = new Size(16, 16);
             imglTreeImages.TransparentColor = Color.Transparent;
             // 
-            // splitContainer2
-            // 
-            splitContainer2.Dock = DockStyle.Fill;
-            splitContainer2.FixedPanel = FixedPanel.Panel2;
-            splitContainer2.Location = new Point(0, 3);
-            splitContainer2.Name = "splitContainer2";
-            splitContainer2.Orientation = Orientation.Horizontal;
-            // 
-            // splitContainer2.Panel1
-            // 
-            splitContainer2.Panel1.Controls.Add(gridProperties);
-            // 
-            // splitContainer2.Panel2
-            // 
-            splitContainer2.Panel2.Controls.Add(gridAttributes);
-            splitContainer2.Size = new Size(577, 683);
-            splitContainer2.SplitterDistance = 400;
-            splitContainer2.TabIndex = 6;
-            // 
             // frmMain
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(984, 761);
-            Controls.Add(splitContainer1);
+            Controls.Add(splitContainerMain);
             Controls.Add(tabControl1);
             Controls.Add(toolStrip1);
             Controls.Add(menuStrip1);
@@ -378,17 +466,25 @@
             toolStrip1.ResumeLayout(false);
             toolStrip1.PerformLayout();
             tabControl1.ResumeLayout(false);
-            splitContainer1.Panel1.ResumeLayout(false);
-            splitContainer1.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
-            splitContainer1.ResumeLayout(false);
+            splitContainerMain.Panel1.ResumeLayout(false);
+            splitContainerMain.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainerMain).EndInit();
+            splitContainerMain.ResumeLayout(false);
+            splitContainerPropertiesAttributes.Panel1.ResumeLayout(false);
+            splitContainerPropertiesAttributes.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainerPropertiesAttributes).EndInit();
+            splitContainerPropertiesAttributes.ResumeLayout(false);
+            splitContainerPropertiesInputs.Panel1.ResumeLayout(false);
+            splitContainerPropertiesInputs.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainerPropertiesInputs).EndInit();
+            splitContainerPropertiesInputs.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)gridProperties).EndInit();
             contextMenuStripGridProperties.ResumeLayout(false);
+            groupInputPorts.ResumeLayout(false);
+            groupInputPorts.PerformLayout();
+            tableInputPorts.ResumeLayout(false);
+            tableInputPorts.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)gridAttributes).EndInit();
-            splitContainer2.Panel1.ResumeLayout(false);
-            splitContainer2.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)splitContainer2).EndInit();
-            splitContainer2.ResumeLayout(false);
             ResumeLayout(false);
             PerformLayout();
         }
@@ -408,7 +504,7 @@
         private TabPage tabChannels;
         private TabPage tabFunctionBlocks;
         private TabPage tabFullTopology;
-        private SplitContainer splitContainer1;
+        private SplitContainer splitContainerMain;
         private ImageList imglTreeImages;
         private ToolStripMenuItem loadConfigurationToolStripMenuItem;
         private ToolStripMenuItem saveConfigurationToolStripMenuItem;
@@ -422,6 +518,12 @@
         private ContextMenuStrip contextMenuStripGridProperties;
         private ToolStripMenuItem conetxtMenuItemGridPropertiesEdit;
         private DataGridView gridAttributes;
-        private SplitContainer splitContainer2;
+        private SplitContainer splitContainerPropertiesAttributes;
+        private GroupBox groupInputPorts;
+        private TableLayoutPanel tableInputPorts;
+        private Label label1;
+        private ComboBox comboBox1;
+        private Button button1;
+        private SplitContainer splitContainerPropertiesInputs;
     }
 }

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.Designer.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            TreeNode treeNode1 = new TreeNode("treeComponents");
+            TreeNode treeNode2 = new TreeNode("treeComponents");
             treeComponents = new TreeView();
             contextMenuStripTreeComponents = new ContextMenuStrip(components);
             contextMenuItemTreeComponentsRemove = new ToolStripMenuItem();
@@ -63,6 +63,14 @@
             label1 = new Label();
             comboBox1 = new ComboBox();
             button1 = new Button();
+            button2 = new Button();
+            lblNoInputPorts = new Label();
+            groupOutputSignals = new GroupBox();
+            tableOutputSignals = new TableLayoutPanel();
+            label2 = new Label();
+            button3 = new Button();
+            label3 = new Label();
+            lblNoOutputSignals = new Label();
             gridAttributes = new DataGridView();
             imglTreeImages = new ImageList(components);
             contextMenuStripTreeComponents.SuspendLayout();
@@ -85,6 +93,8 @@
             contextMenuStripGridProperties.SuspendLayout();
             groupInputPorts.SuspendLayout();
             tableInputPorts.SuspendLayout();
+            groupOutputSignals.SuspendLayout();
+            tableOutputSignals.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)gridAttributes).BeginInit();
             SuspendLayout();
             // 
@@ -94,9 +104,9 @@
             treeComponents.Dock = DockStyle.Fill;
             treeComponents.Location = new Point(3, 3);
             treeComponents.Name = "treeComponents";
-            treeNode1.Name = "Node0";
-            treeNode1.Text = "treeComponents";
-            treeComponents.Nodes.AddRange(new TreeNode[] { treeNode1 });
+            treeNode2.Name = "Node0";
+            treeNode2.Text = "treeComponents";
+            treeComponents.Nodes.AddRange(new TreeNode[] { treeNode2 });
             treeComponents.Size = new Size(397, 683);
             treeComponents.TabIndex = 2;
             treeComponents.AfterSelect += treeComponents_AfterSelect;
@@ -329,6 +339,7 @@
             // splitContainerPropertiesInputs.Panel2
             // 
             splitContainerPropertiesInputs.Panel2.Controls.Add(groupInputPorts);
+            splitContainerPropertiesInputs.Panel2.Controls.Add(groupOutputSignals);
             splitContainerPropertiesInputs.Size = new Size(577, 400);
             splitContainerPropertiesInputs.SplitterDistance = 300;
             splitContainerPropertiesInputs.TabIndex = 8;
@@ -341,6 +352,7 @@
             gridProperties.ContextMenuStrip = contextMenuStripGridProperties;
             gridProperties.Dock = DockStyle.Fill;
             gridProperties.Location = new Point(0, 0);
+            gridProperties.MultiSelect = false;
             gridProperties.Name = "gridProperties";
             gridProperties.ReadOnly = true;
             gridProperties.RowTemplate.Height = 25;
@@ -367,10 +379,11 @@
             // groupInputPorts
             // 
             groupInputPorts.Controls.Add(tableInputPorts);
+            groupInputPorts.Controls.Add(lblNoInputPorts);
             groupInputPorts.Dock = DockStyle.Fill;
             groupInputPorts.Location = new Point(0, 0);
             groupInputPorts.Name = "groupInputPorts";
-            groupInputPorts.Size = new Size(273, 400);
+            groupInputPorts.Size = new Size(273, 316);
             groupInputPorts.TabIndex = 6;
             groupInputPorts.TabStop = false;
             groupInputPorts.Text = "Input ports";
@@ -379,48 +392,142 @@
             // 
             tableInputPorts.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             tableInputPorts.AutoSize = true;
-            tableInputPorts.ColumnCount = 3;
+            tableInputPorts.ColumnCount = 4;
             tableInputPorts.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 75F));
-            tableInputPorts.ColumnStyles.Add(new ColumnStyle());
             tableInputPorts.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tableInputPorts.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 40F));
+            tableInputPorts.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 40F));
             tableInputPorts.Controls.Add(label1, 0, 0);
             tableInputPorts.Controls.Add(comboBox1, 1, 0);
             tableInputPorts.Controls.Add(button1, 2, 0);
+            tableInputPorts.Controls.Add(button2, 3, 0);
             tableInputPorts.Location = new Point(3, 22);
             tableInputPorts.Name = "tableInputPorts";
             tableInputPorts.RowCount = 1;
-            tableInputPorts.RowStyles.Add(new RowStyle(SizeType.Absolute, 29F));
-            tableInputPorts.Size = new Size(262, 29);
+            tableInputPorts.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+            tableInputPorts.Size = new Size(262, 40);
             tableInputPorts.TabIndex = 0;
             // 
             // label1
             // 
             label1.Anchor = AnchorStyles.Left | AnchorStyles.Right;
             label1.AutoSize = true;
-            label1.Location = new Point(3, 7);
+            label1.Location = new Point(3, 12);
             label1.Name = "label1";
             label1.Size = new Size(69, 15);
             label1.TabIndex = 0;
-            label1.Text = "label1";
+            label1.Text = "name";
             label1.TextAlign = ContentAlignment.MiddleRight;
             // 
             // comboBox1
             // 
             comboBox1.Anchor = AnchorStyles.Left | AnchorStyles.Right;
             comboBox1.FormattingEnabled = true;
-            comboBox1.Location = new Point(78, 3);
+            comboBox1.Location = new Point(78, 8);
             comboBox1.Name = "comboBox1";
-            comboBox1.Size = new Size(121, 23);
+            comboBox1.Size = new Size(101, 23);
             comboBox1.TabIndex = 1;
             // 
             // button1
             // 
             button1.Anchor = AnchorStyles.Left;
-            button1.Location = new Point(205, 3);
+            button1.Location = new Point(185, 3);
             button1.Name = "button1";
-            button1.Size = new Size(54, 23);
+            button1.Size = new Size(34, 34);
             button1.TabIndex = 2;
             button1.UseVisualStyleBackColor = true;
+            // 
+            // button2
+            // 
+            button2.Anchor = AnchorStyles.Left;
+            button2.Location = new Point(225, 3);
+            button2.Name = "button2";
+            button2.Size = new Size(34, 34);
+            button2.TabIndex = 2;
+            button2.UseVisualStyleBackColor = true;
+            // 
+            // lblNoInputPorts
+            // 
+            lblNoInputPorts.AutoSize = true;
+            lblNoInputPorts.Location = new Point(92, 4);
+            lblNoInputPorts.Name = "lblNoInputPorts";
+            lblNoInputPorts.Size = new Size(84, 15);
+            lblNoInputPorts.TabIndex = 1;
+            lblNoInputPorts.Text = "No input ports";
+            lblNoInputPorts.TextAlign = ContentAlignment.MiddleCenter;
+            // 
+            // groupOutputSignals
+            // 
+            groupOutputSignals.AutoSize = true;
+            groupOutputSignals.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            groupOutputSignals.Controls.Add(tableOutputSignals);
+            groupOutputSignals.Controls.Add(lblNoOutputSignals);
+            groupOutputSignals.Dock = DockStyle.Bottom;
+            groupOutputSignals.Location = new Point(0, 316);
+            groupOutputSignals.Name = "groupOutputSignals";
+            groupOutputSignals.Size = new Size(273, 84);
+            groupOutputSignals.TabIndex = 6;
+            groupOutputSignals.TabStop = false;
+            groupOutputSignals.Text = "Output signals";
+            // 
+            // tableOutputSignals
+            // 
+            tableOutputSignals.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            tableOutputSignals.AutoSize = true;
+            tableOutputSignals.ColumnCount = 3;
+            tableOutputSignals.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 75F));
+            tableOutputSignals.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tableOutputSignals.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 40F));
+            tableOutputSignals.Controls.Add(label2, 0, 0);
+            tableOutputSignals.Controls.Add(button3, 2, 0);
+            tableOutputSignals.Controls.Add(label3, 1, 0);
+            tableOutputSignals.Location = new Point(3, 22);
+            tableOutputSignals.Name = "tableOutputSignals";
+            tableOutputSignals.RowCount = 1;
+            tableOutputSignals.RowStyles.Add(new RowStyle(SizeType.Absolute, 40F));
+            tableOutputSignals.Size = new Size(262, 40);
+            tableOutputSignals.TabIndex = 0;
+            // 
+            // label2
+            // 
+            label2.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            label2.AutoSize = true;
+            label2.Location = new Point(3, 12);
+            label2.Name = "label2";
+            label2.Size = new Size(69, 15);
+            label2.TabIndex = 0;
+            label2.Text = "name";
+            label2.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // button3
+            // 
+            button3.Anchor = AnchorStyles.Left;
+            button3.Location = new Point(225, 3);
+            button3.Name = "button3";
+            button3.Size = new Size(34, 34);
+            button3.TabIndex = 2;
+            button3.UseVisualStyleBackColor = true;
+            // 
+            // label3
+            // 
+            label3.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            label3.AutoSize = true;
+            label3.Location = new Point(78, 12);
+            label3.Name = "label3";
+            label3.Size = new Size(141, 15);
+            label3.TabIndex = 0;
+            label3.Text = "vlaue";
+            label3.TextAlign = ContentAlignment.MiddleCenter;
+            // 
+            // lblNoOutputSignals
+            // 
+            lblNoOutputSignals.AutoSize = true;
+            lblNoOutputSignals.Location = new Point(92, 4);
+            lblNoOutputSignals.Name = "lblNoOutputSignals";
+            lblNoOutputSignals.Size = new Size(101, 15);
+            lblNoOutputSignals.TabIndex = 2;
+            lblNoOutputSignals.Text = "No output signals";
+            lblNoOutputSignals.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // gridAttributes
             // 
@@ -430,6 +537,7 @@
             gridAttributes.ContextMenuStrip = contextMenuStripGridProperties;
             gridAttributes.Dock = DockStyle.Fill;
             gridAttributes.Location = new Point(0, 0);
+            gridAttributes.MultiSelect = false;
             gridAttributes.Name = "gridAttributes";
             gridAttributes.ReadOnly = true;
             gridAttributes.RowTemplate.Height = 25;
@@ -476,6 +584,7 @@
             splitContainerPropertiesAttributes.ResumeLayout(false);
             splitContainerPropertiesInputs.Panel1.ResumeLayout(false);
             splitContainerPropertiesInputs.Panel2.ResumeLayout(false);
+            splitContainerPropertiesInputs.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)splitContainerPropertiesInputs).EndInit();
             splitContainerPropertiesInputs.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)gridProperties).EndInit();
@@ -484,6 +593,10 @@
             groupInputPorts.PerformLayout();
             tableInputPorts.ResumeLayout(false);
             tableInputPorts.PerformLayout();
+            groupOutputSignals.ResumeLayout(false);
+            groupOutputSignals.PerformLayout();
+            tableOutputSignals.ResumeLayout(false);
+            tableOutputSignals.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)gridAttributes).EndInit();
             ResumeLayout(false);
             PerformLayout();
@@ -525,5 +638,13 @@
         private ComboBox comboBox1;
         private Button button1;
         private SplitContainer splitContainerPropertiesInputs;
+        private GroupBox groupOutputSignals;
+        private TableLayoutPanel tableOutputSignals;
+        private Label label2;
+        private Button button3;
+        private Label label3;
+        private Button button2;
+        private Label lblNoInputPorts;
+        private Label lblNoOutputSignals;
     }
 }

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.cs
@@ -1724,6 +1724,8 @@ public partial class frmMain : Form
         {
             frm.ShowDialog(this);
         }
+
+        UpdateInputPorts(_selectedComponent);
     }
 
     #endregion Input-ports view
@@ -1876,6 +1878,8 @@ public partial class frmMain : Form
         {
             frm.ShowDialog(this);
         }
+
+        UpdateOutputSignals(_selectedComponent);
     }
 
     #endregion Output-signals view

--- a/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQDemo.Net/frmMain.cs
@@ -480,10 +480,7 @@ public partial class frmMain : Form
             return;
         }
 
-        AttributeItem selectedAttributeObject = (AttributeItem)this.gridAttributes.SelectedRows[0].DataBoundItem;
-
-        EditSelectedAttribute(this, selectedAttributeObject);
-        UpdateAttributes((Component)selectedAttributeObject.OpenDaqObject);
+        EditSelectedAttribute();
     }
 
     #endregion gridProperties


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
`Device` and `FunctionBlock` shows `InputPort`s and/or output `Signal`s with their `LastValue` (updated in an 1 second interval).

(Output-) `Signal` attributes don’t show signal descriptor and signal-domain descriptor yet like it is done in python Demo (expandable table too complex for standard WinForms controls).

It also contains a fix where editing a float value did not check min/max range correctly (check always failed).