### PR TITLE
Fix Python GUI Demo app gear icon click action

### DIFF
--- a/examples/python/gui_demo.py
+++ b/examples/python/gui_demo.py
@@ -133,7 +133,10 @@ class App(tk.Tk):
         self.right_side_panel_create(frame_navigator_for_properties)
 
         # High DPI workaround for now
-        ttk.Style().configure('Treeview', rowheight=30 * self.context.ui_scaling_factor)
+        style = ttk.Style()
+        style.configure('Treeview', rowheight=30 * self.context.ui_scaling_factor)
+
+        style.configure("Treeview.Heading", font='Arial 10 bold')
 
         default_font = tkfont.nametofont("TkDefaultFont")
         default_font.configure(size=9 * self.context.ui_scaling_factor)

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -37,8 +37,6 @@ class AttributesDialog(Dialog):
         tree.column('#0', anchor=tk.W, width=80, stretch=True)
         tree.column('#1', anchor=tk.CENTER)
         tree.column('#2', anchor=tk.CENTER, width=60, stretch=False)
-        style = ttk.Style()
-        style.configure("Treeview.Heading", font='Arial 10 bold')
 
         tree.bind("<Double-1>", self.handle_double_click)
         tree.bind("<Button-3>", self.handle_right_click)

--- a/examples/python/gui_demo/components/properties_view.py
+++ b/examples/python/gui_demo/components/properties_view.py
@@ -32,8 +32,7 @@ class PropertiesView(tk.Frame):
         # layout
         tree.column('#0', anchor=tk.CENTER)
         tree.column('#1', anchor=tk.CENTER)
-        style = ttk.Style()
-        style.configure("Treeview.Heading", font='Arial 10 bold')
+
         # bind double-click to editing
         tree.bind('<Double-1>', self.handle_double_click)
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Description:
* Call `ttk.Style().configure("Treeview.Heading", font='Arial 10 bold')` once in `gui_demo.py` instead of multiple times (on click)
* Fix a bug where if you click the gear icon throughout the Python GUI Demo app, for example `open app -> click OpenDAQClient -> gear icon (top right)`, this would shift the underlying GUI in an unexpected way (expanding the Properties view right slightly and shrinking the Output Signals view somewhat)