### PR TITLE
Optimize number of core type objects instantiations

### DIFF
--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/CoreTypesBaseObjectTests.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/CoreTypesBaseObjectTests.cs
@@ -39,6 +39,8 @@ public class CoreTypesBaseObjectTests : OpenDAQTestsBase
     [Test]
     public void CreateTest()
     {
+        var trackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+
         ErrorCode errorCode = CoreTypesFactory.CreateBaseObject(out BaseObject testObject);
 
         Assert.Multiple(() =>
@@ -46,7 +48,9 @@ public class CoreTypesBaseObjectTests : OpenDAQTestsBase
             Assert.That(errorCode, Is.EqualTo(ErrorCode.OPENDAQ_SUCCESS));
             Assert.That(testObject, Is.Not.Null);
             Assert.That(testObject.IsDisposed, Is.False);
-            if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(1));
+
+            var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+            Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount + 1 : 0));
         });
 
         if (!testObject.IsDisposed) //not necessarily needed
@@ -55,18 +59,24 @@ public class CoreTypesBaseObjectTests : OpenDAQTestsBase
         Assert.Multiple(() =>
         {
             Assert.That(testObject.IsDisposed, Is.True);
-            if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(0));
+
+            var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+            Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount : 0));
         });
     }
 
     [Test]
     public void QueryInterfaceTest()
     {
+        var trackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+
         ErrorCode errorCode = CoreTypesFactory.CreateBaseObject(out BaseObject testObject);
         Assert.Multiple(() =>
         {
             Assert.That(errorCode, Is.EqualTo(ErrorCode.OPENDAQ_SUCCESS));
-            if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(1));
+
+            var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+            Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount + 1 : 0));
         });
 
         BaseObject queriedObject = testObject.QueryInterface<BaseObject>();
@@ -74,28 +84,34 @@ public class CoreTypesBaseObjectTests : OpenDAQTestsBase
         Assert.Multiple(() =>
         {
             Assert.That(queriedObject, Is.Not.Null);
-            if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(1));
+
+            var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+            Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount + 1 : 0));
         });
 
         Assert.That(testObject.IsDisposed, Is.Not.True);
         testObject.Dispose();
 
-        if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(1)); //because QueryInterface() increments refCount
+        var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+        Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount + 1 : 0));  //because QueryInterface() increments refCount
 
         Assert.That(queriedObject.IsDisposed, Is.Not.True);
         queriedObject.Dispose();
 
-        if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(0));
+        newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+        Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount : 0));
     }
 
     [Test]
     public void BorrowInterfaceTest()
     {
+        var trackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
         ErrorCode errorCode = CoreTypesFactory.CreateBaseObject(out BaseObject testObject);
         Assert.Multiple(() =>
         {
             Assert.That(errorCode, Is.EqualTo(ErrorCode.OPENDAQ_SUCCESS));
-            if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(1));
+            var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+            Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount + 1 : 0));
         });
 
         //should just return the testObject since we don't "change" the type
@@ -105,18 +121,21 @@ public class CoreTypesBaseObjectTests : OpenDAQTestsBase
         {
             Assert.That(queriedObject, Is.Not.Null);
             Assert.That(queriedObject, Is.SameAs(testObject));
-            if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(1));
+            var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+            Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount + 1 : 0));
         });
 
         Assert.That(testObject.IsDisposed, Is.Not.True);
         testObject.Dispose(); //also disposes of queriedObject since both point to the same object
 
-        if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(0)); //because BorrowInterface() doesn't increment refCount
+        var newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+        Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount : 0)); //because BorrowInterface() doesn't increment refCount
 
         Assert.That(queriedObject.IsDisposed, Is.True);
         queriedObject.Dispose();
 
-        if (_isTrackingObjects) Assert.That(CoreTypes.GetTrackedObjectCount(), Is.EqualTo(0));
+        newTrackedObjectCount = _isTrackingObjects ? CoreTypes.GetTrackedObjectCount() : 0;
+        Assert.That(newTrackedObjectCount, Is.EqualTo(_isTrackingObjects ? trackedObjectCount : 0));
     }
 
     [Test]

