### PR TITLE
Add struct decoder function block

### DIFF
--- a/modules/ref_fb_module/include/ref_fb_module/struct_decoder_fb_impl.h
+++ b/modules/ref_fb_module/include/ref_fb_module/struct_decoder_fb_impl.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022-2024 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <ref_fb_module/common.h>
+#include <opendaq/function_block_ptr.h>
+#include <opendaq/function_block_type_factory.h>
+#include <opendaq/function_block_impl.h>
+#include <opendaq/signal_config_ptr.h>
+#include <opendaq/data_packet_ptr.h>
+#include <opendaq/event_packet_ptr.h>
+
+BEGIN_NAMESPACE_REF_FB_MODULE
+    
+namespace StructDecoder
+{
+
+class StructDecoderFbImpl final : public FunctionBlock
+{
+public:
+    explicit StructDecoderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    ~StructDecoderFbImpl() override = default;
+
+    static FunctionBlockTypePtr CreateType();
+
+    void onPacketReceived(const InputPortPtr& port) override;
+    void onDisconnected(const InputPortPtr& port) override;
+
+private:
+    InputPortPtr inputPort;
+
+    DataDescriptorPtr inputDataDescriptor;
+    DataDescriptorPtr inputDomainDataDescriptor;
+
+    size_t structSize;
+
+    bool configured;
+
+    void createInputPorts();
+
+    void processDataPacket(const DataPacketPtr& packet) const;
+
+    void processEventPacket(const EventPacketPtr& packet);
+
+    void processSignalDescriptorChanged(const DataDescriptorPtr& inputDataDescriptor,
+                                        const DataDescriptorPtr& inputDomainDataDescriptor);
+
+    void configure();
+
+    void initStatuses() const;
+    void setInputStatus(const StringPtr& value) const;
+
+    template <typename T>
+    static void copySample(uint8_t* dest, const uint8_t* source);
+
+    void copySamples(uint8_t* dest, uint8_t* source, const size_t fieldSampleSize, size_t sampleCount) const;
+};
+
+}
+
+END_NAMESPACE_REF_FB_MODULE

--- a/modules/ref_fb_module/src/CMakeLists.txt
+++ b/modules/ref_fb_module/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SRC_Include common.h
                 trigger_fb_impl.h
                 fft_fb_impl.h
                 power_reader_fb_impl.h
