### PR TITLE
Other/property object sync

### DIFF
--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,5 +1,47 @@
 # 8.11.2024
+## Description
+- Implement thread synchronization mechanism in property objects
+- Provides new internal method to allow for recursive locking in onWrite/onRead events via `GenericPropertyObjectImpl::getRecursiveConfigLock()`
+- A standard lock guard can be acquired via `GenericPropertyObjectImpl::getAcquisitionLock()`
+- The `sync` mutex previously available in `ComponentImpl` was moved up to `GenericPropertyObjectImpl`
 
+## Required integration changes:
+- The `sync` mutex available in the `GenericPropertyObjectImpl` should no longer be locked in `onWrite`/`onRead` events. If needed due to used programming patterns, the `getRecursiveConfigLock` method should be used instead. See the reference device implementations for guidance.
+- Current device/function block implementations that lock the `sync` mutex during events will deadlock.
+
+```
++ [function] ICoercer::coerceNoLock(IBaseObject* propObj, IBaseObject* value, IBaseObject** result)
+
++ [function] IValidator::validateNoLock(IBaseObject* propObj, IBaseObject* value)
+
++ [function] IEvalValue::getResultNoLock(IBaseObject** obj)
+
++ [function] IPropertyInternal::getValueTypeNoLock(CoreType* type)    
++ [function] IPropertyInternal::getKeyTypeNoLock(CoreType* type)    
++ [function] IPropertyInternal::getItemTypeNoLock(CoreType* type)    
++ [function] IPropertyInternal::getDescriptionNoLock(IString** description)    
++ [function] IPropertyInternal::getUnitNoLock(IUnit** unit)    
++ [function] IPropertyInternal::getMinValueNoLock(INumber** min)    
++ [function] IPropertyInternal::getMaxValueNoLock(INumber** max)    
++ [function] IPropertyInternal::getDefaultValueNoLock(IBaseObject** value)    
++ [function] IPropertyInternal::getSuggestedValuesNoLock(IList** values)    
++ [function] IPropertyInternal::getVisibleNoLock(Bool* visible)    
++ [function] IPropertyInternal::getReadOnlyNoLock(Bool* readOnly)    
++ [function] IPropertyInternal::getSelectionValuesNoLock(IBaseObject** values)    
++ [function] IPropertyInternal::getReferencedPropertyNoLock(IProperty** propertyEval)    
++ [function] IPropertyInternal::getIsReferencedNoLock(Bool* isReferenced)    
++ [function] IPropertyInternal::getValidatorNoLock(IValidator** validator)    
++ [function] IPropertyInternal::getCoercerNoLock(ICoercer** coercer)    
++ [function] IPropertyInternal::getCallableInfoNoLock(ICallableInfo** callable)    
++ [function] IPropertyInternal::getStructTypeNoLock(IStructType** structType)    
+
++ [function] IPropertyObjectInternal::checkForReferencesNoLock(IProperty* property, Bool* isReferenced)
++ [function] IPropertyObjectInternal::getPropertyValueNoLock(IString* name, IBaseObject** value)
++ [function] IPropertyObjectInternal::getPropertySelectionValueNoLock(IString* name, IBaseObject** value)
++ [function] IPropertyObjectInternal::setPropertyValueNoLock(IString* name, IBaseObject* value)
+```
+
+# 8.11.2024
 ## Description
 - Block Reader, Tail Reader and Stream Reader now skip events by default in Python
 

--- a/core/coreobjects/include/coreobjects/coercer.h
+++ b/core/coreobjects/include/coreobjects/coercer.h
@@ -51,6 +51,7 @@ DECLARE_OPENDAQ_INTERFACE(ICoercer, IBaseObject)
      * @retval OPENDAQ_SUCCESS If the value either already fits the restrictions, or was successfully modified to do so.
      */
     virtual ErrCode INTERFACE_FUNC coerce(IBaseObject* propObj, IBaseObject* value, IBaseObject** result) = 0;
+    virtual ErrCode INTERFACE_FUNC coerceNoLock(IBaseObject* propObj, IBaseObject* value, IBaseObject** result) = 0;
 
     /*!
      * @brief Gets the string expression used when creating the coercer.

--- a/core/coreobjects/include/coreobjects/coercer_impl.h
+++ b/core/coreobjects/include/coreobjects/coercer_impl.h
@@ -26,6 +26,7 @@ public:
     explicit CoercerImpl(const StringPtr& evalStr);
 
     ErrCode INTERFACE_FUNC coerce(IBaseObject* propObj, IBaseObject* value, IBaseObject** result) override;
+    ErrCode INTERFACE_FUNC coerceNoLock(IBaseObject* propObj, IBaseObject* value, IBaseObject** result) override;
     ErrCode INTERFACE_FUNC getEval(IString** eval) override;
     
     // ISerializable

--- a/core/coreobjects/include/coreobjects/eval_nodes.h
+++ b/core/coreobjects/include/coreobjects/eval_nodes.h
@@ -38,7 +38,7 @@ enum class RefType
     PropertyNames
 };
 
-using GetReferenceEvent = std::function<BaseObjectPtr(std::string, RefType, int, std::string&)>;
+using GetReferenceEvent = std::function<BaseObjectPtr(std::string, RefType, int, std::string&, bool)>;
 
 class BaseNode
 {
@@ -50,7 +50,7 @@ public:
     virtual BaseObjectPtr getResult() = 0;
 
     virtual int visit(const std::function<int(BaseNode* node)>& visitFunc);
-    virtual int resolveReference();
+    virtual int resolveReference(bool lock);
 
     virtual std::unique_ptr<BaseNode> clone(GetReferenceEvent refCall) = 0;
 
@@ -75,7 +75,7 @@ public:
     explicit RefNode(int argIndex);
 
     BaseObjectPtr getResult() override;
-    int resolveReference() override;
+    int resolveReference(bool lock) override;
     std::unique_ptr<BaseNode> clone(GetReferenceEvent refCall) override;
 
     void useAsArgument(RefNode* node);

--- a/core/coreobjects/include/coreobjects/eval_value.h
+++ b/core/coreobjects/include/coreobjects/eval_value.h
@@ -84,6 +84,8 @@ DECLARE_OPENDAQ_INTERFACE(IEvalValue, IBaseObject)
      * Referenced properties are all occurrences matching the '"%" propref' pattern in the evaluation string.
      */
     virtual ErrCode INTERFACE_FUNC getPropertyReferences(IList** propertyReferences) = 0;
