### PR TITLE
Prefer same address when establishing streaming connections

### DIFF
--- a/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
@@ -25,13 +25,12 @@
 #include <vector>
 #include <opendaq/mirrored_device_config_ptr.h>
 #include <opendaq/streaming_ptr.h>
-
 #include <map>
 #include <thread>
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
-
-#include "tsl/ordered_map.h"
+#include <opendaq/module_ptr.h>
+#include <tsl/ordered_map.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 struct ModuleLibrary;
@@ -56,35 +55,47 @@ public:
     ErrCode INTERFACE_FUNC createDefaultAddDeviceConfig(IPropertyObject** defaultConfig) override;
 
 private:
+    
+    static void populateDeviceConfigFromConnStrOptions(const PropertyObjectPtr& devConfig,
+                                                       const tsl::ordered_map<std::string, ObjectPtr<IBaseObject>>& options);
+    static PropertyObjectPtr populateDeviceConfig(const PropertyObjectPtr& config,
+                                                  const DeviceTypePtr& deviceType,
+                                                  const tsl::ordered_map<std::string, ObjectPtr<IBaseObject>>& connStrOptions);
+
+    std::string getPrefixFromConnectionString(std::string connectionString) const;
+    static std::pair<std::string, tsl::ordered_map<std::string, BaseObjectPtr>> splitConnectionStringAndOptions(const std::string& connectionString);
+
+    DeviceInfoPtr getDiscoveredDeviceInfo(const StringPtr& inputConnectionString, bool useSmartConnection) const;
+    static StringPtr resolveSmartConnectionString(const StringPtr& inputConnectionString, const DeviceInfoPtr& discoveredDeviceInfo);
+    DeviceTypePtr getDeviceTypeFromConnectionString(const StringPtr& connectionString, const ModulePtr& module) const;
     static uint16_t getServerCapabilityPriority(const ServerCapabilityPtr& cap);
+
+    static void replaceSubDeviceOldProtocolIds(const DevicePtr& device);
+    static ServerCapabilityPtr replaceOldProtocolIds(const ServerCapabilityPtr& cap);
+    static StringPtr convertIfOldIdFB(const StringPtr& id);
+    static StringPtr convertIfOldIdProtocol(const StringPtr& id);
+    
+    static void copyGeneralProperties(const PropertyObjectPtr& general, const PropertyObjectPtr& tartgetObj);
+    static bool isDefaultAddDeviceConfig(const PropertyObjectPtr& config);
+
+    static ServerCapabilityPtr mergeDiscoveryAndDeviceCapability(const ServerCapabilityPtr& discoveryCap, const ServerCapabilityPtr& deviceCap);
+    void mergeDiscoveryAndDeviceCapabilities(const DevicePtr& device, const DeviceInfoPtr& discoveredDeviceInfo) const;
+    void completeServerCapabilities(const DevicePtr& device) const;
 
     void checkNetworkSettings(ListPtr<IDeviceInfo>& list);
     static void setAddressesReachable(const std::map<std::string, bool>& addr, const std::string& type, ListPtr<IDeviceInfo>& info);
     static PropertyObjectPtr populateGeneralConfig(const PropertyObjectPtr& config);
     static ListPtr<IMirroredDeviceConfig> getAllDevicesRecursively(const MirroredDeviceConfigPtr& device);
 
-    void configureStreamings(MirroredDeviceConfigPtr& topDevice, const PropertyObjectPtr& streamingConfig);
-
+    static StringPtr getPreferredStreamingAddress(const DevicePtr& device);
+    void configureStreamings(const MirroredDeviceConfigPtr& topDevice, const PropertyObjectPtr& streamingConfig);
     void attachStreamingsToDevice(const MirroredDeviceConfigPtr& device,
                                   const PropertyObjectPtr& generalConfig,
-                                  const PropertyObjectPtr& config);
+                                  const PropertyObjectPtr& config,
+                                  const StringPtr& preferredAddress);
+    StreamingPtr onCreateStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config) const;
 
-    StreamingPtr onCreateStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config);
-    void completeServerCapabilities(const ServerCapabilityPtr& source, const ListPtr<IServerCapability>& targetCaps);
-    static ServerCapabilityPtr mergeDiscoveryAndDeviceCap(const ServerCapabilityPtr& discoveryCap, const ServerCapabilityPtr& deviceCap);
-    static ServerCapabilityPtr replaceOldProtocolIds(const ServerCapabilityPtr& cap);
-    static void copyGeneralProperties(const PropertyObjectPtr& general, const PropertyObjectPtr& tartgetObj);
-    static bool isDefaultAddDeviceConfig(const PropertyObjectPtr& config);
     static PropertyObjectPtr createGeneralConfig();
