### PR TITLE
Optimize some native config & streaming methods

### DIFF
--- a/shared/libraries/native_streaming_protocol/src/base_session_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/base_session_handler.cpp
@@ -165,6 +165,8 @@ const SessionPtr BaseSessionHandler::getSession() const
 void BaseSessionHandler::sendConfigurationPacket(const config_protocol::PacketBuffer& packetBuffer)
 {
     std::vector<WriteTask> tasks;
+    tasks.reserve(3);
+
     auto packetBufferPtr =
         std::make_shared<config_protocol::PacketBuffer>(packetBuffer.getBuffer(), true);
 
@@ -194,7 +196,7 @@ void BaseSessionHandler::sendConfigurationPacket(const config_protocol::PacketBu
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_CONFIGURATION_PACKET, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 ReadTask BaseSessionHandler::discardPayload(const void* /*data*/, size_t /*size*/)
@@ -334,6 +336,7 @@ ReadTask BaseSessionHandler::readPacketBuffer(const void* data, size_t size)
 void BaseSessionHandler::sendPacketBuffer(const PacketBufferPtr& packetBuffer)
 {
     std::vector<WriteTask> tasks;
+    tasks.reserve(3);
 
     // create write task for packet buffer header
     boost::asio::const_buffer packetBufferHeader(packetBuffer->packetHeader,
@@ -355,7 +358,7 @@ void BaseSessionHandler::sendPacketBuffer(const PacketBufferPtr& packetBuffer)
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_PACKET, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 END_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL

--- a/shared/libraries/native_streaming_protocol/src/client_session_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/client_session_handler.cpp
@@ -26,6 +26,7 @@ ClientSessionHandler::ClientSessionHandler(const ContextPtr& daqContext,
 void ClientSessionHandler::sendSignalSubscribe(const SignalNumericIdType& signalNumericId, const std::string& signalStringId)
 {
     std::vector<WriteTask> tasks;
+    tasks.reserve(3);
 
     // create write task for signal numeric ID
     tasks.push_back(createWriteNumberTask<SignalNumericIdType>(signalNumericId));
@@ -38,12 +39,13 @@ void ClientSessionHandler::sendSignalSubscribe(const SignalNumericIdType& signal
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_SIGNAL_SUBSCRIBE_COMMAND, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 void ClientSessionHandler::sendSignalUnsubscribe(const SignalNumericIdType& signalNumericId, const std::string& signalStringId)
 {
     std::vector<WriteTask> tasks;
+    tasks.reserve(3);
 
     // create write task for signal numeric ID
     tasks.push_back(createWriteNumberTask<SignalNumericIdType>(signalNumericId));
@@ -56,12 +58,13 @@ void ClientSessionHandler::sendSignalUnsubscribe(const SignalNumericIdType& sign
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_SIGNAL_UNSUBSCRIBE_COMMAND, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 void ClientSessionHandler::sendTransportLayerProperties(const PropertyObjectPtr& properties)
 {
     std::vector<WriteTask> tasks;
+    tasks.reserve(2);
 
     auto jsonSerializer = JsonSerializer(False);
     properties.serialize(jsonSerializer);
@@ -74,7 +77,7 @@ void ClientSessionHandler::sendTransportLayerProperties(const PropertyObjectPtr&
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_TRANSPORT_LAYER_PROPERTIES, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 void ClientSessionHandler::sendStreamingRequest()
@@ -83,7 +86,7 @@ void ClientSessionHandler::sendStreamingRequest()
 
     tasks.push_back(createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_PROTOCOL_INIT_REQUEST, 0));
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 ReadTask ClientSessionHandler::readSignalAvailable(const void* data, size_t size)

--- a/shared/libraries/native_streaming_protocol/src/server_session_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/server_session_handler.cpp
@@ -57,7 +57,7 @@ void ServerSessionHandler::sendSignalAvailable(const SignalNumericIdType& signal
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_SIGNAL_AVAILABLE, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 void ServerSessionHandler::sendSignalUnavailable(const SignalNumericIdType& signalNumericId,
@@ -79,7 +79,7 @@ void ServerSessionHandler::sendSignalUnavailable(const SignalNumericIdType& sign
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_SIGNAL_UNAVAILABLE, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 void ServerSessionHandler::sendStreamingInitDone()
@@ -88,7 +88,7 @@ void ServerSessionHandler::sendStreamingInitDone()
 
     tasks.push_back(createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_PROTOCOL_INIT_DONE, 0));
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 void ServerSessionHandler::sendSubscribingDone(const SignalNumericIdType signalNumericId)
@@ -103,7 +103,7 @@ void ServerSessionHandler::sendSubscribingDone(const SignalNumericIdType signalN
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_SIGNAL_SUBSCRIBE_ACK, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 void ServerSessionHandler::sendUnsubscribingDone(const SignalNumericIdType signalNumericId)
@@ -118,7 +118,7 @@ void ServerSessionHandler::sendUnsubscribingDone(const SignalNumericIdType signa
     auto writeHeaderTask = createWriteHeaderTask(PayloadType::PAYLOAD_TYPE_STREAMING_SIGNAL_UNSUBSCRIBE_ACK, payloadSize);
     tasks.insert(tasks.begin(), writeHeaderTask);
 
-    session->scheduleWrite(tasks);
+    session->scheduleWrite(std::move(tasks));
 }
 
 ReadTask ServerSessionHandler::readSignalSubscribe(const void* data, size_t size)


### PR DESCRIPTION
Some small optimization opportunities on native protocols that I noticed when profiling our devices. Avoids unnecessary copies of vectors and heap allocations.