### PR TITLE
<TBBAS-1845> mitigate out-of-memory risk on server-side for native streaming

### DIFF
--- a/docs/tests/test_modules.cpp
+++ b/docs/tests/test_modules.cpp
@@ -199,6 +199,7 @@ TEST_F(ModulesTest, CreateServer)
     ASSERT_NO_THROW(nativeStreamingConfigFields[0].getName());
     nativeStreamingConfig.setPropertyValue("NativeStreamingPort", 7420);
     nativeStreamingConfig.setPropertyValue("MaxAllowedConfigConnections", 0);
+    nativeStreamingConfig.setPropertyValue("StreamingPacketSendTimeout", 0);
     ASSERT_NO_THROW(nativeStreamingServerModule.createServer(nativeStreamingServerType.getId(),
                                                              device,
                                                              nativeStreamingConfig));

--- a/external/native_streaming/CMakeLists.txt
+++ b/external/native_streaming/CMakeLists.txt
@@ -1,7 +1,7 @@
 opendaq_dependency(
     NAME                native_streaming
-    REQUIRED_VERSION    1.0.11
+    REQUIRED_VERSION    1.0.14
     GIT_REPOSITORY      https://github.com/openDAQ/libNativeStreaming.git
-    GIT_REF             v1.0.11
+    GIT_REF             v1.0.14
     EXPECT_TARGET       daq::native_streaming
 )

--- a/modules/native_streaming_server_module/tests/test_native_streaming_server_module.cpp
+++ b/modules/native_streaming_server_module/tests/test_native_streaming_server_module.cpp
@@ -120,6 +120,9 @@ TEST_F(NativeStreamingServerModuleTest, ServerConfig)
 
     ASSERT_TRUE(config.hasProperty("MaxAllowedConfigConnections"));
     ASSERT_EQ(config.getPropertyValue("MaxAllowedConfigConnections"), 0);
+
+    ASSERT_TRUE(config.hasProperty("StreamingPacketSendTimeout"));
+    ASSERT_EQ(config.getPropertyValue("StreamingPacketSendTimeout"), 0);
 }
 
 TEST_F(NativeStreamingServerModuleTest, CreateServer)

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -534,6 +534,7 @@ TEST_F(NativeDeviceModulesTest, checkDeviceInfoPopulatedWithProvider)
                 {
                     "NativeStreamingPort": 1234,
                     "MaxAllowedConfigConnections": 123,
+                    "StreamingPacketSendTimeout": 2000,
                     "Path": "/test/native_configurator/checkDeviceInfoPopulated/"
                 }
             }
@@ -555,6 +556,7 @@ TEST_F(NativeDeviceModulesTest, checkDeviceInfoPopulatedWithProvider)
     ASSERT_EQ(serverConfig.getPropertyValue("NativeStreamingPort").asPtr<IInteger>(), 1234);
     ASSERT_EQ(serverConfig.getPropertyValue("Path").asPtr<IString>(), path);
     ASSERT_EQ(serverConfig.getPropertyValue("MaxAllowedConfigConnections").asPtr<IInteger>(), 123);
+    ASSERT_EQ(serverConfig.getPropertyValue("StreamingPacketSendTimeout").asPtr<IInteger>(), 2000);
 
     instance.addServer("OpenDAQNativeStreaming", serverConfig).enableDiscovery();
 

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/base_session_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/base_session_handler.h
@@ -27,6 +27,8 @@
 
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL
 
+static const SizeT UNLIMITED_PACKET_SEND_TIME = 0;
+
 class BaseSessionHandler: public std::enable_shared_from_this<BaseSessionHandler>
 {
 public:
@@ -34,7 +36,8 @@ public:
                        SessionPtr session,
                        const std::shared_ptr<boost::asio::io_context>& ioContextPtr,
                        native_streaming::OnSessionErrorCallback errorHandler,
-                       ConstCharPtr loggerComponentName);
+                       ConstCharPtr loggerComponentName,
+                       SizeT streamingPacketSendTimeout = UNLIMITED_PACKET_SEND_TIME);
     virtual ~BaseSessionHandler();
 
     void startReading();
@@ -80,5 +83,6 @@ protected:
     std::shared_ptr<boost::asio::steady_timer> connectionInactivityTimer;
     LoggerComponentPtr loggerComponent;
     bool connectionActivityMonitoringStarted{false};
+    std::chrono::milliseconds streamingPacketSendTimeout;
 };
 END_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
@@ -45,7 +45,8 @@ public:
                                           OnSignalSubscribedCallback signalSubscribedHandler,
                                           OnSignalUnsubscribedCallback signalUnsubscribedHandler,
                                           SetUpConfigProtocolServerCb setUpConfigProtocolServerCb,
-                                          SizeT maxAllowedConfigConnections = UNLIMITED_CONFIGURATION_CONNECTIONS);
+                                          SizeT maxAllowedConfigConnections = UNLIMITED_CONFIGURATION_CONNECTIONS,
+                                          SizeT streamingPacketSendTimeout = UNLIMITED_PACKET_SEND_TIME);
     ~NativeStreamingServerHandler() = default;
 
     void startServer(uint16_t port);
