### PR TITLE
IPv6 link local address interface added to connection string; connection string reachability check

### DIFF
--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -251,6 +251,22 @@ void ModuleManagerImpl::setAddressesReachable(const std::map<std::string, bool>&
                                                                  ? AddressReachabilityStatus::Reachable
                                                                  : AddressReachabilityStatus::Unreachable;
                     addressInfo.asPtr<IAddressInfoPrivate>().setReachabilityStatusPrivate(reachability);
+
+                    if (reachability == AddressReachabilityStatus::Unreachable && cap.getConnectionString() == addressInfo.getConnectionString())
+                    {
+                        for (const auto& addressInfoInner : cap.getAddressInfo())
+                        {
+                            if (addressInfoInner == addressInfo)
+                                continue;
+
+                            if (addressInfoInner.getReachabilityStatus() != AddressReachabilityStatus::Unreachable)
+                            {
+                                cap.asPtr<IServerCapabilityConfig>().setConnectionString(addressInfoInner.getConnectionString());
+                                break;
+                            }
+                        }
+                    }
+
                     break;
                 }
             }
@@ -442,7 +458,7 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
         const auto capabilities = discoveredDeviceInfo.getServerCapabilities();
         if (capabilities.getCount() == 0)
         {
-            return this->makeErrorInfo(OPENDAQ_ERR_NOTFOUND, fmt::format("Device with connection string \"{}\" has no availble server capabilites", connectionStringPtr));
+            return this->makeErrorInfo(OPENDAQ_ERR_NOTFOUND, fmt::format("Device with connection string \"{}\" has no available server capabilities", connectionStringPtr));
         }
 
         ServerCapabilityPtr selectedCapability = capabilities[0];

--- a/core/opendaq/synchronization/src/CMakeLists.txt
+++ b/core/opendaq/synchronization/src/CMakeLists.txt
@@ -6,16 +6,19 @@ function(rtgen_component_${BASE_NAME})
     
     set(SRC_PublicHeaders_Component_Generated
         ${SRC_SyncComponent_PublicHeaders}
+        ${SRC_SyncComponentPrivate_PublicHeaders}
         PARENT_SCOPE
     )
     
     set(SRC_PrivateHeaders_Component_Generated
         ${SRC_SyncComponent_PrivateHeaders}
+        ${SRC_SyncComponentPrivate_PrivateHeaders}
         PARENT_SCOPE
     )
     
     set(SRC_Cpp_Component_Generated
         ${SRC_SyncComponent_Cpp}
+        ${SRC_SyncComponentPrivate_Cpp}
         PARENT_SCOPE
     )
 endfunction()

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -112,14 +112,14 @@ void NativeStreamingClientModule::SetupProtocolAddresses(const MdnsDiscoveredDev
     {
         auto connectionStringIpv6 = NativeStreamingClientModule::CreateUrlConnectionString(
             protocolPrefix,
-            "[" + discoveredDevice.ipv6Address + "]",
+            discoveredDevice.ipv6Address,
             discoveredDevice.servicePort,
             discoveredDevice.getPropertyOrDefault("path", "/")
         );
         cap.addConnectionString(connectionStringIpv6);
-        cap.addAddress("[" + discoveredDevice.ipv6Address + "]");
+        cap.addAddress(discoveredDevice.ipv6Address);
 
-        const auto addressInfo = AddressInfoBuilder().setAddress("[" + discoveredDevice.ipv6Address + "]")
+        const auto addressInfo = AddressInfoBuilder().setAddress(discoveredDevice.ipv6Address)
                                                      .setReachabilityStatus(AddressReachabilityStatus::Unknown)
                                                      .setType("IPv6")
                                                      .setConnectionString(connectionStringIpv6)

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -667,8 +667,8 @@ StringPtr NativeStreamingClientModule::GetHostType(const StringPtr& url)
 {
 	std::string urlString = url.toStdString();
 
-	auto regexIpv6Hostname = std::regex("^.*:\\/\\/(\\[([a-fA-F0-9:]+)\\])");
-    auto regexIpv4Hostname = std::regex("^.*:\\/\\/([^:\\/\\s]+)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)(\[[a-fA-F0-9:]+(?:\%\d+)?\]))");
+    auto regexIpv4Hostname = std::regex(R"(^(.*://)([^:/\s]+))");
 	std::smatch match;
 
 	if (std::regex_search(urlString, match, regexIpv6Hostname))
@@ -682,14 +682,14 @@ StringPtr NativeStreamingClientModule::GetHost(const StringPtr& url)
 {
     std::string urlString = url.toStdString();
 
-    auto regexIpv6Hostname = std::regex("^.*:\\/\\/(\\[([a-fA-F0-9:]+)\\])");
-    auto regexIpv4Hostname = std::regex("^.*:\\/\\/([^:\\/\\s]+)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)(\[[a-fA-F0-9:]+(?:\%\d+)?\]))");
+    auto regexIpv4Hostname = std::regex(R"(^(.*://)([^:/\s]+))");
     std::smatch match;
 
     if (std::regex_search(urlString, match, regexIpv6Hostname))
-        return String("[" + std::string(match[2]) + "]");
+        return String(match[2]);
     if (std::regex_search(urlString, match, regexIpv4Hostname))
-        return String(match[1]);
+        return String(match[2]);
     throw InvalidParameterException("Host name not found in url: {}", url);
 }
 

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -667,7 +667,7 @@ StringPtr NativeStreamingClientModule::GetHostType(const StringPtr& url)
 {
 	std::string urlString = url.toStdString();
 
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)(\[[a-fA-F0-9:]+(?:\%\d+)?\]))");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%[a-zA-Z0-9]+)?\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)([^:/\s]+))");
 	std::smatch match;
 
@@ -682,7 +682,7 @@ StringPtr NativeStreamingClientModule::GetHost(const StringPtr& url)
 {
     std::string urlString = url.toStdString();
 
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)(\[[a-fA-F0-9:]+(?:\%\d+)?\]))");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%[a-zA-Z0-9]+)?\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)([^:/\s]+))");
     std::smatch match;
 

