### PR TITLE
[TBBAS-1819] Python GUI: Property metadata view

### DIFF
--- a/examples/python/gui_demo.py
+++ b/examples/python/gui_demo.py
@@ -15,7 +15,7 @@ from tkinter import messagebox
 try:
     from ctypes import windll
     windll.shcore.SetProcessDpiAwareness(1)
-except BaseException:
+except Exception:
     pass
 
 try:
@@ -662,9 +662,8 @@ class App(tk.Tk):
             device.lock()
             self._set_node_lock_status_recursive(node)
         except Exception as e:
-            msg = str(e)
-            print('Lock failed: ', msg, file=sys.stderr)
-            messagebox.showerror("Force unlock failed", msg)
+            utils.show_error('Lock failed', f'{component.name}: {e}', self)
+            print(f'Lock failed: {str(e)}', file=sys.stderr)
 
     def handle_unlock(self):
         node = utils.treeview_get_first_selection(self.tree)
@@ -675,9 +674,9 @@ class App(tk.Tk):
             device.unlock()
             self._set_node_lock_status_recursive(node)
         except Exception as e:
-            print('Unlock failed: ', e, file=sys.stderr)
-            msg = str(e) + ". Do you want to forcefully unlock the device?"
-            do_force_unlock = messagebox.askyesno("Unlock failed", msg)
+            print(f'Unlock failed: {str(e)}', file=sys.stderr)
+            msg = str(e) + '. Do you want to forcefully unlock the device?'
+            do_force_unlock = messagebox.askyesno('Unlock failed', msg)
             if do_force_unlock:
                 self._force_unlock_device(node, component)
 
@@ -688,7 +687,7 @@ class App(tk.Tk):
             self._set_node_lock_status_recursive(node)
         except Exception as e:
             print('Force unlock failed: ', e, file=sys.stderr)
-            messagebox.showerror("Force unlock failed", str(e))
+            utils.show_error('Force unlock failed', str(e), self)
 
     def set_node_update_status(self):
         for node in self.tree.get_children():

--- a/examples/python/gui_demo/app_context.py
+++ b/examples/python/gui_demo/app_context.py
@@ -24,7 +24,7 @@ class AppContext(object):
         self.selected_node = None
         self.include_reference_devices = False
         self.view_hidden_components = False
-        self.metadata_fields = ['unit', 'read_only']
+        self.metadata_fields = []
         # gui
         self.ui_scaling_factor = 1.0
         self.icons = {}

--- a/examples/python/gui_demo/app_context.py
+++ b/examples/python/gui_demo/app_context.py
@@ -24,6 +24,7 @@ class AppContext(object):
         self.selected_node = None
         self.include_reference_devices = False
         self.view_hidden_components = False
+        self.metadata_fields = ['unit', 'read_only']
         # gui
         self.ui_scaling_factor = 1.0
         self.icons = {}
@@ -48,18 +49,15 @@ class AppContext(object):
             return None
         if parent_device is None:
             return None
-        try:
-            device = parent_device.add_device(
-                device_info.connection_string, config)
-            if device:
-                device_info.name = device.local_id
-                device_info.serial_number = device.info.serial_number
-                self.enabled_devices[device.info.connection_string] = {
-                    'device_info': device_info, 'device': device}
-                return device
-        except RuntimeError as e:
-            print(f'Error adding device {device_info.connection_string}: {e}')
-        return None
+
+        device = parent_device.add_device(
+            device_info.connection_string, config)
+        if device:
+            device_info.name = device.local_id
+            device_info.serial_number = device.info.serial_number
+            self.enabled_devices[device.info.connection_string] = {
+                'device_info': device_info, 'device': device}
+        return device
 
     def remove_device(self, device):
         if device is None:

--- a/examples/python/gui_demo/components/add_config_dialog.py
+++ b/examples/python/gui_demo/components/add_config_dialog.py
@@ -105,9 +105,15 @@ class AddConfigDialog(Dialog):
     def edit_value(self, event):
         item_id = self.tree.selection()[0]
         path = utils.get_item_path(self.tree, item_id)
-        prop = utils.get_property_for_path(self.context, path, self.device_config)
+        prop = utils.get_property_for_path(
+            self.context, path, self.device_config)
         if prop.value_type in (daq.CoreType.ctDict, daq.CoreType.ctList):
             EditContainerPropertyDialog(self, prop, self.context).show()
+        elif prop.value_type == daq.CoreType.ctBool:
+            column = self.tree.identify_column(event.x)
+            if column == '#1':
+                prop.value = not prop.value
+                self.tree.set(item_id, column, str(prop.value))
         else:
             column = self.tree.identify_column(event.x)
             if column == '#1':

--- a/examples/python/gui_demo/components/add_device_dialog.py
+++ b/examples/python/gui_demo/components/add_device_dialog.py
@@ -72,7 +72,8 @@ class AddDeviceDialog(Dialog):
         device_tree_frame.pack(fill=tk.BOTH, expand=True)
 
         add_device_frame = ttk.Frame(right_side_frame)
