### PR TITLE
Fix enumeration factory with integer parameter

### DIFF
--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -2088,3 +2088,25 @@ TEST_F(BeginEndUpdatePropertyObjectTest, Recursive)
     ASSERT_EQ(propObj.getPropertyValue("StringProp"), "s");
     ASSERT_EQ(childPropObj.getPropertyValue("ChildStringProp"), "cs");
 }
+
+TEST_F(PropertyObjectTest, EnumerationPropertySetGet)
+{
+    // Add Enumeration type to Type Manager
+    const auto enumType = EnumerationType(
+        "EnumType", List<IString>("Option1", "Option2", "Option3"));
+    objManager.addType(enumType);
+
+    auto enumerationProperty = EnumerationPropertyBuilder("enumProp", Enumeration("EnumType", "Option1", objManager))
+                               .setDefaultValue(Enumeration("EnumType", "Option2", objManager))
+                               .build();
+    
+    // Create a PropertyObject with an Enumeration property
+    auto propObj = PropertyObject();
+    propObj.addProperty(enumerationProperty);
+
+    propObj.setPropertyValue("enumProp", Enumeration("EnumType", "Option1", objManager));
+    ASSERT_EQ(propObj.getPropertyValue("enumProp"), "Option1");
+
+    propObj.setPropertyValue("enumProp", EnumerationWithIntValue("EnumType", 2, objManager));
+    ASSERT_EQ(propObj.getPropertyValue("enumProp"), "Option3");
+}

--- a/core/coretypes/src/enumeration_impl.cpp
+++ b/core/coretypes/src/enumeration_impl.cpp
@@ -40,7 +40,7 @@ EnumerationImpl::EnumerationImpl(const StringPtr& name,
             if (this->enumerationType.getEnumeratorIntValue(fieldName) == intValue)
             {
                 this->value = fieldName;
-                break;
+                return;
             }
     }
 


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

Enumeration construction with an integer parameter failed due to a type (`break` instead of `return`).