### PR TITLE
[BUG]: sync component  backwards compatibility. Removing the device in gui demo

### DIFF
--- a/examples/python/gui_demo/app_context.py
+++ b/examples/python/gui_demo/app_context.py
@@ -48,7 +48,7 @@ class AppContext(object):
             if device:
                 device_info.name = device.local_id
                 device_info.serial_number = device.info.serial_number
-                self.enabled_devices[device_info.connection_string] = {
+                self.enabled_devices[device.info.connection_string] = {
                     'device_info': device_info, 'device': device}
                 return device
         except RuntimeError as e:

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -219,7 +219,7 @@ void GenericConfigClientDeviceImpl<TDeviceBase>::onRemoteUpdate(const Serialized
         {
             if (this->defaultComponents.count(id))
             {
-                LOG_W("The server does not provide default device component: {}", id);
+                DAQLOGF_W(this->loggerComponent, "The server does not provide default device component: {}", id);
             }
             else
             {

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -219,7 +219,7 @@ void GenericConfigClientDeviceImpl<TDeviceBase>::onRemoteUpdate(const Serialized
         {
             if (this->defaultComponents.count(id))
             {
-                DAQLOGF_W(this->loggerComponent, "The server does not provide default device component: {}", id);
+                DAQLOGF_D(this->loggerComponent, "The server does not provide default device component: {}", id);
             }
             else
             {

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -218,9 +218,13 @@ void GenericConfigClientDeviceImpl<TDeviceBase>::onRemoteUpdate(const Serialized
         if (!serialized.hasKey(id))
         {
             if (this->defaultComponents.count(id))
-                throw InvalidOperationException{"Serialized remote object does not contain default device component: " + id};
-            
-            toRemove.push_back(id);
+            {
+                LOG_W("The server does not provide default device component: {}", id);
+            }
+            else
+            {
+                toRemove.push_back(id);
+            }
         }
         else
         {


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

The new version of client could not connect to the device without sync component as it was not found. The exception was replaced with warning. In gui demo the device was registered in dictionary with the typed connection string. If connection string prefix is "daq://" the device automatically chooses the optimal way of connection and stores not the connection string with "daq://" but with the preferred protocol which makes impossible to remove device as the connection string is different