### PR TITLE
Add an option to restore client-side configuration on reconnection

### DIFF
--- a/core/opendaq/streaming/include/opendaq/streaming_impl.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_impl.h
@@ -737,22 +737,15 @@ void StreamingImpl<Interfaces...>::removeFromAvailableSignals(const StringPtr& s
 {
     std::scoped_lock lock(sync);
 
-    if (isReconnecting)
+    if (const auto& it = availableSignalIds.find(signalStreamingId); it != availableSignalIds.end())
     {
-        throw InvalidStateException("Signal unavailable command received during reconnection");
+        this->availableSignalIds.erase(it);
+        remapUnavailableSignal(signalStreamingId);
     }
     else
     {
-        if (const auto& it = availableSignalIds.find(signalStreamingId); it != availableSignalIds.end())
-        {
-            this->availableSignalIds.erase(it);
-            remapUnavailableSignal(signalStreamingId);
-        }
-        else
-        {
-            LOG_E("Signal with id {} was not registered as available", signalStreamingId);
-            throw NotFoundException("Signal with id {} was not registered as available in streaming {}", signalStreamingId, this->connectionString);
-        }
+        LOG_E("Signal with id {} was not registered as available", signalStreamingId);
+        throw NotFoundException("Signal with id {} was not registered as available in streaming {}", signalStreamingId, this->connectionString);
     }
 }
 

--- a/core/opendaq/streaming/tests/test_streaming.cpp
+++ b/core/opendaq/streaming/tests/test_streaming.cpp
@@ -96,8 +96,7 @@ TEST_F(StreamingTest, StartCompleteReconnection)
     // reconnection can be restarted multiple times before completion
     ASSERT_NO_THROW(streaming.mock().triggerReconnectionStart());
 
-    // signal unavailable triggering is not allowed during reconnection
-    ASSERT_THROW(streaming.mock().makeSignalUnavailable("Signal"), InvalidStateException);
+    ASSERT_THROW(streaming.mock().makeSignalUnavailable("Signal"), NotFoundException);
 
     ASSERT_NO_THROW(streaming.mock().triggerReconnectionCompletion());
     ASSERT_THROW(streaming.mock().triggerReconnectionCompletion(), InvalidStateException);

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -42,6 +42,7 @@ public:
     explicit NativeDeviceHelper(const ContextPtr& context,
                                 opendaq_native_streaming_protocol::NativeStreamingClientHandlerPtr transportProtocolClient,
                                 SizeT configProtocolRequestTimeout,
+                                Bool restoreClientConfigOnReconnect,
                                 std::shared_ptr<boost::asio::io_context> processingIOContextPtr,
                                 std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr,
                                 std::thread::id reconnectionProcessingThreadId);
@@ -81,7 +82,9 @@ private:
     std::unordered_map<size_t, std::promise<config_protocol::PacketBuffer>> replyPackets;
     WeakRefPtr<IDevice> deviceRef;
     opendaq_native_streaming_protocol::ClientConnectionStatus connectionStatus;
+    bool acceptNotificationPackets;
     std::chrono::milliseconds configProtocolRequestTimeout;
+    Bool restoreClientConfigOnReconnect;
     std::mutex sync;
 };
 

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -205,6 +205,7 @@ DevicePtr NativeStreamingClientModule::createNativeDevice(const ContextPtr& cont
         auto deviceHelper = std::make_shared<NativeDeviceHelper>(context,
                                                                  transportClient,
                                                                  config.getPropertyValue("ConfigProtocolRequestTimeout"),
+                                                                 config.getPropertyValue("RestoreClientConfigOnReconnect"),
                                                                  processingIOContextPtr,
                                                                  reconnectionProcessingIOContextPtr,
                                                                  reconnectionProcessingThread.get_id());
@@ -247,6 +248,13 @@ void NativeStreamingClientModule::populateDeviceConfigFromContext(PropertyObject
         auto value = options.get("ConfigProtocolRequestTimeout");
         if (value.getCoreType() == CoreType::ctInt)
             deviceConfig.setPropertyValue("ConfigProtocolRequestTimeout", value);
+    }
+
+    if (options.hasKey("RestoreClientConfigOnReconnect"))
+    {
+        auto value = options.get("RestoreClientConfigOnReconnect");
+        if (value.getCoreType() == CoreType::ctBool)
+            deviceConfig.setPropertyValue("RestoreClientConfigOnReconnect", value);
     }
 }
 
