### PR TITLE
TBBAS-1780, TBBAS-1794 MultiReader timeout fixes

### DIFF
--- a/core/opendaq/reader/include/opendaq/multi_reader_impl.h
+++ b/core/opendaq/reader/include/opendaq/multi_reader_impl.h
@@ -89,7 +89,10 @@ private:
     using Clock = std::chrono::steady_clock;
     using Duration = Clock::duration;
 
-    ListPtr<IInputPortConfig> checkPreconditions(const ListPtr<IComponent>& list, bool overrideMethod, bool& fromInputPorts);
+    ListPtr<IInputPortConfig> checkPreconditions(const ListPtr<IComponent>& list,
+                                                 bool overrideMethod,
+                                                 bool& fromInputPorts,
+                                                 InputPortNotificationsPtr listener = nullptr);
     void updateCommonSampleRateAndDividers();
     ListPtr<ISignal> getSignals() const;
 

--- a/core/opendaq/reader/include/opendaq/multi_reader_impl.h
+++ b/core/opendaq/reader/include/opendaq/multi_reader_impl.h
@@ -89,10 +89,7 @@ private:
     using Clock = std::chrono::steady_clock;
     using Duration = Clock::duration;
 
-    ListPtr<IInputPortConfig> checkPreconditions(const ListPtr<IComponent>& list,
-                                                 bool overrideMethod,
-                                                 bool& fromInputPorts,
-                                                 InputPortNotificationsPtr listener = nullptr);
+    ListPtr<IInputPortConfig> checkPreconditions(const ListPtr<IComponent>& list, bool overrideMethod, bool& fromInputPorts);
     void updateCommonSampleRateAndDividers();
     ListPtr<ISignal> getSignals() const;
 

--- a/core/opendaq/reader/include/opendaq/read_info.h
+++ b/core/opendaq/reader/include/opendaq/read_info.h
@@ -78,12 +78,10 @@ struct NotifyInfo
     NotifyInfo() = default;
 
     NotifyInfo(const NotifyInfo& other)
-        : packetReady(other.packetReady)
     {
     }
 
     NotifyInfo(NotifyInfo&& other) noexcept
-        : packetReady(other.packetReady)
     {
     }
 
@@ -92,7 +90,6 @@ struct NotifyInfo
         if (this == &other)
             return *this;
 
-        packetReady = other.packetReady;
         return *this;
     }
 
@@ -101,14 +98,11 @@ struct NotifyInfo
         if (this == &other)
             return *this;
 
-        packetReady = other.packetReady;
         return *this;
     }
 
     std::mutex mutex;
     std::condition_variable condition;
-
-    bool packetReady{};
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -891,9 +891,6 @@ MultiReaderStatusPtr MultiReaderImpl::readPackets()
         {
             if (zeroDataRead && (availableSamples < minReadCount) && hasEventOrGapInQueue())
             {
-                // set condition_flag = true;
-//                dataAvailable = true;
-
                 // skip remaining samples
                 readSamples(availableSamples);
             }

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -792,6 +792,7 @@ MultiReaderStatusPtr MultiReaderImpl::readPackets()
     std::unique_lock notifyLock(notify.mutex);
     SizeT availableSamples{};
     SyncStatus syncStatus{};
+    bool dataAvailable{};
     const bool zeroDataRead = remainingSamplesToRead == 0;
 
     if (timeout.count() > 0)
@@ -854,8 +855,7 @@ MultiReaderStatusPtr MultiReaderImpl::readPackets()
 
         notify.condition.wait_for(notifyLock, timeout, condition);
 
-        auto statusAssigned = status.assigned();
-        auto statusHasEvents = statusAssigned && (status.getReadStatus() == ReadStatus::Event);
+        auto statusHasEvents = status.assigned() && (status.getReadStatus() == ReadStatus::Event);
         auto statusEventCount = statusHasEvents ? status.getEventPackets().getCount() : 0;
 
         if ((portConnected && status.assigned()) || statusEventCount)
@@ -891,6 +891,9 @@ MultiReaderStatusPtr MultiReaderImpl::readPackets()
         {
             if (zeroDataRead && (availableSamples < minReadCount) && hasEventOrGapInQueue())
             {
+                // set condition_flag = true;
+//                dataAvailable = true;
+
                 // skip remaining samples
                 readSamples(availableSamples);
             }
@@ -898,6 +901,8 @@ MultiReaderStatusPtr MultiReaderImpl::readPackets()
             return createReaderStatus();
         }
     }
+
+    //////
 
     NumberPtr offset = 0;
     if (syncStatus == SyncStatus::Synchronized && availableSamples > 0u)

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -813,13 +813,11 @@ MultiReaderStatusPtr MultiReaderImpl::readPackets()
                 hasDataPacket &= (signal.getAvailable(true) != 0);
             }
 
-            notify.packetReady = (hasEventPacket || hasDataPacket) && !portDisconnected;
-            //-----------------
-
-            if (notify.packetReady == false)
+            auto packetReady = (hasEventPacket || hasDataPacket) && !portDisconnected;
+            if (!packetReady)
                 return false;
 
-            notify.packetReady = false;
+            //-----------------
 
             if (auto eventPackets = readUntilFirstDataPacket(); eventPackets.getCount() != 0)
             {
@@ -1059,7 +1057,6 @@ ErrCode MultiReaderImpl::packetReceived(IInputPort* inputPort)
     std::unique_lock lock(notify.mutex);
     if (portDisconnected)
     {
-        notify.packetReady = false;
         return OPENDAQ_SUCCESS;
     }
 
@@ -1075,7 +1072,6 @@ ErrCode MultiReaderImpl::packetReceived(IInputPort* inputPort)
 
     if (hasEventPacket || hasDataPacket)
     {
-        notify.packetReady = true;
         ProcedurePtr callback = readCallback;
         lock.unlock();
         notify.condition.notify_one();

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -792,7 +792,6 @@ MultiReaderStatusPtr MultiReaderImpl::readPackets()
     std::unique_lock notifyLock(notify.mutex);
     SizeT availableSamples{};
     SyncStatus syncStatus{};
-    bool dataAvailable{};
     const bool zeroDataRead = remainingSamplesToRead == 0;
 
     if (timeout.count() > 0)

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -25,13 +25,9 @@ class TestEvent
 {
 public:
     TestEvent()
-    {
-        std::cout << "TestEvent::TestEvent" << std::endl;
-    }
+    {}
     ~TestEvent()
-    {
-        std::cout << "TestEvent::~TestEvent" << std::endl;
-    }
+    {}
     template <typename Rep, typename Period>
     auto wait_for(std::chrono::duration<Rep, Period> duration)
     {
@@ -4430,7 +4426,7 @@ TEST_F(MultiReaderTest, MultiReaderActiveDataAvailableCallback)
 
     while (state != 6)
     {
-        bool result = testEvent.wait_for(2s);
+        bool result = testEvent.wait_for(5s);
         ASSERT_TRUE(result);
         testEvent.reset();
 


### PR DESCRIPTION
# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
TBBAS-1780 - Multireader timeouts not working properly when the reader is created with builder from signals
Reason: listener has been set up for port after port was connected

TBBAS-1794 - Multi reader with timeout waits for data even if there's enough data available
Reason: if synchronization happened in conditional variable predicate, zero read is not happened after waiting on conditional variable