### PR TITLE
Make Python wheel install instructions explicit

### DIFF
--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
@@ -17,6 +17,12 @@ The latest versions of the Python bindings are available at https://docs-dev.ope
 
 The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-3.4.0_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
 
+To install the wheel, use:
+[source,bash]
+----
+pip install path/to/.whl
+----
+
 == Prerequisites
 
 Python *3.8-12* for Windows can be downloaded from https://www.python.org/downloads/. On Linux it can be installed via the package manager.


### PR DESCRIPTION
## Type of change

- [x] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Description:
Makes it easier to discriminate between latest major release (eg. 3.0.0) vs. latest main wheel installation in the Antora docs.
I would also suggest considering https://pip.pypa.io/en/stable/cli/pip_install/#install-pre or similar for minor and/or patch versions of the SDK.