### PR TITLE
<TBBAS-1842> Remove redundant properties from native streaming config

### DIFF
--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -243,6 +243,13 @@ void NativeStreamingClientModule::populateDeviceConfigFromContext(PropertyObject
     if (options.getCount() == 0)
         return;
 
+    if (options.hasKey("ProtocolVersion"))
+    {
+        auto value = options.get("ProtocolVersion");
+        if (value.getCoreType() == CoreType::ctInt)
+            deviceConfig.setPropertyValue("ProtocolVersion", value);
+    }
+
     if (options.hasKey("ConfigProtocolRequestTimeout"))
     {
         auto value = options.get("ConfigProtocolRequestTimeout");
@@ -463,13 +470,14 @@ PropertyObjectPtr NativeStreamingClientModule::createConnectionDefaultConfig(Nat
     defaultConfig.addProperty(StringProperty("Username", ""));
     defaultConfig.addProperty(StringProperty("Password", ""));
 
-    defaultConfig.addProperty(IntProperty("ConfigProtocolRequestTimeout", 10000));
-    defaultConfig.addProperty(BoolProperty("RestoreClientConfigOnReconnect", False));
-
     if (nativeConfigType == NativeType::config)
+    {
         defaultConfig.addProperty(IntProperty("ProtocolVersion", std::numeric_limits<uint16_t>::max()));
+        defaultConfig.addProperty(IntProperty("ConfigProtocolRequestTimeout", 10000));
+        defaultConfig.addProperty(BoolProperty("RestoreClientConfigOnReconnect", False));
 
-    populateDeviceConfigFromContext(defaultConfig);
+        populateDeviceConfigFromContext(defaultConfig);
+    }
 
     return defaultConfig;
 }

--- a/modules/tests/test_opendaq_device_modules/test_default_config.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_default_config.cpp
@@ -31,6 +31,10 @@ TEST_F(ModulesDefaultConfigTest, NativeConfigDevice)
     const PropertyObjectPtr deviceConfig = config.getPropertyValue("Device");
     const PropertyObjectPtr nativeDeviceConfig = deviceConfig.getPropertyValue("OpenDAQNativeConfiguration");
     ASSERT_TRUE(nativeDeviceConfig.hasProperty("Port"));
+    ASSERT_TRUE(nativeDeviceConfig.hasProperty("TransportLayerConfig"));
+    ASSERT_TRUE(nativeDeviceConfig.hasProperty("ProtocolVersion"));
+    ASSERT_TRUE(nativeDeviceConfig.hasProperty("ConfigProtocolRequestTimeout"));
+    ASSERT_TRUE(nativeDeviceConfig.hasProperty("RestoreClientConfigOnReconnect"));
 }
 
 TEST_F(ModulesDefaultConfigTest, NativeConfigDeviceConnect)
@@ -49,6 +53,19 @@ TEST_F(ModulesDefaultConfigTest, NativeConfigDeviceConnect)
     ASSERT_TRUE(instance.addDevice("daq.nd://127.0.0.1", config).assigned());
 }
 
+TEST_F(ModulesDefaultConfigTest, NativeStreaming)
+{
+    const auto instance = Instance();
+    const auto config = instance.createDefaultAddDeviceConfig();
+    const PropertyObjectPtr deviceConfig = config.getPropertyValue("Streaming");
+    const PropertyObjectPtr nativeDeviceConfig = deviceConfig.getPropertyValue("OpenDAQNativeStreaming");
+    ASSERT_TRUE(nativeDeviceConfig.hasProperty("Port"));
+    ASSERT_TRUE(nativeDeviceConfig.hasProperty("TransportLayerConfig"));
+    ASSERT_FALSE(nativeDeviceConfig.hasProperty("ProtocolVersion"));
+    ASSERT_FALSE(nativeDeviceConfig.hasProperty("ConfigProtocolRequestTimeout"));
+    ASSERT_FALSE(nativeDeviceConfig.hasProperty("RestoreClientConfigOnReconnect"));
+}
+
 TEST_F(ModulesDefaultConfigTest, NativeStreamingDevice)
 {
     const auto instance = Instance();
@@ -56,6 +73,10 @@ TEST_F(ModulesDefaultConfigTest, NativeStreamingDevice)
     const PropertyObjectPtr deviceConfig = config.getPropertyValue("Device");
     const PropertyObjectPtr nativeDeviceConfig = deviceConfig.getPropertyValue("OpenDAQNativeStreaming");
     ASSERT_TRUE(nativeDeviceConfig.hasProperty("Port"));
+    ASSERT_TRUE(nativeDeviceConfig.hasProperty("TransportLayerConfig"));
+    ASSERT_FALSE(nativeDeviceConfig.hasProperty("ProtocolVersion"));
+    ASSERT_FALSE(nativeDeviceConfig.hasProperty("ConfigProtocolRequestTimeout"));
+    ASSERT_FALSE(nativeDeviceConfig.hasProperty("RestoreClientConfigOnReconnect"));
 }
 
 TEST_F(ModulesDefaultConfigTest, NativeStreamingDeviceConnect)


### PR DESCRIPTION
* Additionally allow the `"ProtocolVersion"` property to be populated from the module options JSON file.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