-        ttk.Label(add_device_frame, text='Connection string:').pack(side=tk.LEFT)
+        ttk.Label(add_device_frame, text='Connection string:').pack(
+            side=tk.LEFT)
         self.conn_string_entry = ttk.Entry(add_device_frame)
         self.conn_string_entry.bind('<Return>', self.handle_entry_enter)
         self.conn_string_entry.pack(
@@ -81,10 +82,10 @@ class AddDeviceDialog(Dialog):
         self.add_device_option = tk.StringVar(add_device_frame)
         add_device_options = ['no config', 'with config']
         ttk.OptionMenu(add_device_frame, self.add_device_option, 'no config',
-                      *add_device_options).pack(side=tk.RIGHT)
+                       *add_device_options).pack(side=tk.RIGHT)
 
         ttk.Button(add_device_frame, text='Add',
-                  command=self.handle_add_device).pack(side=tk.RIGHT)
+                   command=self.handle_add_device).pack(side=tk.RIGHT)
 
         add_device_frame.pack(side=tk.BOTTOM, fill=tk.X,
                               padx=(5, 0), pady=(5, 0))
@@ -118,7 +119,8 @@ class AddDeviceDialog(Dialog):
             self.parent_device_tree)
         if selected_item is None:
             return
-        parent_device = utils.find_component(selected_item, self.context.instance)
+        parent_device = utils.find_component(
+            selected_item, self.context.instance)
         if parent_device is not None and daq.IDevice.can_cast_from(parent_device):
             parent_device = daq.IDevice.cast_from(parent_device)
             self.dialog_parent_device = parent_device
@@ -151,13 +153,18 @@ class AddDeviceDialog(Dialog):
 
     def add_device(self, connection_string, config):
         if connection_string and self.dialog_parent_device is not None:
-            device = self.context.add_device(DeviceInfoLocal(
-                connection_string), self.dialog_parent_device, config)
-            if device:
+            try:
+                device = self.context.add_device(DeviceInfoLocal(
+                    connection_string), self.dialog_parent_device, config)
+
                 self.update_parent_devices(
                     self.parent_device_tree, '', self.context.instance)
                 self.select_parent_device(device.global_id)
                 self.event_port.emit()
+            except RuntimeError as e:
+                utils.show_error('Error adding device', f'{
+                                 connection_string}: {e}', self)
+                return
 
     def handle_add_device(self):
         config = None

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -13,7 +13,6 @@ from .dialog import Dialog
 class AttributesDialog(Dialog):
     def __init__(self, parent, title, node, context: AppContext, **kwargs):
         Dialog.__init__(self, parent, title, None, **kwargs)
-        self.title(title)
         self.parent = parent
         self.node = node
         self.context = context
@@ -56,8 +55,10 @@ class AttributesDialog(Dialog):
                 signal_domain_desc_frame = ttk.Frame(self.notebook)
                 self.notebook.add(signal_desc_frame, text='Signal Descriptor')
                 if self.node.domain_signal is not None:
-                    self.notebook.add(signal_domain_desc_frame, text='Signal Domain Descriptor')
-                self.notebook.bind('<<NotebookTabChanged>>', self.on_tab_change)
+                    self.notebook.add(signal_domain_desc_frame,
+                                      text='Signal Domain Descriptor')
+                self.notebook.bind('<<NotebookTabChanged>>',
+                                   self.on_tab_change)
             elif daq.IDevice.can_cast_from(node):
                 self.node = daq.IDevice.cast_from(node)
                 ttk.Label(self, text='Device Info').pack(
@@ -82,7 +83,8 @@ class AttributesDialog(Dialog):
             additional_tree.column('#1', anchor=tk.W, minwidth=100)
 
             self.additional_tree = additional_tree
-            additional_tree.bind('<Button-3>', self.handle_right_click_additional)
+            additional_tree.bind(
+                '<Button-3>', self.handle_right_click_additional)
 
         self.tree = tree
         self.initial_update_func = lambda: self.tree_update()

--- a/examples/python/gui_demo/components/dialog.py
+++ b/examples/python/gui_demo/components/dialog.py
@@ -9,7 +9,7 @@ class Dialog(tk.Toplevel):
         tk.Toplevel.__init__(self, parent, **kwargs)
         self.title(title)
         self.parent = parent
-        self.context: AppContext = context
+        self.context = context
         self.initial_update_func = None
 
         self.configure(padx=10, pady=5)

--- a/examples/python/gui_demo/components/edit_container_property.py
+++ b/examples/python/gui_demo/components/edit_container_property.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
-from tkinter import messagebox, simpledialog
+from tkinter import simpledialog
 
 import opendaq as daq
 
@@ -8,6 +8,7 @@ from .. import utils
 from .dialog import Dialog
 from ..app_context import AppContext
 from ..event_port import EventPort
+
 
 class EditContainerPropertyDialog(Dialog):
     def __init__(self, parent, property: daq.IProperty, context: AppContext, **kwargs):
@@ -19,7 +20,7 @@ class EditContainerPropertyDialog(Dialog):
 
         self.geometry('{}x{}'.format(
             800 * self.context.ui_scaling_factor, 600 * self.context.ui_scaling_factor))
-        
+
         item_types = []
         if isinstance(self.data, daq.IDict):
             item_types.append(str(self.property.key_type))
@@ -46,7 +47,8 @@ class EditContainerPropertyDialog(Dialog):
         # Upper buttons
         button_frame_top = ttk.Frame(self)
 
-        self.add_button = ttk.Button(button_frame_top, text='Add', command=self.add_item, width=10)
+        self.add_button = ttk.Button(
+            button_frame_top, text='Add', command=self.add_item, width=10)
         self.add_button.pack(
             padx=10, side=tk.LEFT)
         self.edit_button = ttk.Button(
@@ -61,7 +63,7 @@ class EditContainerPropertyDialog(Dialog):
             button_frame_top, text='Clear', command=self.clear, width=10)
         self.clear_button.pack(
             padx=10, side=tk.LEFT)
-        
+
         button_frame_top.pack(anchor=tk.E, pady=10)
 
         # Bottom buttons
@@ -75,7 +77,7 @@ class EditContainerPropertyDialog(Dialog):
             button_frame_bottom, text='Close', command=self.close, width=10)
         self.cancel_button.pack(
             padx=10, side=tk.LEFT)