--- a/modules/opcua_client_module/src/opcua_client_module_impl.cpp
+++ b/modules/opcua_client_module/src/opcua_client_module_impl.cpp
@@ -52,15 +52,15 @@ OpcUaClientModule::OpcUaClientModule(ContextPtr context)
                 }
                 if(!discoveredDevice.ipv6Address.empty())
                 {
-                    auto connectionStringIpv6 = fmt::format("{}://[{}]:{}{}",
+                    auto connectionStringIpv6 = fmt::format("{}://{}:{}{}",
                                     DaqOpcUaDevicePrefix,
                                     discoveredDevice.ipv6Address,
                                     discoveredDevice.servicePort,
                                     discoveredDevice.getPropertyOrDefault("path", "/"));
                     cap.addConnectionString(connectionStringIpv6);
-                    cap.addAddress("[" + discoveredDevice.ipv6Address + "]");
+                    cap.addAddress(discoveredDevice.ipv6Address);
 
-                    const auto addressInfo = AddressInfoBuilder().setAddress("[" + discoveredDevice.ipv6Address + "]")
+                    const auto addressInfo = AddressInfoBuilder().setAddress(discoveredDevice.ipv6Address)
                                                                  .setReachabilityStatus(AddressReachabilityStatus::Unknown)
                                                                  .setType("IPv6")
                                                                  .setConnectionString(connectionStringIpv6)

--- a/modules/opcua_client_module/src/opcua_client_module_impl.cpp
+++ b/modules/opcua_client_module/src/opcua_client_module_impl.cpp
@@ -194,7 +194,7 @@ StringPtr OpcUaClientModule::formConnectionString(const StringPtr& connectionStr
 {
     std::string urlString = connectionString.toStdString();
 
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%\d+)?\])(?::(\d+))?(/.*)?$)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%[a-zA-Z0-9]+)?\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)?([^:/\s]+)(?::(\d+))?(/.*)?$)");
     std::smatch match;
 

--- a/modules/opcua_client_module/src/opcua_client_module_impl.cpp
+++ b/modules/opcua_client_module/src/opcua_client_module_impl.cpp
@@ -194,13 +194,12 @@ StringPtr OpcUaClientModule::formConnectionString(const StringPtr& connectionStr
 {
     std::string urlString = connectionString.toStdString();
 
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)(\[[a-fA-F0-9:]+\])(?::(\d+))?(/.*)?$)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%\d+)?\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)?([^:/\s]+)(?::(\d+))?(/.*)?$)");
     std::smatch match;
 
-    std::string target = "/";
     std::string prefix = "";
