### PR TITLE
OPC UA - Add missing namepaceUri field in EUInformationWithQuantity Struct

### DIFF
--- a/shared/libraries/opcuatms/opcuatms/src/converters/unit_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/converters/unit_converter.cpp
@@ -32,6 +32,7 @@ OpcUaObject<UA_EUInformationWithQuantity> StructConverter<IUnit, UA_EUInformatio
 {
     OpcUaObject<UA_EUInformationWithQuantity> tmsUnit;
 
+    tmsUnit->namespaceUri = UA_STRING_ALLOC("http://www.opcfoundation.org/UA/units/un/cefact");
     tmsUnit->unitId = object.getId();
     tmsUnit->description = UA_LOCALIZEDTEXT_ALLOC("en-US", object.getName().getCharPtr());
     tmsUnit->displayName = UA_LOCALIZEDTEXT_ALLOC("en-US", object.getSymbol().getCharPtr());

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_fusion_device.cpp
@@ -75,6 +75,7 @@ protected:
                                 {"MaximumElectrical", 5.0},
                                 {"UsedWires", 6}}),
                            objManager)))
+                .addProperty(StructProperty("EUInformationWithQuantity", Unit("m/s", 1, "meter per second", "50")))
                 .build();
         objManager.addType(fusionAmpClass);
     }
@@ -164,6 +165,18 @@ TEST_F(TmsFusionDevice, FullBridge)
 
     ASSERT_EQ(serverFullBridge, clientFullBridge);
     ASSERT_EQ(serverFullBridge, newFullBridge);
+}
+
+TEST_F(TmsFusionDevice, EUInformationWithQuantity)
+{
+    const auto obj = PropertyObject(objManager, "FusionAmp");
+    auto [serverObj, fusionAmp] = registerPropertyObject(obj);
+
+    // Test unit property
+    const auto EUInformationStruct = Unit("s", 1, "seconds", "50");
+    fusionAmp.setPropertyValue("EUInformationWithQuantity", EUInformationStruct);
+
+    ASSERT_EQ(fusionAmp.getPropertyValue("EUInformationWithQuantity"), EUInformationStruct);
 }
 
 TEST_F(TmsFusionDevice, EnumTest)


### PR DESCRIPTION
OPC UA - Add missing namepaceUri field in EUInformationWithQuantity Struct and extend unit tests

# Type of change:

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:
Missing namespaceUri was hardcoded in struct converter. Value is now "http://[www.opcfoundation.org/UA/units/un/cefact](http://www.opcfoundation.org/UA/units/un/cefact)" taken from [here ](https://reference.opcfoundation.org/Core/Part8/v104/docs/5.6.3): 