+
+    virtual ErrCode INTERFACE_FUNC getResultNoLock(IBaseObject** obj) = 0;
 };
 
 /*!

--- a/core/coreobjects/include/coreobjects/eval_value_impl.h
+++ b/core/coreobjects/include/coreobjects/eval_value_impl.h
@@ -41,6 +41,7 @@ public:
     ErrCode INTERFACE_FUNC getEval(IString** evalString) override;
 
     ErrCode INTERFACE_FUNC getResult(IBaseObject** obj) override;
+    ErrCode INTERFACE_FUNC getResultNoLock(IBaseObject** obj) override;
     ErrCode INTERFACE_FUNC cloneWithOwner(IPropertyObject* newOwner, IEvalValue** clonedValue) override;
     ErrCode INTERFACE_FUNC getParseErrorCode() override;
     ErrCode INTERFACE_FUNC getPropertyReferences(IList** propertyReferences) override;
@@ -166,10 +167,10 @@ private:
     bool useFunctionResolver;
     FunctionPtr func;
 
-    BaseObjectPtr getReference(const std::string& str, RefType refType, int argIndex, std::string& postRef) const;
-    int resolveReferences();
+    BaseObjectPtr getReference(const std::string& str, RefType refType, int argIndex, std::string& postRef, bool lock) const;
+    int resolveReferences(bool lock);
 
-    ErrCode checkParseAndResolve();
+    ErrCode checkParseAndResolve(bool lock);
 
     template <typename T>
     inline ErrCode getValueInternal(T& value);
@@ -179,7 +180,7 @@ private:
 
     BaseObjectPtr calc();
     void checkForEvalValue(BaseObjectPtr& prop) const;
-    BaseObjectPtr getReferenceFromPrefix(const PropertyObjectPtr& propObject, const std::string& str, RefType refType) const;
+    BaseObjectPtr getReferenceFromPrefix(const PropertyObjectPtr& propObject, const std::string& str, RefType refType, bool lock) const;
 
 protected:
     void internalDispose(bool disposing) override;

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -31,6 +31,7 @@
 #include <coreobjects/unit_ptr.h>
 #include <coretypes/coretypes.h>
 #include <coretypes/exceptions.h>
+#include <coretypes/validation.h>
 #include <iostream>
 #include <coreobjects/permission_manager_factory.h>
 #include <coreobjects/permissions_builder_factory.h>
@@ -314,71 +315,84 @@ public:
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override
     {
-        if (type == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+        return getValueTypeInternal(type, true);
+    }
 
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
+    ErrCode INTERFACE_FUNC getValueTypeNoLock(CoreType* type) override
+    {
+        return getValueTypeInternal(type, false);
+    }
+
+    ErrCode INTERFACE_FUNC getValueTypeInternal(CoreType* type, bool lock)
+    {
+        OPENDAQ_PARAM_NOT_NULL(type);
+
+	    return daqTry([&]()
             {
-                *type = prop.getValueType();
-            }
-            else
-            {
-                *type = this->valueType;
-            }
-            return OPENDAQ_SUCCESS;
-        });
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *type = lock ? prop.getValueType() : prop.asPtr<IPropertyInternal>().getValueTypeNoLock();
+		        else
+			        *type = this->valueType;
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
     }
     
     ErrCode INTERFACE_FUNC getKeyType(CoreType* type) override
     {
-        if (type == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+        return getKeyTypeInternal(type, true);    
+    }
+
+    ErrCode INTERFACE_FUNC getKeyTypeNoLock(CoreType* type) override
+    {
+        return getKeyTypeInternal(type, false);    
+    }
+
+    ErrCode INTERFACE_FUNC getKeyTypeInternal(CoreType* type, bool lock)
+    {
+        OPENDAQ_PARAM_NOT_NULL(type);
 
         *type = ctUndefined;
         BaseObjectPtr defVal;
-        ErrCode err = this->getDefaultValue(&defVal);
+        auto err = lock ? this->getDefaultValue(&defVal) : this->getDefaultValueNoLock(&defVal);
         if (OPENDAQ_FAILED(err))
-        {
             return err;
-        }
 
         if (!defVal.assigned())
-        {
             return OPENDAQ_SUCCESS;
-        }
 
-        DictPtr<IBaseObject, IBaseObject> value = defVal.asPtrOrNull<IDict>();
+        const auto value = defVal.asPtrOrNull<IDict>();
         if (!value.assigned())
-        {
             return OPENDAQ_SUCCESS;
-        }
 
         IntfID intfID;
         err = value.asPtr<IDictElementType>()->getKeyInterfaceId(&intfID);
         if (OPENDAQ_FAILED(err))
-        {
             return err;
-        }
 
         auto coreType = details::intfIdToCoreType(intfID);
 
         // TODO: Workaround if item type of dict/list is undefined
         if (coreType == ctUndefined && value.getCount() > 0)
-        {
             coreType = value.getKeyList()[0].getCoreType();
-        }
 
         *type = coreType;
         return OPENDAQ_SUCCESS;
     }
-
+        
     ErrCode INTERFACE_FUNC getItemType(CoreType* type) override
     {
-        if (type == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+        return getItemTypeInternal(type, true);    
+    }
+
+    ErrCode INTERFACE_FUNC getItemTypeNoLock(CoreType* type) override
+    {
+        return getItemTypeInternal(type, false);    
+    }
+
+    ErrCode INTERFACE_FUNC getItemTypeInternal(CoreType* type, bool lock)
+    {
+        OPENDAQ_PARAM_NOT_NULL(type);
 
         try
         {
@@ -386,51 +400,39 @@ public:
             *type = ctUndefined;
 
             BaseObjectPtr defVal;
-            ErrCode err = this->getDefaultValue(&defVal);
+            auto err = lock ? this->getDefaultValue(&defVal) : this->getDefaultValueNoLock(&defVal);
             if (OPENDAQ_FAILED(err))
-            {
                 return err;
-            }
 
             BaseObjectPtr selVal;
-            err = this->getSelectionValues(&selVal);
+            err = lock ? this->getSelectionValues(&selVal) : this->getSelectionValuesNoLock(&selVal);
             if (OPENDAQ_FAILED(err))
-            {
                 return err;
-            }
 
             BaseObjectPtr value = defVal.assigned() ? defVal : nullptr;
             value = selVal.assigned() ? selVal : value;
             if (!value.assigned())
-            {
                 return err;
-            }
 
             const auto dictElementType = value.asPtrOrNull<IDictElementType>();
             if (dictElementType.assigned())
-            {
                 err = dictElementType->getValueInterfaceId(&intfID);
-            }
 
             const auto listElementType = value.asPtrOrNull<IListElementType>();
             if (listElementType.assigned())
-            {
                 err = listElementType->getElementInterfaceId(&intfID);
-            }
 
             auto coreType = details::intfIdToCoreType(intfID);
 
             // TODO: Workaround if item type of dict/list is undefined
             if (coreType == ctUndefined)
             {
-                ListPtr<IBaseObject> asList = value.asPtrOrNull<IList>();
-                DictPtr<IBaseObject, IBaseObject> asDict = value.asPtrOrNull<IDict>();
-                if (asList.assigned() && asList.getCount() > 0)
+                if (const auto asList = value.asPtrOrNull<IList>(); asList.assigned() && asList.getCount() > 0)
                 {
                     coreType = asList[0].getCoreType();
                     err = OPENDAQ_SUCCESS;
                 }
-                else if (asDict.assigned() && asDict.getCount() > 0)
+                else if (const auto asDict = value.asPtrOrNull<IDict>();asDict.assigned() && asDict.getCount() > 0)
                 {
                     coreType = asDict.getValueList()[0].getCoreType();
                     err = OPENDAQ_SUCCESS;
@@ -465,302 +467,380 @@ public:
 
     ErrCode INTERFACE_FUNC getDescription(IString** description) override
     {
-        if (description == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+	    return getDescriptionInternal(description, true);
+    }
 
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
+    ErrCode INTERFACE_FUNC getDescriptionNoLock(IString** description) override
+    {
+	    return getDescriptionInternal(description, false);
+    }
+
+    ErrCode getDescriptionInternal(IString** description, bool lock)
+    {
+        OPENDAQ_PARAM_NOT_NULL(description);
+
+	    return daqTry([&]()
             {
-                *description = prop.getDescription().detach();
-            }
-            else
-            {
-                StringPtr descriptionBound = bindAndGet(this->description);
-                *description = descriptionBound.detach();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *description = lock ? prop.getDescription().detach() : prop.asPtr<IPropertyInternal>().getDescriptionNoLock().detach();
+		        else
+			        *description = bindAndGet<StringPtr>(this->description, lock).detach();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
     }
 
     ErrCode INTERFACE_FUNC getUnit(IUnit** unit) override
     {
-        if (unit == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
-
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
-            {
-                *unit = prop.getUnit().detach();
-            }
-            else
-            {
-                UnitPtr unitBound = bindAndGet(this->unit);
-                *unit = unitBound.detach();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+	    return getUnitInternal(unit, true);
     }
-    
+
+    ErrCode INTERFACE_FUNC getUnitNoLock(IUnit** unit) override
+    {
+	    return getUnitInternal(unit, false);
+    }
+
+    ErrCode getUnitInternal(IUnit** unit, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(unit);
+
+	    return daqTry([&]()
+            {
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *unit = lock ? prop.getUnit().detach() : prop.asPtr<IPropertyInternal>().getUnitNoLock().detach();
+		        else
+			        *unit = bindAndGet<UnitPtr>(this->unit, lock).detach();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
+    }
+
     ErrCode INTERFACE_FUNC getMinValue(INumber** min) override
     {
-        if (min == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+	    return getMinValueInternal(min, true);
+    }
 
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
+    ErrCode INTERFACE_FUNC getMinValueNoLock(INumber** min) override
+    {
+	    return getMinValueInternal(min, false);
+    }
+
+    ErrCode getMinValueInternal(INumber** min, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(min);
+
+	    return daqTry([&]()
             {
-                *min = prop.getMinValue().detach();
-            }
-            else
-            {
-                NumberPtr minBound = bindAndGet(this->minValue);
-                *min = minBound.detach();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *min = lock ? prop.getMinValue().detach() : prop.asPtr<IPropertyInternal>().getMinValueNoLock().detach();
+		        else
+			        *min = bindAndGet<NumberPtr>(this->minValue, lock).detach();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
     }
 
     ErrCode INTERFACE_FUNC getMaxValue(INumber** max) override
     {
-        if (max == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+	    return getMaxValueInternal(max, true);
+    }
 
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
+    ErrCode INTERFACE_FUNC getMaxValueNoLock(INumber** max) override
+    {
+	    return getMaxValueInternal(max, false);
+    }
+
+    ErrCode getMaxValueInternal(INumber** max, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(max);
+
+	    return daqTry([&]()
             {
-                *max = prop.getMaxValue().detach();
-            }
-            else
-            {
-                NumberPtr maxBound = bindAndGet(this->maxValue);
-                *max = maxBound.detach();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *max = lock ? prop.getMaxValue().detach() : prop.asPtr<IPropertyInternal>().getMaxValueNoLock().detach();
+		        else
+			        *max = bindAndGet<NumberPtr>(this->maxValue, lock).detach();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
     }
     
     ErrCode INTERFACE_FUNC getDefaultValue(IBaseObject** value) override
     {
-        if (value == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
-
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
-            {
-                *value = prop.getDefaultValue().detach();
-            }
-            else
-            {
-                BaseObjectPtr defaultValueBound = bindAndGet(this->defaultValue);
-                *value = defaultValueBound.detach();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+	    return getDefaultValueInternal(value, true);
     }
 
+    ErrCode INTERFACE_FUNC getDefaultValueNoLock(IBaseObject** value) override
+    {
+	    return getDefaultValueInternal(value, false);
+    }
+
+    ErrCode getDefaultValueInternal(IBaseObject** value, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(value);
+
+	    return daqTry([&]()
+            {
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *value = lock ? prop.getDefaultValue().detach() : prop.asPtr<IPropertyInternal>().getDefaultValueNoLock().detach();
+		        else
+			        *value = bindAndGet<BaseObjectPtr>(this->defaultValue, lock).detach();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
+    }
+        
     ErrCode INTERFACE_FUNC getSuggestedValues(IList** values) override
     {
-        if (values == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
-
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
-            {
-                *values = prop.getSuggestedValues().detach();
-            }
-            else
-            {
-                ListPtr<IBaseObject> suggestedValuesBound = bindAndGet(this->suggestedValues);
-                *values = suggestedValuesBound.detach();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+	    return getSuggestedValuesInternal(values, true);
     }
-    
+
+    ErrCode INTERFACE_FUNC getSuggestedValuesNoLock(IList** values) override
+    {
+	    return getSuggestedValuesInternal(values, false);
+    }
+
+    ErrCode getSuggestedValuesInternal(IList** values, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(values);
+
+	    return daqTry([&]()
+            {
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *values = lock ? prop.getSuggestedValues().detach() : prop.asPtr<IPropertyInternal>().getSuggestedValuesNoLock().detach();
+		        else
+			        *values = bindAndGet<ListPtr<IBaseObject>>(this->suggestedValues, lock).detach();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
+    }
+            
     ErrCode INTERFACE_FUNC getVisible(Bool* visible) override
     {
-        if (visible == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
-
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
-            {
-                *visible = prop.getVisible();
-            }
-            else
-            {
-                *visible = bindAndGet(this->visible);
-            }
-            return OPENDAQ_SUCCESS;
-        });
+	    return getVisibleInternal(visible, true);
     }
-    
-    ErrCode INTERFACE_FUNC getReadOnly(Bool* isReadOnly) override
+
+    ErrCode INTERFACE_FUNC getVisibleNoLock(Bool* visible) override
     {
-        if (isReadOnly == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+	    return getVisibleInternal(visible, false);
+    }
 
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
+    ErrCode getVisibleInternal(Bool* visible, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(visible);
+
+	    return daqTry([&]()
             {
-                *isReadOnly = prop.getReadOnly();
-            }
-            else
-            {
-                *isReadOnly = bindAndGet(readOnly);
-            }
-            return OPENDAQ_SUCCESS;
-        });
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *visible = lock ? prop.getVisible() : prop.asPtr<IPropertyInternal>().getVisibleNoLock();
+		        else
+			        *visible = bindAndGet<BooleanPtr>(this->visible, lock);
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
     }
     
+    ErrCode INTERFACE_FUNC getReadOnly(Bool* readOnly) override
+    {
+	    return getReadOnlyInternal(readOnly, true);
+    }
+
+    ErrCode INTERFACE_FUNC getReadOnlyNoLock(Bool* readOnly) override
+    {
+	    return getReadOnlyInternal(readOnly, false);
+    }
+
+    ErrCode getReadOnlyInternal(Bool* readOnly, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(readOnly);
+
+	    return daqTry([&]()
+            {
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *readOnly = lock ? prop.getReadOnly() : prop.asPtr<IPropertyInternal>().getReadOnlyNoLock();
+		        else
+			        *readOnly = bindAndGet<BooleanPtr>(this->readOnly, lock);
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
+    }
+
     ErrCode INTERFACE_FUNC getSelectionValues(IBaseObject** values) override
     {
-        if (values == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+	    return getSelectionValuesInternal(values, true);
+    }
 
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
+    ErrCode INTERFACE_FUNC getSelectionValuesNoLock(IBaseObject** values) override
+    {
+	    return getSelectionValuesInternal(values, false);
+    }
+
+    ErrCode getSelectionValuesInternal(IBaseObject** values, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(values);
+
+	    return daqTry([&]()
             {
-                *values = prop.getSelectionValues().detach();
-            }
-            else
-            {
-                *values = bindAndGet(this->selectionValues).detach();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *values = lock ? prop.getSelectionValues().detach() : prop.asPtr<IPropertyInternal>().getSelectionValuesNoLock().detach();
+		        else
+			        *values = bindAndGet<BaseObjectPtr>(this->selectionValues, lock).detach();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
     }
     
     ErrCode INTERFACE_FUNC getReferencedProperty(IProperty** property) override
     {
-        if (property == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
-
-        return daqTry([&]() {
-            PropertyPtr prop = bindAndGet(this->refProp);
-            *property = prop.detach();
-            return OPENDAQ_SUCCESS;
-        });
+	    return getReferencedPropertyInternal(property, true);
     }
-    
+
+    ErrCode INTERFACE_FUNC getReferencedPropertyNoLock(IProperty** property) override
+    {
+	    return getReferencedPropertyInternal(property, false);
+    }
+
+    ErrCode getReferencedPropertyInternal(IProperty** property, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(property);
+
+	    return daqTry([&]()
+            {
+	            *property = bindAndGet<PropertyPtr>(this->refProp, lock).detach();
+		        return OPENDAQ_SUCCESS;
+	        });
+    }
+
     ErrCode INTERFACE_FUNC getIsReferenced(Bool* isReferenced) override
     {
-        if (isReferenced == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+	    return getIsReferencedInternal(isReferenced, true);
+    }
+
+    ErrCode INTERFACE_FUNC getIsReferencedNoLock(Bool* isReferenced) override
+    {
+	    return getIsReferencedInternal(isReferenced, false);
+    }
+
+    ErrCode getIsReferencedInternal(Bool* isReferenced, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(isReferenced);
 
         return daqTry([&]() {
             *isReferenced = false;
+	        const auto ownerPtr = owner.assigned() ? owner.getRef() : nullptr;
+
             if (owner.assigned())
             {
                 const auto ownerInternal = owner.getRef().asPtr<IPropertyObjectInternal>();
-                *isReferenced = ownerInternal.checkForReferences(propPtr);
+                *isReferenced = lock ? ownerInternal.checkForReferences(propPtr) : ownerInternal.checkForReferencesNoLock(propPtr);
             }
 
             return OPENDAQ_SUCCESS;
         });
     }
-
+        
     ErrCode INTERFACE_FUNC getValidator(IValidator** validator) override
     {
-        if (validator == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
-
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
-            {
-                *validator = prop.getValidator().detach();
-            }
-            else
-            {
-                *validator = this->validator.addRefAndReturn();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+	    return getValidatorInternal(validator, true);
     }
-    
+
+    ErrCode INTERFACE_FUNC getValidatorNoLock(IValidator** validator) override
+    {
+	    return getValidatorInternal(validator, false);
+    }
+
+    ErrCode getValidatorInternal(IValidator** validator, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(validator);
+
+	    return daqTry([&]()
+            {
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *validator = lock ? prop.getValidator().detach() : prop.asPtr<IPropertyInternal>().getValidatorNoLock().detach();
+		        else
+			        *validator = this->validator.addRefAndReturn();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
+    }
+            
     ErrCode INTERFACE_FUNC getCoercer(ICoercer** coercer) override
     {
-        if (coercer == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
-
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
-            {
-                *coercer = prop.getCoercer().detach();
-            }
-            else
-            {
-                *coercer = this->coercer.addRefAndReturn();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+	    return getCoercerInternal(coercer, true);
     }
-    
-    ErrCode INTERFACE_FUNC getCallableInfo(ICallableInfo** callable) override
-    {
-        if (callable == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
 
-        return daqTry([&]() {
-            bool bound = false;
-            const auto prop = bindAndGetRefProp(bound);
-            if (bound)
+    ErrCode INTERFACE_FUNC getCoercerNoLock(ICoercer** coercer) override
+    {
+	    return getCoercerInternal(coercer, false);
+    }
+
+    ErrCode getCoercerInternal(ICoercer** coercer, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(coercer);
+
+	    return daqTry([&]()
             {
-                *callable = prop.getCallableInfo();
-            }
-            else
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *coercer = lock ? prop.getCoercer().detach() : prop.asPtr<IPropertyInternal>().getCoercerNoLock().detach();
+		        else
+			        *coercer = this->coercer.addRefAndReturn();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
+    }
+           
+    ErrCode INTERFACE_FUNC getCallableInfo(ICallableInfo** callableInfo) override
+    {
+	    return getCallableInfoInternal(callableInfo, true);
+    }
+
+    ErrCode INTERFACE_FUNC getCallableInfoNoLock(ICallableInfo** callableInfo) override
+    {
+	    return getCallableInfoInternal(callableInfo, false);
+    }
+
+    ErrCode getCallableInfoInternal(ICallableInfo** callableInfo, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(callableInfo);
+
+	    return daqTry([&]()
             {
-                *callable = this->callableInfo.addRefAndReturn();
-            }
-            return OPENDAQ_SUCCESS;
-        });
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        *callableInfo = lock ? prop.getCallableInfo().detach() : prop.asPtr<IPropertyInternal>().getCallableInfoNoLock().detach();
+		        else
+			        *callableInfo = this->callableInfo.addRefAndReturn();
+			        
+		        return OPENDAQ_SUCCESS;
+	        });
     }
 
     ErrCode INTERFACE_FUNC getStructType(IStructType** structType) override
     {
-        if (structType == nullptr)
-            return OPENDAQ_ERR_ARGUMENT_NULL;
+	    return getStructTypeInternal(structType, true);
+    }
 
-        return daqTry(
-            [&]()
+    ErrCode INTERFACE_FUNC getStructTypeNoLock(IStructType** structType) override
+    {
+	    return getStructTypeInternal(structType, false);
+    }
+
+    ErrCode getStructTypeInternal(IStructType** structType, bool lock)
+    {
+	    OPENDAQ_PARAM_NOT_NULL(structType);
+
+	    return daqTry([&]()
             {
-                bool bound = false;
-                const auto prop = bindAndGetRefProp(bound);
                 BaseObjectPtr defaultStruct;
-                if (bound)
-                {
-                    defaultStruct = prop.getDefaultValue();
-                }
-                else
-                {
+		        if (const PropertyPtr prop = bindAndGetRefProp(lock); prop.assigned())
+			        defaultStruct = lock ? prop.getDefaultValue().detach() : prop.asPtr<IPropertyInternal>().getDefaultValueNoLock().detach();
+                else if (lock)
                     checkErrorInfo(this->getDefaultValue(&defaultStruct));
-                }
+                else
+                    checkErrorInfo(this->getDefaultValueNoLock(&defaultStruct));
 
-                *structType = defaultValue.asPtr<IStruct>().getStructType().detach();
-                return OPENDAQ_SUCCESS;
-            });
+                *structType = defaultStruct.asPtr<IStruct>().getStructType().detach();
+		        return OPENDAQ_SUCCESS;
+	        });
     }
 
     ErrCode INTERFACE_FUNC getClassOnPropertyValueWrite(IEvent** event) override
@@ -1393,7 +1473,6 @@ public:
         return OPENDAQ_SUCCESS;
     }
 
-
     //
     // IOwnable
     //
@@ -1442,54 +1521,44 @@ protected:
     PermissionManagerPtr defaultPermissionManager;
 
 private:
-    PropertyPtr bindAndGetRefProp(bool& bound)
+
+    PropertyPtr bindAndGetRefProp(bool lock)
     {
-        auto refPropPtr = propPtr.getReferencedProperty();
-        if (!refPropPtr.assigned())
-        {
-            bound = false;
-            return propPtr;
-        }
-        bound = true;
-        return refPropPtr;
+	    PropertyPtr refPropPtr;
+	    checkErrorInfo(getReferencedPropertyInternal(&refPropPtr, lock));
+	    if (!refPropPtr.assigned())
+		    return nullptr;
+		    
+	    return refPropPtr;
     }
 
-    BaseObjectPtr bindAndGet(BaseObjectPtr metadata) const
+    template <typename TPtr>
+    TPtr bindAndGet(const BaseObjectPtr& metadata, bool lock) const
     {
-        if (!metadata.assigned())
-        {
-            return nullptr;
-        }
+	    if (!metadata.assigned())
+		    return nullptr;
+		    
+	    auto eval = metadata.asPtrOrNull<IEvalValue>();
+	    if (!eval.assigned())
+		    return metadata;
 
-        auto eval = metadata.asPtrOrNull<IEvalValue>();
-        if (!eval.assigned())
-        {
-            return metadata;
-        }
+	    const auto ownerPtr = owner.assigned() ? owner.getRef() : nullptr;
+	    if (ownerPtr.assigned())
+		    eval = eval.cloneWithOwner(ownerPtr);
 
-        const auto ownerPtr = owner.assigned() ? owner.getRef() : nullptr;
-        if (ownerPtr.assigned())
-        {
-            eval = eval.cloneWithOwner(ownerPtr);
-        }
-
-        return eval.getResult();
+	    return lock ? eval.getResult() : eval.getResultNoLock();
     }
 
-    BaseObjectPtr getUnresolved(BaseObjectPtr localMetadata) const
+    BaseObjectPtr getUnresolved(const BaseObjectPtr& localMetadata) const
     {
         if (!localMetadata.assigned())
-        {
             return nullptr;
-        }
 
-        auto eval = localMetadata.asPtrOrNull<IEvalValue>();
-        if (eval.assigned())
+        if (const auto eval = localMetadata.asPtrOrNull<IEvalValue>(); eval.assigned())
         {
             const auto ownerPtr = owner.assigned() ? owner.getRef() : nullptr;
             if (ownerPtr.assigned())
-                eval = eval.cloneWithOwner(ownerPtr);
-            return eval;
+                return eval.cloneWithOwner(ownerPtr);
         }
 
         return localMetadata;

--- a/core/coreobjects/include/coreobjects/property_internal.h
+++ b/core/coreobjects/include/coreobjects/property_internal.h
@@ -30,6 +30,7 @@ struct IEvalValue;
 /*#
  * [interfaceSmartPtr(IBoolean, BooleanPtr, "<coretypes/boolean_factory.h>")]
  * [interfaceLibrary(INumber, CoreTypes)]
+ * [interfaceLibrary(IStructType, CoreTypes)]
  */
 DECLARE_OPENDAQ_INTERFACE(IPropertyInternal, IBaseObject)
 {
@@ -116,6 +117,26 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyInternal, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getClassOnPropertyValueRead(IEvent** event) = 0;
     // [templateType(event, IPropertyObject, IPropertyValueEventArgs)]
     virtual ErrCode INTERFACE_FUNC getClassOnPropertyValueWrite(IEvent** event) = 0;
+
+    virtual ErrCode INTERFACE_FUNC getValueTypeNoLock(CoreType* type) = 0;
+    virtual ErrCode INTERFACE_FUNC getKeyTypeNoLock(CoreType* type) = 0;
+    virtual ErrCode INTERFACE_FUNC getItemTypeNoLock(CoreType* type) = 0;
+    virtual ErrCode INTERFACE_FUNC getDescriptionNoLock(IString** description) = 0;
+    virtual ErrCode INTERFACE_FUNC getUnitNoLock(IUnit** unit) = 0;
+    virtual ErrCode INTERFACE_FUNC getMinValueNoLock(INumber** min) = 0;
+    virtual ErrCode INTERFACE_FUNC getMaxValueNoLock(INumber** max) = 0;
+    virtual ErrCode INTERFACE_FUNC getDefaultValueNoLock(IBaseObject** value) = 0;
+    // [templateType(values, IBaseObject)]
+    virtual ErrCode INTERFACE_FUNC getSuggestedValuesNoLock(IList** values) = 0;
+    virtual ErrCode INTERFACE_FUNC getVisibleNoLock(Bool* visible) = 0;
+    virtual ErrCode INTERFACE_FUNC getReadOnlyNoLock(Bool* readOnly) = 0;
+    virtual ErrCode INTERFACE_FUNC getSelectionValuesNoLock(IBaseObject** values) = 0;
+    virtual ErrCode INTERFACE_FUNC getReferencedPropertyNoLock(IProperty** propertyEval) = 0;
+    virtual ErrCode INTERFACE_FUNC getIsReferencedNoLock(Bool* isReferenced) = 0;
+    virtual ErrCode INTERFACE_FUNC getValidatorNoLock(IValidator** validator) = 0;
+    virtual ErrCode INTERFACE_FUNC getCoercerNoLock(ICoercer** coercer) = 0;
+    virtual ErrCode INTERFACE_FUNC getCallableInfoNoLock(ICallableInfo** callable) = 0;
+    virtual ErrCode INTERFACE_FUNC getStructTypeNoLock(IStructType** structType) = 0;
 };
 /*!@}*/
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -46,6 +46,7 @@
 #include <coreobjects/permission_manager_internal_ptr.h>
 #include <coreobjects/permission_mask_builder_factory.h>
 #include <coreobjects/permissions_builder_factory.h>
