### PR TITLE
openDAQ versioning fixes

### DIFF
--- a/docs/Antora-specs/antora.yml
+++ b/docs/Antora-specs/antora.yml
@@ -1,6 +1,6 @@
 name: opendaq
 title: openDAQ protocols specification
-version: opendaq_version
+version: latest_dev_opendaq_version
 start_page: ROOT:overview.adoc
 asciidoc:
   attributes:

--- a/docs/Antora-specs/antora.yml
+++ b/docs/Antora-specs/antora.yml
@@ -1,11 +1,12 @@
 name: opendaq
 title: openDAQ protocols specification
-version: latest_dev_opendaq_version
+version: {opendaq-version}
 start_page: ROOT:overview.adoc
 asciidoc:
   attributes:
     page-toclevels: 3@
     experimental: true
+    version: {opendaq-version}
 nav:
   - modules/packet_streaming/nav-packet-streaming.adoc
   - modules/native_communication_protocol/nav-native-communication-protocol.adoc

--- a/docs/Antora/antora.yml
+++ b/docs/Antora/antora.yml
@@ -1,6 +1,6 @@
 name: opendaq
 title: openDAQ Documentation
-version: opendaq_version
+version: latest_dev_opendaq_version
 start_page: ROOT:introduction.adoc
 asciidoc:
   attributes:

--- a/docs/Antora/antora.yml
+++ b/docs/Antora/antora.yml
@@ -1,11 +1,12 @@
 name: opendaq
 title: openDAQ Documentation
-version: latest_dev_opendaq_version
+version: {opendaq-version}
 start_page: ROOT:introduction.adoc
 asciidoc:
   attributes:
     page-toclevels: 3@
     experimental: true
+    version: {opendaq-version}
 nav:
 - modules/getting_started/nav-getting_started.adoc
 - modules/howto_guides/nav-howto-guides.adoc

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
@@ -7,7 +7,7 @@ To start working with openDAQ(TM), the requisite binaries are required. They can
 Windows::
 +
 --
-To install openDAQ(TM), download the `opendaq-latest_dev_opendaq_version-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
+To install openDAQ(TM), download the `opendaq-:version:-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
 
 We recommend using the default installation path to avoid issues requiring additional environment variable modifications and troubleshooting.
 --
@@ -15,11 +15,11 @@ We recommend using the default installation path to avoid issues requiring addit
 Linux::
 +
 --
-To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-latest_dev_opendaq_version-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
+To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-:version:-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
 
 [source,shell]
 ----
-sudo apt install ./opendaq-latest_dev_opendaq_version-ubuntu20.04-x86_64.deb
+sudo apt install ./opendaq-:version:-ubuntu20.04-x86_64.deb
 ----
 --
 ====

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
@@ -7,7 +7,7 @@ To start working with openDAQ(TM), the requisite binaries are required. They can
 Windows::
 +
 --
-To install openDAQ(TM), download the `opendaq-:version:-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
+To install openDAQ(TM), download the `opendaq-{version}-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
 
 We recommend using the default installation path to avoid issues requiring additional environment variable modifications and troubleshooting.
 --
@@ -15,11 +15,11 @@ We recommend using the default installation path to avoid issues requiring addit
 Linux::
 +
 --
-To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-:version:-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
+To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-{version}-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
 
 [source,shell]
 ----
-sudo apt install ./opendaq-:version:-ubuntu20.04-x86_64.deb
+sudo apt install ./opendaq-{version}-ubuntu20.04-x86_64.deb
 ----
 --
 ====

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
@@ -7,7 +7,7 @@ To start working with openDAQ(TM), the requisite binaries are required. They can
 Windows::
 +
 --
-To install openDAQ(TM), download the `opendaq-opendaq_version-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
+To install openDAQ(TM), download the `opendaq-latest_dev_opendaq_version-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
 
 We recommend using the default installation path to avoid issues requiring additional environment variable modifications and troubleshooting.
 --
@@ -15,11 +15,11 @@ We recommend using the default installation path to avoid issues requiring addit
 Linux::
 +
 --
-To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-opendaq_version-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
+To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-latest_dev_opendaq_version-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
 
 [source,shell]
 ----
-sudo apt install ./opendaq-opendaq_version-ubuntu20.04-x86_64.deb
+sudo apt install ./opendaq-latest_dev_opendaq_version-ubuntu20.04-x86_64.deb
 ----
 --
 ====

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
@@ -15,7 +15,7 @@ pip install opendaq
 
 The latest versions of the Python bindings are available at https://docs-dev.opendaq.com. There you can download the Python Wheels for your OS/Python version. 
 
-The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-:version:_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
+The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-{version}_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
 
 To install the wheel, use:
 [source,bash]

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
@@ -15,7 +15,7 @@ pip install opendaq
 
 The latest versions of the Python bindings are available at https://docs-dev.opendaq.com. There you can download the Python Wheels for your OS/Python version. 
 
-The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-latest_dev_opendaq_version_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
+The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-:version:_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
 
 To install the wheel, use:
 [source,bash]

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
@@ -15,7 +15,7 @@ pip install opendaq
 
 The latest versions of the Python bindings are available at https://docs-dev.opendaq.com. There you can download the Python Wheels for your OS/Python version. 
 
-The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-opendaq_version_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
+The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-latest_dev_opendaq_version_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
 
 To install the wheel, use:
 [source,bash]

--- a/docs/Antora/modules/howto_guides/pages/howto_read_aligned_signals.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_read_aligned_signals.adoc
@@ -36,7 +36,7 @@ Some of the above limitations might be lifted in the future.
 
 Using the Multi-Reader is largely the same as any other Reader and is basically a xref:knowledge_base:readers.adoc#stream_reader[Stream Reader] for multiple Signals at once except that with multiple Signals it performs some additional checks to keep the Signals compatible and synchronized to the same Domain point.
 
-[#create]
+[#create-signals]
 .Creating a default Multi-Reader with list of Signals
 [tabs]
 ====
@@ -52,7 +52,7 @@ auto reader = MultiReader(signals, SampleType::Float64, SampleType::Int64);
 ====
 
 Developer can set list of Input Ports instead of Signals.
-[#create]
+[#create-ports]
 .Creating a default Multi-Reader with list of ports 
 [tabs]
 ====

--- a/docs/version_injector.py
+++ b/docs/version_injector.py
@@ -10,7 +10,7 @@ def write_file(filename, content):
         file.write(content)
 
 def read_and_replace(filename):
-    new = read_file(filename).replace("latest_dev_opendaq_version", version)
+    new = read_file(filename).replace("{opendaq-version}", version)
     write_file(filename, new)
 
 # this code is used to inject opqnDAQ version into Antora docs during CI
@@ -19,6 +19,3 @@ version = read_file("opendaq_version").strip()
 
 read_and_replace("docs/Antora/antora.yml")
 read_and_replace("docs/Antora-specs/antora.yml")
-read_and_replace("docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc")
-read_and_replace("docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc")
-

--- a/docs/version_injector.py
+++ b/docs/version_injector.py
@@ -10,7 +10,7 @@ def write_file(filename, content):
         file.write(content)
 
 def read_and_replace(filename):
-    new = read_file(filename).replace("opendaq_version", version)
+    new = read_file(filename).replace("latest_dev_opendaq_version", version)
     write_file(filename, new)
 
 # this code is used to inject opqnDAQ version into Antora docs during CI


### PR DESCRIPTION
* Rename placeholder because it is shown in https://opendaq.github.io/
* Showing the version as `latest_dev_opendaq_version` is more correct than showing future version