### PR TITLE
<TBBAS-1892> Restore DeviceInfo fields after native device update

### DIFF
--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -45,7 +45,8 @@ public:
                                 Bool restoreClientConfigOnReconnect,
                                 std::shared_ptr<boost::asio::io_context> processingIOContextPtr,
                                 std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr,
-                                std::thread::id reconnectionProcessingThreadId);
+                                std::thread::id reconnectionProcessingThreadId,
+                                const StringPtr& connectionString);
     ~NativeDeviceHelper();
 
     void setupProtocolClients(const ContextPtr& context);
@@ -86,6 +87,7 @@ private:
     bool acceptNotificationPackets;
     std::chrono::milliseconds configProtocolRequestTimeout;
     Bool restoreClientConfigOnReconnect;
+    const StringPtr connectionString;
     std::mutex sync;
 };
 
@@ -93,6 +95,7 @@ DECLARE_OPENDAQ_INTERFACE(INativeDevicePrivate, IBaseObject)
 {
     virtual void INTERFACE_FUNC publishConnectionStatus(ConstCharPtr statusValue) = 0;
     virtual void INTERFACE_FUNC completeInitialization(std::shared_ptr<NativeDeviceHelper> deviceHelper, const StringPtr& connectionString) = 0;
+    virtual void INTERFACE_FUNC updateDeviceInfo(const StringPtr& connectionString) = 0;
 };
 
 class NativeDeviceImpl final : public config_protocol::GenericConfigClientDeviceImpl<config_protocol::ConfigClientDeviceBase<INativeDevicePrivate>>
@@ -111,6 +114,7 @@ public:
     // INativeDevicePrivate
     void INTERFACE_FUNC publishConnectionStatus(ConstCharPtr statusValue) override;
     void INTERFACE_FUNC completeInitialization(std::shared_ptr<NativeDeviceHelper> deviceHelper, const StringPtr& connectionString) override;
+    void INTERFACE_FUNC updateDeviceInfo(const StringPtr& connectionString) override;
 
     // ISerializable
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
@@ -121,10 +125,8 @@ protected:
 private:
     void initStatuses();
     void attachDeviceHelper(std::shared_ptr<NativeDeviceHelper> deviceHelper);
-    void updateDeviceInfo(const StringPtr& connectionString);
 
     std::shared_ptr<NativeDeviceHelper> deviceHelper;
-    bool deviceInfoSet;
 };
 
 END_NAMESPACE_OPENDAQ_NATIVE_STREAMING_CLIENT_MODULE

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -209,7 +209,8 @@ DevicePtr NativeStreamingClientModule::createNativeDevice(const ContextPtr& cont
                                                                  config.getPropertyValue("RestoreClientConfigOnReconnect"),
                                                                  processingIOContextPtr,
                                                                  reconnectionProcessingIOContextPtr,
-                                                                 reconnectionProcessingThread.get_id());
+                                                                 reconnectionProcessingThread.get_id(),
+                                                                 connectionString);
         deviceHelper->setupProtocolClients(context);
         auto device = deviceHelper->connectAndGetDevice(parent, protocolVersion);
         protocolVersion = deviceHelper->getProtocolVersion();

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -926,6 +926,7 @@ TEST_F(NativeDeviceModulesTest, DeviceInfo)
     auto info = client.getDevices()[0].getInfo();
     ASSERT_TRUE(info.assigned());
     ASSERT_EQ(info.getConnectionString(), "daq.nd://127.0.0.1");
+    ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
     ASSERT_EQ(info.getServerCapabilities().getCount(), 2u);
     ASSERT_EQ(info.getServerCapabilities()[0].getProtocolId(), "OpenDAQNativeStreaming");
     ASSERT_EQ(info.getServerCapabilities()[1].getProtocolId(), "OpenDAQNativeConfiguration");
@@ -1074,7 +1075,7 @@ TEST_F(NativeDeviceModulesTest, DISABLED_RendererSimple)
     auto server = CreateServerInstance();
     auto client = CreateClientInstance();
 
-    auto device = client.getDevices()[0].getDevices()[0];
+    auto device = client.getDevices()[0];
     const auto deviceChannel0 = device.getChannels()[0];
     const auto deviceSignal0 = deviceChannel0.getSignals(search::Recursive(search::Visible()))[0];
 
@@ -1586,6 +1587,11 @@ TEST_F(NativeDeviceModulesTest, Reconnection)
         ASSERT_GT(mirroredSignalPtr.getStreamingSources().getCount(), 0u) << signal.getGlobalId();
         ASSERT_TRUE(mirroredSignalPtr.getActiveStreamingSource().assigned()) << signal.getGlobalId();
     }
+
+    auto info = client.getDevices()[0].getInfo();
+    ASSERT_TRUE(info.assigned());
+    ASSERT_EQ(info.getConnectionString(), "daq.nd://127.0.0.1");
+    ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
 }
 
 TEST_F(NativeDeviceModulesTest, ReconnectionRestoreClientConfig)
