### PR TITLE
 Add an option to mark functions and procedures as const

### DIFF
--- a/bindings/python/core_objects/generated/py_authentication_provider.cpp
+++ b/bindings/python/core_objects/generated/py_authentication_provider.cpp
@@ -71,4 +71,12 @@ void defineIAuthenticationProvider(pybind11::module_ m, PyDaqIntf<daq::IAuthenti
             return objectPtr.isAnonymousAllowed();
         },
         "Returns true if anonymous authentication is allowed. When anonymous authentication is enabled, user can connect to the server without providing username or password.");
+    cls.def("authenticate_anonymous",
+        [](daq::IAuthenticationProvider *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::AuthenticationProviderPtr::Borrow(object);
+            return objectPtr.authenticateAnonymous().detach();
+        },
+        "Authenticate as anonymous user. If anonymous authentication is not allowed, an exception is thrown.");
 }

--- a/bindings/python/core_objects/generated/py_callable_info.cpp
+++ b/bindings/python/core_objects/generated/py_callable_info.cpp
@@ -40,9 +40,9 @@ void defineICallableInfo(pybind11::module_ m, PyDaqIntf<daq::ICallableInfo, daq:
 {
     cls.doc() = "Provides information about the argument count and types, as well as the return type of Function/Procedure-type properties.";
 
-    m.def("CallableInfo", [](std::variant<daq::IList*, py::list, daq::IEvalValue*>& argumentInfo, daq::CoreType returnType){
-        return daq::CallableInfo_Create(getVariantValue<daq::IList*>(argumentInfo), returnType);
-    }, py::arg("argument_info"), py::arg("return_type"));
+    m.def("CallableInfo", [](std::variant<daq::IList*, py::list, daq::IEvalValue*>& argumentInfo, daq::CoreType returnType, const bool constFlag){
+        return daq::CallableInfo_Create(getVariantValue<daq::IList*>(argumentInfo), returnType, constFlag);
+    }, py::arg("argument_info"), py::arg("return_type"), py::arg("const_flag"));
 
 
     cls.def_property_readonly("return_type",
@@ -62,4 +62,12 @@ void defineICallableInfo(pybind11::module_ m, PyDaqIntf<daq::ICallableInfo, daq:
         },
         py::return_value_policy::take_ownership,
         "Gets the list of arguments the callable function/procedure expects.");
+    cls.def_property_readonly("const",
+        [](daq::ICallableInfo *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::CallableInfoPtr::Borrow(object);
+            return objectPtr.isConst();
+        },
+        "A flag indicating if function is marked as const. A const function promises not to modify the state of the device or any other objects under the openDAQ instance.");
 }

--- a/bindings/python/opendaq/generated/device/py_device.cpp
+++ b/bindings/python/opendaq/generated/device/py_device.cpp
@@ -328,6 +328,7 @@ void defineIDevice(pybind11::module_ m, PyDaqIntf<daq::IDevice, daq::IFolder> cl
     cls.def("lock",
         [](daq::IDevice *object)
         {
+            py::gil_scoped_release release;
             const auto objectPtr = daq::DevicePtr::Borrow(object);
             objectPtr.lock();
         },
@@ -335,6 +336,7 @@ void defineIDevice(pybind11::module_ m, PyDaqIntf<daq::IDevice, daq::IFolder> cl
     cls.def("unlock",
         [](daq::IDevice *object)
         {
+            py::gil_scoped_release release;
             const auto objectPtr = daq::DevicePtr::Borrow(object);
             objectPtr.unlock();
         },
@@ -342,6 +344,7 @@ void defineIDevice(pybind11::module_ m, PyDaqIntf<daq::IDevice, daq::IFolder> cl
     cls.def_property_readonly("locked",
         [](daq::IDevice *object)
         {
+            py::gil_scoped_release release;
             const auto objectPtr = daq::DevicePtr::Borrow(object);
             return objectPtr.isLocked();
         },

--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -51,6 +51,9 @@ Required integration changes:
 
 + [function] ICallableInfo::isConst(Bool* constFlag)
 
+-m[factory] CallableInfo_Create(IList* arguments, CoreType returnType)
++m[factory] CallableInfo_Create(IList* arguments, CoreType returnType, Bool constFlag)
+
 4.10.2024
 Description:
     - Adds min read count option to multi reader. Default = 1. Reader will not read less that "min read count". If there are less

--- a/changelog/changelog_3.0.0-4.0.0.txt
+++ b/changelog/changelog_3.0.0-4.0.0.txt
@@ -4,12 +4,12 @@ Description
 
 Required integration changes:
     - Breaks binary compatibility
-    - For function blocks that contain nested function blocks, developers should override the method 
-    `FunctionBlockPtr onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config)` as this method is used during the loadConfiguration process. 
-    Additionally, developers may optionally override the methods `DictPtr<IString, IFunctionBlockType> onGetAvailableFunctionBlockTypes()` 
+    - For function blocks that contain nested function blocks, developers should override the method
+    `FunctionBlockPtr onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config)` as this method is used during the loadConfiguration process.
+    Additionally, developers may optionally override the methods `DictPtr<IString, IFunctionBlockType> onGetAvailableFunctionBlockTypes()`
     and `void onRemoveFunctionBlock(const FunctionBlockPtr& functionBlock)`.
-    
-    Examples of this can be found in the mock function block (`core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb.h`) 
+
+    Examples of this can be found in the mock function block (`core/opendaq/opendaq/mocks/include/opendaq/mock/mock_fb.h`)
     or the statistics function block (`modules/ref_fb_module/include/ref_fb_module/statistics_fb_impl.h`).
 
 IFunctionBlock::getAvailableFunctionBlockTypes(IDict** functionBlockTypes)
@@ -39,6 +39,17 @@ Required integration changes:
 
 -m[function] IDevice::loadConfiguration(IString* configuration)
 +m[function] IDevice::loadConfiguration(IString* configuration, IUpdateParameters* config = nullptr)
+
+08.10.2024
+Description:
+    - Add an option to mark functions and procedures as const
+    - Allow triggering of const function properties under locked device over native config protocol
+    - Native config protocol bumped to version 4
+
+Required integration changes:
+    - Breaks binary compatibility
+
++ [function] ICallableInfo::isConst(Bool* constFlag)
 
 4.10.2024
 Description:

--- a/core/coreobjects/include/coreobjects/callable_info.h
+++ b/core/coreobjects/include/coreobjects/callable_info.h
@@ -72,6 +72,8 @@ DECLARE_OPENDAQ_INTERFACE(ICallableInfo, IBaseObject)
  * @brief Creates a CallableInfo object with the specified arguments and return type.
  * @param argumentInfo The list of `ArgumentInfo` type argument information.
  * @param returnType The return type of the described callable object.
+ * @param constFlag A flag indicating if the function is marked as const or not. A const function promises not to modify the state
+ * of the device or any other objects under the openDAQ instance.
  */
 OPENDAQ_DECLARE_CLASS_FACTORY(
     LIBRARY_FACTORY, CallableInfo,

--- a/core/coreobjects/include/coreobjects/callable_info.h
+++ b/core/coreobjects/include/coreobjects/callable_info.h
@@ -45,12 +45,20 @@ DECLARE_OPENDAQ_INTERFACE(ICallableInfo, IBaseObject)
      * @param[out] type The return type of the callable.
      */
     virtual ErrCode INTERFACE_FUNC getReturnType(CoreType* type) = 0;
+
     // [elementType(argumentInfo, IArgumentInfo)]
     /*!
      * @brief Gets the list of arguments the callable function/procedure expects.
      * @param[out] argumentInfo the list of arguments of type `ArgumentInfo`.
      */
     virtual ErrCode INTERFACE_FUNC getArguments(IList** argumentInfo) = 0;
+
+    /*!
+     * @brief A flag indicating if function is marked as const. A const function promises not to modify the state
+     * of the device or any other objects under the openDAQ instance.
+     * @param[out] constFlag a flag indicating if the function is marked as const or not.
+     */
+    virtual ErrCode INTERFACE_FUNC isConst(Bool* constFlag) = 0;
 };
 
 /*!@}*/
@@ -68,7 +76,8 @@ DECLARE_OPENDAQ_INTERFACE(ICallableInfo, IBaseObject)
 OPENDAQ_DECLARE_CLASS_FACTORY(
     LIBRARY_FACTORY, CallableInfo,
     IList*, argumentInfo,
-    CoreType, returnType
+    CoreType, returnType,
+    Bool, constFlag
 );
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/callable_info_factory.h
+++ b/core/coreobjects/include/coreobjects/callable_info_factory.h
@@ -57,9 +57,9 @@ inline CallableInfoPtr ProcedureInfo(ListPtr<IArgumentInfo> arguments = nullptr,
 inline StructTypePtr CallableInfoStructType()
 {
     return StructType("CallableInfo",
-                      List<IString>("Arguments", "ReturnType"),
-                      List<IBaseObject>(List<IArgumentInfo>(), ""),
-                      List<IType>(SimpleType(ctList), SimpleType(ctInt)));
+                      List<IString>("Arguments", "ReturnType", "Const"),
+                      List<IBaseObject>(List<IArgumentInfo>(), "", false),
+                      List<IType>(SimpleType(ctList), SimpleType(ctInt), SimpleType(ctBool)));
 }
 
 /*@}*/

--- a/core/coreobjects/include/coreobjects/callable_info_factory.h
+++ b/core/coreobjects/include/coreobjects/callable_info_factory.h
@@ -30,21 +30,25 @@ BEGIN_NAMESPACE_OPENDAQ
 
 /*!
  * @brief Creates a CallableInfo object that describes a function-type callable with the specified arguments and return type.
- * @param arguments The list of `IArgumentInfo` type argument information.
  * @param returnType The return type of the described function callable object.
+ * @param arguments The list of `IArgumentInfo` type argument information.
+ * @param isConst Flag indicating if the function is marked as const. A const function promises not to modify the state
+ * of the device or any other objects under the openDAQ instance.
  */
-inline CallableInfoPtr FunctionInfo(CoreType returnType, ListPtr<IArgumentInfo> arguments = nullptr)
+inline CallableInfoPtr FunctionInfo(CoreType returnType, ListPtr<IArgumentInfo> arguments = nullptr, Bool isConst = false)
 {
-    return CallableInfoPtr::Adopt(CallableInfo_Create(arguments, returnType));
+    return CallableInfoPtr::Adopt(CallableInfo_Create(arguments, returnType, isConst));
 }
 
 /*!
  * @brief Creates a CallableInfo object that describes a procedure-type callable with the specified arguments.
  * @param arguments The list of `IArgumentInfo` type argument information.
+ * @param isConst Flag indicating if the function is marked as const. A const function promises not to modify the state
+ * of the device or any other objects under the openDAQ instance.
  */
-inline CallableInfoPtr ProcedureInfo(ListPtr<IArgumentInfo> arguments = nullptr)
+inline CallableInfoPtr ProcedureInfo(ListPtr<IArgumentInfo> arguments = nullptr, Bool isConst = false)
 {
-    return FunctionInfo(CoreType::ctUndefined, std::move(arguments));
+    return FunctionInfo(CoreType::ctUndefined, std::move(arguments), isConst);
 }
 
 /*!

--- a/core/coreobjects/include/coreobjects/callable_info_impl.h
+++ b/core/coreobjects/include/coreobjects/callable_info_impl.h
@@ -27,10 +27,11 @@ BEGIN_NAMESPACE_OPENDAQ
 class CallableInfoImpl : public GenericStructImpl<ICallableInfo, IStruct>
 {
 public:
-    CallableInfoImpl(ListPtr<IArgumentInfo> arguments, CoreType returnType);
+    CallableInfoImpl(ListPtr<IArgumentInfo> arguments, CoreType returnType, Bool constFlag);
 
     ErrCode INTERFACE_FUNC getReturnType(CoreType* type) override;
     ErrCode INTERFACE_FUNC getArguments(IList** argumentInfo) override;
+    ErrCode INTERFACE_FUNC isConst(Bool* constFlag) override;
     
     ErrCode INTERFACE_FUNC equals(IBaseObject* other, Bool* equal) const override;
 
@@ -44,6 +45,7 @@ public:
 private:
     CoreType returnType{};
     ListPtr<IArgumentInfo> arguments;
+    Bool constFlag = false;
 };
 
 OPENDAQ_REGISTER_DESERIALIZE_FACTORY(CallableInfoImpl)

--- a/core/coreobjects/src/callable_info_impl.cpp
+++ b/core/coreobjects/src/callable_info_impl.cpp
@@ -137,7 +137,9 @@ ErrCode CallableInfoImpl::Deserialize(ISerializedObject* serialized, IBaseObject
 
             const auto returnType = static_cast<CoreType>(serializedObj.readInt("returnType"));
 
-            const auto isConst = static_cast<Bool>(serializedObj.readBool("const"));
+            bool isConst = false;
+            if (serializedObj.hasKey("const"))
+                isConst = static_cast<Bool>(serializedObj.readBool("const"));
 
             *obj = createWithImplementation<ICallableInfo, CallableInfoImpl>(arguments, returnType, isConst).detach();
         });

--- a/core/coreobjects/src/callable_info_impl.cpp
+++ b/core/coreobjects/src/callable_info_impl.cpp
@@ -12,11 +12,13 @@ namespace detail
 
 CallableInfoImpl::CallableInfoImpl(ListPtr<IArgumentInfo> arguments, CoreType returnType, Bool constFlag)
     : GenericStructImpl<daq::ICallableInfo, daq::IStruct>(
-          detail::callableInfoStructType, Dict<IString, IBaseObject>({{"Arguments", arguments}, {"ReturnType", static_cast<Int>(returnType)}}))
+          detail::callableInfoStructType,
+          Dict<IString, IBaseObject>(
+              {{"Arguments", arguments}, {"ReturnType", static_cast<Int>(returnType)}, {"Const", constFlag}}))
 {
     this->returnType = this->fields.get("ReturnType");
     this->arguments = this->fields.get("Arguments");
-    this->constFlag = constFlag;
+    this->constFlag = this->fields.get("Const");
 }
 
 ErrCode CallableInfoImpl::getReturnType(CoreType* type)

--- a/core/coreobjects/tests/test_callable_info.cpp
+++ b/core/coreobjects/tests/test_callable_info.cpp
@@ -136,3 +136,33 @@ TEST_F(CallableInfoTest, SerializeDeserialize)
     const CallableInfoPtr functionInfo2 = deserializer.deserialize(jsonStr);
     ASSERT_EQ(functionInfo1, functionInfo2);
 }
+
+TEST_F(CallableInfoTest, Const)
+{
+    auto functionInfo = FunctionInfo(ctInt, nullptr, true);
+    ASSERT_TRUE(functionInfo.isConst());
+
+    functionInfo = FunctionInfo(ctInt, nullptr);
+    ASSERT_FALSE(functionInfo.isConst());
+
+    auto procInfo = ProcedureInfo(nullptr, true);
+    ASSERT_TRUE(procInfo.isConst());
+
+    procInfo = ProcedureInfo(nullptr);
+    ASSERT_FALSE(procInfo.isConst());
+}
+
+TEST_F(CallableInfoTest, ConstEquals)
+{
+    auto functionInfo1 = FunctionInfo(ctInt, nullptr, true);
+    auto functionInfo2 = FunctionInfo(ctInt, nullptr, false);
+
+    ASSERT_EQ(functionInfo1, functionInfo1);
+    ASSERT_NE(functionInfo1, functionInfo2);
+
+    auto procInfo1 = ProcedureInfo(nullptr, true);
+    auto procInfo2 = ProcedureInfo(nullptr, false);
+
+    ASSERT_EQ(procInfo1, procInfo1);
+    ASSERT_NE(procInfo1, procInfo2);
+}

--- a/core/coreobjects/tests/test_callable_info.cpp
+++ b/core/coreobjects/tests/test_callable_info.cpp
@@ -113,6 +113,7 @@ TEST_F(CallableInfoTest, StructFields)
 
     ASSERT_EQ(structPtr.get("ReturnType"), static_cast<Int>(ctString));
     ASSERT_EQ(structPtr.get("Arguments"), nullptr);
+    ASSERT_EQ(structPtr.get("Const"), false);
 }
 
 TEST_F(CallableInfoTest, StructNames)

--- a/docs/Antora/modules/knowledge_base/pages/property_system.adoc
+++ b/docs/Antora/modules/knowledge_base/pages/property_system.adoc
@@ -729,6 +729,11 @@ To determine the parameter count and types, as well as the return type, the Call
 field must be configured. Callable info contains a list of argument types that need to
 be passed as arguments when invoking the callable object. If the Property is a Function,
 the Callable info field also contains the type of the variable returned by the function.
+Additionally, the Callable Info object contains a `const` qualifier. If the function or procedure
+is marked as `const`, it promises that it won't modify the state of the device or any properties
+under the openDAQ instance. For example, the `SumFunction` in the code below is marked as
+`const`, as it simply calculates the sum of two numbers without altering the state of a device.
+By default, functions and procedures are *not* marked as `const`.
 
 IMPORTANT: Function and Procedure type Properties are currently not accessible through the
 OPC UA layer. Thus, they will not appear on connected-to devices.
@@ -740,7 +745,7 @@ Function and Procedure type Properties can't have a default value.
 ----
 auto propObj = PropertyObject();
 
-auto arguments = List<IArgumentInfo>(ArgumentInfo("Val1", ctInt), ArgumentInfo("Val2", ctInt));
+auto arguments = List<IArgumentInfo>(ArgumentInfo("Val1", ctInt), ArgumentInfo("Val2", ctInt), true);
 propObj.addProperty(FunctionProperty("SumFunction", FunctionInfo(ctInt, arguments)));
 
 auto func = Function([](IntegerPtr val1, IntegerPtr val2)

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -126,7 +126,7 @@ TEST_F(NativeDeviceModulesTest, CheckProtocolVersion)
 
     const auto info = client.getDevices()[0].getInfo();
     ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
-    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 3);
+    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 4);
 
     client->releaseRef();
     server->releaseRef();

--- a/regression/simulator/regression_simulator.cpp
+++ b/regression/simulator/regression_simulator.cpp
@@ -58,7 +58,7 @@ int main(int /*argc*/, const char* /*argv*/[])
     auto argInfoProp = PropertyBuilder("TestArgInfoProp").setDefaultValue(argInfo).setValueType(CoreType::ctStruct).build();
     instance.addProperty(argInfoProp);
     // Add custom Callable Info Property
-    auto callInfo = CallableInfo_Create(list, CoreType::ctInt);
+    auto callInfo = CallableInfo_Create(list, CoreType::ctInt, false);
     auto callInfoProp = PropertyBuilder("TestCallInfoProp").setDefaultValue(callInfo).setValueType(CoreType::ctStruct).build();
     instance.addProperty(callInfoProp);
     // Add custom Unit Property

--- a/regression/tests/reg_p_test_channel.cpp
+++ b/regression/tests/reg_p_test_channel.cpp
@@ -49,5 +49,5 @@ TEST_F(RegressionTestChannel, setPropertyValueGetPropertyValue)
     ASSERT_NO_THROW(channel.setPropertyValue("NoiseAmplitude", 0.2));
     FloatPtr property;
     ASSERT_NO_THROW(property = channel.getPropertyValue("NoiseAmplitude"));
-    ASSERT_FLOAT_EQ(property, 0.2);
+    ASSERT_FLOAT_EQ(property, 0.2f);
 }

--- a/regression/tests/reg_p_test_component.cpp
+++ b/regression/tests/reg_p_test_component.cpp
@@ -88,7 +88,7 @@ TEST_F(RegressionTestComponent, setVisibleGetVisible)
     componentPrivate.unlockAllAttributes();
 
     ASSERT_NO_THROW(component.setVisible(False));
-    Bool visible1;
+    Bool visible1 = true;
     ASSERT_NO_THROW(visible1 = component.getVisible());
     ASSERT_FALSE(visible1);
 

--- a/regression/tests/reg_p_test_folder.cpp
+++ b/regression/tests/reg_p_test_folder.cpp
@@ -37,7 +37,7 @@ TEST_F(RegressionTestFolder, getItems)
 
 TEST_F(RegressionTestFolder, isEmpty)
 {
-    Bool isEmpty;
+    Bool isEmpty = true;
     ASSERT_NO_THROW(isEmpty = folder.isEmpty());
     ASSERT_FALSE(isEmpty);
 }

--- a/regression/tests/reg_p_test_serialization.cpp
+++ b/regression/tests/reg_p_test_serialization.cpp
@@ -57,7 +57,7 @@ TEST_F(RegressionTestSerialization, deserializeCallInfo)
     list.pushBack(1);
     list.pushBack(2);
     list.pushBack(3);
-    CallableInfoPtr expectedDefault = CallableInfo_Create(list, CoreType::ctInt);
+    CallableInfoPtr expectedDefault = CallableInfo_Create(list, CoreType::ctInt, false);
     CallableInfoPtr defaultVal = prop.getDefaultValue();
     ASSERT_EQ(expectedDefault, defaultVal);
 
@@ -69,7 +69,7 @@ TEST_F(RegressionTestSerialization, deserializeCallInfo)
     newList.pushBack(4);
     newList.pushBack(2);
     newList.pushBack(6);
-    CallableInfoPtr newVal = CallableInfo_Create(newList, CoreType::ctInt);
+    CallableInfoPtr newVal = CallableInfo_Create(newList, CoreType::ctInt, false);
     device.setPropertyValue("TestCallInfoProp", newVal);
     ASSERT_EQ(newVal, device.getPropertyValue("TestCallInfoProp"));
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -229,7 +229,7 @@ void ConfigProtocolClient<TRootDeviceImpl>::protocolHandshake(uint16_t protocolV
     if (replyPacketBuffer.getPacketType() == PacketType::ConnectionRejected)
         clientComm->parseRpcOrRejectReply(replyPacketBuffer.parseConnectionRejectedReply(), nullptr);
 
-    const std::set<uint16_t> supportedClientVersions {0, 1, 2, 3};
+    const std::set<uint16_t> supportedClientVersions {0, 1, 2, 3, 4};
 
     uint16_t currentVersion;
     std::set<uint16_t> supportedServerVersions;

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -78,7 +78,7 @@ ConfigProtocolServer::ConfigProtocolServer(DevicePtr rootDevice,
     , componentFinder(std::make_unique<ComponentFinderRootDevice>(this->rootDevice))
     , user(user)
     , protocolVersion(0)
-    , supportedServerVersions({0, 1, 2, 3})
+    , supportedServerVersions({0, 1, 2, 3, 4})
     , streamingConsumer(this->daqContext, externalSignalsFolder)
 {
     assert(user.assigned());

--- a/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
@@ -101,7 +101,7 @@ public:
         const auto func = Function([](Int a, Int b) { return a + b; });
 
         const auto funcProp =
-            FunctionPropertyBuilder("SumProp", FunctionInfo(ctInt, List<IArgumentInfo>(ArgumentInfo("A", ctInt), ArgumentInfo("B", ctInt))))
+            FunctionPropertyBuilder("SumProp", FunctionInfo(ctInt, List<IArgumentInfo>(ArgumentInfo("A", ctInt), ArgumentInfo("B", ctInt)), true))
                 .setReadOnly(false)
                 .build();
 
@@ -239,7 +239,7 @@ TEST_F(ConfigProtocolAccessControlTest, CallProperty)
         const auto func = Function([](Int a, Int b) { return a + b; });
 
         const auto funcProp = FunctionPropertyBuilder(
-                                  "SumProp", FunctionInfo(ctInt, List<IArgumentInfo>(ArgumentInfo("A", ctInt), ArgumentInfo("B", ctInt))))
+                                  "SumProp", FunctionInfo(ctInt, List<IArgumentInfo>(ArgumentInfo("A", ctInt), ArgumentInfo("B", ctInt)), true))
                                   .setReadOnly(false)
                                   .build();
 

--- a/shared/libraries/config_protocol/tests/test_config_protocol_device_locking.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_device_locking.cpp
@@ -83,7 +83,7 @@ public:
 protected:
     DevicePtr serverDevice;
     DevicePtr clientDevice;
-    size_t counter = 0;
+    Int counter = 0;
 
 private:
     std::unique_ptr<ConfigProtocolServer> server;
@@ -196,7 +196,7 @@ TEST_F(ConfigProtocolDeviceLockingTest, SetProtectedPropertyValue)
 TEST_F(ConfigProtocolDeviceLockingTest, CallProperty)
 {
     auto device = createDevice();
-    SizeT counter = 0;
+    Int counter = 0;
 
     {
         const auto func = Function([&counter]() { return ++counter; });
@@ -215,9 +215,9 @@ TEST_F(ConfigProtocolDeviceLockingTest, CallProperty)
 
     clientDevice.unlock();
 
-    ASSERT_EQ(counter, 0u);
+    ASSERT_EQ(counter, 0);
     auto result = clientDevice.getPropertyValue("CountProp").call();
-    ASSERT_EQ(result, 1u);
+    ASSERT_EQ(result, 1);
 }
 
 TEST_F(ConfigProtocolDeviceLockingTest, CallConstProperty)
@@ -464,7 +464,7 @@ TEST_F(ConfigProtocolDeviceLockingTest, NestedCallProperty)
 
     clientDevice.unlock();
 
-    ASSERT_EQ(counter, 0u);
+    ASSERT_EQ(counter, 0);
     auto result = clientDevice.getPropertyValue("Advanced.CountProp").call();
-    ASSERT_EQ(result, 1u);
+    ASSERT_EQ(result, 1);
 }


### PR DESCRIPTION
-  Add an option to mark functions and procedures as const
- Allow triggering of const function properties under locked device over native config protocol