### PR TITLE
Fix being able to re-add reference devices after removal

### DIFF
--- a/modules/ref_device_module/include/ref_device_module/ref_device_module_impl.h
+++ b/modules/ref_device_module/include/ref_device_module/ref_device_module_impl.h
@@ -35,6 +35,7 @@ private:
     size_t maxNumberOfDevices;
 
     size_t getIdFromConnectionString(const std::string& connectionString) const;
+    void clearRemovedDevices();
 };
 
 END_NAMESPACE_REF_DEVICE_MODULE

--- a/modules/ref_device_module/src/ref_device_module_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_module_impl.cpp
@@ -74,6 +74,7 @@ DevicePtr RefDeviceModule::onCreateDevice(const StringPtr& connectionString,
         throw NotFoundException();
     }
 
+    clearRemovedDevices();
     if (devices[id].assigned() && devices[id].getRef().assigned())
     {
         LOG_W("Device with id \"{}\" already exist", id);
@@ -131,6 +132,16 @@ size_t RefDeviceModule::getIdFromConnectionString(const std::string& connectionS
     }
 
     return id;
+}
+
+void RefDeviceModule::clearRemovedDevices()
+{
+    for (auto& device : devices)
+    {
+        const bool isNull = !device.assigned() || !device.getRef().assigned();
+        if (isNull || device.getRef().isRemoved())
+            device = nullptr;
+    }
 }
 
 END_NAMESPACE_REF_DEVICE_MODULE

--- a/modules/ref_device_module/tests/test_ref_device_module.cpp
+++ b/modules/ref_device_module/tests/test_ref_device_module.cpp
@@ -18,6 +18,7 @@
 #include <testutils/testutils.h>
 #include <thread>
 #include "../../../core/opendaq/opendaq/tests/test_config_provider.h"
+#include <opendaq/instance_factory.h>
 
 using namespace daq;
 using RefDeviceModuleTest = testing::Test;
@@ -877,4 +878,30 @@ TEST_F(RefDeviceModuleTestConfig, DeviceModuleJsonConfigEmptyString)
 
     DevicePtr ptr;
     ASSERT_THROW(ptr = module.createDevice("daqref://device1", nullptr), GeneralErrorException);
+}
+
+TEST_F(RefDeviceModuleTest, AddRemoveAddDevice)
+{
+    const auto instance = Instance();
+
+    auto dev0 = instance.addDevice("daqref://device0");
+    auto dev1 = instance.addDevice("daqref://device1");
+    instance.removeDevice(dev0);
+    instance.removeDevice(dev1);
+
+    dev0.release();
+    dev1.release();
+
+    ASSERT_NO_THROW(dev0 = instance.addDevice("daqref://device0"));
+    ASSERT_NO_THROW(dev1 = instance.addDevice("daqref://device1"));
+    ASSERT_TRUE(dev0.assigned());
+    ASSERT_TRUE(dev1.assigned());
+
+    instance.removeDevice(dev0);
+    instance.removeDevice(dev1);
+
+    ASSERT_NO_THROW(dev0 = instance.addDevice("daqref://device0"));
+    ASSERT_NO_THROW(dev1 = instance.addDevice("daqref://device1"));
+    ASSERT_TRUE(dev0.assigned());
+    ASSERT_TRUE(dev1.assigned());
 }


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

Reference device vector that was used to check whether a device is already added was never pruned. This PR addresses that issue.