@@ -1652,6 +1658,11 @@ TEST_F(NativeDeviceModulesTest, ReconnectionRestoreClientConfig)
         ASSERT_GT(mirroredSignalPtr.getStreamingSources().getCount(), 0u) << signal.getGlobalId();
         ASSERT_TRUE(mirroredSignalPtr.getActiveStreamingSource().assigned()) << signal.getGlobalId();
     }
+
+    auto info = client.getDevices()[0].getInfo();
+    ASSERT_TRUE(info.assigned());
+    ASSERT_EQ(info.getConnectionString(), "daq.nd://127.0.0.1");
+    ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
 }
 
 TEST_F(NativeDeviceModulesTest, Update)
@@ -2024,16 +2035,17 @@ TEST_F(NativeDeviceModulesTest, LimitConfigConnections)
 TEST_F(NativeDeviceModulesTest, ClientSaveLoadConfiguration)
 {
     StringPtr config;
-    auto server = CreateServerInstance();
-    
+
     {
-        auto client = CreateClientInstance();
+        auto server = CreateServerInstance();
+        auto client = CreateClientInstance(0);
         auto clientFb = client.addFunctionBlock("RefFBModuleStatistics");
         clientFb.addFunctionBlock("RefFBModuleTrigger");
 
         config = client.saveConfiguration();
     }
-    
+
+    auto server = CreateServerInstance();
     auto restoredClient = Instance();
     restoredClient.loadConfiguration(config);
     auto restoredFb = restoredClient.getFunctionBlocks();
@@ -2042,13 +2054,26 @@ TEST_F(NativeDeviceModulesTest, ClientSaveLoadConfiguration)
     auto nestedFb = restoredFb[0].getFunctionBlocks();
     ASSERT_EQ(nestedFb.getCount(), 1u);
     ASSERT_EQ(nestedFb[0].getFunctionBlockType().getId(), "RefFBModuleTrigger");
+
+    auto signals = restoredClient.getDevices()[0].getSignals(search::Recursive(search::Any()));
+    for (const auto& signal : signals)
+    {
+        auto mirroredSignalPtr = signal.asPtr<IMirroredSignalConfig>();
+        ASSERT_GT(mirroredSignalPtr.getStreamingSources().getCount(), 0u) << signal.getGlobalId();
+        ASSERT_TRUE(mirroredSignalPtr.getActiveStreamingSource().assigned()) << signal.getGlobalId();
+    }
+
+    auto info = restoredClient.getDevices()[0].getInfo();
+    ASSERT_TRUE(info.assigned());
+    ASSERT_EQ(info.getConnectionString(), "daq.nd://127.0.0.1");
+    ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
 }
 
 TEST_F(NativeDeviceModulesTest, ClientSaveLoadConfiguration2)
 {
     StringPtr config;
     auto server = CreateServerInstance();
-    
+
     {
         auto client = CreateClientInstance();
         auto clientFb = client.addFunctionBlock("RefFBModuleStatistics");
@@ -2056,7 +2081,7 @@ TEST_F(NativeDeviceModulesTest, ClientSaveLoadConfiguration2)
 
         config = client.saveConfiguration();
     }
-    
+
     auto restoredClient = Instance();
     restoredClient.addFunctionBlock("RefFBModuleStatistics");
 
@@ -2073,7 +2098,7 @@ TEST_F(NativeDeviceModulesTest, ClientSaveLoadConfiguration3)
 {
     StringPtr config;
     auto server = CreateServerInstance();
-    
+
     {
         auto client = CreateClientInstance();
         auto clientFb = client.addFunctionBlock("RefFBModuleStatistics");
@@ -2099,7 +2124,7 @@ TEST_F(NativeDeviceModulesTest, ClientSaveLoadConfigurationWithAnotherDevice)
 {
     StringPtr config;
     auto server = CreateServerInstance();
-    
+
     {
         auto client = CreateClientInstance();
         config = client.saveConfiguration();
@@ -2113,7 +2138,7 @@ TEST_F(NativeDeviceModulesTest, ClientSaveLoadConfigurationWithAnotherDevice)
     auto devices = restoredClient.getDevices();
     ASSERT_EQ(devices.getCount(), 2u);
     ASSERT_EQ(devices[0].getInfo().getConnectionString(), "daqref://device0");
-    ASSERT_EQ(devices[1].getInfo().getConnectionString(), "daqmock://client_device");
+    ASSERT_EQ(devices[1].getInfo().getConnectionString(), "daq.nd://127.0.0.1");
     auto serverDevices = devices[1].getDevices();
     ASSERT_EQ(serverDevices.getCount(), 1u);
     ASSERT_EQ(serverDevices[0].getInfo().getConnectionString(), "daqref://device0");


### PR DESCRIPTION
# Description:
* Resolved issue with client-side modified DeviceInfo fields being lost after device update due to loadConfig and reconnection
* Fixed issue where signals newly added on the server during client-triggered loadConfig lack streaming sources on client side once the loadConfig completed

# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