@@ -94,6 +95,8 @@ protected:
 
     SizeT maxAllowedConfigConnections;
     SizeT configConnectionsCount;
+
+    SizeT streamingPacketSendTimeout;
 };
 
 END_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/server_session_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/server_session_handler.h
@@ -32,7 +32,8 @@ public:
                          const std::string& clientId,
                          OnFindSignalCallback findSignalHandler,
                          OnSignalSubscriptionCallback signalSubscriptionHandler,
-                         native_streaming::OnSessionErrorCallback errorHandler);
+                         native_streaming::OnSessionErrorCallback errorHandler,
+                         SizeT streamingPacketSendTimeout);
 
     void sendSignalAvailable(const SignalNumericIdType& signalNumericId, const SignalPtr& signal);
     void sendSignalUnavailable(const SignalNumericIdType& signalNumericId, const SignalPtr& signal);

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
@@ -63,8 +63,9 @@ public:
     /// Registers a connected client as a streaming client.
     /// @param clientId The unique string ID provided by the client or automatically assigned by the server.
     /// @param reconnected true if the client was reconnected, false otherwise.
+    /// @param enablePacketBufferTimestamps enables timestamp creation for PacketBuffers
     /// @throw NativeStreamingProtocolException if the client is already registered.
-    void registerClient(const std::string& clientId, bool reconnected);
+    void registerClient(const std::string& clientId, bool reconnected, bool enablePacketBufferTimestamps);
 
     /// Removes a registered client on disconnection.
     /// @param clientId The unique string ID provided by the client or automatically assigned by the server.

--- a/shared/libraries/native_streaming_protocol/src/server_session_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/server_session_handler.cpp
@@ -15,8 +15,9 @@ ServerSessionHandler::ServerSessionHandler(const ContextPtr& daqContext,
                                            const std::string& clientId,
                                            OnFindSignalCallback findSignalHandler,
                                            OnSignalSubscriptionCallback signalSubscriptionHandler,
-                                           OnSessionErrorCallback errorHandler)
-    : BaseSessionHandler(daqContext, session, ioContextPtr, errorHandler, "NativeProtocolServerSessionHandler")
+                                           OnSessionErrorCallback errorHandler,
+                                           SizeT streamingPacketSendTimeout)
+    : BaseSessionHandler(daqContext, session, ioContextPtr, errorHandler, "NativeProtocolServerSessionHandler", streamingPacketSendTimeout)
     , findSignalHandler(findSignalHandler)
     , signalSubscriptionHandler(signalSubscriptionHandler)
     , transportLayerPropsHandler(nullptr)

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -112,7 +112,7 @@ bool StreamingManager::removeSignal(const SignalPtr& signal)
     return doSignalUnsubscribe;
 }
 
