### PR TITLE
Fix `spdlog` dependency

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Type of change
+# Type of change:
 
 Please delete options that are not relevant.
 

--- a/cmake/openDAQConfig.cmake.in
+++ b/cmake/openDAQConfig.cmake.in
@@ -20,7 +20,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(fmt REQUIRED)
 find_dependency(tsl-ordered-map REQUIRED)
 find_dependency(date REQUIRED)
-find_dependency(spdlog REQUIRED)
 
 find_package(xxHash QUIET)
 if (NOT xxHash_FOUND)

--- a/docs/Antora/modules/howto_guides/pages/howto.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto.adoc
@@ -8,6 +8,7 @@
 * xref:howto_configure_instance_providers.adoc[]
 * xref:howto_configure_streaming.adoc[]
 * xref:howto_measure_single_value.adoc[]
+
 == Read data with Readers
 
 * xref:howto_read_with_domain.adoc[]


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:
While following the cpp “getting started” guide here https://docs-dev.opendaq.com/manual/opendaq/3.4.0/getting_started/quick_start_setting_up_cpp.html,  there is an issue with the spdlog dependency in the first step of building the project (while executing `cmake -DCMAKE_BUILD_TYPE=Release -Bbuild .`). This dependency is already included in the openDAQ SDK and should not be referenced as an external dependency, at least not in this manner.

## To reproduce: 

Follow https://docs-dev.opendaq.com/manual/opendaq/3.4.0/getting_started/quick_start_setting_up_cpp.html up until building the project.

In the first step of building the project (executing `cmake -DCMAKE_BUILD_TYPE=Release -Bbuild .`), the following error appears: 

```
Could not find a package configuration file provided by "spdlog" with any
  of the following names:

spdlogConfig.cmake
spdlog-config.cmake
```

## Desired outcome / requirement:
Build successfully executes without errors.

## Solution:
Remove `find_dependency(spdlog REQUIRED)` from `cmake/openDAQConfig.cmake.in`.
(Based on https://github.com/openDAQ/openDAQ/tree/norris/spdlog)