+                struct_decoder_fb_impl.h
 )
 
 set(SRC_Srcs module_dll.cpp
@@ -27,6 +28,7 @@ set(SRC_Srcs module_dll.cpp
              trigger_fb_impl.cpp
              fft_fb_impl.cpp
              power_reader_fb_impl.cpp
+             struct_decoder_fb_impl.cpp
 )
 
 if (DAQMODULES_REF_FB_MODULE_ENABLE_RENDERER)
@@ -60,6 +62,7 @@ set(MODULE_FILES ${MODULE_HEADERS_DIR}/ref_fb_module_common.h
                             ${MODULE_HEADERS_DIR}/classifier_fb_impl.h
                             ${MODULE_HEADERS_DIR}/fft_fb_impl.h
                             ${MODULE_HEADERS_DIR}/power_reader_fb_impl.h
+                            ${MODULE_HEADERS_DIR}/struct_decoder_fb_impl.h
                             module_dll.cpp
                             power_fb_impl.cpp
                             statistics_fb_impl.cpp
@@ -67,7 +70,8 @@ set(MODULE_FILES ${MODULE_HEADERS_DIR}/ref_fb_module_common.h
                             classifier_fb_impl.cpp
                             trigger_fb_impl.cpp
                             fft_fb_impl.cpp
-                            power_reader_fb_impl.cpp)
+                            power_reader_fb_impl.cpp
+                            struct_decoder_fb_impl.cpp)
 
 if (DAQMODULES_REF_FB_MODULE_ENABLE_RENDERER)
     set(MODULE_FILES ${MODULE_FILES} ${MODULE_HEADERS_DIR}/renderer_fb_impl.h

--- a/modules/ref_fb_module/src/ref_fb_module_impl.cpp
+++ b/modules/ref_fb_module/src/ref_fb_module_impl.cpp
@@ -12,6 +12,7 @@
 #include <ref_fb_module/fft_fb_impl.h>
 #include <ref_fb_module/version.h>
 #include <ref_fb_module/power_reader_fb_impl.h>
+#include <ref_fb_module/struct_decoder_fb_impl.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
@@ -52,6 +53,9 @@ DictPtr<IString, IFunctionBlockType> RefFBModule::onGetAvailableFunctionBlockTyp
 
     const auto typePowerReader = PowerReader::PowerReaderFbImpl::CreateType();
     types.set(typePowerReader.getId(), typePowerReader);
+
+    const auto typeStructDecoder = StructDecoder::StructDecoderFbImpl::CreateType();
+    types.set(typeStructDecoder.getId(), typeStructDecoder);
 
     return types;
 }
@@ -101,6 +105,11 @@ FunctionBlockPtr RefFBModule::onCreateFunctionBlock(const StringPtr& id,
     if (id == PowerReader::PowerReaderFbImpl::CreateType().getId())
     {
         FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, PowerReader::PowerReaderFbImpl>(context, parent, localId);
+        return fb;
+    }
+    if (id == StructDecoder::StructDecoderFbImpl::CreateType().getId())
+    {
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, StructDecoder::StructDecoderFbImpl>(context, parent, localId);
         return fb;
     }
 

--- a/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
+++ b/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
@@ -1,0 +1,292 @@
+#include <ref_fb_module/struct_decoder_fb_impl.h>
+#include <opendaq/input_port_factory.h>
+#include <opendaq/data_descriptor_ptr.h>
+#include <opendaq/event_packet_ptr.h>
+#include <opendaq/custom_log.h>
+#include <opendaq/event_packet_params.h>
+#include <opendaq/data_packet.h>
+#include <opendaq/data_packet_ptr.h>
+#include <opendaq/event_packet_ids.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/component_status_container_private_ptr.h>
+#include <opendaq/sample_type_traits.h>
+#include <opendaq/search_filter_factory.h>
+
+BEGIN_NAMESPACE_REF_FB_MODULE
+namespace StructDecoder
+{
+
+static const char* InputDisconnected = "Disconnected";
+static const char* InputConnected = "Connected";
+static const char* InputInvalid = "Invalid";
+
+StructDecoderFbImpl::StructDecoderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+    : FunctionBlock(CreateType(), ctx, parent, localId)
+    , configured(false)
+{
+    createInputPorts();
+    initStatuses();
+}
+
+FunctionBlockTypePtr StructDecoderFbImpl::CreateType()
+{
+    return FunctionBlockType("RefFBModuleStructDecoder", "Struct decoder", "Decodes signals with struct data type and outputs signal for each struct component.");
+}
+
+void StructDecoderFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inputDataDescriptor,
+                                                         const DataDescriptorPtr& inputDomainDataDescriptor)
+{
+    if (inputDataDescriptor.assigned())
+        this->inputDataDescriptor = inputDataDescriptor;
+    if (inputDomainDataDescriptor.assigned())
+        this->inputDomainDataDescriptor = inputDomainDataDescriptor;
+
+    configure();
+}
+
+void StructDecoderFbImpl::configure()
+{
+    if (!inputDataDescriptor.assigned() || !inputDomainDataDescriptor.assigned())
+    {
+        configured = false;
+        setInputStatus(InputInvalid);
+        return;
+    }
+
+    try
+    {
+        if (inputDataDescriptor.getDimensions().getCount() > 0)
+            throw std::runtime_error("Arrays not supported");
+
+        const auto inputSampleType = inputDataDescriptor.getSampleType();
+        if (inputSampleType != SampleType::Struct)
+            throw std::runtime_error("Invalid sample type");
+
+        signals.clear();
+
+        constexpr std::array<SampleType, 11> validFieldTypes{
+            SampleType::Int8,
+            SampleType::Int16,
+            SampleType::Int32,
+            SampleType::Int64,
+            SampleType::UInt8,
+            SampleType::UInt16,
+            SampleType::UInt32,
+            SampleType::UInt64,
+            SampleType::Float32,
+            SampleType::Float64,
+            SampleType::Struct,
+        };
+
+        const auto domainSignal = createAndAddSignal("__domain", inputDomainDataDescriptor, false);
+
+        const auto structFields = inputDataDescriptor.getStructFields();
+        for (const auto& field: structFields)
+        {
+            const auto fieldSampleType = field.getSampleType();
+            if (std::find(validFieldTypes.begin(), validFieldTypes.end(), fieldSampleType) == validFieldTypes.end())
+                throw std::runtime_error(fmt::format("Field \"{}\" has invalid sample type", field.getName()));
+
+            const auto signal = createAndAddSignal(field.getName(), field);
+            signal.setDomainSignal(domainSignal);
+        }
+
+        structSize = inputDataDescriptor.getSampleSize();
+
+        configured = true;
+        setInputStatus(InputConnected);
+    }
+    catch (const std::exception& e)
+    {
+        configured = false;
+        setInputStatus(InputInvalid);
+        LOG_W("Failed to configure output signals: {}", e.what())
+        signals.clear();
+    }
+}
+
+
+void StructDecoderFbImpl::onPacketReceived(const InputPortPtr& port)
+{
+    std::scoped_lock lock(sync);
+
+    const auto connection = inputPort.getConnection();
+    if (!connection.assigned())
+        return;
+
+    PacketPtr packet = connection.dequeue();
+
+    while (packet.assigned())
+    {
+        switch (packet.getType())
+        {
+            case PacketType::Event:
+                processEventPacket(packet);
+                break;
+
+            case PacketType::Data:
+                processDataPacket(packet);
+                break;
+
+            default:
+                break;
+        }
+
+        packet = connection.dequeue();
+    }
+}
+
+void StructDecoderFbImpl::processEventPacket(const EventPacketPtr& packet)
+{
+    if (packet.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED)
+    {
+        const DataDescriptorPtr inputDataDescriptor = packet.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
+        const DataDescriptorPtr inputDomainDataDescriptor = packet.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
+        processSignalDescriptorChanged(inputDataDescriptor, inputDomainDataDescriptor);
+    }
+}
+
+template <typename T>
+void StructDecoderFbImpl::copySample(uint8_t* dest, const uint8_t* source)
+{
+    *(reinterpret_cast<T*>(dest)) = *(reinterpret_cast<const T*>(source));
+}
+
+void StructDecoderFbImpl::copySamples(uint8_t* dest, uint8_t* source, const size_t fieldSampleSize, size_t sampleCount) const
+{
+    switch (fieldSampleSize)
+    {
+        case 1:
+        {
+            for (size_t i = 0; i < sampleCount; i++)
+            {
+                copySample<uint8_t>(dest, source);
+                dest += fieldSampleSize;
+                source += structSize;
+            }
+            break;
+        }
+        case 2:
+        {
+            for (size_t i = 0; i < sampleCount; i++)
+            {
+                copySample<uint16_t>(dest, source);
+                dest += fieldSampleSize;
+                source += structSize;
+            }
+            break;
+        }
+        case 4:
+        {
+            for (size_t i = 0; i < sampleCount; i++)
+            {
+                copySample<uint32_t>(dest, source);
+                dest += fieldSampleSize;
+                source += structSize;
+            }
+            break;
+        }
+        case 8:
+        {
+            for (size_t i = 0; i < sampleCount; i++)
+            {
+                copySample<uint64_t>(dest, source);
+                dest += fieldSampleSize;
+                source += structSize;
+            }
+            break;
+        }
+        default:
+            for (size_t i = 0; i < sampleCount; i++)
+            {
+                std::memcpy(dest, source, fieldSampleSize);
+                dest += fieldSampleSize;
+                source += structSize;
+            }
+    }
+}
+
+void StructDecoderFbImpl::processDataPacket(const DataPacketPtr& packet) const
+{
+    if (!configured)
+        return;
+
+    const auto inputData = static_cast<uint8_t*>(packet.getData());
+    const size_t sampleCount = packet.getSampleCount();
+    const auto domainPacket = packet.getDomainPacket();
+
+    const auto structFields = inputDataDescriptor.getStructFields();
+    const auto signals = this->signals.getItems(search::Any());
+
+    signals[0].asPtr<ISignalConfig>(true).sendPacket(domainPacket);
+
+    size_t offset = 0;
+    for (size_t i = 0; i < structFields.getCount(); ++i)
+    {
+        const auto field = structFields[i];
+        const auto signal = signals[i + 1].asPtr<ISignalConfig>(true);
+
+        const auto outputPacket = DataPacketWithDomain(domainPacket, field, sampleCount);
+        const auto outputData = static_cast<uint8_t*>(outputPacket.getRawData());
+
+        const auto fieldSampleSize = field.getRawSampleSize();
+        copySamples(outputData, inputData + offset, fieldSampleSize, sampleCount);
+
+        signal.sendPacket(outputPacket);
+
+        offset += fieldSampleSize;
+    }
+}
+
+void StructDecoderFbImpl::createInputPorts()
+{
+    inputPort = createAndAddInputPort("Input", PacketReadyNotification::SchedulerQueueWasEmpty);
+}
+
+void StructDecoderFbImpl::initStatuses() const
+{
+    const auto inputStatusType = EnumerationType("InputStatusType", List<IString>(InputDisconnected, InputConnected, InputInvalid));
+
+    try
+    {
+        this->context.getTypeManager().addType(inputStatusType);
+    }
+    catch (const std::exception& e)
+    {
+        const auto loggerComponent = this->context.getLogger().getOrAddComponent("ScalingFunctionBlock");
+        LOG_W("Couldn't add type {} to type manager: {}", inputStatusType.getName(), e.what());
+    }
+    catch (...)
+    {
+        const auto loggerComponent = this->context.getLogger().getOrAddComponent("ScalingFunctionBlock");
+        LOG_W("Couldn't add type {} to type manager!", inputStatusType.getName());
+    }
+
+    const auto thisStatusContainer = this->statusContainer.asPtr<IComponentStatusContainerPrivate>();
+
+    const auto inputStatusValue = Enumeration("InputStatusType", InputDisconnected, context.getTypeManager());
+    thisStatusContainer.addStatus("InputStatus", inputStatusValue);
+}
+
+void StructDecoderFbImpl::setInputStatus(const StringPtr& value) const
+{
+    const auto thisStatusContainer = this->statusContainer.asPtr<IComponentStatusContainerPrivate>();
+
+    const auto inputStatusValue = Enumeration("InputStatusType", value, context.getTypeManager());
+    thisStatusContainer.setStatus("InputStatus", inputStatusValue);
+}
+
+void StructDecoderFbImpl::onDisconnected(const InputPortPtr& inputPort)
+{
+    std::scoped_lock lock(sync);
+
+    signals.clear();
+
+    configured = false;
+
+    setInputStatus(InputDisconnected);
+}
+
+}
+
+END_NAMESPACE_REF_FB_MODULE

--- a/modules/ref_fb_module/tests/CMakeLists.txt
+++ b/modules/ref_fb_module/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SOURCES test_ref_fb_module.cpp
                  test_fb_trigger.cpp
                  test_fb_statistics.cpp
                  test_fb_power_reader.cpp
+                 test_fb_struct_decoder.cpp
 )
 
 add_executable(${TEST_APP} ${TEST_SOURCES}

--- a/modules/ref_fb_module/tests/test_fb_struct_decoder.cpp
+++ b/modules/ref_fb_module/tests/test_fb_struct_decoder.cpp
@@ -1,0 +1,203 @@
+#include <opendaq/context_internal_ptr.h>
+#include <opendaq/instance_factory.h>
+#include <opendaq/module_ptr.h>
+#include <opendaq/opendaq.h>
+#include <ref_fb_module/module_dll.h>
+#include <testutils/memcheck_listener.h>
+#include <gmock/gmock.h>
+#include <opendaq/search_filter_factory.h>
+
+using namespace daq;
+
+static ModulePtr createModule(const ContextPtr& context)
+{
+    ModulePtr module;
+    auto logger = Logger();
+    createModule(&module, context);
+    return module;
+}
+
+class StructDecoderTest : public testing::Test
+{
+protected:
+    static void prepare(const ContextPtr& ctx, SignalConfigPtr& valueSignal, SignalConfigPtr& timeSignal)
+    {
+        const auto field1Descriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).setName("Field1").build();
+
+        const auto field2Descriptor = DataDescriptorBuilder()
+                                          .setSampleType(SampleType::Int32)
+                                          .setDimensions(List<IDimension>(Dimension(LinearDimensionRule(1, 0, 2))))
+                                          .setName("Field2")
+                                          .build();
+
+        const auto dataDescriptor = DataDescriptorBuilder()
+                                        .setSampleType(SampleType::Struct)
+                                        .setName("Struct")
+                                        .setStructFields(List<IDataDescriptor>(field1Descriptor, field2Descriptor))
+                                        .build();
+
+        const auto timeDescriptor = DataDescriptorBuilder()
+                                        .setSampleType(SampleType::Int64)
+                                        .setTickResolution(Ratio(1, 1000))
+                                        .setUnit(Unit("s", -1, "second", "time"))
+                                        .setRule(LinearDataRule(1, 0))
+                                        .build();
+
+        valueSignal = SignalWithDescriptor(ctx, dataDescriptor, nullptr, "valuesig");
+        timeSignal = SignalWithDescriptor(ctx, timeDescriptor, nullptr, "timesig");
+
+        valueSignal.setDomainSignal(timeSignal);
+    }
+};
+
+TEST_F(StructDecoderTest, ConnectAndReadStruct)
+{
+    const auto ctx = NullContext();
+
+    const auto module = createModule(ctx);
+
+    auto fb = module.createFunctionBlock("RefFBModuleStructDecoder", nullptr, "id");
+    ASSERT_TRUE(fb.assigned());
+
+    const auto statusContainer = fb.getStatusContainer();
+    ASSERT_EQ(statusContainer.getStatus("InputStatus").getValue(), "Disconnected");
+
+    ASSERT_EQ(fb.getSignals().getCount(), 0);
+    ASSERT_EQ(fb.getInputPorts().getCount(), 1);
+
+    SignalConfigPtr valueSignal;
+    SignalConfigPtr timeSignal;
+    prepare(ctx, valueSignal, timeSignal);
+
+    fb.getInputPorts()[0].connect(valueSignal);
+
+    auto signals = fb.getSignals(search::Any());
+    ASSERT_EQ(signals.getCount(), 3);
+
+    ASSERT_EQ(signals[0].getDescriptor(), timeSignal.getDescriptor());
+    ASSERT_EQ(signals[1].getDescriptor(), valueSignal.getDescriptor().getStructFields()[0]);
+    ASSERT_EQ(signals[2].getDescriptor(), valueSignal.getDescriptor().getStructFields()[1]);
+
+    signals = fb.getSignals();
+    ASSERT_EQ(signals.getCount(), 2);
+
+    ASSERT_EQ(signals[0].getDescriptor(), valueSignal.getDescriptor().getStructFields()[0]);
+    ASSERT_EQ(signals[1].getDescriptor(), valueSignal.getDescriptor().getStructFields()[1]);
+
+    ASSERT_EQ(statusContainer.getStatus("InputStatus").getValue(), "Connected");
+
+    const auto multiReader = MultiReaderBuilder()
+        .setReadTimeoutType(ReadTimeoutType::All)
+        .setValueReadType(SampleType::Undefined)
+        .addSignal(signals[0])
+        .addSignal(signals[1])
+        .build();
+
+    const auto timePacket = DataPacket(timeSignal.getDescriptor(), 2, 0);
+    const auto valuePacket = DataPacketWithDomain(timePacket, valueSignal.getDescriptor(), 2);
+
+    struct Data
+    {
+        float field1;
+        int32_t field2[2];
+    };
+
+    auto valueData = static_cast<Data*>(valuePacket.getRawData());
+    valueData->field1 = 2.0;
+    valueData->field2[0] = 21;
+    valueData++->field2[1] = 22;
+    valueData->field1 = 3.0;
+    valueData->field2[0] = 31;
+    valueData++->field2[1] = 32;
+
+    valueSignal.sendPacket(valuePacket);
+
+    std::array<float, 2> valuesFloat;
+    std::array<int32_t[2], 2> valuesIntArray;
+
+    void* valuesPerSignal[2]{valuesFloat.data(), valuesIntArray.data()};
+
+    SizeT count = 0;
+    auto status = multiReader.read(nullptr, &count, 0);
+    ASSERT_EQ(status.getReadStatus(), ReadStatus::Event);
+
+    count = 2;
+    status = multiReader.read(valuesPerSignal, &count, 5000);
+    ASSERT_EQ(status.getReadStatus(), ReadStatus::Ok);
+
+    ASSERT_EQ(count, 2);
+    ASSERT_THAT(valuesFloat, testing::ElementsAre(2.0, 3.0));
+    ASSERT_EQ(valuesIntArray[0][0], 21);
+    ASSERT_EQ(valuesIntArray[0][1], 22);
+    ASSERT_EQ(valuesIntArray[1][0], 31);
+    ASSERT_EQ(valuesIntArray[1][1], 32);
+}
+
+TEST_F(StructDecoderTest, ConnectAndDisconnect)
+{
+    const auto ctx = NullContext();
+
+    const auto module = createModule(ctx);
+
+    auto fb = module.createFunctionBlock("RefFBModuleStructDecoder", nullptr, "id");
+    ASSERT_TRUE(fb.assigned());
+
+    const auto statusContainer = fb.getStatusContainer();
+    ASSERT_EQ(statusContainer.getStatus("InputStatus").getValue(), "Disconnected");
+
+    ASSERT_EQ(fb.getSignals().getCount(), 0);
+    ASSERT_EQ(fb.getInputPorts().getCount(), 1);
+
+    SignalConfigPtr valueSignal;
+    SignalConfigPtr timeSignal;
+    prepare(ctx, valueSignal, timeSignal);
+
+    fb.getInputPorts()[0].connect(valueSignal);
+
+    auto signals = fb.getSignals(search::Any());
+    ASSERT_EQ(signals.getCount(), 3);
+
+    fb.getInputPorts()[0].disconnect();
+
+    signals = fb.getSignals(search::Any());
+    ASSERT_EQ(signals.getCount(), 0);
+}
+
+TEST_F(StructDecoderTest, ConnectScalar)
+{
+    const auto ctx = NullContext();
+
+    const auto module = createModule(ctx);
+
+    const auto fb = module.createFunctionBlock("RefFBModuleStructDecoder", nullptr, "id");
+    ASSERT_TRUE(fb.assigned());
+
+    const auto statusContainer = fb.getStatusContainer();
+    ASSERT_EQ(statusContainer.getStatus("InputStatus").getValue(), "Disconnected");
+
+    ASSERT_EQ(fb.getSignals().getCount(), 0);
+    ASSERT_EQ(fb.getInputPorts().getCount(), 1);
+
+    const auto dataDescriptor = DataDescriptorBuilder()
+                                    .setSampleType(SampleType::Float32)
+                                    .build();
+
+    const auto timeDescriptor = DataDescriptorBuilder()
+                                    .setSampleType(SampleType::Int64)
+                                    .setTickResolution(Ratio(1, 1000))
+                                    .setUnit(Unit("s", -1, "second", "time"))
+                                    .setRule(LinearDataRule(1, 0))
+                                    .build();
+
+    const auto valueSignal = SignalWithDescriptor(ctx, dataDescriptor, nullptr, "valuesig");
+    const auto timeSignal = SignalWithDescriptor(ctx, timeDescriptor, nullptr, "timesig");
+
+    valueSignal.setDomainSignal(timeSignal);
+
+    fb.getInputPorts()[0].connect(valueSignal);
+
+    const auto signals = fb.getSignals(search::Any());
+    ASSERT_EQ(signals.getCount(), 0);
+
+    ASSERT_EQ(statusContainer.getStatus("InputStatus").getValue(), "Invalid");
+}