-void StreamingManager::registerClient(const std::string& clientId, bool reconnected)
+void StreamingManager::registerClient(const std::string& clientId, bool reconnected, bool enablePacketBufferTimestamps)
 {
     std::scoped_lock lock(sync);
 
@@ -133,7 +133,7 @@ void StreamingManager::registerClient(const std::string& clientId, bool reconnec
 
     // create new associated packet server if required
     if (auto it = packetStreamingServers.find(clientId); it == packetStreamingServers.end())
-        packetStreamingServers.insert({clientId, std::make_shared<packet_streaming::PacketStreamingServer>(10)});
+        packetStreamingServers.insert({clientId, std::make_shared<packet_streaming::PacketStreamingServer>(10, enablePacketBufferTimestamps)});
 }
 
 ListPtr<ISignal> StreamingManager::unregisterClient(const std::string& clientId)

--- a/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming.h
+++ b/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <coretypes/baseobject_factory.h>
+#include <optional>
 
 namespace daq::packet_streaming
 {
@@ -67,7 +68,7 @@ struct PacketBuffer
 {
     PacketBuffer(const PacketBuffer&) = delete;
     PacketBuffer(PacketBuffer&& packetBuffer) noexcept;
-    PacketBuffer(GenericPacketHeader* packetHeader, const void* payload, std::function<void()> onDestroy);
+    PacketBuffer(GenericPacketHeader* packetHeader, const void* payload, std::function<void()> onDestroy, bool enableTimeStamp);
 
     GenericPacketHeader* packetHeader;
     const void* payload;
@@ -76,6 +77,8 @@ struct PacketBuffer
     std::vector<uint32_t> additionalSignalIds;
 
     ~PacketBuffer();
+
+    std::optional<std::chrono::steady_clock::time_point> timeStamp;
 };
 
 using PacketBufferPtr = std::shared_ptr<PacketBuffer>;

--- a/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming_server.h
+++ b/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming_server.h
@@ -38,7 +38,7 @@ enum class ReleaseAction { markForRelease, subscribe, alreadySent };
 class PacketStreamingServer
 {
 public:
-    PacketStreamingServer(size_t releaseThreshold = 1);
+    PacketStreamingServer(size_t releaseThreshold = 1, bool attachTimestampToPacketBuffer = false);
 
     void addDaqPacket(const uint32_t signalId, const PacketPtr& packet);
     void addDaqPacket(const uint32_t signalId, PacketPtr&& packet);
@@ -53,6 +53,7 @@ private:
     std::unordered_map<uint32_t, DataDescriptorPtr> dataDescriptors;
     PacketCollectionPtr packetCollection;
     size_t releaseThreshold;
+    const bool attachTimestampToPacketBuffer;
 
     void addEventPacket(const uint32_t signalId, const EventPacketPtr& packet);
     template <bool CheckRefCount>
@@ -63,6 +64,8 @@ private:
 
     template <class DataPacket>
     void addDataPacket(const uint32_t signalId, DataPacket&& packet);
+
+    void queuePacketBuffer(const PacketBufferPtr& packetBuffer);
 };
 
 }

--- a/shared/libraries/packet_streaming/src/packet_streaming.cpp
+++ b/shared/libraries/packet_streaming/src/packet_streaming.cpp
@@ -3,10 +3,11 @@
 namespace daq::packet_streaming
 {
 
-PacketBuffer::PacketBuffer(GenericPacketHeader* packetHeader, const void* payload, std::function<void()> onDestroy)
+PacketBuffer::PacketBuffer(GenericPacketHeader* packetHeader, const void* payload, std::function<void()> onDestroy, bool enableTimeStamp)
     : packetHeader(packetHeader)
     , payload(payload)
     , onDestroy(std::move(onDestroy))
+    , timeStamp(enableTimeStamp ? std::optional(std::chrono::steady_clock::now()) : std::nullopt)
 {
 }
 
@@ -17,6 +18,7 @@ PacketBuffer::PacketBuffer(PacketBuffer&& packetBuffer) noexcept
     payload = packetBuffer.payload;
 
     onDestroy = packetBuffer.onDestroy;
+    timeStamp = packetBuffer.timeStamp;
 
     packetBuffer.onDestroy = [](){};
     packetBuffer.packetHeader = nullptr;

--- a/shared/libraries/packet_streaming/tests/packet_transmission.cpp
+++ b/shared/libraries/packet_streaming/tests/packet_transmission.cpp
@@ -19,11 +19,16 @@ void PacketTransmission::sendPacketBuffer(const PacketBufferPtr& packetBuffer)
     else
         recvPayload = nullptr;
 
-    auto recvPacketBuffer = std::make_shared<PacketBuffer>(recvPacketHeader, recvPayload, [recvPacketHeader, recvPayload]() {
+    auto recvPacketBuffer = std::make_shared<PacketBuffer>(
+        recvPacketHeader,
+        recvPayload,
+        [recvPacketHeader, recvPayload]() {
         std::free(recvPacketHeader);
         if (recvPayload != nullptr)
           std::free(recvPayload);
-    });
+        },
+        false
+    );
 
     queue.push(recvPacketBuffer);
 }

--- a/shared/libraries/packet_streaming/tests/test_packet_streaming.cpp
+++ b/shared/libraries/packet_streaming/tests/test_packet_streaming.cpp
@@ -39,6 +39,26 @@ protected:
     }
 };
 
+TEST_F(PacketStreamingTest, PacketTimeStamp)
+{
+    const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
+    const auto domainDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Int64).build();
+    const auto serverEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, domainDescriptor);
+
+    {
+        PacketStreamingServer serverEnabledTimeStamps {1, true};
+        serverEnabledTimeStamps.addDaqPacket(1, serverEventPacket);
+        const auto serverPacketBuffer = serverEnabledTimeStamps.getNextPacketBuffer();
+        ASSERT_TRUE(serverPacketBuffer->timeStamp.has_value());
+    }
+    {
+        PacketStreamingServer serverDisabledTimeStamps {1, false};
+        serverDisabledTimeStamps.addDaqPacket(1, serverEventPacket);
+        const auto serverPacketBuffer = serverDisabledTimeStamps.getNextPacketBuffer();
+        ASSERT_FALSE(serverPacketBuffer->timeStamp.has_value());
+    }
+}
+
 TEST_F(PacketStreamingTest, DataDescChangedEventPacket)
 {
     const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();


### PR DESCRIPTION
Related PR in libNative - https://github.com/openDAQ/libNativeStreaming/pull/18

# Description:
Introduce an optional timeout for streaming packet writes:

* Add the "StreamingPacketSendTimeout" property to the native server for specifying the timeout value.
* Enable "PacketStreamingServer" to optionally add a timestamp to serialized openDAQ packets at "PacketBuffer" creation.
* Calculate the deadline for the start time point of the packet write operation using the serialized packet's timestamp and the specified timeout.
* Server resets the client connection if the deadline is exceeded.

# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


