### PR TITLE
Disable config client property object onWrite/Read events

### DIFF
--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -1,3 +1,9 @@
+03.10.2024
+Description:
+	- Bugfix where onPropertyValueWrite/Read events were available on the native protocol client, but were not fully supported.
+	- Said property object events were disabled to reduce probability of misuse.
+	- CoreEvents should be used instead of onWrite/Read events where needed.
+
 23.09.2024
 Description:
     - Enable multireader to be manually set inactive to drop data packets

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -23,9 +23,9 @@
 #include <opendaq/deserialize_component_ptr.h>
 #include <config_protocol/config_protocol_deserialize_context.h>
 #include <opendaq/custom_log.h>
-
-#include "config_protocol_deserialize_context_impl.h"
+#include <config_protocol/config_protocol_deserialize_context_impl.h>
 #include <opendaq/context_factory.h>
+#include <config_protocol/errors.h>
 
 namespace daq::config_protocol
 {
@@ -283,13 +283,13 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::removeProperty(IString* proper
 template <class Impl>
 ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::getOnPropertyValueWrite(IString* propertyName, IEvent** event)
 {
-    return Impl::getOnPropertyValueWrite(propertyName, event);
+    return OPENDAQ_ERR_NATIVE_CLIENT_CALL_NOT_AVAILABLE;
 }
 
 template <class Impl>
 ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::getOnPropertyValueRead(IString* propertyName, IEvent** event)
 {
-    return Impl::getOnPropertyValueRead(propertyName, event);
+    return OPENDAQ_ERR_NATIVE_CLIENT_CALL_NOT_AVAILABLE;
 }
 
 template <class Impl>

--- a/shared/libraries/config_protocol/include/config_protocol/errors.h
+++ b/shared/libraries/config_protocol/include/config_protocol/errors.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022-2024 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/errors.h>
+
+#define OPENDAQ_ERRTYPE_NATIVE 0x10u
+
+#define OPENDAQ_ERR_NATIVE_CLIENT_CALL_NOT_AVAILABLE OPENDAQ_ERROR_CODE(OPENDAQ_ERRTYPE_NATIVE, 0x001)

--- a/shared/libraries/config_protocol/include/config_protocol/exceptions.h
+++ b/shared/libraries/config_protocol/include/config_protocol/exceptions.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022-2024 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/exceptions.h>
+#include <config_protocol/errors.h>
+
+namespace daq::config_protocol
+{
+
+DEFINE_EXCEPTION(NativeClientCallNotAvailable, OPENDAQ_ERR_NATIVE_CLIENT_CALL_NOT_AVAILABLE, "This function call is not available/implemented for usage on connected-to Native servers.")
+
+}

--- a/shared/libraries/config_protocol/src/CMakeLists.txt
+++ b/shared/libraries/config_protocol/src/CMakeLists.txt
@@ -40,11 +40,13 @@ set(SRC_PublicHeaders config_protocol.h
                       config_server_access_control.h
                       config_protocol_streaming_producer.h
                       config_protocol_streaming_consumer.h
+                      errors.h
 )
 
 set(SRC_PrivateHeaders config_protocol_deserialize_context_impl.h
                        config_server_input_port.h
                        config_mirrored_ext_sig_impl.h
+                       exceptions.h
 )                       
 
 

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -7,13 +7,13 @@
 #include <config_protocol/config_protocol_server.h>
 #include <config_protocol/config_protocol_client.h>
 #include "test_utils.h"
-#include "coreobjects/argument_info_factory.h"
-#include "coreobjects/callable_info_factory.h"
-#include "opendaq/context_factory.h"
+#include <coreobjects/argument_info_factory.h>
+#include <coreobjects/callable_info_factory.h>
+#include <opendaq/context_factory.h>
 #include <config_protocol/config_client_device_impl.h>
-
-#include "opendaq/packet_factory.h"
+#include <opendaq/packet_factory.h>
 #include <coreobjects/user_factory.h>
+#include <config_protocol/exceptions.h>
 
 using namespace daq;
 using namespace config_protocol;
@@ -600,4 +600,10 @@ TEST_F(ConfigProtocolIntegrationTest, DeviceInfoChanges)
 
     ASSERT_EQ(serverDeviceInfo.getName(), clientDeviceInfo.getName());
     ASSERT_EQ(serverDeviceInfo.getLocation(), clientDeviceInfo.getLocation());
+}
+
+TEST_F(ConfigProtocolIntegrationTest, OnWriteReadEvents)
+{
+    ASSERT_THROW(clientDevice.getOnPropertyValueWrite("location"), NativeClientCallNotAvailableException);
+    ASSERT_THROW(clientDevice.getOnPropertyValueRead("location"), NativeClientCallNotAvailableException);
 }


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

- Bugfix where onPropertyValueWrite/Read events were available on the native protocol client, but were not fully supported.
- Said property object events were disabled to reduce probability of misuse.
- CoreEvents should be used instead of onWrite/Read events where needed.