### PR TITLE
<TBBAS-1843> Add timeout constraint for re-connection attempt in native

### DIFF
--- a/external/native_streaming/CMakeLists.txt
+++ b/external/native_streaming/CMakeLists.txt
@@ -1,7 +1,7 @@
 opendaq_dependency(
     NAME                native_streaming
-    REQUIRED_VERSION    1.0.11
+    REQUIRED_VERSION    1.0.14
     GIT_REPOSITORY      https://github.com/openDAQ/libNativeStreaming.git
-    GIT_REF             v1.0.11
+    GIT_REF             v1.0.14
     EXPECT_TARGET       daq::native_streaming
 )

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
@@ -173,7 +173,7 @@ void NativeStreamingClientImpl::tryReconnect()
     reconnectionTimer->expires_from_now(reconnectionPeriod);
     reconnectionTimer->async_wait(std::bind(&NativeStreamingClientImpl::checkReconnectionResult, this, std::placeholders::_1));
 
-    client->connect();
+    client->connect(connectionTimeout);
 }
 
 void NativeStreamingClientImpl::connectionStatusChanged(ClientConnectionStatus status)
@@ -188,7 +188,7 @@ bool NativeStreamingClientImpl::connect(std::string host,
 {
     initClient(host, port, path);
     connectedFuture = connectedPromise.get_future();
-    client->connect();
+    client->connect(connectionTimeout);
 
     if (connectedFuture.wait_for(connectionTimeout) == std::future_status::ready &&
         connectedFuture.get() == ConnectionResult::Connected)


### PR DESCRIPTION
Related PR - https://github.com/openDAQ/libNativeStreaming/pull/19

# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