-        
+
         button_frame_bottom.pack(anchor=tk.E, pady=10)
 
         # State
@@ -111,9 +113,10 @@ class EditContainerPropertyDialog(Dialog):
                 self.data_index = []
                 for key, value in self.data.items():
                     self.data_index.append(key)
-                    self.listbox.insert(tk.END, f'{str(key)} : {str(value)}')            
+                    self.listbox.insert(tk.END, f'{str(key)} : {str(value)}')
         except RuntimeError as e:
-            messagebox.showerror('Display error', f'Can\'t display data: {e}', parent=self)
+            utils.show_error(
+                'Display error', f'Can\'t display data: {e}', self)
 
         self.listbox.focus_set()
         self.listbox.select_set(tk.END)
@@ -124,23 +127,27 @@ class EditContainerPropertyDialog(Dialog):
             if value is None:
                 return
             try:
-                self.data.append(utils.value_to_coretype(value, self.property.item_type))
+                self.data.append(utils.value_to_coretype(
+                    value, self.property.item_type))
                 self.fill()
             except Exception as e:
-                messagebox.showerror('Add item error', f'Can\'t add item: {e}', parent=self)
+                utils.show_error('Add item error',
+                                 f'Can\'t add item: {e}', self)
         elif isinstance(self.data, daq.IDict):
             key = simpledialog.askstring('Add item', 'Key:', parent=self)
             if key is None:
                 return
-            self.update() #it is here for next dialog to be able to grab focus
+            self.update()  # it is here for next dialog to be able to grab focus
             value = simpledialog.askstring('Add item', 'Value:', parent=self)
             if value is None:
                 return
             try:
-                self.data[utils.value_to_coretype(key, self.property.key_type)] = utils.value_to_coretype(value, self.property.item_type)
+                self.data[utils.value_to_coretype(key, self.property.key_type)] = utils.value_to_coretype(
+                    value, self.property.item_type)
                 self.fill()
             except Exception as e:
-                messagebox.showerror('Add item error', f'Can\'t add item: {e}', parent=self)
+                utils.show_error('Add item error',
+                                 f'Can\'t add item: {e}', self)
 
     def edit_item(self):
         selection = self.listbox.curselection()
@@ -150,20 +157,24 @@ class EditContainerPropertyDialog(Dialog):
                     'Edit item', 'Value:', parent=self, initialvalue=self.data[selection[0]])
                 if new_value:
                     try:
-                        self.data[selection[0]] = utils.value_to_coretype(new_value, self.property.item_type)
+                        self.data[selection[0]] = utils.value_to_coretype(
+                            new_value, self.property.item_type)
                         self.fill()
                     except Exception as e:
-                        messagebox.showerror('Edit item error', f'Can\'t edit item: {e}', parent=self)
+                        utils.show_error('Edit item error',
+                                         f'Can\'t edit item: {e}', self)
             elif isinstance(self.data, daq.IDict):
-                key = self.data_index[selection[0]] 
+                key = self.data_index[selection[0]]
                 new_value = simpledialog.askstring(
                     'Edit item', 'Value:', parent=self, initialvalue=self.data[key])
                 if new_value:
                     try:
-                        self.data[utils.value_to_coretype(key, self.property.key_type)] = utils.value_to_coretype(new_value, self.property.item_type)
+                        self.data[utils.value_to_coretype(key, self.property.key_type)] = utils.value_to_coretype(
+                            new_value, self.property.item_type)
                         self.fill()
                     except Exception as e:
-                        messagebox.showerror('Edit item error', f'Can\'t edit item: {e}', parent=self)
+                        utils.show_error('Edit item error',
+                                         f'Can\'t edit item: {e}', self)
 
     def delete_item(self):
         selection = self.listbox.curselection()

--- a/examples/python/gui_demo/components/load_instance_config_dialog.py
+++ b/examples/python/gui_demo/components/load_instance_config_dialog.py
@@ -99,9 +99,15 @@ class LoadInstanceConfigDialog(Dialog):
     def edit_value(self, event):
         item_id = self.tree.selection()[0]
         path = utils.get_item_path(self.tree, item_id)
-        prop = utils.get_property_for_path(self.context, path, self.updata_params)
+        prop = utils.get_property_for_path(
+            self.context, path, self.updata_params)
         if prop.value_type in (daq.CoreType.ctDict, daq.CoreType.ctList):
             EditContainerPropertyDialog(self, prop, self.updata_params).show()
+        elif prop.value_type == daq.CoreType.ctBool:
+            column = self.tree.identify_column(event.x)
+            if column == '#1':
+                prop.value = not prop.value
+                self.tree.set(item_id, column, str(prop.value))
         else:
             column = self.tree.identify_column(event.x)
             if column == '#1':
@@ -111,7 +117,7 @@ class LoadInstanceConfigDialog(Dialog):
                 entry.place(x=x, y=y, width=width, height=height)
                 entry.insert(0, value)
                 entry.focus()
