### PR TITLE
Temporary revert beginUpdate/endUpdate optimizations

### DIFF
--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -59,6 +59,9 @@ public:
     ErrCode INTERFACE_FUNC getAllProperties(IList** properties) override;
     ErrCode INTERFACE_FUNC setPropertyOrder(IList* orderedPropertyNames) override;
 
+    ErrCode INTERFACE_FUNC beginUpdate() override;
+    ErrCode INTERFACE_FUNC endUpdate() override;
+
     ErrCode INTERFACE_FUNC updateInternal(ISerializedObject* obj, IBaseObject* context) override;
     ErrCode INTERFACE_FUNC update(ISerializedObject* obj, IBaseObject* config) override;
 
@@ -77,8 +80,10 @@ protected:
     virtual void onRemoteUpdate(const SerializedObjectPtr& serialized);
     void cloneAndSetChildPropertyObject(const PropertyPtr& prop) override;
 
+/*
     void beginApplyUpdate() override;
     void endApplyUpdate() override;
+    */
 
     bool remoteUpdating;
 
@@ -115,6 +120,9 @@ public:
     ErrCode INTERFACE_FUNC clearPropertyValue(IString* propertyName) override;
     ErrCode INTERFACE_FUNC addProperty(IProperty* property) override;
     ErrCode INTERFACE_FUNC removeProperty(IString* propertyName) override;
+
+    ErrCode INTERFACE_FUNC beginUpdate() override;
+    ErrCode INTERFACE_FUNC endUpdate() override;
 
     ErrCode INTERFACE_FUNC deserializeValues(ISerializedObject* serializedObject,
                                              IBaseObject* context,
@@ -169,8 +177,8 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::setPropertyValue(IString* prop
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    if (this->updateCount > 0)
-        return Impl::setPropertyValue(propertyName, value);
+//    if (this->updateCount > 0)
+//        return Impl::setPropertyValue(propertyName, value);
 
     const auto propertyNamePtr = StringPtr::Borrow(propertyName);
     const auto valuePtr = BaseObjectPtr::Borrow(value);
@@ -316,7 +324,6 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::setPropertyOrder(IList* ordere
     return OPENDAQ_ERR_INVALID_OPERATION;
 }
 
-/*
 template <class Impl>
 ErrCode INTERFACE_FUNC ConfigClientPropertyObjectBaseImpl<Impl>::beginUpdate()
 {
@@ -340,7 +347,7 @@ ErrCode INTERFACE_FUNC ConfigClientPropertyObjectBaseImpl<Impl>::endUpdate()
                 path = this->path.toStdString();
             clientComm->endUpdate(remoteGlobalId, path);
         });
-}*/
+}
 
 template <class Impl>
 ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::updateInternal(ISerializedObject* obj, IBaseObject* /* context */)
@@ -630,6 +637,7 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::cloneAndSetChildPropertyObject(co
     }
 }
 
+/*
 template <class Impl>
 void ConfigClientPropertyObjectBaseImpl<Impl>::beginApplyUpdate()
 {
@@ -668,7 +676,7 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::endApplyUpdate()
     this->updatingPropsAndValues.clear();
 
     clientComm->endUpdate(remoteGlobalId, getPath(), propsAndValuesEx);
-}
+}*/
 
 template <class Impl>
 void ConfigClientPropertyObjectBaseImpl<Impl>::applyUpdatingPropsAndValuesProtocolVer0()
@@ -882,6 +890,22 @@ inline ErrCode ConfigClientPropertyObjectImpl::removeProperty(IString* propertyN
     if (remoteUpdating)
         return GenericPropertyObjectImpl<IPropertyObject, IConfigClientObject, IDeserializeComponent>::removeProperty(propertyName);
     return ConfigClientPropertyObjectBaseImpl<GenericPropertyObjectImpl<IPropertyObject, IConfigClientObject, IDeserializeComponent>>::removeProperty(propertyName);
+}
+
+inline ErrCode ConfigClientPropertyObjectImpl::beginUpdate()
+{
+    if (remoteUpdating)
+        return GenericPropertyObjectImpl<IPropertyObject, IConfigClientObject, IDeserializeComponent>::beginUpdate();
+    return ConfigClientPropertyObjectBaseImpl<
+        GenericPropertyObjectImpl<IPropertyObject, IConfigClientObject, IDeserializeComponent>>::beginUpdate();
+}
+
+inline ErrCode ConfigClientPropertyObjectImpl::endUpdate()
+{
+    if (remoteUpdating)
+        return GenericPropertyObjectImpl<IPropertyObject, IConfigClientObject, IDeserializeComponent>::endUpdate();
+    return ConfigClientPropertyObjectBaseImpl<
+        GenericPropertyObjectImpl<IPropertyObject, IConfigClientObject, IDeserializeComponent>>::endUpdate();
 }
 
 inline ErrCode ConfigClientPropertyObjectImpl::deserializeValues(ISerializedObject* serializedObject,

--- a/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
@@ -263,7 +263,7 @@ TEST_F(ConfigProtocolAccessControlTest, BeginEndUpdate)
 
     setupServerAndClient(device, UserRegular);
 
-    clientDevice.beginUpdate();
+    ASSERT_THROW(clientDevice.beginUpdate(), AccessDeniedException);
     ASSERT_THROW(clientDevice.endUpdate(), AccessDeniedException);
 
     setupServerAndClient(device, UserAdmin);

--- a/shared/libraries/config_protocol/tests/test_config_protocol_device_locking.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_device_locking.cpp
@@ -230,7 +230,7 @@ TEST_F(ConfigProtocolDeviceLockingTest, BeginEndUpdate)
 
     clientDevice.lock();
 
-    clientDevice.beginUpdate();
+    ASSERT_THROW(clientDevice.beginUpdate(), DeviceLockedException);
     ASSERT_THROW(clientDevice.endUpdate(), DeviceLockedException);
 
     clientDevice.unlock();


### PR DESCRIPTION
beginUpdate & endUpdate optimizations don't work in some edge cases. I need to take a second look. Until then the changes will be reverted