### PR TITLE
Fix object permissions without owner

### DIFF
--- a/core/coreobjects/include/coreobjects/permission_manager.h
+++ b/core/coreobjects/include/coreobjects/permission_manager.h
@@ -37,7 +37,7 @@ BEGIN_NAMESPACE_OPENDAQ
 DECLARE_OPENDAQ_INTERFACE(IPermissionManager, IBaseObject)
 {
     /*!
-     * @brief Set object permisison configuration.
+     * @brief Set object permission configuration.
      * @param permissions Permissions configuration object.
      */
     virtual ErrCode INTERFACE_FUNC setPermissions(IPermissions* permissions) = 0;
@@ -45,8 +45,8 @@ DECLARE_OPENDAQ_INTERFACE(IPermissionManager, IBaseObject)
     /*!
      * @brief Check if user has a given permission on an object of the permission manager.
      * @param user A reference to the user.
-     * @param permission A permisson to test.
-     * @param authorizedOut[out] Returns true if user is authorized and false otherwise.
+     * @param permission A permission to test.
+     * @param[out] authorizedOut Returns true if user is authorized and false otherwise.
      */
     virtual ErrCode INTERFACE_FUNC isAuthorized(IUser * user, Permission permission, Bool* authorizedOut) = 0;
 };

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -44,6 +44,8 @@
 #include <coretypes/cloneable.h>
 #include <coreobjects/permission_manager_factory.h>
 #include <coreobjects/permission_manager_internal_ptr.h>
+#include <coreobjects/permission_mask_builder_factory.h>
+#include <coreobjects/permissions_builder_factory.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -324,6 +326,9 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
 {
     this->internalAddRef();
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
+
+    this->permissionManager.setPermissions(
+        PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build());
 }
 
 template <typename PropObjInterface, typename... Interfaces>

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -238,13 +238,9 @@ ComponentImpl<Intf, Intfs...>::ComponentImpl(
 
     if (parent.assigned())
     {
+        this->permissionManager.setPermissions(PermissionsBuilder().inherit(true).build());
         const auto parentManager = parent.getPermissionManager();
         this->permissionManager.template asPtr<IPermissionManagerInternal>(true).setParent(parentManager);
-    }
-    else
-    {
-        this->permissionManager.setPermissions(
-            PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build());
     }
 }
 

--- a/core/opendaq/opendaq/tests/test_access_control.cpp
+++ b/core/opendaq/opendaq/tests/test_access_control.cpp
@@ -63,6 +63,18 @@ TEST_F(AccessControlTest, DefaultPermissions)
     ASSERT_TRUE(fbManager.isAuthorized(user, Permission::Execute));
 }
 
+TEST_F(AccessControlTest, DefaultPermissionsPropObj)
+{
+    auto anonymousUser = User("", "");
+
+    auto obj = PropertyObject();
+
+    auto permissionManager = obj.getPermissionManager();
+    ASSERT_TRUE(permissionManager.isAuthorized(anonymousUser, Permission::Read));
+    ASSERT_TRUE(permissionManager.isAuthorized(anonymousUser, Permission::Write));
+    ASSERT_TRUE(permissionManager.isAuthorized(anonymousUser, Permission::Execute));
+}
+
 TEST_F(AccessControlTest, ComponentInherit)
 {
     const auto user = User("user", "psswordHash", List<IString>("user", "guest"));


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

Property objects without parents had no access by default. Any type objects getters (eg. getAvailableFunctionBlockType) were crashing over native due to it.

# TODO:
- Add test