-    std::string path = "";
+    std::string path = "/";
 
     if (config.assigned() )
     {
@@ -238,7 +237,7 @@ StringPtr OpcUaClientModule::formConnectionString(const StringPtr& connectionStr
     if (prefix != std::string(DaqOpcUaDevicePrefix) + "://")
         throw InvalidParameterException("OpcUa does not support connection string with prefix {}", prefix);
 
-    return std::string(OpcUaScheme) + "://" + host + ":" + std::to_string(port) + "/" + path;
+    return std::string(OpcUaScheme) + "://" + host + ":" + std::to_string(port) + path;
 }
 
 bool OpcUaClientModule::acceptsConnectionParameters(const StringPtr& connectionString, const PropertyObjectPtr& config)

--- a/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
+++ b/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
@@ -299,7 +299,7 @@ StringPtr WebsocketStreamingClientModule::formConnectionString(const StringPtr& 
 
     std::string urlString = connectionString.toStdString();
 
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%\d+)?\])(?::(\d+))?(/.*)?$)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%[a-zA-Z0-9]+)?\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)?([^:/\s]+)(?::(\d+))?(/.*)?$)");
     std::smatch match;
 

--- a/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
+++ b/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
@@ -299,14 +299,13 @@ StringPtr WebsocketStreamingClientModule::formConnectionString(const StringPtr& 
 
     std::string urlString = connectionString.toStdString();
 
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)(\[[a-fA-F0-9:]+\])(?::(\d+))?(/.*)?$)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%\d+)?\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)?([^:/\s]+)(?::(\d+))?(/.*)?$)");
     std::smatch match;
 
     std::string host = "";
-    std::string target = "/";
     std::string prefix = "";
-    std::string path = "";
+    std::string path = "/";
 
     bool parsed = false;
     parsed = std::regex_search(urlString, match, regexIpv6Hostname);
@@ -323,7 +322,7 @@ StringPtr WebsocketStreamingClientModule::formConnectionString(const StringPtr& 
         if (match[4].matched)
             path = match[4];
 
-        return prefix + host + ":" + std::to_string(port) + "/" + path;
+        return prefix + host + ":" + std::to_string(port) + path;
     }
 
     return connectionString;

--- a/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
+++ b/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
@@ -51,14 +51,14 @@ WebsocketStreamingClientModule::WebsocketStreamingClientModule(ContextPtr contex
                 if(!discoveredDevice.ipv6Address.empty())
                 {
                     auto connectionStringIpv6 = WebsocketStreamingClientModule::createUrlConnectionString(
-                        "[" + discoveredDevice.ipv6Address + "]",
+                        discoveredDevice.ipv6Address,
                         discoveredDevice.servicePort,
                         discoveredDevice.getPropertyOrDefault("path", "/")
                     );
                     cap.addConnectionString(connectionStringIpv6);
-                    cap.addAddress("[" + discoveredDevice.ipv6Address + "]");
+                    cap.addAddress(discoveredDevice.ipv6Address);
 
-                    const auto addressInfo = AddressInfoBuilder().setAddress("[" + discoveredDevice.ipv6Address + "]")
+                    const auto addressInfo = AddressInfoBuilder().setAddress(discoveredDevice.ipv6Address)
                                                                  .setReachabilityStatus(AddressReachabilityStatus::Unknown)
                                                                  .setType("IPv6")
                                                                  .setConnectionString(connectionStringIpv6)

--- a/shared/libraries/websocket_streaming/src/streaming_client.cpp
+++ b/shared/libraries/websocket_streaming/src/streaming_client.cpp
@@ -243,7 +243,7 @@ void StreamingClient::parseConnectionString(const std::string& url)
     std::smatch match;
 
     // parsing connection string to four groups: prefix, host, port, path
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%\d+)?\])(?::(\d+))?(/.*)?$)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(?:\[([a-fA-F0-9:]+(?:\%[a-zA-Z0-9]+)?)\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)?([^:/\s]+)(?::(\d+))?(/.*)?$)");
 
     bool parsed = false;

--- a/shared/libraries/websocket_streaming/src/streaming_client.cpp
+++ b/shared/libraries/websocket_streaming/src/streaming_client.cpp
@@ -243,7 +243,7 @@ void StreamingClient::parseConnectionString(const std::string& url)
     std::smatch match;
 
     // parsing connection string to four groups: prefix, host, port, path
-    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(?:\[([a-fA-F0-9:]+)\])(?::(\d+))?(/.*)?$)");
+    auto regexIpv6Hostname = std::regex(R"(^(.*://)?(\[[a-fA-F0-9:]+(?:\%\d+)?\])(?::(\d+))?(/.*)?$)");
     auto regexIpv4Hostname = std::regex(R"(^(.*://)?([^:/\s]+)(?::(\d+))?(/.*)?$)");
 
     bool parsed = false;


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

- Primary connection string is changed if the address is unreachable
- IPv6 connection strings can include link local interface identifier