### PR TITLE
Improve thread-safety of config protocol client

### DIFF
--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -96,11 +96,10 @@ public:
 
 private:
     ContextPtr daqContext;
-    uint64_t id;
+    std::atomic<uint64_t> id;
     SendRequestCallback sendRequestCallback;
     SendNoReplyRequestCallback sendNoReplyRequestCallback;
     ComponentDeserializeCallback rootDeviceDeserializeCallback;
-    DeserializerPtr deserializer;
     bool connected;
     WeakRefPtr<IDevice> rootDeviceRef;
     uint16_t protocolVersion;

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -23,7 +23,6 @@ ConfigProtocolClientComm::ConfigProtocolClientComm(const ContextPtr& daqContext,
         , sendRequestCallback(std::move(sendRequestCallback))
         , sendNoReplyRequestCallback(std::move(sendNoReplyRequestCallback))
         , rootDeviceDeserializeCallback(std::move(rootDeviceDeserializeCallback))
-        , deserializer(JsonDeserializer())
         , connected(false)
         , protocolVersion(0)
         , streamingProducerRef(streamingProducer)
@@ -32,7 +31,7 @@ ConfigProtocolClientComm::ConfigProtocolClientComm(const ContextPtr& daqContext,
 
 uint64_t ConfigProtocolClientComm::generateId()
 {
-    return id++;
+    return std::atomic_fetch_add_explicit(&id, uint64_t(1), std::memory_order_relaxed);
 }
 
 void ConfigProtocolClientComm::setPropertyValue(
@@ -222,6 +221,7 @@ BaseObjectPtr ConfigProtocolClientComm::parseRpcReplyPacketBuffer(const PacketBu
     try
     {
         ComponentDeserializeCallback customDeviceDeserilazeCallback = isGetRootDeviceReply ? rootDeviceDeserializeCallback : nullptr;
+        const auto deserializer = JsonDeserializer();
         reply = deserializer.deserialize(
             jsonStr,
             context,


### PR DESCRIPTION
# Description:

* Ensure thread-safe generation of unique ID for config request
* Instantiate a separate deserializer for parsing each config request reply

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules