### PR TITLE
fix mismatched whitespace, causing compiler warnings

### DIFF
--- a/core/opendaq/signal/include/opendaq/input_port_config_ptr.custom.h
+++ b/core/opendaq/signal/include/opendaq/input_port_config_ptr.custom.h
@@ -24,17 +24,17 @@ void remove() const
 {	
     if (this->object == nullptr)
         throw daq::InvalidParameterException();
-	
-	IRemovable* removable;
-	auto errCode = this->object->borrowInterface(IRemovable::Id, reinterpret_cast<void**>(&removable));
-	if (OPENDAQ_FAILED(errCode))
-	{
-		if (errCode == OPENDAQ_ERR_NOINTERFACE)
-			return;
-		daq::checkErrorInfo(errCode);
-	}
+    
+    IRemovable* removable;
+    auto errCode = this->object->borrowInterface(IRemovable::Id, reinterpret_cast<void**>(&removable));
+    if (OPENDAQ_FAILED(errCode))
+    {
+        if (errCode == OPENDAQ_ERR_NOINTERFACE)
+            return;
+        daq::checkErrorInfo(errCode);
+    }
 
-	errCode = removable->remove();
+    errCode = removable->remove();
     daq::checkErrorInfo(errCode);
 }
 
@@ -46,14 +46,14 @@ bool isRemoved() const
 {
     if (this->object == nullptr)
         throw daq::InvalidParameterException();
-	
-	IRemovable* removable;
-	auto errCode = this->object->borrowInterface(IRemovable::Id, reinterpret_cast<void**>(&removable));
-	daq::checkErrorInfo(errCode);
+    
+    IRemovable* removable;
+    auto errCode = this->object->borrowInterface(IRemovable::Id, reinterpret_cast<void**>(&removable));
+    daq::checkErrorInfo(errCode);
 
-	Bool removed;
-	errCode = removable->isRemoved(&removed);
-	daq::checkErrorInfo(errCode);
-	
-	return removed;
+    Bool removed;
+    errCode = removable->isRemoved(&removed);
+    daq::checkErrorInfo(errCode);
+    
+    return removed;
 }


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] Pull request title reflects its content
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

# Description:

`core/opendaq/signal/include/opendaq/input_port_config_ptr.custom.h` contained inconsistent whitespace: in half a dozen lines, 4 spaces were used instead of tabs. Most of the file used tabs. This mixture of whitespace formats leads to compiler warnings like:

    error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]