--- a/core/coretypes/src/boolean_impl.cpp
+++ b/core/coretypes/src/boolean_impl.cpp
@@ -3,14 +3,53 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, Boolean, const Bool, value)
-OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(
-    LIBRARY_FACTORY,
-    Boolean,
-    IBoolean,
-    createBoolObject,
-    const Bool,
-    value
-)
+class StaticBools
+{
+public:
+    IBoolean* trueValue;
+    IBoolean* falseValue;
+
+    StaticBools()
+    {
+        daq::createObject<IBoolean, BooleanImpl, const Bool>(&trueValue, True);
+        daq::createObject<IBoolean, BooleanImpl, const Bool>(&falseValue, False);
+    }
+
+    ~StaticBools()
+    {
+        trueValue->releaseRef();
+        falseValue->releaseRef();
+    }
+
+} staticBools;
+
+inline daq::ErrCode createBoolInternal(IBoolean**objTmp, const Bool value)
+{
+    if (!objTmp)
+        return OPENDAQ_ERR_ARGUMENT_NULL;
+
+    if (value)
+    {
+        staticBools.trueValue->addRef();
+        *objTmp = staticBools.trueValue;
+    }
+    else
+    {
+        staticBools.falseValue->addRef();
+        *objTmp = staticBools.falseValue;
+    }
+
+    return OPENDAQ_SUCCESS;
+}
+
+extern "C" daq::ErrCode LIBRARY_FACTORY createBoolean(IBoolean** objTmp, const Bool value)
+{
+    return createBoolInternal(objTmp, value);
+}
+
+extern "C" daq::ErrCode LIBRARY_FACTORY createBoolObject(IBoolean** objTmp, const Bool value)
+{
+    return createBoolInternal(objTmp, value);
+}
 
 END_NAMESPACE_OPENDAQ

--- a/core/coretypes/src/float_impl.cpp
+++ b/core/coretypes/src/float_impl.cpp
@@ -3,13 +3,46 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, Float, const Float, value)
-OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(
-    LIBRARY_FACTORY,
-    Float, IFloat,
-    createFloatObject,
-    const Float,
-    value
-)
+class StaticFloats
+{
+public:
+    IFloat* zeroValue;
+
+    StaticFloats()
+    {
+        daq::createObject<IFloat, FloatImpl, const Float>(&zeroValue, 0.0);
+    }
+
+    ~StaticFloats()
+    {
+        zeroValue->releaseRef();
+    }
+
+} staticFloats;
+
+inline daq::ErrCode createFloatInternal(IFloat** objTmp, const Float value)
+{
+    if (!objTmp)
+        return OPENDAQ_ERR_ARGUMENT_NULL;
+
+    if (value == 0.0)
+    {
+        staticFloats.zeroValue->addRef();
+        *objTmp = staticFloats.zeroValue;
+        return OPENDAQ_SUCCESS;
+    }
+
+    return daq::createObject<IFloat, FloatImpl, const Float>(objTmp, value);
+}
+
+extern "C" daq::ErrCode LIBRARY_FACTORY createFloat(IFloat** objTmp, const Float value)
+{
+    return createFloatInternal(objTmp, value);
+}
+
+extern "C" daq::ErrCode LIBRARY_FACTORY createFloatObject(IFloat** objTmp, const Float value)
+{
+    return createFloatInternal(objTmp, value);
+}
 
 END_NAMESPACE_OPENDAQ