--- a/modules/ref_fb_module/tests/test_ref_fb_module.cpp
+++ b/modules/ref_fb_module/tests/test_ref_fb_module.cpp
@@ -148,7 +148,7 @@ TEST_F(RefFbModuleTest, GetAvailableComponentTypes)
     DictPtr<IString, IFunctionBlockType> functionBlockTypes;
     ASSERT_NO_THROW(functionBlockTypes = module.getAvailableFunctionBlockTypes());
     ASSERT_TRUE(functionBlockTypes.assigned());
-    ASSERT_EQ(functionBlockTypes.getCount(), 8u);
+    ASSERT_EQ(functionBlockTypes.getCount(), 9u);
 
     ASSERT_TRUE(functionBlockTypes.hasKey("RefFBModuleRenderer"));
     ASSERT_EQ("RefFBModuleRenderer", functionBlockTypes.get("RefFBModuleRenderer").getId());
@@ -170,6 +170,9 @@ TEST_F(RefFbModuleTest, GetAvailableComponentTypes)
 
     ASSERT_TRUE(functionBlockTypes.hasKey("RefFBModuleTrigger"));
     ASSERT_EQ("RefFBModuleTrigger", functionBlockTypes.get("RefFBModuleTrigger").getId());
+
+    ASSERT_TRUE(functionBlockTypes.hasKey("RefFBModuleStructDecoder"));
+    ASSERT_EQ("RefFBModuleStructDecoder", functionBlockTypes.get("RefFBModuleStructDecoder").getId());
 }
 
 TEST_F(RefFbModuleTest, CreateFunctionBlockNotFound)

--- a/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -481,7 +481,7 @@ TEST_F(OpcuaDeviceModulesTest, DeviceDynamicFeatures)
     auto daqDevice = client.getDevices()[0];
 
     ASSERT_EQ(daqDevice.getAvailableDevices().getCount(), 0u);
-    ASSERT_EQ(daqDevice.getAvailableFunctionBlockTypes().getCount(), 9u);
+    ASSERT_EQ(daqDevice.getAvailableFunctionBlockTypes().getCount(), 10u);
     ASSERT_THROW(daqDevice.addDevice("daqref://device0"),
                  opcua::OpcUaClientCallNotAvailableException);  // Are these the correct errors to return?
 


### PR DESCRIPTION
Adds a struct decoder function block that decomposes the struct signal into sub-signals. Signals are created when the data descriptor changed event is handled.

Tested with Python GUI demo and CAN channel; unit tests are still missing.

Update 1:

Added unit tests