-                path = utils.get_item_path(self.tree,item_id)
+                path = utils.get_item_path(self.tree, item_id)
                 entry.bind('<Return>', lambda e: self.save_value(
                     entry, item_id, column, path))
                 entry.bind('<FocusOut>', lambda e: self.save_value(

--- a/examples/python/gui_demo/components/metadata_dialog.py
+++ b/examples/python/gui_demo/components/metadata_dialog.py
@@ -48,8 +48,10 @@ class MetadataDialog(Dialog):
         def fill_tree(key, value, parent=''):
 
             # displaying Nones but not traversing further
+            display_value = utils.metadata_converters[key](
+                value) if key in utils.metadata_converters else value
             id = self.tree.insert(
-                parent, tk.END, text=str(key), values=(str(value), ))
+                parent, tk.END, text=str(key), values=(str(display_value), ))
 
             if value is None:
                 return

--- a/examples/python/gui_demo/components/metadata_dialog.py
+++ b/examples/python/gui_demo/components/metadata_dialog.py
@@ -1,0 +1,92 @@
+import tkinter as tk
+from tkinter import ttk
+
+import opendaq as daq
+
+from .. import utils
+from ..app_context import AppContext
+from .dialog import Dialog
+
+
+class MetadataDialog(Dialog):
+
+    def __init__(self, parent, node: daq.IProperty, context: AppContext, **kwargs):
+        super().__init__(parent, f'{node.name} metadata', context, **kwargs)
+
+        self.parent = parent
+        self.node = node
+        self.context = context
+
+        self.geometry(f'{600}x{800}')
+        tree_frame = ttk.Frame(self)
+
+        tree = ttk.Treeview(tree_frame, columns=(
+            'value'), show='tree headings')
+
+        scroll_bar = ttk.Scrollbar(
+            tree_frame, orient=tk.VERTICAL, command=tree.yview)
+        tree.configure(yscrollcommand=scroll_bar.set)
+        scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
+        tree.pack(fill=tk.BOTH, expand=True)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+
+        # define headings
+        tree.heading('#0', anchor=tk.W, text='Name')
+        tree.heading('value', anchor=tk.W, text='Value')
+        # layout
+        tree.column('#0', anchor=tk.W, minwidth=100, width=120)
+        tree.column('value', anchor=tk.W, minwidth=100, width=300)
+
+        tree.bind('<Button-3>', self.handle_right_click)
+
+        self.tree = tree
+        self.initial_update_func = self.update
+
+    def update(self):
+        self.tree.delete(*self.tree.get_children())
+
+        def fill_tree(key, value, parent=''):
+
+            # displaying Nones but not traversing further
+            id = self.tree.insert(
+                parent, tk.END, text=str(key), values=(str(value), ))
+
+            if value is None:
+                return
+
+            if isinstance(value, daq.IPropertyObject):
+                for property in value.all_properties if self.context.view_hidden_components else value.visible_properties:
+                    fill_tree(property.name, property, id)
+            elif isinstance(value, daq.IList):
+                try:
+                    for i, item in enumerate(value):
+                        fill_tree(i, item, id)
+                except Exception:
+                    pass
+            elif isinstance(value, daq.IDict):
+                try:
+                    for k, v in value.items():
+                        fill_tree(k, v, id)
+                except Exception:
+                    pass
+            elif issubclass(type(value), daq.IBaseObject):
+                for name in utils.get_attributes_of_node(value):
+                    v = getattr(value, name)
+                    fill_tree(name, v, id)
+
+        for name in utils.get_attributes_of_node(self.node):
+            fill_tree(name, getattr(self.node, name), '')
+
+    def handle_copy(self):
+        selected_iid = utils.treeview_get_first_selection(self.tree)
+        if selected_iid is None:
+            return
+        item = self.tree.item(selected_iid)
+        self.clipboard_clear()
+        self.clipboard_append(item['values'][0])
+
+    def handle_right_click(self, event):
+        utils.treeview_select_item(self.tree, event)
+        menu = tk.Menu(self, tearoff=0)
+        menu.add_command(label='Copy', command=self.handle_copy)
+        menu.tk_popup(event.x_root, event.y_root)

--- a/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
+++ b/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
@@ -1,0 +1,76 @@
+import tkinter as tk
+from tkinter import ttk
+
+from .. import utils
+from ..event_port import EventPort
+from ..app_context import AppContext
+from .dialog import Dialog
+
+
+class MetadataFieldsSelectorDialog(Dialog):
+    def __init__(self, parent, context: AppContext):
+        Dialog.__init__(self, parent, 'Metadata fields to display', context)
+        self.evet_port = EventPort(parent)
+        self.fields = []
+        try:
+            self.fields = utils.get_attributes_of_node(
+                self.context.instance.all_properties[0])
+            self.fields.remove('name')
+            self.fields.remove('value')
+        except:
+            pass
+
+        self.protocol('WM_DELETE_WINDOW', self.cancel)
+
+        self.geometry(f'{400}x{600}')
+
+        tree_frame = ttk.Frame(self)
+        self.tree = ttk.Treeview(tree_frame)
+        scroll_bar = ttk.Scrollbar(
+            tree_frame, orient=tk.VERTICAL, command=self.tree.yview)
+        self.tree.configure(yscrollcommand=scroll_bar.set)
+        scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.tree.pack(fill=tk.BOTH, expand=True)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+
+        # define headings
+        self.tree.heading('#0', anchor=tk.W, text='Fields')
+        # layout
+        self.tree.column('#0', anchor=tk.W, minwidth=100)
+
+        bottom_button_frame = ttk.Frame(self)
+        ttk.Button(bottom_button_frame, text='OK',
+                   command=self.ok).pack(padx=10, side=tk.LEFT)
+        ttk.Button(bottom_button_frame, text='Cancel',
+                   command=self.cancel).pack(padx=10, side=tk.LEFT)
+        bottom_button_frame.pack(side=tk.BOTTOM, anchor=tk.E, pady=(5, 0))
+
+        upper_button_frame = ttk.Frame(self)
+        ttk.Button(upper_button_frame, text='Reset',
+                   command=self.reset_selection).pack(padx=10, side=tk.LEFT)
+        ttk.Button(upper_button_frame, text='Deselect all',
+                   command=self.clean_selection).pack(padx=10, side=tk.LEFT)
+        upper_button_frame.pack(side=tk.BOTTOM, anchor=tk.E, pady=(5, 0))
+
+        for field in self.fields:
+            self.tree.insert('', 'end', text=field)
+            if field in self.context.metadata_fields:
+                self.tree.selection_add(self.tree.get_children()[-1])
+
+    def ok(self):
+        self.context.metadata_fields = [self.tree.item(
+            item, 'text') for item in self.tree.selection()]
+        self.evet_port.emit()
+        self.destroy()
+
+    def cancel(self):
+        self.destroy()
+
+    def reset_selection(self):
+        self.clean_selection()
+        for item in self.tree.get_children():
+            if self.tree.item(item, 'text') in self.context.metadata_fields:
+                self.tree.selection_add(item)
+
+    def clean_selection(self):
+        self.tree.selection_remove(*self.tree.selection())

--- a/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
+++ b/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
@@ -53,13 +53,13 @@ class MetadataFieldsSelectorDialog(Dialog):
         upper_button_frame.pack(side=tk.BOTTOM, anchor=tk.E, pady=(5, 0))
 
         for field in self.fields:
-            self.tree.insert('', 'end', text=field)
+            self.tree.insert('', 'end', text=utils.snake_case_to_title(field))
             if field in self.context.metadata_fields:
                 self.tree.selection_add(self.tree.get_children()[-1])
 
     def ok(self):
-        self.context.metadata_fields = [self.tree.item(
-            item, 'text') for item in self.tree.selection()]
+        self.context.metadata_fields = [utils.title_to_snake_case(self.tree.item(
+            item, 'text')) for item in self.tree.selection()]
         self.evet_port.emit()
         self.destroy()
 

--- a/examples/python/gui_demo/components/properties_view.py
+++ b/examples/python/gui_demo/components/properties_view.py
@@ -8,6 +8,8 @@ from ..event_port import EventPort
 from ..app_context import AppContext
 from .function_dialog import FunctionDialog
 from .edit_container_property import EditContainerPropertyDialog
+from .metadata_dialog import MetadataDialog
+from .metadata_fields_selector_dialog import MetadataFieldsSelectorDialog
 
 
 class PropertiesView(ttk.Frame):
@@ -20,27 +22,45 @@ class PropertiesView(ttk.Frame):
 
         self.configure(padding=(10, 5))
 
-        ttk.Label(self, text='Properties').pack(anchor=tk.W)
-        tree = ttk.Treeview(self, columns=('value'), show='tree headings')
+        header_frame = ttk.Frame(self)
 
-        scroll_bar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=tree.yview)
+        ttk.Label(header_frame, text='Properties').pack(side=tk.LEFT, pady=5)
+        tk.Button(header_frame, text='Edit', image=self.context.icons['settings'], borderwidth=0,
+                  command=lambda: MetadataFieldsSelectorDialog(
+                      self, self.context).show()
+                  ).pack(
+            side=tk.RIGHT, padx=30)
+
+        header_frame.pack(fill=tk.X)
+        tree = ttk.Treeview(self, columns=(
+            'value', *self.context.metadata_fields), show='tree headings')
+
+        scroll_bar = ttk.Scrollbar(
+            self, orient=tk.VERTICAL, command=tree.yview)
         tree.configure(yscrollcommand=scroll_bar.set)
         scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