+#include <thread>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -55,6 +56,51 @@ struct PropertyNameInfo
 {
     StringPtr name;
     Int index{};
+};
+
+namespace object_utils
+{
+    struct NullMutex
+    {
+         void lock() {}
+         void unlock() noexcept {}
+         bool try_lock() { return true; }
+    };
+}
+
+class RecursiveConfigLockGuard: public std::enable_shared_from_this<RecursiveConfigLockGuard>
+{
+public:
+    virtual ~RecursiveConfigLockGuard() = default;
+};
+
+template <typename TMutex>
+class GenericRecursiveConfigLockGuard : public RecursiveConfigLockGuard
+{
+public:
+    GenericRecursiveConfigLockGuard(TMutex* lock, std::thread::id* threadId, int* depth)
+        : id(threadId)
+        , depth(depth)
+        , lock(std::lock_guard(*lock))
+    {
+        assert(this->id != nullptr);
+        assert(this->depth != nullptr);
+
+        *id = std::this_thread::get_id();
+        ++(*this->depth);
+    }
+
+    ~GenericRecursiveConfigLockGuard() override
+    {
+        --(*depth);
+        if (*depth == 0)
+            *id = std::thread::id();
+    }
+
+private:
+    std::thread::id* id;
+    int* depth;
+    std::lock_guard<TMutex> lock;
 };
 
 template <typename PropObjInterface, typename... Interfaces>
@@ -74,9 +120,13 @@ public:
     virtual ErrCode INTERFACE_FUNC getClassName(IString** className) override;
 
     virtual ErrCode INTERFACE_FUNC setPropertyValue(IString* propertyName, IBaseObject* value) override;
+    virtual ErrCode INTERFACE_FUNC setPropertyValueNoLock(IString* propertyName, IBaseObject* value) override;
     virtual ErrCode INTERFACE_FUNC getPropertyValue(IString* propertyName, IBaseObject** value) override;
+    virtual ErrCode INTERFACE_FUNC getPropertyValueNoLock(IString* propertyName, IBaseObject** value) override;
     virtual ErrCode INTERFACE_FUNC getPropertySelectionValue(IString* propertyName, IBaseObject** value) override;
+    virtual ErrCode INTERFACE_FUNC getPropertySelectionValueNoLock(IString* propertyName, IBaseObject** value) override;
     virtual ErrCode INTERFACE_FUNC clearPropertyValue(IString* propertyName) override;
+    virtual ErrCode INTERFACE_FUNC clearPropertyValueNoLock(IString* propertyName) override;
 
     virtual ErrCode INTERFACE_FUNC hasProperty(IString* propertyName, Bool* hasProperty) override;
     virtual ErrCode INTERFACE_FUNC getProperty(IString* propertyName, IProperty** property) override;
@@ -100,6 +150,7 @@ public:
 
     // IPropertyObjectInternal
     virtual ErrCode INTERFACE_FUNC checkForReferences(IProperty* property, Bool* isReferenced) override;
+    virtual ErrCode INTERFACE_FUNC checkForReferencesNoLock(IProperty* property, Bool* isReferenced) override;
     virtual ErrCode INTERFACE_FUNC enableCoreEventTrigger() override;
     virtual ErrCode INTERFACE_FUNC disableCoreEventTrigger() override;
     virtual ErrCode INTERFACE_FUNC getCoreEventTrigger(IProcedure** trigger) override;
@@ -163,6 +214,20 @@ protected:
 
     // Using vector to preserve write order when the same property is changed twice within an update
     using UpdatingActions = std::vector<std::pair<std::string, UpdatingAction>>;
+    
+    // Gets a lock for the configuration of the object. Can be used to lock the sync mutex in a function
+    // that is called during a property value read/write event to prevent deadlocks. The lock behaves
+    // similarly to a recursive mutex.
+    std::unique_ptr<RecursiveConfigLockGuard> getRecursiveConfigLock();
+
+    // Gets a lock to be used in the data acquisition loop, or in other performance-critical parts of
+    // a module implementation. The lock is not recursive in comparison to the config lock and should
+    // be used with caution to prevent deadlocks.
+    std::lock_guard<std::mutex> getAcquisitionLock();
+
+    // Mutex that is locked in the getRecursiveConfigLock and getAcquisitionLock methods. Those should
+    // be used instead of locking this mutex directly unless a different type of lock is needed.
+    std::mutex sync;
 
     bool frozen;
     WeakRefPtr<IPropertyObject> owner;
@@ -179,6 +244,9 @@ protected:
     void internalDispose(bool) override;
     ErrCode setPropertyValueInternal(IString* name, IBaseObject* value, bool triggerEvent, bool protectedAccess, bool batch, bool isUpdating = false);
     ErrCode clearPropertyValueInternal(IString* name, bool protectedAccess, bool batch, bool isUpdating = false);