--- a/core/coretypes/src/integer_impl.cpp
+++ b/core/coretypes/src/integer_impl.cpp
@@ -3,6 +3,93 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, Integer, const Int, value)
+class StaticInts
+{
+public:
+    IInteger* zeroValue;
+    IInteger* oneValue;
+    IInteger* twoValue;
+    IInteger* threeValue;
+    IInteger* fourValue;
+    IInteger* fiveValue;
+    IInteger* sixValue;
+    IInteger* sevenValue;
+    IInteger* minusOneValue;
+
+    StaticInts()
+    {
+        daq::createObject<IInteger, IntegerImpl, const Int>(&zeroValue, 0);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&oneValue, 1);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&twoValue, 2);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&threeValue, 3);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&fourValue, 4);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&fiveValue, 5);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&sixValue, 6);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&sevenValue, 7);
+        daq::createObject<IInteger, IntegerImpl, const Int>(&minusOneValue, -1);
+    }
+
+    ~StaticInts()
+    {
+        zeroValue->releaseRef();
+        oneValue->releaseRef();
+        twoValue->releaseRef();
+        threeValue->releaseRef();
+        fourValue->releaseRef();
+        fiveValue->releaseRef();
+        sixValue->releaseRef();
+        minusOneValue->releaseRef();
+        sevenValue->releaseRef();
+    }
+
+} staticInts;
+
+extern "C" daq::ErrCode LIBRARY_FACTORY createInteger(IInteger** objTmp, const Int value)
+{
+    if (!objTmp)
+        return OPENDAQ_ERR_ARGUMENT_NULL;
+
+    switch (value)
+    {
+        case -1:
+            staticInts.minusOneValue->addRef();
+            *objTmp = staticInts.minusOneValue;
+            return OPENDAQ_SUCCESS;
+        case 0:
+            staticInts.zeroValue->addRef();
+            *objTmp = staticInts.zeroValue;
+            return OPENDAQ_SUCCESS;
+        case 1:
+            staticInts.oneValue->addRef();
+            *objTmp = staticInts.oneValue;
+            return OPENDAQ_SUCCESS;
+        case 2:
+            staticInts.twoValue->addRef();
+            *objTmp = staticInts.twoValue;
+            return OPENDAQ_SUCCESS;
+        case 3:
+            staticInts.threeValue->addRef();
+            *objTmp = staticInts.threeValue;
+            return OPENDAQ_SUCCESS;
+        case 4:
+            staticInts.fourValue->addRef();
+            *objTmp = staticInts.fourValue;
+            return OPENDAQ_SUCCESS;
+        case 5:
+            staticInts.fiveValue->addRef();
+            *objTmp = staticInts.fiveValue;
+            return OPENDAQ_SUCCESS;
+        case 6:
+            staticInts.sixValue->addRef();
+            *objTmp = staticInts.sixValue;
+            return OPENDAQ_SUCCESS;
+        case 7:
+            staticInts.sevenValue->addRef();
+            *objTmp = staticInts.sevenValue;
+            return OPENDAQ_SUCCESS;
+        default:
+            return daq::createObject<IInteger, IntegerImpl, const Int>(objTmp, value);
+    }
+}
 
 END_NAMESPACE_OPENDAQ

--- a/core/coretypes/src/intfs.cpp
+++ b/core/coretypes/src/intfs.cpp
@@ -18,14 +18,18 @@ using namespace daq;
         return *objects;
     }
 
-    static std::mutex ObjectContainerMutex;
+    std::mutex& getObjectsMutex()
+    {
+        static std::mutex mtx;
+        return mtx;
+    }
 #endif
 
 extern "C"
 PUBLIC_EXPORT void daqTrackObject(IBaseObject* obj)
 {
 #ifndef NDEBUG
-    std::lock_guard<std::mutex> lock(ObjectContainerMutex);
+    std::lock_guard<std::mutex> lock(getObjectsMutex());
     getObjects().insert(obj);
 #endif
 }
@@ -34,7 +38,7 @@ extern "C"
 PUBLIC_EXPORT void daqUntrackObject(IBaseObject* obj)
 {
 #ifndef NDEBUG
-    std::lock_guard<std::mutex> lock(ObjectContainerMutex);
+    std::lock_guard<std::mutex> lock(getObjectsMutex());
     const auto it = getObjects().find(obj);
     if (it != getObjects().end())
         getObjects().erase(it);
@@ -45,7 +49,7 @@ extern "C"
 PUBLIC_EXPORT size_t daqGetTrackedObjectCount()
 {
 #ifndef NDEBUG
-    std::lock_guard<std::mutex> lock(ObjectContainerMutex);
+    std::lock_guard<std::mutex> lock(getObjectsMutex());
     return getObjects().size();
 #else
     return 0;
@@ -56,7 +60,7 @@ extern "C"
 PUBLIC_EXPORT void daqPrintTrackedObjects()
 {
 #ifndef NDEBUG
-    std::lock_guard<std::mutex> lock(ObjectContainerMutex);
+    std::lock_guard<std::mutex> lock(getObjectsMutex());
     for (auto obj : getObjects())
     {
         assert(obj != nullptr);
@@ -69,7 +73,7 @@ extern "C"
 PUBLIC_EXPORT void daqClearTrackedObjects()
 {
 #ifndef NDEBUG
-    std::lock_guard<std::mutex> lock(ObjectContainerMutex);
+    std::lock_guard<std::mutex> lock(getObjectsMutex());
     getObjects().clear();
 #endif
 }


### PR DESCRIPTION
When an instance/device/function block is created, several hundred objects are allocated. This PR pre-allocates and caches the most often used core types and increments the reference when the factory is called. It drastically reduces the number of malloc calls and object instantiations.