-
-    std::string getPrefixFromConnectionString(std::string connectionString) const;
-    static std::pair<std::string, tsl::ordered_map<std::string, BaseObjectPtr>> splitConnectionStringAndOptions(const std::string& connectionString);
-
-    static StringPtr convertIfOldIdFB(const StringPtr& id);
-    static StringPtr convertIfOldIdProtocol(const StringPtr& id);
-
-    static void populateDeviceConfigFromConnStrOptions(const PropertyObjectPtr& devConfig,
-                                                       const tsl::ordered_map<std::string, ObjectPtr<IBaseObject>>& options);
 
     bool modulesLoaded;
     std::vector<std::string> paths;

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -587,10 +587,7 @@ PropertyObjectPtr ModuleManagerImpl::populateDeviceConfig(const PropertyObjectPt
     if (config.assigned())
         checkErrorInfo(config.asPtr<IPropertyObjectInternal>()->clone(&configClone));
     else
-        return deviceType.createDefaultConfig();
-
-    if (!configClone.assigned())
-        throw GeneralErrorException("Failure while cloning device config object. Clone is null.");
+        configClone = deviceType.createDefaultConfig();
 
     const bool isDefaultAddDeviceConfigRes = isDefaultAddDeviceConfig(configClone);
     const PropertyObjectPtr generalConfig = isDefaultAddDeviceConfigRes ? configClone.getPropertyValue("General").asPtr<IPropertyObject>() : PropertyObject();

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -586,6 +586,8 @@ PropertyObjectPtr ModuleManagerImpl::populateDeviceConfig(const PropertyObjectPt
     PropertyObjectPtr configClone;
     if (config.assigned())
         checkErrorInfo(config.asPtr<IPropertyObjectInternal>()->clone(&configClone));
+    else
+        return deviceType.createDefaultConfig();
 
     if (!configClone.assigned())
         throw GeneralErrorException("Failure while cloning device config object. Clone is null.");
@@ -1295,7 +1297,7 @@ ServerCapabilityPtr ModuleManagerImpl::replaceOldProtocolIds(const ServerCapabil
 }
 
 ServerCapabilityPtr ModuleManagerImpl::mergeDiscoveryAndDeviceCapability(const ServerCapabilityPtr& discoveryCap,
-                                                                  const ServerCapabilityPtr& deviceCap)
+                                                                         const ServerCapabilityPtr& deviceCap)
 {
     auto merged = ServerCapability(deviceCap.getProtocolId(), deviceCap.getProtocolName(), deviceCap.getProtocolType());
     const auto caps = List<IServerCapability>(deviceCap, discoveryCap);

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -585,7 +585,10 @@ PropertyObjectPtr ModuleManagerImpl::populateDeviceConfig(const PropertyObjectPt
 {
     PropertyObjectPtr configClone;
     if (config.assigned())
-        config.asPtr<IPropertyObjectInternal>()->clone(&configClone);
+        checkErrorInfo(config.asPtr<IPropertyObjectInternal>()->clone(&configClone));
+
+    if (!configClone.assigned())
+        throw GeneralErrorException("Failure while cloning device config object. Clone is null.");
 
     const bool isDefaultAddDeviceConfigRes = isDefaultAddDeviceConfig(configClone);
     const PropertyObjectPtr generalConfig = isDefaultAddDeviceConfigRes ? configClone.getPropertyValue("General").asPtr<IPropertyObject>() : PropertyObject();
@@ -845,10 +848,7 @@ StringPtr ModuleManagerImpl::resolveSmartConnectionString(const StringPtr& input
         }
     }
 
-    if (selectedCapability.assigned())
-        return selectedCapability.getConnectionString();
-
-    return nullptr;
+    return selectedCapability.getConnectionString();
 }
 
 DeviceTypePtr ModuleManagerImpl::getDeviceTypeFromConnectionString(const StringPtr& connectionString, const ModulePtr& module) const

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -1740,7 +1740,8 @@ public:
 
 TEST_F(NativeDeviceModulesTest, SameStreamingAddress)
 {
-    SKIP_TEST_MAC_CI
+    SKIP_TEST_MAC_CI;
+
     const auto server = Instance();
     server.setRootDevice("daqref://device0");
     server.addServer("OpenDAQNativeStreaming", nullptr);


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

- Streaming now uses the address used by configuration when establishing connections.
- Refactored device creation code in module manager