+    ErrCode getPropertyValueInternal(IString* propertyName, IBaseObject** value);
+    ErrCode getPropertySelectionValueInternal(IString* propertyName, IBaseObject** value);
+    ErrCode checkForReferencesInternal(IProperty* property, Bool* isReferenced);
 
     // Serialization
 
@@ -237,6 +305,7 @@ protected:
 
     ErrCode beginUpdateInternal(bool deep);
     ErrCode endUpdateInternal(bool deep);
+    ErrCode getUpdatingInternal(Bool* updating);
 
 private:
 
@@ -246,8 +315,14 @@ private:
     std::unordered_map<StringPtr, PropertyValueEventEmitter> valueReadEvents;
     EndUpdateEventEmitter endUpdateEvent;
     ProcedurePtr triggerCoreEvent;
+    
+    object_utils::NullMutex nullSync;
+    std::thread::id externalCallThreadId{};
+    int externalCallDepth = 0;
 
     std::unordered_map<StringPtr, BaseObjectPtr, StringHash, StringEqualTo> propValues;
+
+    void triggerCoreEventInternal(const CoreEventArgsPtr& args);
 
     // Gets the property, as well as its value. Gets the referenced property, if the property is a refProp
     ErrCode getPropertyAndValueInternal(const StringPtr& name, BaseObjectPtr& value, PropertyPtr& property, bool triggerEvent = true);
@@ -302,7 +377,7 @@ private:
     void coercePropertyWrite(const PropertyPtr& prop, ObjectPtr<IBaseObject>& valuePtr) const;
     void validatePropertyWrite(const PropertyPtr& prop, ObjectPtr<IBaseObject>& valuePtr) const;
     void coerceMinMax(const PropertyPtr& prop, ObjectPtr<IBaseObject>& valuePtr);
-    bool checkIsReferenced(const StringPtr& referencedPropName, const PropertyInternalPtr& prop);
+    Bool checkIsReferenced(const StringPtr& referencedPropName, const PropertyInternalPtr& prop);
 
     // update
     ErrCode updateObjectProperties(const PropertyObjectPtr& propObj,
@@ -449,7 +524,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getChildProp
     }
 
     BaseObjectPtr childProp;
-    err = getPropertyValue(name, &childProp);
+    err = getPropertyValueInternal(name, &childProp);
     if (OPENDAQ_FAILED(err))
     {
         return err;
@@ -540,7 +615,7 @@ BaseObjectPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::callPr
             valueReadEvents[name](objPtr, args);
         }
     }
-    
+
     return args.getValue();
 }
 