+        scroll_bar_x = ttk.Scrollbar(
+            self, orient=tk.HORIZONTAL, command=tree.xview)
+        tree.configure(xscrollcommand=scroll_bar_x.set)
+        scroll_bar_x.pack(side=tk.BOTTOM, fill=tk.X)
         tree.pack(fill=tk.BOTH, expand=True)
 
         # define headings
         tree.heading('#0', anchor=tk.W, text='Property name')
         tree.heading('value', anchor=tk.W, text='Value')
         # layout
-        tree.column('#0', anchor=tk.W)
-        tree.column('#1', anchor=tk.W)
+        tree.column('#0', anchor=tk.W, minwidth=200)
+        tree.column('#1', anchor=tk.W, minwidth=200)
+
+        for field in self.context.metadata_fields:
+            tree.heading(field, anchor=tk.W, text=field)
+            tree.column(field, anchor=tk.W, minwidth=200)
 
         # bind double-click to editing
         tree.bind('<Double-1>', self.handle_double_click)
 
         tree.bind('<Button-3>', self.handle_right_click)
         self.tree = tree
-        self.nodes_by_iids = {}
 
         self.refresh()
 
@@ -51,12 +71,20 @@ class PropertiesView(ttk.Frame):
                 self.fillProperties(
                     '', daq.IPropertyObject.cast_from(self.node))
 
