### PR TITLE
Change event mutex to recursive

### DIFF
--- a/core/coreobjects/tests/test_value_changed_events.cpp
+++ b/core/coreobjects/tests/test_value_changed_events.cpp
@@ -334,3 +334,24 @@ TEST_F(PropertyValueChangedEventsTest, PropertyEventClassCall)
 
     ASSERT_EQ(callCount, 13);
 }
+
+TEST_F(PropertyValueChangedEventsTest, NestedEventCalls)
+{
+    PropertyPtr prop = IntProperty("int", -1);
+    
+    const auto obj = PropertyObject();
+    obj.addProperty(prop);
+
+    int callCount = 0;
+    prop.getOnPropertyValueWrite() +=
+        [&callCount, &obj](const PropertyObjectPtr&, const PropertyValueEventArgsPtr&)
+        {
+            callCount++;
+            if (callCount < 10)
+            {
+                obj.setPropertyValue("int", callCount);
+            }
+        };
+
+    ASSERT_NO_THROW(obj.setPropertyValue("int", callCount));
+}

--- a/core/coretypes/include/coretypes/event_impl.h
+++ b/core/coretypes/include/coretypes/event_impl.h
@@ -96,7 +96,7 @@ private:
     std::atomic<bool> frozen{};
     std::vector<Handler> handlers;
 
-    mutable daq::mutex sync;
+    mutable daq::RecursiveMutex sync;
 };
 
 END_NAMESPACE_OPENDAQ


### PR DESCRIPTION
# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

Introduces recursive mutex for events to avoid deadlocks.