@@ -550,12 +625,12 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::coercePropertyW
 {
     if (prop.assigned() && valuePtr.assigned())
     {
-        const auto coercer = prop.getCoercer();
+        const auto coercer = prop.asPtr<IPropertyInternal>().getCoercerNoLock();
         if (coercer.assigned())
         {
             try
             {
-                valuePtr = coercer.coerce(objPtr, valuePtr);
+                valuePtr = coercer.coerceNoLock(objPtr, valuePtr);
             }
             catch (const DaqException&)
             {
@@ -575,12 +650,12 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::validatePropert
 {
     if (prop.assigned() && valuePtr.assigned())
     {
-        const auto validator = prop.getValidator();
+        const auto validator = prop.asPtr<IPropertyInternal>().getValidatorNoLock();
         if (validator.assigned())
         {
             try
             {
-                validator.validate(objPtr, valuePtr);
+                validator.validateNoLock(objPtr, valuePtr);
             }
             catch (const DaqException&)
             {
@@ -600,7 +675,8 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::coerceMinMax(co
     if (!prop.assigned() || !valuePtr.assigned())
         return;
 
-    const auto min = prop.getMinValue();
+    const auto propInternal = prop.asPtr<IPropertyInternal>();
+    const auto min = propInternal.getMinValueNoLock();
     if (min.assigned())
     {
         try
@@ -613,7 +689,7 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::coerceMinMax(co
         }
     }
 
-    const auto max = prop.getMaxValue();
+    const auto max = propInternal.getMaxValueNoLock();
     if (max.assigned())
     {
         try
@@ -630,11 +706,19 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::coerceMinMax(co
 template <class PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setProtectedPropertyValue(IString* propertyName, IBaseObject* value)
 {
+    auto lock = getRecursiveConfigLock();
     return setPropertyValueInternal(propertyName, value, true, true, updateCount > 0);
 }
 
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyValue(IString* propertyName, IBaseObject* value)
+{
+    auto lock = getRecursiveConfigLock();
+    return setPropertyValueInternal(propertyName, value, true, false, updateCount > 0);
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyValueNoLock(IString* propertyName, IBaseObject* value)
 {
     return setPropertyValueInternal(propertyName, value, true, false, updateCount > 0);
 }
@@ -680,11 +764,13 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkContain
         return true;
     };
     
+    const auto propInternal = prop.asPtr<IPropertyInternal>();
     if (coreType == ctDict)
     {
         const auto dict = value.asPtr<IDict>();
-        const auto keyType = prop.getKeyType();
-        const auto itemType = prop.getItemType();
+        const auto keyType = propInternal.getKeyTypeNoLock();
+        const auto itemType = propInternal.getItemTypeNoLock();
+		
         IterablePtr<IBaseObject> it;
         dict->getKeys(&it);
         if (!iterate(it, keyType))
@@ -702,7 +788,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkContain
     
     if (coreType == ctList)
     {
-        const auto itemType = prop.getItemType();
+        const auto itemType = propInternal.getItemTypeNoLock();
 
         if (itemType != ctUndefined && !iterate(value, itemType))
         {
@@ -723,7 +809,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkStructT
     if (!structPtr.assigned())
         return this->makeErrorInfo(OPENDAQ_ERR_INVALIDSTATE, "Set value is not a struct");
 
-    StructTypePtr structType = prop.getStructType();
+    StructTypePtr structType = prop.asPtr<IPropertyInternal>().getStructTypeNoLock();
     StructTypePtr valueStructType = structPtr.getStructType();
 
     if (structType != valueStructType)
@@ -735,14 +821,15 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkStructT
 template <typename PropObjInterface, typename ... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkEnumerationType(const PropertyPtr& prop, const BaseObjectPtr& value)
 {
-    if (prop.getValueType() != ctEnumeration)
+    const auto propInternal = prop.asPtr<IPropertyInternal>();
+    if (propInternal.getValueTypeNoLock() != ctEnumeration)
         return OPENDAQ_SUCCESS;
 
     auto enumerationPtr = value.asPtrOrNull<IEnumeration>();
     if (!enumerationPtr.assigned())
         return this->makeErrorInfo(OPENDAQ_ERR_INVALIDSTATE, "Set value is not an enumeration");
 
-    auto propEnumerationPtr = prop.getDefaultValue().asPtrOrNull<IEnumeration>();
+    auto propEnumerationPtr = propInternal.getDefaultValueNoLock().asPtrOrNull<IEnumeration>();
     if (!propEnumerationPtr.assigned())
         return this->makeErrorInfo(OPENDAQ_ERR_INVALIDSTATE, "Property default value is not an enumeration");
 
@@ -758,7 +845,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkEnumera
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkSelectionValues(const PropertyPtr& prop, const BaseObjectPtr& value)
 {
-    const auto selectionValues = prop.getSelectionValues();
+    const auto selectionValues = prop.asPtr<IPropertyInternal>().getSelectionValuesNoLock();
     if (selectionValues.assigned())
     {
         const SizeT key = value;
@@ -818,10 +905,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
         }
 
         propName = prop.getName();
+        const auto propInternal = prop.asPtr<IPropertyInternal>();
 
         if (!protectedAccess)
         {
-            if (prop.getReadOnly() && !isChildProp)
+            if (propInternal.getReadOnlyNoLock() && !isChildProp)
             {
                 return OPENDAQ_ERR_ACCESSDENIED;
             }
@@ -830,7 +918,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
         if (isChildProp)
         {
             BaseObjectPtr childProp;
-            const ErrCode err = getPropertyValue(propName, &childProp);
+            const ErrCode err = getPropertyValueInternal(propName, &childProp);
             if (OPENDAQ_FAILED(err))
             {
                 return err;
@@ -852,7 +940,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             // TODO: If function type, check if return value is correct type.
             if (!protectedAccess)
             {
-                if (prop.getReadOnly() || prop.getValueType() == ctObject)
+                if (propInternal.getReadOnlyNoLock() || propInternal.getValueTypeNoLock() == ctObject)
                 {
                     return OPENDAQ_ERR_ACCESSDENIED;
                 }
@@ -892,7 +980,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             validatePropertyWrite(prop, valuePtr);
             coerceMinMax(prop, valuePtr);
             
-            const auto ct = prop.getValueType();
+            const auto ct = propInternal.getValueTypeNoLock();
             if (ct == ctList || ct == ctDict)
             {
                 BaseObjectPtr clonedValue;
@@ -914,8 +1002,8 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             if (triggerEvent)
             {
                 const auto newVal = callPropertyValueWrite(prop, valuePtr, PropertyEventType::Update, isUpdating);
-                if (!coreEventMuted && !isUpdating && triggerCoreEvent.assigned())
-                    triggerCoreEvent(CoreEventArgsPropertyValueChanged(objPtr, propName, newVal, path));
+                if (!isUpdating)
+                    triggerCoreEventInternal(CoreEventArgsPropertyValueChanged(objPtr, propName, newVal, path));
             }
         }
 
@@ -941,14 +1029,15 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkPropert
 
     try
     {
-        const auto propCoreType = prop.getValueType();
+        const auto propInternal = prop.asPtr<IPropertyInternal>();
+        const auto propCoreType = propInternal.getValueTypeNoLock();
         const auto valueCoreType = value.getCoreType();
 
         if (propCoreType != valueCoreType)
         {
             if (propCoreType == ctEnumeration)
             {
-                const auto enumVal = prop.getDefaultValue().asPtrOrNull<IEnumeration>();
+                const auto enumVal = propInternal.getDefaultValueNoLock().asPtrOrNull<IEnumeration>();
                 if (!enumVal.assigned())
                     return this->makeErrorInfo(OPENDAQ_ERR_INVALIDSTATE, fmt::format(R"(Default value of enumeration property {} is not assigned)", prop.getName()));
 
@@ -983,7 +1072,7 @@ bool GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::writeLocalValue
         bool shouldWrite = true;
         try
         {
-            shouldWrite = objPtr.getProperty(name).getDefaultValue() != value;
+            shouldWrite = objPtr.getProperty(name).template asPtr<IPropertyInternal>().getDefaultValueNoLock() != value;
         }
         catch(...)
         {
@@ -1059,15 +1148,15 @@ PropertyPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getUnbou
 
 template <class PropObjInterface, class... Interfaces>
 PropertyPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForRefPropAndGetBoundProp(PropertyPtr& prop,
-                                                                                                  bool* isReferenced) const
+                                                                                                       bool* isReferenced) const
 {
     if (!prop.assigned())
     {
         return prop;
     }
 
-    auto boundProp = prop.asPtr<IPropertyInternal>().cloneWithOwner(objPtr);
-    auto refProp = boundProp.getReferencedProperty();
+    PropertyInternalPtr boundProp = prop.asPtr<IPropertyInternal>().cloneWithOwner(objPtr);
+    auto refProp = boundProp.getReferencedPropertyNoLock();
     if (refProp.assigned())
     {
         CoreType ct = refProp.getCoreType();
@@ -1236,6 +1325,13 @@ ConstCharPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getProp
     return first;
 }
 
+template <typename PropObjInterface, typename ... Interfaces>
+void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::triggerCoreEventInternal(const CoreEventArgsPtr& args)
+{
+    if (!coreEventMuted && triggerCoreEvent.assigned())
+        triggerCoreEvent(args);
+}
+
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyAndValueInternal(const StringPtr& name,
                                                                                                 BaseObjectPtr& value,
@@ -1283,8 +1379,8 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyA
     if (res == OPENDAQ_ERR_NOTFOUND)
     {
         this->clearErrorInfo();
-
-        res = property->getDefaultValue(&value);
+        const auto propInternal = property.asPtr<IPropertyInternal>();
+        res = propInternal->getDefaultValueNoLock(&value);
 
         if (OPENDAQ_FAILED(res) || !value.assigned())
         {
@@ -1326,101 +1422,33 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyA
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyValue(IString* propertyName, IBaseObject** value)
 {
-    if (propertyName == nullptr || value == nullptr)
-        return OPENDAQ_ERR_ARGUMENT_NULL;
+    auto lock = getRecursiveConfigLock();
+    return getPropertyValueInternal(propertyName, value);
+}
 
-    try
-    {
-        auto propName = StringPtr::Borrow(propertyName);
-        BaseObjectPtr valuePtr;
-        ErrCode err;
-
-        StringPtr childName;
-        StringPtr subName;
-
-        if (isChildProperty(propName, childName, subName))
-        {
-            err = getChildPropertyValue(childName, subName, valuePtr);
-        }
-        else
-        {
-            PropertyPtr prop;
-            err = getPropertyAndValueInternal(propName, valuePtr, prop);
-        }
-
-        if (OPENDAQ_SUCCEEDED(err))
-            *value = valuePtr.detach();
-
-        return err;
-    }
-    catch (const DaqException& e)
-    {
-        return errorFromException(e);
-    }
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyValueNoLock(IString* propertyName, IBaseObject** value)
+{
+    return getPropertyValueInternal(propertyName, value);
 }
 
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertySelectionValue(IString* propertyName, IBaseObject** value)
 {
-    if (propertyName == nullptr || value == nullptr)
-        return OPENDAQ_ERR_ARGUMENT_NULL;
-
-    try
-    {
-        const auto propName = StringPtr::Borrow(propertyName);
-        BaseObjectPtr valuePtr;
-        PropertyPtr prop;
-
-        getPropertyAndValueInternal(propName, valuePtr, prop);
-
-        if (!prop.assigned())
-            throw NotFoundException(R"(Selection property "{}" not found)", propName);
-
-        auto values = prop.getSelectionValues();
-        if (!values.assigned())
-            throw InvalidPropertyException(R"(Selection property "{}" has no selection values assigned)", propName);
-
-        auto valuesList = values.asPtrOrNull<IList, ListPtr<IBaseObject>>(true);
-        if (valuesList.assigned())
-        {
-            valuePtr = valuesList.getItemAt(valuePtr);
-        }
-        else
-        {
-            auto valuesDict = values.asPtrOrNull<IDict, DictPtr<IBaseObject, IBaseObject>>(true);
-            if (!valuesDict.assigned())
-            {
-                throw InvalidPropertyException(R"(Selection property "{}" values is not a list or dictionary)", propName);
-            }
-
-            valuePtr = valuesDict.get(valuePtr);
-        }
-
-        if (prop.getItemType() != valuePtr.getCoreType())
-        {
-            return this->makeErrorInfo(OPENDAQ_ERR_INVALIDTYPE, "List item type mismatch");
-        }
-
-        *value = valuePtr.detach();
-        return OPENDAQ_SUCCESS;
-    }
-    catch (const DaqException& e)
-    {
-        return errorFromException(e);
-    }
-    catch (const std::exception& e)
-    {
-        return errorFromException(e);
-    }
-    catch (...)
-    {
-        return OPENDAQ_ERR_GENERALERROR;
-    }
+    auto lock = getRecursiveConfigLock();
+    return getPropertySelectionValueInternal(propertyName, value);
+}
+	
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertySelectionValueNoLock(IString* propertyName, IBaseObject** value)
+{
+    return getPropertySelectionValueInternal(propertyName, value);
 }
 
 template <class PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearProtectedPropertyValue(IString* propertyName)
 {
+    auto lock = getRecursiveConfigLock();
     return clearPropertyValueInternal(propertyName, true, updateCount > 0);
 }
 
@@ -1484,8 +1512,30 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::configureCloned
     }
 }
 
+template <typename PropObjInterface, typename ... Interfaces>
+std::unique_ptr<RecursiveConfigLockGuard> GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getRecursiveConfigLock()
+{
+    if (externalCallThreadId != std::thread::id() && externalCallThreadId == std::this_thread::get_id())
+        return std::make_unique<GenericRecursiveConfigLockGuard<object_utils::NullMutex>>(&nullSync, &externalCallThreadId, &externalCallDepth);
+
+    return std::make_unique<GenericRecursiveConfigLockGuard<std::mutex>>(&sync, &externalCallThreadId, &externalCallDepth);
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+std::lock_guard<std::mutex> GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getAcquisitionLock()
+{
+    return std::lock_guard(sync);
+}
+
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropertyValue(IString* propertyName)
+{
+    auto lock = getRecursiveConfigLock();
+    return clearPropertyValueInternal(propertyName, false, updateCount > 0);
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropertyValueNoLock(IString* propertyName)
 {
     return clearPropertyValueInternal(propertyName, false, updateCount > 0);
 }
@@ -1526,10 +1576,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
         }
 
         propName = prop.getName();
+        const auto propInternal = prop.asPtr<IPropertyInternal>();
 
         if (!protectedAccess)
         {
-            if (prop.getReadOnly() && !isChildProp)
+            if (propInternal.getReadOnlyNoLock() && !isChildProp)
             {
                 return OPENDAQ_ERR_ACCESSDENIED;
             }
@@ -1538,7 +1589,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
         if (isChildProp)
         {
             BaseObjectPtr childProp;
-            const ErrCode err = getPropertyValue(propName, &childProp);
+            const ErrCode err = getPropertyValueInternal(propName, &childProp);
             if (OPENDAQ_FAILED(err))
             {
                 return err;
@@ -1574,8 +1625,8 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
             cloneAndSetChildPropertyObject(prop);
 
             const auto val = callPropertyValueWrite(prop, nullptr, PropertyEventType::Clear, isUpdating);
-            if (!coreEventMuted && !isUpdating && triggerCoreEvent.assigned())
-                triggerCoreEvent(CoreEventArgsPropertyValueChanged(objPtr, propName, val, path));
+            if (!isUpdating)
+                triggerCoreEventInternal(CoreEventArgsPropertyValueChanged(objPtr, propName, val, path));
         }
     }
     catch (const DaqException& e)
@@ -1584,6 +1635,102 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
     }
 
     return OPENDAQ_SUCCESS;
+}
+
+template <typename PropObjInterface, typename... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyValueInternal(IString* propertyName, IBaseObject** value)
+{
+    if (propertyName == nullptr || value == nullptr)
+        return OPENDAQ_ERR_ARGUMENT_NULL;
+
+    try
+    {
+        auto propName = StringPtr::Borrow(propertyName);
+        BaseObjectPtr valuePtr;
+        ErrCode err;
+
+        StringPtr childName;
+        StringPtr subName;
+
+        if (isChildProperty(propName, childName, subName))
+        {
+            err = getChildPropertyValue(childName, subName, valuePtr);
+        }
+        else
+        {
+            PropertyPtr prop;
+            err = getPropertyAndValueInternal(propName, valuePtr, prop);
+        }
+
+        if (OPENDAQ_SUCCEEDED(err))
+            *value = valuePtr.detach();
+
+        return err;
+    }
+    catch (const DaqException& e)
+    {
+        return errorFromException(e);
+    }
+}
+
+template <typename PropObjInterface, typename... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertySelectionValueInternal(IString* propertyName, IBaseObject** value)
+{
+    if (propertyName == nullptr || value == nullptr)
+        return OPENDAQ_ERR_ARGUMENT_NULL;
+
+    try
+    {
+        const auto propName = StringPtr::Borrow(propertyName);
+        BaseObjectPtr valuePtr;
+        PropertyPtr prop;
+
+        getPropertyAndValueInternal(propName, valuePtr, prop);
+
+        if (!prop.assigned())
+            throw NotFoundException(R"(Selection property "{}" not found)", propName);
+
+        const auto propInternal = prop.asPtr<IPropertyInternal>();
+        auto values = propInternal.getSelectionValuesNoLock();
+        if (!values.assigned())
+            throw InvalidPropertyException(R"(Selection property "{}" has no selection values assigned)", propName);
+
+        auto valuesList = values.asPtrOrNull<IList, ListPtr<IBaseObject>>(true);
+        if (!valuesList.assigned())
+        {
+            auto valuesDict = values.asPtrOrNull<IDict, DictPtr<IBaseObject, IBaseObject>>(true);
+            if (!valuesDict.assigned())
+            {
+                throw InvalidPropertyException(R"(Selection property "{}" values is not a list or dictionary)", propName);
+            }
+
+            valuePtr = valuesDict.get(valuePtr);
+        }
+        else
+        {
+            valuePtr = valuesList.getItemAt(valuePtr);
+        }
+
+        if (propInternal.getItemTypeNoLock() != valuePtr.getCoreType())
+        {
+            return this->makeErrorInfo(OPENDAQ_ERR_INVALIDTYPE, "List item type mismatch");
+        }
+
+        *value = valuePtr.detach();
+        return OPENDAQ_SUCCESS;
+    }
+    catch (const DaqException& e)
+    {
+        return errorFromException(e);
+    }
+    catch (const std::exception& e)
+    {
+        return errorFromException(e);
+    }
+    catch (...)
+    {
+        return OPENDAQ_ERR_GENERALERROR;
+    }
 }
 
 template <class PropObjInterface, class... Interfaces>
@@ -1606,7 +1753,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getProperty(
         {
             propName = childName;
             BaseObjectPtr childProp;
-            const ErrCode err = getPropertyValue(propName, &childProp);
+            const ErrCode err = getPropertyValueInternal(propName, &childProp);
             if (OPENDAQ_FAILED(err))
             {
                 return err;
@@ -1676,9 +1823,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::addProperty(
         }
 
         cloneAndSetChildPropertyObject(propPtr);
-
-        if (!coreEventMuted && triggerCoreEvent.assigned())
-            triggerCoreEvent(CoreEventArgsPropertyAdded(objPtr, propPtr, path));
+        triggerCoreEventInternal(CoreEventArgsPropertyAdded(objPtr, propPtr, path));
 
         return OPENDAQ_SUCCESS;
     });
@@ -1709,8 +1854,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::removeProper
         propValues.erase(propertyName);
     }
 
-    if(!coreEventMuted && triggerCoreEvent.assigned())
-        triggerCoreEvent(CoreEventArgsPropertyRemoved(objPtr, propertyName, path));
+    triggerCoreEventInternal(CoreEventArgsPropertyRemoved(objPtr, propertyName, path));
 
     return OPENDAQ_SUCCESS;
 }
@@ -1905,6 +2049,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getOnPropert
 template <typename PropObjInterface, typename ... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::beginUpdate()
 {
+    auto lock = getRecursiveConfigLock();
     return beginUpdateInternal(true);
 }
 
@@ -2005,6 +2150,15 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::endUpdateInt
     return OPENDAQ_SUCCESS;
 }
 
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getUpdatingInternal(Bool* updating)
+{
+    OPENDAQ_PARAM_NOT_NULL(updating);
+
+    *updating = updateCount > 0 ? True : False;
+    return OPENDAQ_SUCCESS;
+}
+
 template <typename PropObjInterface, typename... Interfaces>
 void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::beginApplyUpdate()
 {
@@ -2077,16 +2231,15 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::onUpdatableUpda
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::endUpdate()
 {
+    auto lock = getRecursiveConfigLock();
     return endUpdateInternal(true);
 }
 
 template <typename PropObjInterface, typename ... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getUpdating(Bool* updating)
 {
-    OPENDAQ_PARAM_NOT_NULL(updating);
-
-    *updating = updateCount > 0 ? True : False;
-    return OPENDAQ_SUCCESS;
+    auto lock = getRecursiveConfigLock();
+    return getUpdatingInternal(updating);
 }
 
 template <typename PropObjInterface, typename ... Interfaces>
@@ -2109,10 +2262,10 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPermissio
 }
 
 template <typename PropObjInterface, typename... Interfaces>
-bool GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkIsReferenced(const StringPtr& referencedPropName,
+Bool GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkIsReferenced(const StringPtr& referencedPropName,
                                                                                    const PropertyInternalPtr& prop)
 {
-    if (auto refProp = prop.getReferencedPropertyUnresolved(); refProp.assigned())
+    if (const auto refProp = prop.getReferencedPropertyUnresolved(); refProp.assigned())
     {
         for (auto propName : refProp.getPropertyReferences())
         {
@@ -2122,14 +2275,15 @@ bool GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkIsReferenc
             }
         }
     }
+
     return false;
 }
 
 template <typename PropObjInterface, typename ... Interfaces>
-ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForReferences(IProperty* property, Bool* isReferenced)
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForReferencesInternal(IProperty* property, Bool* isReferenced)
 {
-    if (isReferenced == nullptr)
-        return OPENDAQ_ERR_ARGUMENT_NULL;
+    OPENDAQ_PARAM_NOT_NULL(isReferenced);
+    *isReferenced = false;
 
     try
     {
@@ -2140,21 +2294,15 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForRefe
         {
             for (const auto& prop : objectClass.getProperties(True))
             {
-                if (checkIsReferenced(name, prop))
-                {
-                    *isReferenced = true;
+                if (*isReferenced = checkIsReferenced(name, prop); *isReferenced)
                     return OPENDAQ_SUCCESS;
-                }
             }
         }
 
         for (const auto& prop : localProperties)
         {
-            if (checkIsReferenced(name, prop.second))
-            {
-                *isReferenced = true;
+            if (*isReferenced = checkIsReferenced(name, prop.second); *isReferenced)
                 return OPENDAQ_SUCCESS;
-            }
         }
     }
     catch (const DaqException& e)
@@ -2166,9 +2314,20 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForRefe
         return OPENDAQ_ERR_GENERALERROR;
     }
 
-
-    *isReferenced = false;
     return OPENDAQ_SUCCESS;
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForReferencesNoLock(IProperty* property, Bool* isReferenced)
+{
+    return checkForReferencesInternal(property, isReferenced);
+}
+
+template <typename PropObjInterface, typename ... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForReferences(IProperty* property, Bool* isReferenced)
+{
+    auto lock = getRecursiveConfigLock();
+    return checkForReferencesInternal(property, isReferenced);
 }
 
 template <typename PropObjInterface, typename ... Interfaces>
@@ -2752,8 +2911,8 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::endApplyPropert
         endUpdateEvent(objPtr, args);
     }
 
-    if(!coreEventMuted && triggerCoreEvent.assigned() && dict.getCount() > 0)
-        triggerCoreEvent(CoreEventArgsPropertyObjectUpdateEnd(objPtr, dict, path));
+    if(dict.getCount() > 0)
+        triggerCoreEventInternal(CoreEventArgsPropertyObjectUpdateEnd(objPtr, dict, path));
 }
 
 template <typename PropObjInterface, typename... Interfaces>

--- a/core/coreobjects/include/coreobjects/property_object_internal.h
+++ b/core/coreobjects/include/coreobjects/property_object_internal.h
@@ -30,6 +30,7 @@ BEGIN_NAMESPACE_OPENDAQ
 DECLARE_OPENDAQ_INTERFACE(IPropertyObjectInternal, IBaseObject)
 {
     virtual ErrCode INTERFACE_FUNC checkForReferences(IProperty* property, Bool* isReferenced) = 0;
+    virtual ErrCode INTERFACE_FUNC checkForReferencesNoLock(IProperty* property, Bool* isReferenced) = 0;
     virtual ErrCode INTERFACE_FUNC enableCoreEventTrigger() = 0;
     virtual ErrCode INTERFACE_FUNC disableCoreEventTrigger() = 0;
     virtual ErrCode INTERFACE_FUNC getCoreEventTrigger(IProcedure** trigger) = 0;
@@ -38,6 +39,11 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObjectInternal, IBaseObject)
     virtual ErrCode INTERFACE_FUNC setPath(IString* path) = 0;
     virtual ErrCode INTERFACE_FUNC isUpdating(Bool* updating) = 0;
     virtual ErrCode INTERFACE_FUNC hasUserReadAccess(IBaseObject* userContext, Bool * hasAccessOut) = 0;
+
+    virtual ErrCode INTERFACE_FUNC getPropertyValueNoLock(IString* name, IBaseObject** value) = 0;
+    virtual ErrCode INTERFACE_FUNC getPropertySelectionValueNoLock(IString* name, IBaseObject** value) = 0;
+    virtual ErrCode INTERFACE_FUNC setPropertyValueNoLock(IString* name, IBaseObject* value) = 0;
+    virtual ErrCode INTERFACE_FUNC clearPropertyValueNoLock(IString* name) = 0;
 };
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/validator.h
+++ b/core/coreobjects/include/coreobjects/validator.h
@@ -49,6 +49,7 @@ DECLARE_OPENDAQ_INTERFACE(IValidator, IBaseObject)
      * @retval OPENDAQ_SUCCESS if `value` is valid.
      */
     virtual ErrCode INTERFACE_FUNC validate(IBaseObject* propObj, IBaseObject* value) = 0;
+    virtual ErrCode INTERFACE_FUNC validateNoLock(IBaseObject* propObj, IBaseObject* value) = 0;
 
     /*!
      * @brief Gets the string expression used when creating the validator.

--- a/core/coreobjects/include/coreobjects/validator_impl.h
+++ b/core/coreobjects/include/coreobjects/validator_impl.h
@@ -26,6 +26,7 @@ public:
     explicit ValidatorImpl(const StringPtr& evalStr);
 
     ErrCode INTERFACE_FUNC validate(IBaseObject* propObj, IBaseObject* value) override;
+    ErrCode INTERFACE_FUNC validateNoLock(IBaseObject* propObj, IBaseObject* value) override;
     ErrCode INTERFACE_FUNC getEval(IString** eval) override;
 
     // ISerializable

--- a/core/coreobjects/src/coercer_impl.cpp
+++ b/core/coreobjects/src/coercer_impl.cpp
@@ -43,6 +43,32 @@ ErrCode CoercerImpl::coerce(IBaseObject* propObj, IBaseObject* value, IBaseObjec
     return OPENDAQ_SUCCESS;
 }
 
+ErrCode CoercerImpl::coerceNoLock(IBaseObject* propObj, IBaseObject* value, IBaseObject** result)
+{
+    try
+    {
+        this->value = value;
+
+        if (propObj != nullptr)
+        {
+            auto cloned = evalValue.cloneWithOwner(propObj);
+            *result = cloned.getResultNoLock().detach();
+        }
+        else
+        {
+            *result = evalValue.getResultNoLock().detach();
+        }
+
+        this->value = nullptr;
+    }
+    catch (...)
+    {
+        return OPENDAQ_ERR_COERCE_FAILED;
+    }
+
+    return OPENDAQ_SUCCESS;
+}
+
 ErrCode CoercerImpl::getEval(IString** eval)
 {
     if (eval == nullptr)

--- a/core/coreobjects/src/eval_nodes.cpp
+++ b/core/coreobjects/src/eval_nodes.cpp
@@ -18,7 +18,7 @@ int BaseNode::visit(const std::function<int(BaseNode* node)>& visitFunc)
     return visitFunc(this);
 }
 
-int BaseNode::resolveReference()
+int BaseNode::resolveReference(bool /*lock*/)
 {
     return 0;
 }
@@ -52,7 +52,7 @@ BaseObjectPtr RefNode::getResult()
     return refObject;
 }
 
-int RefNode::resolveReference()
+int RefNode::resolveReference(bool lock)
 {
     if (resolveStatus == ResolveStatus::Resolved && refType != RefType::Value && refType != RefType::Func && refType != RefType::SelectedValue)
     {
@@ -63,7 +63,7 @@ int RefNode::resolveReference()
 
     try
     {
-        refObject = onResolveReference(refStr, refType, argIndex, postRef);
+        refObject = onResolveReference(refStr, refType, argIndex, postRef, lock);
         if (refObject.assigned())
         {
             resolveStatus = ResolveStatus::Resolved;

--- a/core/coreobjects/src/validator_impl.cpp
+++ b/core/coreobjects/src/validator_impl.cpp
@@ -47,6 +47,35 @@ ErrCode ValidatorImpl::validate(IBaseObject* propObj, IBaseObject* value)
     return OPENDAQ_ERR_VALIDATE_FAILED;
 }
 
+ErrCode ValidatorImpl::validateNoLock(IBaseObject* propObj, IBaseObject* value)
+{
+        try
+    {
+        Bool validated = false;
+        this->value = value;
+
+        if (propObj != nullptr)
+        {
+            auto cloned = evalValue.cloneWithOwner(propObj);
+            validated = cloned.getResultNoLock();
+        }
+        else
+        {
+            validated = evalValue.getResultNoLock();
+        }
+
+        this->value = nullptr;
+        if (validated)
+            return OPENDAQ_SUCCESS;
+        
+    }
+    catch (...)
+    {
+    }
+
+    return OPENDAQ_ERR_VALIDATE_FAILED;
+}
+
 ErrCode ValidatorImpl::getEval(IString** eval)
 {
     if (eval == nullptr)

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -17,6 +17,7 @@
 #include <coreobjects/argument_info_factory.h>
 #include <coreobjects/property_object_internal_ptr.h>
 #include <coretypes/listobject_factory.h>
+#include <thread>
 
 using namespace daq;
 

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -125,7 +125,6 @@ protected:
     ListPtr<IComponent> searchItems(const SearchFilterPtr& searchFilter, const std::vector<ComponentPtr>& items);
     void setActiveRecursive(const std::vector<ComponentPtr>& items, Bool active);
 
-    std::mutex sync;
     ContextPtr context;
 
     bool isComponentRemoved;
@@ -267,7 +266,7 @@ ErrCode ComponentImpl<Intf, Intfs ...>::getActive(Bool* active)
 {
     OPENDAQ_PARAM_NOT_NULL(active);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     *active = this->active;
     return OPENDAQ_SUCCESS;
@@ -280,7 +279,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setActive(Bool active)
         return OPENDAQ_ERR_FROZEN;
 
     {
-        std::scoped_lock lock(sync);
+        auto lock = this->getRecursiveConfigLock();
 
         if (this->isComponentRemoved)
             return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -364,7 +363,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setName(IString* name)
         return OPENDAQ_ERR_FROZEN;
 
     {
-        std::scoped_lock lock(sync);
+        auto lock = this->getRecursiveConfigLock();
 
         if (this->isComponentRemoved)
             return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -415,7 +414,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setDescription(IString* description)
         return OPENDAQ_ERR_FROZEN;
 
     {
-        std::scoped_lock lock(sync);
+        auto lock = this->getRecursiveConfigLock();
 
         if (this->isComponentRemoved)
             return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -476,7 +475,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setVisible(Bool visible)
         return OPENDAQ_ERR_FROZEN;
 
     {
-        std::scoped_lock lock(sync);
+        auto lock = this->getRecursiveConfigLock();
 
         if (this->isComponentRemoved)
             return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -524,7 +523,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::lockAttributes(IList* attributes)
     if (!attributes)
         return OPENDAQ_SUCCESS;
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (this->isComponentRemoved)
         return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -544,7 +543,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::lockAttributes(IList* attributes)
 template <class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs...>::lockAllAttributes()
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (this->isComponentRemoved)
         return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -558,7 +557,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::unlockAttributes(IList* attributes)
     if (!attributes)
         return OPENDAQ_SUCCESS;
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (this->isComponentRemoved)
         return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -578,7 +577,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::unlockAttributes(IList* attributes)
 template <class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs...>::unlockAllAttributes()
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (this->isComponentRemoved)
         return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -592,7 +591,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::getLockedAttributes(IList** attributes)
 {
     OPENDAQ_PARAM_NOT_NULL(attributes);
     
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (this->isComponentRemoved)
         return OPENDAQ_ERR_COMPONENT_REMOVED;
@@ -669,7 +668,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::findComponent(IString* id, IComponent** o
 template<class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs ...>::remove()
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (isComponentRemoved)
         return  OPENDAQ_IGNORED;

--- a/core/opendaq/component/include/opendaq/component_status_container_impl.h
+++ b/core/opendaq/component/include/opendaq/component_status_container_impl.h
@@ -46,7 +46,7 @@ public:
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 
 private:
-    std::mutex sync;
+    std::recursive_mutex sync;
 
     DictPtr<IString, IEnumeration> statuses;
     ProcedurePtr triggerCoreEvent;

--- a/core/opendaq/component/include/opendaq/folder_impl.h
+++ b/core/opendaq/component/include/opendaq/folder_impl.h
@@ -136,7 +136,7 @@ ErrCode FolderImpl<Intf, Intfs...>::getItems(IList** items, ISearchFilter* searc
 {
     OPENDAQ_PARAM_NOT_NULL(items);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (searchFilter)
     {
@@ -172,7 +172,7 @@ ErrCode FolderImpl<Intf, Intfs...>::getItem(IString* localId, IComponent** item)
     OPENDAQ_PARAM_NOT_NULL(localId);
     OPENDAQ_PARAM_NOT_NULL(item);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto it = items.find(StringPtr::Borrow(localId).toStdString());
     if (it == items.end())
@@ -197,7 +197,7 @@ ErrCode FolderImpl<Intf, Intfs...>::hasItem(IString* localId, Bool* value)
 {
     OPENDAQ_PARAM_NOT_NULL(localId);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     const auto it = items.find(StringPtr::Borrow(localId).toStdString());
     if (it == items.end())
@@ -214,7 +214,7 @@ ErrCode FolderImpl<Intf, Intfs...>::addItem(IComponent* item)
     OPENDAQ_PARAM_NOT_NULL(item);
 
     {
-        std::scoped_lock lock(this->sync);
+        auto lock = this->getRecursiveConfigLock();
 
         const ErrCode err = daqTry(
             [this, &item]
@@ -251,7 +251,7 @@ ErrCode FolderImpl<Intf, Intfs...>::removeItem(IComponent* item)
     const auto str = ComponentPtr::Borrow(item).getLocalId().toStdString();
 
     {
-        std::scoped_lock lock(this->sync);
+        auto lock = this->getRecursiveConfigLock();
 
         const ErrCode err = daqTry(
             [this, &str]
@@ -286,7 +286,7 @@ ErrCode FolderImpl<Intf, Intfs...>::removeItemWithLocalId(IString* localId)
     const auto str = StringPtr::Borrow(localId).toStdString();
 
     {
-        std::scoped_lock lock(this->sync);
+        auto lock = this->getRecursiveConfigLock();
 
         const ErrCode err = daqTry(
             [this, &str]
@@ -316,7 +316,7 @@ ErrCode FolderImpl<Intf, Intfs...>::removeItemWithLocalId(IString* localId)
 template <class Intf, class... Intfs>
 ErrCode FolderImpl<Intf, Intfs...>::clear()
 {
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
     clearInternal();
 
     return OPENDAQ_SUCCESS;

--- a/core/opendaq/functionblock/include/opendaq/function_block_wrapper_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block_wrapper_impl.h
@@ -121,7 +121,7 @@ ErrCode FunctionBlockWrapperImpl::setOverridenObject(
         std::unordered_map<std::string, TSmartPtr>& objects,
         TInterface* object)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     return wrapHandler(
         [this, &propertyName, &objects, &object]()

--- a/core/opendaq/functionblock/src/function_block_wrapper_impl.cpp
+++ b/core/opendaq/functionblock/src/function_block_wrapper_impl.cpp
@@ -27,7 +27,7 @@ ErrCode FunctionBlockWrapperImpl::includeObject(IString* objectName,
 {
     const auto objectNameStr = StringPtr::Borrow(objectName).toStdString();
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (includeObjectsByDefault)
     {
@@ -58,7 +58,7 @@ ErrCode FunctionBlockWrapperImpl::excludeObject(IString* objectName,
 {
     const auto objectNameStr = StringPtr::Borrow(objectName).toStdString();
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (!includeObjectsByDefault)
     {
@@ -157,7 +157,7 @@ ErrCode FunctionBlockWrapperImpl::setPropertySelectionValues(IString* propertyNa
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     return wrapHandler(
         [this, &propertyName, &enumValues]()
@@ -226,7 +226,7 @@ ErrCode FunctionBlockWrapperImpl::getInputPorts(IList** ports, ISearchFilter* se
 
     const auto innerPorts = functionBlock.getInputPorts(searchFilter);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto portList = getObjects<IInputPort>(innerPorts,
                                                  includedInputPorts,
@@ -243,7 +243,7 @@ ErrCode FunctionBlockWrapperImpl::getSignals(IList** signals, ISearchFilter* sea
 
     const auto innerSignals = functionBlock.getSignals(searchFilter);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto signalList = getObjects<ISignal>(innerSignals,
                                            includedSignals,
@@ -260,7 +260,7 @@ ErrCode FunctionBlockWrapperImpl::getFunctionBlocks(IList** functionBlocks, ISea
 
     const auto innerFbs = functionBlock.getFunctionBlocks(searchFilter);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto fbList = getObjects<IFunctionBlock>(
         innerFbs,
@@ -295,7 +295,7 @@ ErrCode FunctionBlockWrapperImpl::setPropertyValue(IString* propertyName, IBaseO
 
     auto propertyNameStr = StringPtr::Borrow(propertyName);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     return wrapHandler(
         [this, &propertyNameStr, &value]()
@@ -340,7 +340,7 @@ ErrCode FunctionBlockWrapperImpl::getPropertyValue(IString* propertyName, IBaseO
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->getPropertyValue(propertyName, value);
@@ -352,7 +352,7 @@ ErrCode FunctionBlockWrapperImpl::getPropertySelectionValue(IString* propertyNam
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->getPropertySelectionValue(propertyName, value);
@@ -364,7 +364,7 @@ ErrCode FunctionBlockWrapperImpl::clearPropertyValue(IString* propertyName)
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->clearPropertyValue(propertyName);
@@ -376,7 +376,7 @@ ErrCode FunctionBlockWrapperImpl::hasProperty(IString* propertyName, Bool* hasPr
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->hasProperty(propertyName, hasProperty);
@@ -418,7 +418,7 @@ ErrCode FunctionBlockWrapperImpl::getProperty(IString* propertyName, IProperty**
 
     auto propertyNamePtr = StringPtr::Borrow(propertyName);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     return wrapHandler(
         [this, &propertyNamePtr, &property]()
@@ -448,7 +448,7 @@ ErrCode FunctionBlockWrapperImpl::getProperties(const ListPtr<IProperty>& innerP
 {
     assert(properties != nullptr);
 
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     const auto propertyList = getObjects<IProperty>(innerProperties,
                                                     includedProperties,

--- a/core/opendaq/opendaq/mocks/mock_fb_dynamic_input_ports.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb_dynamic_input_ports.cpp
@@ -26,13 +26,13 @@ daq::FunctionBlockTypePtr MockFunctionBlockDynamicInputPortImpl::CreateType()
 
 void MockFunctionBlockDynamicInputPortImpl::onConnected(const daq::InputPortPtr& /* port */)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
     updateInputPorts();
 }
 
 void MockFunctionBlockDynamicInputPortImpl::onDisconnected(const daq::InputPortPtr& port)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
     removeInputPort(port);
 }
 

--- a/core/opendaq/opendaq/mocks/mock_fb_dynamic_output_ports.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb_dynamic_output_ports.cpp
@@ -42,7 +42,7 @@ void MockFunctionBlockDynamicOutputPortImpl::onPacketReceived(const daq::InputPo
 
 void MockFunctionBlockDynamicOutputPortImpl::onDisconnected(const daq::InputPortPtr& /* port */)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
     this->signals.clear();
 }
 

--- a/core/opendaq/reader/include/opendaq/multi_reader_builder.h
+++ b/core/opendaq/reader/include/opendaq/multi_reader_builder.h
@@ -102,17 +102,17 @@ DECLARE_OPENDAQ_INTERFACE(IMultiReaderBuilder, IBaseObject)
     // [returnSelf]
     /*!
      * @brief Sets the read timeout mode
-     * @param mode The timeout mode. 
-     * if "Any" returns immediatly if there is available data otherwise time-out is exceeded.
-     * if "All" waiting until timeout and returns avaiable data if existing. otherwise time-out is exceeded.
+     * @param type The timeout mode. 
+     * if "Any" returns immediately if there is available data otherwise time-out is exceeded.
+     * if "All" waiting until timeout and returns available data if existing. otherwise time-out is exceeded.
      */
     virtual ErrCode INTERFACE_FUNC setReadTimeoutType(ReadTimeoutType type) = 0;
 
     /*!
      * @brief Gets the read timeout mode
-     * @param mode The timeout mode. 
-     * if "Any" returns immediatly if there is available data otherwise time-out is exceeded.
-     * if "All" waiting until timeout and returns avaiable data if existing. otherwise time-out is exceeded.
+     * @param type The timeout mode. 
+     * if "Any" returns immediately if there is available data otherwise time-out is exceeded.
+     * if "All" waiting until timeout and returns available data if existing. otherwise time-out is exceeded.
      */
     virtual ErrCode INTERFACE_FUNC getReadTimeoutType(ReadTimeoutType* type) = 0;
 

--- a/core/opendaq/signal/include/opendaq/connection.h
+++ b/core/opendaq/signal/include/opendaq/connection.h
@@ -128,14 +128,14 @@ DECLARE_OPENDAQ_INTERFACE(IConnection, IBaseObject)
     // [elementType(packets, IPacket)]
     /*!
      * @brief Places multiple packets at the back of the queue.
-     * @param packet The packets to be enqueued.
+     * @param packets The packets to be enqueued.
      */
     virtual ErrCode INTERFACE_FUNC enqueueMultiple(IList* packets) = 0;
 
     // [elementType(packets, IPacket), overloadFor(enqueueMultiple), stealRef(packets)]
     /*!
      * @brief Places multiple packets at the back of the queue. The references of the packets are stolen.
-     * @param packet The packets to be enqueued.
+     * @param packets The packets to be enqueued.
      *
      * After calling the method, the packets should not be touched again. The ownership of the packets
      * is taken by underlying connections and it could be destroyed before the function returns.

--- a/core/opendaq/signal/include/opendaq/input_port_impl.h
+++ b/core/opendaq/signal/include/opendaq/input_port_impl.h
@@ -193,7 +193,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::connect(ISignal* signal)
 
         InputPortNotificationsPtr inputPortListener;
         {
-            std::scoped_lock lock(this->sync);
+            auto lock = this->getRecursiveConfigLock();
             if (this->isComponentRemoved)
                 return this->makeErrorInfo(OPENDAQ_ERR_INVALIDSTATE, "Cannot connect signal to removed input port");
 
@@ -303,7 +303,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::disconnect()
         {
             ConnectionPtr connection;
             {
-                std::scoped_lock lock(this->sync);
+                auto lock = this->getRecursiveConfigLock();
                 connection = getConnectionNoLock();
                 connectionRef.release();
             }
@@ -319,7 +319,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getSignal(ISignal** signal)
     if (signal == nullptr)
         return OPENDAQ_ERR_ARGUMENT_NULL;
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     *signal = getSignalNoLock().detach();
 
@@ -342,7 +342,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getConnection(IConnection** connect
     if (connection == nullptr)
         return OPENDAQ_ERR_ARGUMENT_NULL;
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     return daqTry([this, &connection] { *connection = getConnectionNoLock().detach(); });
 }
@@ -350,7 +350,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getConnection(IConnection** connect
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setNotificationMethod(PacketReadyNotification method)
 {
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if ((method == PacketReadyNotification::Scheduler || method == PacketReadyNotification::SchedulerQueueWasEmpty) && !scheduler.assigned())
     {
@@ -445,7 +445,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::notifyPacketEnqueuedOnThisThread()
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setListener(IInputPortNotifications* port)
 {
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (auto connection = getConnectionNoLock(); connection.assigned())
     {
@@ -484,7 +484,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getCustomData(IBaseObject** data)
 {
     OPENDAQ_PARAM_NOT_NULL(data);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     *data = this->customData.addRefAndReturn();
 
@@ -494,7 +494,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getCustomData(IBaseObject** data)
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setCustomData(IBaseObject* data)
 {
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
     this->customData = data;
 
     return OPENDAQ_SUCCESS;
@@ -508,7 +508,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::disconnectWithoutSignalNotification
         {
             ConnectionPtr connection;
             {
-                std::scoped_lock lock(this->sync);
+                auto lock = this->getRecursiveConfigLock();
                 connection = getConnectionNoLock();
                 connectionRef.release();
             }
@@ -731,7 +731,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getRequiresSignal(Bool* requiresSig
 {
     OPENDAQ_PARAM_NOT_NULL(requiresSignal);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     *requiresSignal = this->requiresSignal;
     return OPENDAQ_SUCCESS;
@@ -740,7 +740,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getRequiresSignal(Bool* requiresSig
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setRequiresSignal(Bool requiresSignal)
 {
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     this->requiresSignal = requiresSignal;
     return OPENDAQ_SUCCESS;

--- a/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
@@ -73,7 +73,7 @@ ErrCode MirroredDeviceBase<Interfaces...>::getStreamingSources(IList** streaming
 
     auto streamingSourcesPtr = List<IStreaming>();
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
     for (const auto& streaming : this->streamingSources)
     {
         streamingSourcesPtr.pushBack(streaming);
@@ -91,7 +91,7 @@ ErrCode MirroredDeviceBase<Interfaces...>::addStreamingSource(IStreaming* stream
     const auto streamingPtr = StreamingPtr::Borrow(streamingSource);
     const auto connectionString = streamingPtr.getConnectionString();
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto it = std::find_if(streamingSources.begin(),
                            streamingSources.end(),
@@ -121,7 +121,7 @@ ErrCode MirroredDeviceBase<Interfaces...>::removeStreamingSource(IString* stream
 {
     OPENDAQ_PARAM_NOT_NULL(streamingConnectionString);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     const auto streamingConnectionStringPtr = StringPtr::Borrow(streamingConnectionString);
 
@@ -163,7 +163,7 @@ void MirroredDeviceBase<Interfaces...>::removed()
 template <typename... Interfaces>
 StreamingPtr MirroredDeviceBase<Interfaces...>::onAddStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config)
 {
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto it = std::find_if(streamingSources.begin(),
                            streamingSources.end(),

--- a/core/opendaq/streaming/include/opendaq/mirrored_signal_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_signal_impl.h
@@ -220,7 +220,7 @@ ErrCode MirroredSignalBase<Interfaces...>::addStreamingSource(IStreaming* stream
     const auto streamingPtr = StreamingPtr::Borrow(streaming);
     const auto connectionString = streamingPtr.getConnectionString();
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto it = std::find_if(streamingSourcesRefs.begin(),
                            streamingSourcesRefs.end(),
@@ -250,7 +250,7 @@ ErrCode MirroredSignalBase<Interfaces...>::removeStreamingSource(IString* stream
 {
     OPENDAQ_PARAM_NOT_NULL(streamingConnectionString);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     const auto streamingConnectionStringPtr = StringPtr::Borrow(streamingConnectionString);
 
@@ -347,7 +347,7 @@ ErrCode MirroredSignalBase<Interfaces...>::unsubscribeCompletedInternal(IString*
 
     if (syncLock)
     {
-        std::scoped_lock lock(this->sync);
+        auto lock = this->getRecursiveConfigLock();
         this->lastDataValue = nullptr;
     }
     else
@@ -469,7 +469,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getStreamingSources(IList** streaming
 
     auto stringsPtr = List<IString>();
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
     for (const auto& [connectionString, streamingRef] : streamingSourcesRefs)
     {
         auto streamingSource = streamingRef.getRef();
@@ -490,7 +490,7 @@ ErrCode MirroredSignalBase<Interfaces...>::setActiveStreamingSource(IString* str
     const auto connectionStringPtr = StringPtr::Borrow(streamingConnectionString);
     auto thisPtr = this->template borrowPtr<MirroredSignalConfigPtr>();
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     auto activeStreamingSource = activeStreamingSourceRef.assigned() ? activeStreamingSourceRef.getRef() : nullptr;
     if (activeStreamingSource.assigned() &&
@@ -552,7 +552,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getActiveStreamingSource(IString** st
 {
     OPENDAQ_PARAM_NOT_NULL(streamingConnectionString);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
     auto activeStreamingSource = activeStreamingSourceRef.assigned() ? activeStreamingSourceRef.getRef() : nullptr;
     if (activeStreamingSource.assigned())
         *streamingConnectionString = activeStreamingSource.getConnectionString().addRefAndReturn();
@@ -567,7 +567,7 @@ ErrCode MirroredSignalBase<Interfaces...>::deactivateStreaming()
 {
     auto thisPtr = this->template borrowPtr<MirroredSignalConfigPtr>();
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     ErrCode errCode = OPENDAQ_SUCCESS;
     if (listened && streamed)
@@ -694,7 +694,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getStreamed(Bool* streamed)
 {
     OPENDAQ_PARAM_NOT_NULL(streamed);
 
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
     *streamed = this->streamed;
     return OPENDAQ_SUCCESS;
 }
@@ -702,7 +702,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getStreamed(Bool* streamed)
 template <typename... Interfaces>
 ErrCode MirroredSignalBase<Interfaces...>::setStreamed(Bool streamed)
 {
-    std::scoped_lock lock(this->sync);
+    auto lock = this->getRecursiveConfigLock();
 
     if (static_cast<bool>(streamed) == this->streamed)
         return OPENDAQ_IGNORED;

--- a/core/opendaq/synchronization/include/opendaq/sync_component.h
+++ b/core/opendaq/synchronization/include/opendaq/sync_component.h
@@ -78,7 +78,7 @@ DECLARE_OPENDAQ_INTERFACE(ISyncComponent, IComponent)
     // [templateType(interfaces, IString, IPropertyObject)]
     /*!
      * @brief Retrieves the list of interfaces associated with this synchronization component.
-     * @param[out] interface List of interfaces associated with this component.
+     * @param[out] interfaces List of interfaces associated with this component.
      */
     virtual ErrCode INTERFACE_FUNC getInterfaces(IDict** interfaces) = 0;
 };

--- a/modules/audio_device_module/include/audio_device_module/wav_writer_fb_impl.h
+++ b/modules/audio_device_module/include/audio_device_module/wav_writer_fb_impl.h
@@ -50,7 +50,6 @@ private:
 
     void fileNameChanged();
     void storingChanged(bool store);
-    void storingChangedNoLock(bool store);
     void startStore();
     void stopStore();
     void stopStoreInternal();

--- a/modules/audio_device_module/src/audio_channel_impl.cpp
+++ b/modules/audio_device_module/src/audio_channel_impl.cpp
@@ -19,7 +19,7 @@ void AudioChannelImpl::configure(const ma_device& device, const SignalPtr& timeS
     auto dataDescriptor =
         DataDescriptorBuilder().setSampleType(SampleType::Float32).setValueRange(Range(-1.0, 1.0)).setName(channelName).build();
 
-    std::scoped_lock lock(sync);
+    auto lock = getRecursiveConfigLock();
 
     outputSignal.setDomainSignal(timeSignal);
     outputSignal.setDescriptor(dataDescriptor);

--- a/modules/audio_device_module/src/audio_device_impl.cpp
+++ b/modules/audio_device_module/src/audio_device_impl.cpp
@@ -156,8 +156,6 @@ void AudioDeviceImpl::createAudioChannel()
 
 void AudioDeviceImpl::propertyChanged()
 {
-    std::scoped_lock lock(sync);
-
     stop();
 
     readProperties();

--- a/modules/ref_device_module/src/ref_can_channel_impl.cpp
+++ b/modules/ref_device_module/src/ref_can_channel_impl.cpp
@@ -58,13 +58,12 @@ void RefCANChannelImpl::propChangedInternal()
 
 void RefCANChannelImpl::propChanged()
 {
-    std::scoped_lock lock(sync);
     propChangedInternal();
 }
 
 void RefCANChannelImpl::collectSamples(std::chrono::microseconds curTime)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
     const auto duration = static_cast<int64_t>(curTime.count() - lastCollectTime.count());
 
     if (duration > 0 && valueSignal.getActive())

--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -61,7 +61,7 @@ RefDeviceImpl::RefDeviceImpl(size_t id, const PropertyObjectPtr& config, const C
 RefDeviceImpl::~RefDeviceImpl()
 {
     {
-        std::scoped_lock<std::mutex> lock(sync);
+        auto lock = this->getAcquisitionLock();
         stopAcq = true;
     }
     cv.notify_one();
@@ -311,8 +311,6 @@ void RefDeviceImpl::updateNumberOfChannels()
     LOG_I("Properties: NumberOfChannels {}", num);
     auto globalSampleRate = objPtr.getPropertyValue("GlobalSampleRate");
 
-    std::scoped_lock lock(sync);
-
     if (num < channels.size())
     {
         std::for_each(std::next(channels.begin(), num), channels.end(), [this](const ChannelPtr& ch)
@@ -336,8 +334,6 @@ void RefDeviceImpl::enableCANChannel()
 {
     bool enableCANChannel = objPtr.getPropertyValue("EnableCANChannel");
 
-    std::scoped_lock lock(sync);
-
     if (!enableCANChannel)
     {
         if (canChannel.assigned() && hasChannel(canFolder, canChannel))
@@ -356,8 +352,6 @@ void RefDeviceImpl::enableCANChannel()
 void RefDeviceImpl::enableProtectedChannel()
 {
     bool enabled = objPtr.getPropertyValue("EnableProtectedChannel");
-
-    std::scoped_lock lock(sync);
 
     if (!enabled)
     {
@@ -389,8 +383,6 @@ void RefDeviceImpl::updateGlobalSampleRate()
     auto globalSampleRate = objPtr.getPropertyValue("GlobalSampleRate");
     LOG_I("Properties: GlobalSampleRate {}", globalSampleRate);
 
-    std::scoped_lock lock(sync);
-
     for (auto& ch : channels)
     {
         auto chPriv = ch.asPtr<IRefChannel>();
@@ -403,13 +395,11 @@ void RefDeviceImpl::updateAcqLoopTime()
     Int loopTime = objPtr.getPropertyValue("AcquisitionLoopTime");
     LOG_I("Properties: AcquisitionLoopTime {}", loopTime);
 
-    std::scoped_lock lock(sync);
     this->acqLoopTime = static_cast<size_t>(loopTime);
 }
 
 void RefDeviceImpl::enableLogging()
 {
-    std::scoped_lock lock(sync);
     loggingEnabled = objPtr.getPropertyValue("EnableLogging");
 }
 

--- a/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -78,7 +78,6 @@ void ClassifierFbImpl::initProperties()
 
 void ClassifierFbImpl::propertyChanged(bool configure)
 {
-    std::scoped_lock lock(sync);
     readProperties();
     if (configure)
         this->configure();
@@ -260,7 +259,7 @@ void ClassifierFbImpl::configure()
 
 void ClassifierFbImpl::processData()
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
     while (!linearReader.getEmpty())
     {
         size_t blocksToRead = 1;

--- a/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -47,7 +47,6 @@ void FFTFbImpl::initProperties()
 
 void FFTFbImpl::propertyChanged(bool configure)
 {
-    std::scoped_lock lock(sync);
     readProperties();
     if (configure)
         this->configure();
@@ -192,7 +191,7 @@ void FFTFbImpl::processEventPacket(const EventPacketPtr& packet)
 
 void FFTFbImpl::calculate()
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
 
     while (!linearReader.getEmpty())
     {

--- a/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -72,7 +72,6 @@ void PowerFbImpl::initProperties()
 
 void PowerFbImpl::propertyChanged(bool configure)
 {
-    std::scoped_lock lock(sync);
     readProperties();
     if (configure)
         this->configure(false);
@@ -118,7 +117,7 @@ void PowerFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& voltag
 
 void PowerFbImpl::processPackets()
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
 
     PacketPtr voltagePacket;
     PacketPtr currentPacket;
@@ -460,13 +459,13 @@ void PowerFbImpl::createSignals()
 
 void PowerFbImpl::onConnected(const InputPortPtr& inputPort)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
     LOG_T("Connected to port {}", inputPort.getLocalId())
 }
 
 void PowerFbImpl::onDisconnected(const InputPortPtr& inputPort)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
     LOG_T("Disconnected from port {}", inputPort.getLocalId())
 }
 

--- a/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -73,7 +73,7 @@ void PowerReaderFbImpl::initProperties()
 
 void PowerReaderFbImpl::propertyChanged(bool configure)
 {
-    std::scoped_lock lock(sync);
+    auto lock = getRecursiveConfigLock();
     readProperties();
     if (configure)
         this->configure(nullptr, nullptr, nullptr);
@@ -117,7 +117,7 @@ bool PowerReaderFbImpl::getDomainDescriptor(const EventPacketPtr& eventPacket, D
 
 void PowerReaderFbImpl::onDataReceived()
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
 
     SizeT cnt = reader.getAvailableCount();
     const auto voltageData = std::make_unique<double[]>(cnt);

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -133,13 +133,11 @@ void RendererFbImpl::initProperties()
 
 void RendererFbImpl::propertyChanged()
 {
-    std::scoped_lock lock(sync);
     readProperties();
 }
 
 void RendererFbImpl::resolutionChanged()
 {
-    std::scoped_lock lock(sync);
     readResolutionProperty();
     resChanged = true;
 }
@@ -644,7 +642,7 @@ void RendererFbImpl::renderSignal(SignalContext& signalContext, sf::RenderTarget
 
 void RendererFbImpl::onConnected(const InputPortPtr& inputPort)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     subscribeToSignalCoreEvent(inputPort.getSignal());
     updateInputPorts();
@@ -653,7 +651,7 @@ void RendererFbImpl::onConnected(const InputPortPtr& inputPort)
 
 void RendererFbImpl::onDisconnected(const InputPortPtr& inputPort)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     updateInputPorts();
     LOG_T("Disconnected from port {}", inputPort.getLocalId());

--- a/modules/ref_fb_module/src/scaling_fb_impl.cpp
+++ b/modules/ref_fb_module/src/scaling_fb_impl.cpp
@@ -80,7 +80,6 @@ void ScalingFbImpl::initProperties()
 
 void ScalingFbImpl::propertyChanged(bool configure)
 {
-    std::scoped_lock lock(sync);
     readProperties();
     if (configure)
         this->configure();
@@ -189,8 +188,8 @@ void ScalingFbImpl::onPacketReceived(const InputPortPtr& port)
 {
     auto outQueue = List<IPacket>();
     auto outDomainQueue = List<IPacket>();
-
-    std::scoped_lock lock(sync);
+    
+    auto lock = this->getAcquisitionLock();
 
     PacketPtr packet;
     const auto connection = inputPort.getConnection();

--- a/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -104,7 +104,6 @@ void StatisticsFbImpl::initProperties()
 
 void StatisticsFbImpl::propertyChanged()
 {
-    std::scoped_lock lock(sync);
     readProperties();
     configure();
 }
@@ -669,7 +668,7 @@ void StatisticsFbImpl::onPacketReceived(const InputPortPtr& port)
 
 void StatisticsFbImpl::processTriggerPackets(const InputPortPtr& port)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
 
     const auto conn = port.getConnection();
     if (!conn.assigned())
@@ -703,7 +702,7 @@ void StatisticsFbImpl::processTriggerPackets(const InputPortPtr& port)
 
 void StatisticsFbImpl::processInputPackets(const InputPortPtr& port)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
 
     const auto conn = port.getConnection();
     if (!conn.assigned())

--- a/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
+++ b/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
@@ -109,7 +109,7 @@ void StructDecoderFbImpl::configure()
 
 void StructDecoderFbImpl::onPacketReceived(const InputPortPtr& port)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
 
     const auto connection = inputPort.getConnection();
     if (!connection.assigned())
@@ -275,7 +275,7 @@ void StructDecoderFbImpl::setInputStatus(const StringPtr& value) const
 
 void StructDecoderFbImpl::onDisconnected(const InputPortPtr& inputPort)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getRecursiveConfigLock();
 
     signals.clear();
 

--- a/modules/ref_fb_module/src/trigger_fb_impl.cpp
+++ b/modules/ref_fb_module/src/trigger_fb_impl.cpp
@@ -35,7 +35,6 @@ void TriggerFbImpl::initProperties()
 
 void TriggerFbImpl::propertyChanged()
 {
-    std::scoped_lock lock(sync);
     readProperties();
 }
 
@@ -98,7 +97,7 @@ void TriggerFbImpl::configure()
 
 void TriggerFbImpl::onPacketReceived(const InputPortPtr& port)
 {
-    std::scoped_lock lock(sync);
+    auto lock = this->getAcquisitionLock();
 
     PacketPtr packet;
     const auto connection = inputPort.getConnection();

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
@@ -80,7 +80,7 @@ inline ErrCode ConfigClientInputPortImpl::connect(ISignal* signal)
             if (!isSignalFromTheSameComponentTree(signalPtr))
                 return OPENDAQ_ERR_SIGNAL_NOT_ACCEPTED;
             {
-                std::scoped_lock lock(this->sync);
+                auto lock = this->getRecursiveConfigLock();
 
                 const auto connectedSignal = getConnectedSignal();
                 if (connectedSignal == signalPtr)


### PR DESCRIPTION
# Type of change:

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

- Introduces synchronization primitives to the property object implementation, making external API calls thread-safe.
- Introduces a recursive lock guard object for configuration call locking that's built on top a standard mutex

# Breaking changes:

- The `sync` mutex previously available in component implementations can no longer be locked normally within an event (onWrite, onRead...), nor does it need to be, as it's locked internally in the Property object implementation.
- If locking is needed (the function might be called from another thread), the `getRecursiveConfigLock()` method should be used instead. 