+    def fillList(self, parent_iid, l):
+        for i, value in enumerate(l):
+            self.tree.insert('' if not parent_iid else parent_iid,
+                             tk.END, text=str(i), values=(str(value),))
+
+    def fillDict(self, parent_iid, d):
+        for key, value in d.items():
+            self.tree.insert('' if not parent_iid else parent_iid,
+                             tk.END, text=str(key), values=(str(value),))
+
     def fillStruct(self, parent_iid, node):
         for key, value in node.as_dictionary.items():
-            iid = key if parent_iid is None else parent_iid + '.' + key
-            self.nodes_by_iids[iid] = node
             self.tree.insert('' if not parent_iid else parent_iid,
-                             tk.END, iid=iid, text=key, values=(value,))
+                             tk.END, text=key, values=(value,))
 
     def fillProperties(self, parent_iid, node):
         def printed_value(value_type, value):
@@ -66,9 +94,6 @@ class PropertiesView(ttk.Frame):
                 return value
 
         for property_info in self.context.properties_of_component(node):
-            iid = property_info.name if parent_iid is None else parent_iid + '.' + property_info.name
-            self.nodes_by_iids[iid] = node
-
             if property_info.selection_values is not None:
                 if len(property_info.selection_values) > 0:
                     property_value = printed_value(
@@ -85,8 +110,16 @@ class PropertiesView(ttk.Frame):
                 property_value = printed_value(
                     property_info.item_type, node.get_property_value(property_info.name))
 
-            self.tree.insert('' if not parent_iid else parent_iid, tk.END, iid=iid, text=property_info.name, values=(
-                property_value,))
+            meta_fields = [None] * len(self.context.metadata_fields)
+
+            try:
+                for i, field in enumerate(self.context.metadata_fields):
+                    meta_fields[i] = getattr(property_info, field)
+            except Exception as e:
+                print(e)
+
+            iid = self.tree.insert('' if not parent_iid else parent_iid, tk.END, text=property_info.name, values=(
+                property_value, *meta_fields))
 
             if property_info.value_type == daq.CoreType.ctObject:
                 self.fillProperties(
@@ -94,98 +127,130 @@ class PropertiesView(ttk.Frame):
             elif property_info.value_type == daq.CoreType.ctStruct:
                 self.fillStruct(
                     iid, node.get_property_value(property_info.name))
+            elif property_info.value_type == daq.CoreType.ctList:
+                self.fillList(iid, node.get_property_value(property_info.name))
+            elif property_info.value_type == daq.CoreType.ctDict:
+                self.fillDict(iid, node.get_property_value(property_info.name))
 
     def handle_copy(self):
         selected_item = utils.treeview_get_first_selection(self.tree)
         if selected_item is None:
             return
         item = self.tree.item(selected_item)
-        property_name = item['text']
-        node = self.nodes_by_iids.get(selected_item)
-        node = daq.IPropertyObject.cast_from(node)
-        if not node:
-            return
-        property_value = node.get_property_value(property_name)
+
         self.clipboard_clear()
-        self.clipboard_append(property_value)
+        value = '' if len(item['values']) == 0 else item['values'][0]
+        self.clipboard_append(value)
 
-    def handle_paste(self):
+    def handle_show_metadata(self):
         selected_item = utils.treeview_get_first_selection(self.tree)
-
         if selected_item is None:
             return
-        item = self.tree.item(selected_item)
-        property_name = item['text']
 
-        node = self.nodes_by_iids.get(selected_item)
+        path = utils.get_item_path(self.tree, selected_item)
+        prop = utils.get_property_for_path(self.context, path, self.node)
+        if not prop:
+            return
 
-        node = daq.IPropertyObject.cast_from(node)
-        if not node:
+        MetadataDialog(self, prop, self.context).show()
+
+    def nearest_property_with_path(self, path):
+        prop = utils.get_property_for_path(self.context, path, self.node)
+        while prop is None and len(path) > 0:
+            path = path[:-1]
+            prop = utils.get_property_for_path(self.context, path, self.node)
+        return (prop, path)
+
+    def handle_paste(self):
+        selected_item_id = utils.treeview_get_first_selection(self.tree)
+        if selected_item_id is None:
             return
-        property_info = node.get_property(property_name)
-        if not property_info:
+
+        path = utils.get_item_path(self.tree, selected_item_id)
+        prop, prop_path = self.nearest_property_with_path(path)
+
+        if not prop:
             return
-        if property_info.read_only:
+
+        path_diff = list(set(path) - set(prop_path))
+        if len(path_diff) > 1:
             return
-        property_value = self.clipboard_get()
-        if property_value is None:
-            return
-        node.set_property_value(property_name, property_value)
-        self.refresh()
-        self.event_port.emit()
+
+        value = prop.value
+        try:
+            if prop.value_type == daq.CoreType.ctObject:
+                pass  # ignoring paste to objects
+            elif prop.value_type == daq.CoreType.ctStruct:
+                field_type = [
+                    field for field in prop.struct_type.field_types if field.name == path_diff[0]][0].core_type
+                setattr(value, path_diff[0], utils.value_to_coretype(
+                    self.clipboard_get(), field_type))
+                prop.value = value
+            elif prop.value_type == daq.CoreType.ctList:
+                value[int(path_diff[0])] = utils.value_to_coretype(
+                    self.clipboard_get(), prop.item_type)
+                prop.value = value
+            elif prop.value_type == daq.CoreType.ctDict:
+                value[utils.value_to_coretype(path_diff[0], prop.key_type)] = utils.value_to_coretype(
+                    self.clipboard_get(), prop.item_type)
+                prop.value = value
+            else:
+                prop.value = utils.value_to_coretype(
+                    self.clipboard_get(), prop.value_type)
+
+            self.event_port.emit()
+
+        except Exception as e:
+            utils.show_error('Paste error', f'Can\'t paste: {e}', parent=self)
 
     def handle_right_click(self, event):
+        utils.treeview_select_item(self.tree, event)
+
         menu = tk.Menu(self, tearoff=0)
         menu.add_command(label='Copy', command=self.handle_copy)
         menu.add_command(label='Paste',
                          command=self.handle_paste)
+        menu.add_separator()
+        menu.add_command(label='Metadata', command=self.handle_show_metadata)
         menu.tk_popup(event.x_root, event.y_root)
 
     def handle_double_click(self, event):
-        selected_item = utils.treeview_get_first_selection(self.tree)
-        if selected_item is None:
+        selected_item_id = utils.treeview_get_first_selection(self.tree)
+        if selected_item_id is None:
             return
-        item = self.tree.item(selected_item)
-        property_name = item['text']
-        node = self.nodes_by_iids.get(selected_item)
-        if not node:
-            return
-        if not daq.IPropertyObject.can_cast_from(node):
-            return
-        node = daq.IPropertyObject.cast_from(node)
-        if not node:
+        property_name = self.tree.item(selected_item_id, 'text')
+        path = utils.get_item_path(self.tree, selected_item_id)
+        prop = utils.get_property_for_path(self.context, path, self.node)
+        if not prop:
             return
 
-        property_info = node.get_property(property_name)
-        property_value = node.get_property_value(property_name)
-        old_value = property_value
-        if not property_info:
-            return
+        old_value = prop.value
+        property_value = prop.value
 
-        if property_info.value_type == daq.CoreType.ctFunc:
+        if prop.value_type == daq.CoreType.ctFunc:
             f = daq.IFunction.cast_from(property_value)
-            FunctionDialog(self, property_info, f, self.context).show()
+            FunctionDialog(self, prop, f, self.context).show()
             return
 
-        if property_info.value_type == daq.CoreType.ctProc:
+        if prop.value_type == daq.CoreType.ctProc:
             p = daq.IProcedure.cast_from(property_value)
-            FunctionDialog(self, property_info, p, self.context).show()
+            FunctionDialog(self, prop, p, self.context).show()
             return
 
-        if (property_info is None or property_info.read_only):
+        if prop.read_only:
             return
 
         prompt = 'Enter the new value for {}:'.format(property_name)
 
-        if property_info.value_type == daq.CoreType.ctBool:
+        if prop.value_type == daq.CoreType.ctBool:
             property_value = not property_value
-        elif property_info.value_type == daq.CoreType.ctInt:
-            if property_info.selection_values is not None:
+        elif prop.value_type == daq.CoreType.ctInt:
+            if prop.selection_values is not None:
                 property_value = utils.show_selection(
-                    prompt, property_value, property_info.selection_values)
+                    prompt, property_value, prop.selection_values)
             else:
-                min_value = property_info.min_value
-                max_value = property_info.max_value
+                min_value = prop.min_value
+                max_value = prop.max_value
                 if min_value is not None and max_value is not None:
                     property_value = simpledialog.askinteger(
                         property_name, prompt=prompt, initialvalue=property_value, minvalue=min_value.int_value,
@@ -194,9 +259,9 @@ class PropertiesView(ttk.Frame):
                     property_value = simpledialog.askinteger(
                         property_name, prompt=prompt, initialvalue=property_value)
 
-        elif property_info.value_type == daq.CoreType.ctFloat:
-            min_value = property_info.min_value
-            max_value = property_info.max_value
+        elif prop.value_type == daq.CoreType.ctFloat:
+            min_value = prop.min_value
+            max_value = prop.max_value
             if min_value is not None and max_value is not None:
                 property_value = simpledialog.askfloat(
                     property_name, prompt=prompt, initialvalue=property_value, minvalue=min_value.float_value,
@@ -204,11 +269,12 @@ class PropertiesView(ttk.Frame):
             else:
                 property_value = simpledialog.askfloat(
                     property_name, prompt=prompt, initialvalue=property_value)
-        elif property_info.value_type == daq.CoreType.ctString:
+        elif prop.value_type == daq.CoreType.ctString:
             property_value = simpledialog.askstring(
                 property_name, prompt=prompt, initialvalue=property_value)
-        elif property_info.value_type in (daq.CoreType.ctDict, daq.CoreType.ctList):
-            EditContainerPropertyDialog(self, property_info, self.context).show()
+        elif prop.value_type in (daq.CoreType.ctDict, daq.CoreType.ctList):
+            EditContainerPropertyDialog(
+                self, prop, self.context).show()
         else:
             return
 
@@ -216,6 +282,6 @@ class PropertiesView(ttk.Frame):
             return
 
         if old_value != property_value:
-            node.set_property_value(property_name, property_value)
+            prop.value = property_value
             self.refresh()
             self.event_port.emit()

--- a/examples/python/gui_demo/components/properties_view.py
+++ b/examples/python/gui_demo/components/properties_view.py
@@ -29,7 +29,7 @@ class PropertiesView(ttk.Frame):
                   command=lambda: MetadataFieldsSelectorDialog(
                       self, self.context).show()
                   ).pack(
-            side=tk.RIGHT, padx=30)
+            side=tk.RIGHT, anchor=tk.E)
 
         header_frame.pack(fill=tk.X)
         tree = ttk.Treeview(self, columns=(
@@ -53,7 +53,8 @@ class PropertiesView(ttk.Frame):
         tree.column('#1', anchor=tk.W, minwidth=200)
 
         for field in self.context.metadata_fields:
-            tree.heading(field, anchor=tk.W, text=field)
+            tree.heading(field, anchor=tk.W,
+                         text=utils.snake_case_to_title(field))
             tree.column(field, anchor=tk.W, minwidth=200)
 
         # bind double-click to editing
@@ -108,13 +109,16 @@ class PropertiesView(ttk.Frame):
                 property_value = 'Struct {{{}}}'.format(property_info.name)
             else:
                 property_value = printed_value(
-                    property_info.item_type, node.get_property_value(property_info.name))
+                    property_info.value_type, node.get_property_value(property_info.name))
 
             meta_fields = [None] * len(self.context.metadata_fields)
 
             try:
                 for i, field in enumerate(self.context.metadata_fields):
-                    meta_fields[i] = getattr(property_info, field)
+                    metadata_value = getattr(property_info, field)
+                    metadata_value = utils.metadata_converters[field](
+                        metadata_value) if field in utils.metadata_converters else metadata_value
+                    meta_fields[i] = metadata_value
             except Exception as e:
                 print(e)
 

--- a/examples/python/gui_demo/utils.py
+++ b/examples/python/gui_demo/utils.py
@@ -9,7 +9,9 @@ yes_no = ['No', 'Yes']
 
 yes_no_inv = {
     'No':  False,
+    'no': False,
     'Yes': True,
+    'yes': True
 }
 
 
@@ -168,8 +170,15 @@ def str_to_num_or_eval(num_str: str):
 
 
 def value_to_coretype(value, coretype: daq.CoreType):
+    # removing unit symbols
+    if coretype in (daq.CoreType.ctBool, daq.CoreType.ctInt, daq.CoreType.ctFloat):
+        value = str.split(value, ' ')[0]
     if coretype == daq.CoreType.ctBool:
-        return daq.Boolean(bool(value))
+        value = value.lower()
+        if value in ('yes', 'no'):
+            return daq.Boolean(yes_no_inv[value])
+        else:
+            return daq.Boolean(bool(value))
     if coretype == daq.CoreType.ctInt:
         return daq.Integer(int(value))
     if coretype == daq.CoreType.ctFloat:

--- a/examples/python/gui_demo/utils.py
+++ b/examples/python/gui_demo/utils.py
@@ -1,6 +1,7 @@
 import os
 import tkinter as tk
 from tkinter import ttk
+from tkinter import messagebox
 
 import opendaq as daq
 
@@ -24,6 +25,11 @@ def treeview_get_first_selection(treeview):
     if len(sel) == 0:
         return None
     return sel[0]
+
+
+def treeview_select_item(treeview, event):
+    item = treeview.identify_row(event.y)
+    treeview.selection_set(item)
 
 
 def get_nearest_device(component, default=None):
@@ -81,7 +87,7 @@ def show_selection(title, current_value, values):
         else:
             sel_text = ''
         button = ttk.Button(top, text=sel_text + str(value),
-                           command=make_closure(idx))
+                            command=make_closure(idx))
         button.pack(expand=True, fill=tk.BOTH)
 
     if daq.IDict.can_cast_from(values):
@@ -193,3 +199,27 @@ def get_property_for_path(context, path: list, property_object: daq.IPropertyObj
                         property.value)
                     return get_property_for_path(context, path[1:], casted_property)
     return None
+
+
+def get_attributes_of_node(node):
+
+    # to filter callables
+    def is_callable(obj, key):
+        try:
+            return callable(getattr(obj, key))
+        except Exception:
+            return True
+
+    try:
+        attributes = dir(node)
+        attributes = list(
+            filter(lambda x: not x.startswith('_'), attributes))
+        attributes = list(
+            filter(lambda x: not is_callable(node, x), attributes))
+    except Exception:
+        attributes = []
+    return attributes
+
+
+def show_error(title, message, parent=None):
+    messagebox.showerror(title, message, parent=parent)

--- a/examples/python/gui_demo/utils.py
+++ b/examples/python/gui_demo/utils.py
@@ -223,3 +223,27 @@ def get_attributes_of_node(node):
 
 def show_error(title, message, parent=None):
     messagebox.showerror(title, message, parent=parent)
+
+
+def snake_case_to_title(snake_case: str):
+    return snake_case.replace('_', ' ').title()
+
+
+def title_to_snake_case(title: str):
+    return title.lower().replace(' ', '_')
+
+
+def prettify_unit(unit: daq.IStruct):
+    return unit.symbol if unit is not None and unit.symbol is not None else 'None'
+
+
+def prettify_bool(value):
+    return yes_no[value]
+
+
+metadata_converters = {
+    'is_referenced': prettify_bool,
+    'unit': prettify_unit,
+    'read_only': prettify_bool,
+    'visible': prettify_bool
+}


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
This PR adds functionality to view **Metadata fields** of components' **properties**. It also includes some additional changes:
- Boolean properties could be flipped by double click
- Errors notification dialogs
- Various properties view UX improvements