@@ -456,6 +464,8 @@ PropertyObjectPtr NativeStreamingClientModule::createConnectionDefaultConfig(Nat
     defaultConfig.addProperty(StringProperty("Password", ""));
 
     defaultConfig.addProperty(IntProperty("ConfigProtocolRequestTimeout", 10000));
+    defaultConfig.addProperty(BoolProperty("RestoreClientConfigOnReconnect", False));
+
     if (nativeConfigType == NativeType::config)
         defaultConfig.addProperty(IntProperty("ProtocolVersion", std::numeric_limits<uint16_t>::max()));
 
@@ -782,6 +792,8 @@ bool NativeStreamingClientModule::validateDeviceConfig(const PropertyObjectPtr& 
 {
     return config.hasProperty("ConfigProtocolRequestTimeout") &&
            config.getProperty("ConfigProtocolRequestTimeout").getValueType() == ctInt &&
+           config.hasProperty("RestoreClientConfigOnReconnect") &&
+           config.getProperty("RestoreClientConfigOnReconnect").getValueType() == ctBool &&
            validateConnectionConfig(config);
 }
 

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -160,7 +160,7 @@ public:
 
     // called from client module
     DevicePtr connect(const ComponentPtr& parent = nullptr, uint16_t protocolVersion = std::numeric_limits<uint16_t>::max());
-    void reconnect();
+    void reconnect(Bool restoreClientConfigOnReconnect);
     void disconnectExternalSignals();
 
     DevicePtr getDevice();
@@ -313,7 +313,7 @@ void ConfigProtocolClient<TRootDeviceImpl>::enumerateTypes()
 }
 
 template<class TRootDeviceImpl>
-void ConfigProtocolClient<TRootDeviceImpl>::reconnect()
+void ConfigProtocolClient<TRootDeviceImpl>::reconnect(Bool restoreClientConfigOnReconnect)
 {
     if (!clientComm->getConnected())
         throw ConfigProtocolException("The 'reconnect' called without a prior successful 'connect' call.");
@@ -325,13 +325,25 @@ void ConfigProtocolClient<TRootDeviceImpl>::reconnect()
     protocolHandshake(clientComm->getProtocolVersion());
     enumerateTypes();
 
-    const StringPtr serializedDevice = clientComm->requestSerializedRootDevice();
+    if (restoreClientConfigOnReconnect)
+    {
+        const auto serializer = JsonSerializer();
+        rootDevice.asPtr<IUpdatable>().serializeForUpdate(serializer);
+        StringPtr serializedClientRootDevice = serializer.getOutput();
 
-    auto dict = Dict<IString, IBaseObject>();
-    dict.set("SerializedComponent", serializedDevice);
+        const auto deserializer = JsonDeserializer();
+        deserializer.update(rootDevice.asPtr<IUpdatable>(), serializedClientRootDevice);
+    }
+    else
+    {
+        const StringPtr serializedServerRootDevice = clientComm->requestSerializedRootDevice();
 
-    auto args = CoreEventArgs(CoreEventId::ComponentUpdateEnd, nullptr, dict);
-    rootDevice.asPtr<IConfigClientObject>()->handleRemoteCoreEvent(rootDevice, args);
+        auto dict = Dict<IString, IBaseObject>();
+        dict.set("SerializedComponent", serializedServerRootDevice);
+
+        auto args = CoreEventArgs(CoreEventId::ComponentUpdateEnd, nullptr, dict);
+        rootDevice.asPtr<IConfigClientObject>()->handleRemoteCoreEvent(rootDevice, args);
+    }
 }
 
 template<class TRootDeviceImpl>

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
@@ -423,6 +423,8 @@ void NativeStreamingServerHandler::setUpStreamingInitCallback(std::shared_ptr<Se
 
 void NativeStreamingServerHandler::handleStreamingInit(std::shared_ptr<ServerSessionHandler> sessionHandler)
 {
+    std::scoped_lock lock(sync);
+
     streamingManager.registerClient(sessionHandler->getClientId(), sessionHandler->getReconnected());
 
     auto registeredSignals = streamingManager.getRegisteredSignals();


### PR DESCRIPTION
# Type of change:

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
* Add a new Bool-type option in the native device config - RestoreClientConfigOnReconnect (default is False)
* Enable signals to become unavailable in native streaming during the reconnection is in progress