### PR TITLE
Allow to disable flaky tests

### DIFF
--- a/CMakeBasePresets.json
+++ b/CMakeBasePresets.json
@@ -158,7 +158,9 @@
                 "OPENDAQ_GENERATE_CSHARP_BINDINGS": true,
                 "APP_ENABLE_AUDIO_APP": true,
                 "APP_ENABLE_EXAMPLE_APPS": true,
-                "DAQSIMULATOR_ENABLE_SIMULATOR_APP": true
+                "DAQSIMULATOR_ENABLE_SIMULATOR_APP": true,
+                "OPENDAQ_ENABLE_FLAKY_TEST_LABELS": true,
+                "OPENDAQ_SKIP_FLAKY_TESTS": true
             }
         },
         {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ option(OPENDAQ_ENABLE_TEST_UTILS "Enable testing utils library" ON)
 option(OPENDAQ_ENABLE_OPTIONAL_TESTS "Enable optional (debugging) tests" OFF)
 option(OPENDAQ_ENABLE_COVERAGE "Enable code coverage in testing" OFF)
 option(OPENDAQ_ENABLE_REGRESSION_TESTS "Enable regression testing" OFF)
+option(OPENDAQ_ENABLE_FLAKY_TEST_LABELS "Enable labeling flaky tests" OFF)
 
 # Additional build options
 option(OPENDAQ_DISABLE_DEBUG_POSTFIX "Disable debug ('-debug') postfix" OFF)
@@ -158,6 +159,7 @@ if (NOT APPLE AND UNIX)
     cmake_dependent_option(OPENDAQ_ENABLE_WS_SIGGEN_INTEGRATION_TESTS "Enable websocket streaming integration tests" ON "OPENDAQ_ENABLE_TESTS;OPENDAQ_ENABLE_WEBSOCKET_STREAMING" OFF)
 endif()
 cmake_dependent_option(OPENDAQ_GENERATE_PYTHON_BINDINGS_STUBS "Generate python bindings stubs for auto-completion" OFF "OPENDAQ_GENERATE_PYTHON_BINDINGS" OFF)
+cmake_dependent_option(OPENDAQ_SKIP_FLAKY_TESTS "Skip tests marked as flaky" ON "OPENDAQ_ENABLE_FLAKY_TEST_LABELS" ON)
 
 if (OPENDAQ_ENABLE_TESTS)
     set(OPENDAQ_ENABLE_TEST_UTILS ON)
@@ -613,6 +615,16 @@ if (OPENDAQ_ENABLE_OPTIONAL_TESTS)
     message(STATUS "Optional tests enabled")
     add_compile_definitions(OPENDAQ_ENABLE_OPTIONAL_TESTS)
     set(OPENDAQ_TEST_COMPILE_DEFINES "OPENDAQ_ENABLE_OPTIONAL_TESTS=1")
+endif()
+
+if (OPENDAQ_ENABLE_FLAKY_TEST_LABELS)
+    message(STATUS "Labeling flaky tests enabled")
+    add_compile_definitions(OPENDAQ_ENABLE_FLAKY_TEST_LABELS)
+endif()
+
+if (OPENDAQ_SKIP_FLAKY_TESTS)
+    message(STATUS "Skipping flaky tests enabled")
+    add_compile_definitions(OPENDAQ_SKIP_FLAKY_TESTS)
 endif()
 
 if (OPENDAQ_ENABLE_PARAMETER_VALIDATION)

--- a/core/opendaq/reader/tests/reader_common.h
+++ b/core/opendaq/reader/tests/reader_common.h
@@ -33,7 +33,7 @@ using namespace daq;
 
 #if !defined(SKIP_TEST_MAC_CI)
 #if defined(__clang__) && !defined(__RESHARPER__)
-#define SKIP_TEST_MAC_CI return
+#define SKIP_TEST_MAC_CI GTEST_SKIP() << "Skipping test on MacOs"
 #else
 #define SKIP_TEST_MAC_CI
 #endif

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -2475,7 +2475,7 @@ TEST_F(MultiReaderTest, ReadWhilePortIsNotConnected)
     ASSERT_EQ(status.getEventPackets().getCount(), 3u);
 }
 
-TEST_F(MultiReaderTest, ReconnectWhileReading)
+TEST_F_FLAKY_SKIPPED(MultiReaderTest, ReconnectWhileReading)
 {
     constexpr const auto NUM_SIGNALS = 3;
     readSignals.reserve(NUM_SIGNALS);

--- a/docs/tests/docs_test_helpers.h
+++ b/docs/tests/docs_test_helpers.h
@@ -22,7 +22,7 @@
 // MAC CI issue
 #if !defined(SKIP_TEST_MAC_CI)
     #if defined(__clang__)
-        #define SKIP_TEST_MAC_CI return 
+        #define SKIP_TEST_MAC_CI GTEST_SKIP() << "Skipping test on MacOs"
     #else
         #define SKIP_TEST_MAC_CI
     #endif

--- a/docs/tests/test_quick_start.cpp
+++ b/docs/tests/test_quick_start.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <testutils/testutils.h>
 #include <thread>
 #include <opendaq/opendaq.h>
 #include "docs_test_helpers.h"
@@ -147,7 +148,7 @@ TEST_F(QuickStartTest, QuickStartAppConnectOldWebsocket)
 }
 
 // Corresponding document: Antora/modules/quick_start/pages/quick_start_application.adoc
-TEST_F(QuickStartTest, QuickStartAppReaderWebsocket)
+TEST_F_FLAKY_SKIPPED(QuickStartTest, QuickStartAppReaderWebsocket)
 {
     SKIP_TEST_MAC_CI;
 

--- a/modules/tests/test_opendaq_device_modules/test_default_config.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_default_config.cpp
@@ -320,8 +320,10 @@ TEST_F(ModulesDefaultConfigTest, SmartConnectWithIpVerNative)
         instance.removeDevice(device);
     }
 
-    if (test_helpers::Ipv6IsDisabled("ipv6.google.com"))
-        return;
+    if (test_helpers::Ipv6IsDisabled(true))
+    {
+        GTEST_SKIP() << "Ipv6 is disabled - skip rest of the test";
+    }
 
     generalConfig.setPropertyValue("PrimaryAddressType", "IPv6");
     {
@@ -377,8 +379,10 @@ TEST_F(ModulesDefaultConfigTest, SmartConnectWithIpVerOpcUa)
         instance.removeDevice(device);
     }
 
-    if (test_helpers::Ipv6IsDisabled("ipv6.google.com"))
-        return;
+    if (test_helpers::Ipv6IsDisabled(true))
+    {
+        GTEST_SKIP() << "Ipv6 is disabled - skip rest of the test";
+    }
 
     generalConfig.setPropertyValue("PrimaryAddressType", "IPv6");
     {
@@ -428,8 +432,10 @@ TEST_F(ModulesDefaultConfigTest, SmartConnectWithIpVerLt)
         instance.removeDevice(device);
     }
 
-    if (test_helpers::Ipv6IsDisabled("ipv6.google.com"))
-        return;
+    if (test_helpers::Ipv6IsDisabled(true))
+    {
+        GTEST_SKIP() << "Ipv6 is disabled - skip rest of the test";
+    }
 
     generalConfig.setPropertyValue("PrimaryAddressType", "IPv6");
     {

--- a/modules/tests/test_opendaq_device_modules/test_helpers/test_helpers.h
+++ b/modules/tests/test_opendaq_device_modules/test_helpers/test_helpers.h
@@ -38,7 +38,7 @@
 // MAC CI issue
 #if !defined(SKIP_TEST_MAC_CI)
 #   if defined(__clang__)
-#       define SKIP_TEST_MAC_CI return
+#       define SKIP_TEST_MAC_CI GTEST_SKIP() << "Skipping test on MacOs"
 #   else
 #       define SKIP_TEST_MAC_CI
 #   endif
@@ -104,9 +104,15 @@ namespace test_helpers
         return acknowledgementFuture.wait_for(timeout) == std::future_status::ready;
     }
 
+    // Successfully resolving the localhost address confirms that an IPv6 connection is possible with the localhost address.
+    // However, this does not guarantee connectivity via an external IPv6 addresses (e.g., when connecting to a discovered
+    // address of a local simulator).
+    // To verify external IPv6 connectivity as well, resolving a real external address like "ipv6.google.com" is a reliable workaround.
     [[maybe_unused]]
-    static bool Ipv6IsDisabled(std::string hostName = "localhost")
+    static bool Ipv6IsDisabled(bool testExternalAddrConnectivity = false)
     {
+        std::string hostName = testExternalAddrConnectivity ? "ipv6.google.com" : "localhost";
+
         boost::asio::io_service service;
         boost::asio::ip::tcp::resolver resolver(service);
 

--- a/modules/tests/test_opendaq_device_modules/test_native_streaming_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_streaming_modules.cpp
@@ -419,7 +419,7 @@ TEST_F(NativeStreamingModulesTest, GetRemoteDeviceObjectsAfterReconnect)
     }
 }
 
-TEST_F(NativeStreamingModulesTest, ReconnectWhileRead)
+TEST_F_FLAKY_SKIPPED(NativeStreamingModulesTest, ReconnectWhileRead)
 {
     SKIP_TEST_MAC_CI;
     auto server = CreateServerInstance();

--- a/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -63,7 +63,9 @@ TEST_F(OpcuaDeviceModulesTest, ConnectAndDisconnect)
 TEST_F(OpcuaDeviceModulesTest, ConnectViaIpv6)
 {
     if (test_helpers::Ipv6IsDisabled())
-        return;
+    {
+        GTEST_SKIP() << "Ipv6 is disabled";
+    }
 
     auto server = CreateServerInstance();
     auto client = Instance();
@@ -180,7 +182,9 @@ TEST_F(OpcuaDeviceModulesTest, checkDeviceInfoPopulatedWithProvider)
 TEST_F(OpcuaDeviceModulesTest, TestDiscoveryReachability)
 {
     if (test_helpers::Ipv6IsDisabled())
-        return;
+    {
+        GTEST_SKIP() << "Ipv6 is disabled";
+    }
 
     auto instance = InstanceBuilder().addDiscoveryServer("mdns").build();
     auto serverConfig = instance.getAvailableServerTypes().get("OpenDAQOPCUA").createDefaultConfig();
@@ -220,7 +224,9 @@ TEST_F(OpcuaDeviceModulesTest, TestDiscoveryReachability)
 TEST_F(OpcuaDeviceModulesTest, TestDiscoveryReachabilityAfterConnectIPv6)
 {
     if (test_helpers::Ipv6IsDisabled())
-        return;
+    {
+        GTEST_SKIP() << "Ipv6 is disabled";
+    }
 
     auto instance = InstanceBuilder().addDiscoveryServer("mdns").build();
     auto serverConfig = instance.getAvailableServerTypes().get("OpenDAQOPCUA").createDefaultConfig();
@@ -286,7 +292,9 @@ DevicePtr FindOpcuaDeviceByPath(const InstancePtr& instance, const std::string& 
 TEST_F(OpcuaDeviceModulesTest, TestDiscoveryReachabilityAfterConnect)
 {
     if (test_helpers::Ipv6IsDisabled())
-        return;
+    {
+        GTEST_SKIP() << "Ipv6 is disabled";
+    }
 
     auto instance = InstanceBuilder().addDiscoveryServer("mdns").build();
     auto serverConfig = instance.getAvailableServerTypes().get("OpenDAQOPCUA").createDefaultConfig();
@@ -1025,7 +1033,9 @@ TEST_F(OpcuaDeviceModulesTest, TestAddressInfoIPv4)
 TEST_F(OpcuaDeviceModulesTest, TestAddressInfoIPv6)
 {
     if (test_helpers::Ipv6IsDisabled())
-        return;
+    {
+        GTEST_SKIP() << "Ipv6 is disabled";
+    }
 
     auto server = InstanceBuilder().setRootDevice("daqref://device0").build();
     server.addServer("OpenDAQNativeStreaming", nullptr);

--- a/modules/tests/test_opendaq_device_modules/test_streaming.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_streaming.cpp
@@ -647,7 +647,7 @@ INSTANTIATE_TEST_SUITE_P(
 class NativeDeviceStreamingTest : public testing::Test
 {};
 
-TEST_F(NativeDeviceStreamingTest, ChangedDataDescriptorBeforeSubscribeNativeDevice)
+TEST_F_FLAKY_SKIPPED(NativeDeviceStreamingTest, ChangedDataDescriptorBeforeSubscribeNativeDevice)
 {
     SKIP_TEST_MAC_CI;
     const auto moduleManager = ModuleManager("");

--- a/modules/tests/test_opendaq_device_modules/test_streaming.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_streaming.cpp
@@ -292,7 +292,9 @@ TEST_P(StreamingTest, SetNullDescriptor)
 TEST_P(StreamingTest, ChangedDataDescriptorBeforeSubscribe)
 {
     if (std::get<1>(GetParam()).find("daq.nd://") == 0)
-        return;
+    {
+        GTEST_SKIP();
+    }
 
     SKIP_TEST_MAC_CI;
     SignalConfigPtr serverSignalPtr = getSignal(serverInstance, "ByteStep");

--- a/modules/tests/test_opendaq_device_modules/test_subdevices.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_subdevices.cpp
@@ -278,8 +278,7 @@ TEST_P(SubDevicesTest, LeafStreamingToGatewayAndClient)
 
     if (std::get<2>(GetParam()) == StreamingProtocolType::WebsocketStreaming)
     {
-        // skip test
-        return;
+        GTEST_SKIP();
     }
 
     auto subdevice1 = CreateSubdeviceInstance(1u);

--- a/modules/tests/test_opendaq_device_modules/test_subdevices.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_subdevices.cpp
@@ -158,7 +158,7 @@ public:
     }
 };
 
-TEST_P(SubDevicesTest, RootStreamingToClient)
+TEST_P_FLAKY_SKIPPED(SubDevicesTest, RootStreamingToClient)
 {
     SKIP_TEST_MAC_CI;
     auto subdevice1 = CreateSubdeviceInstance(1u);

--- a/modules/tests/test_opendaq_device_modules/test_websocket_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_websocket_modules.cpp
@@ -82,7 +82,9 @@ TEST_F(WebsocketModulesTest, ConnectAndDisconnectBackwardCompatibility)
 TEST_F(WebsocketModulesTest, ConnectViaIpv6)
 {
     if (test_helpers::Ipv6IsDisabled())
-        return;
+    {
+        GTEST_SKIP() << "Ipv6 is disabled";
+    }
 
     auto server = CreateServerInstance();
     auto client = Instance();
@@ -209,7 +211,9 @@ TEST_F(WebsocketModulesTest, checkDeviceInfoPopulatedWithProvider)
 TEST_F(WebsocketModulesTest, TestDiscoveryReachability)
 {
     if (test_helpers::Ipv6IsDisabled())
-        return;
+    {
+        GTEST_SKIP() << "Ipv6 is disabled";
+    }
 
     auto instance = InstanceBuilder().addDiscoveryServer("mdns").build();
     auto serverConfig = instance.getAvailableServerTypes().get("OpenDAQLTStreaming").createDefaultConfig();

--- a/modules/tests/test_ref_modules/test_ref_modules.cpp
+++ b/modules/tests/test_ref_modules/test_ref_modules.cpp
@@ -1014,7 +1014,7 @@ TEST_F(RefModulesTest, ClassifierAsyncData)
     ASSERT_EQ(outputData[0], 1.0);
 }
 
-TEST_F(RefModulesTest, ClassifierCheckAsyncMultiData)
+TEST_F_FLAKY_SKIPPED(RefModulesTest, ClassifierCheckAsyncMultiData)
 {
     using inputSignalType = Int;
     using outputSignalType = Float;

--- a/shared/libraries/config_protocol/tests/test_c2d_streaming.cpp
+++ b/shared/libraries/config_protocol/tests/test_c2d_streaming.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <testutils/testutils.h>
 #include <gmock/gmock.h>
 #include <config_protocol/config_protocol_streaming_producer.h>
 #include <opendaq/gmock/signal.h>
@@ -540,7 +541,7 @@ TEST_F(ClientToDeviceStreamingTest, SignalWithoutDomainConnectDisconnect)
     EXPECT_FALSE(fbIpClient2.getSignal().assigned());
 }
 
-TEST_F(ClientToDeviceStreamingTest, ReplaceConnectedSignalWithServerSignal)
+TEST_F_FLAKY_SKIPPED(ClientToDeviceStreamingTest, ReplaceConnectedSignalWithServerSignal)
 {
     SignalPtr localRootSigClient1 = client1RootDevice.getSignals()[0];
     SignalPtr localRootSigClient2 = client2RootDevice.getSignals()[0];

--- a/shared/libraries/packet_streaming/tests/CMakeLists.txt
+++ b/shared/libraries/packet_streaming/tests/CMakeLists.txt
@@ -6,12 +6,13 @@ add_executable(${TEST_APP}
     test_packet_streaming.cpp
     packet_transmission.h
     packet_transmission.cpp
+    test_app.cpp
 )
 
 target_link_libraries(${TEST_APP} PRIVATE
     ${SDK_TARGET_NAMESPACE}::${BASE_NAME}
     daq::opendaq
-    GTest::GTest GTest::Main
+    ${SDK_TARGET_NAMESPACE}::test_utils
 )
 
 set_target_properties(${TEST_APP} PROPERTIES DEBUG_POSTFIX _debug)

--- a/shared/libraries/packet_streaming/tests/test_app.cpp
+++ b/shared/libraries/packet_streaming/tests/test_app.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include <testutils/bb_memcheck_listener.h>
+
+int main(int argc, char** args)
+{
+    testing::InitGoogleTest(&argc, args);
+
+    testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new DaqMemCheckListener());
+
+    return RUN_ALL_TESTS();
+}

--- a/shared/libraries/testutils/include/testutils/base_test_listener.h
+++ b/shared/libraries/testutils/include/testutils/base_test_listener.h
@@ -15,31 +15,12 @@
  */
 
 #pragma once
-
-#ifndef NDEBUG
-    #ifdef _MSC_VER
-        #define _CRTDBG_MAP_ALLOC  
-        #include <crtdbg.h> 
-    #endif // _MSC_VER 
-#endif // !NDEBUG
-
+#include <gtest/gtest.h>
 #include <testutils/base_test_listener.h>
 
-class MemCheckListener : public BaseTestListener
+class BaseTestListener : public ::testing::EmptyTestEventListener
 {
-public:
-    static bool expectMemoryLeak;
-
 protected:
     void OnTestStart(const testing::TestInfo& info) override;
     void OnTestEnd(const testing::TestInfo& info) override;
-
-private:
-#ifndef NDEBUG
-    #ifdef _MSC_VER
-        _CrtMemState state1;
-    #elif defined(__MINGW32__)
-        size_t curBytesAllocated;
-    #endif
-#endif
 };

--- a/shared/libraries/testutils/include/testutils/testutils.h
+++ b/shared/libraries/testutils/include/testutils/testutils.h
@@ -40,6 +40,15 @@
     // ReSharper restore CppInconsistentNaming
 #endif
 
+#ifndef OPENDAQ_ENABLE_FLAKY_TEST_LABELS
+#   define TEST_F_FLAKY_SKIPPED TEST_F
+#   define TEST_P_FLAKY_SKIPPED TEST_P
+#else
+    // ReSharper disable CppInconsistentNaming
+#   define TEST_F_FLAKY_SKIPPED(test_fixture, test_name)  TEST_F(test_fixture, FLAKY_SKIPPED_##test_name)
+#   define TEST_P_FLAKY_SKIPPED(test_fixture, test_name)  TEST_P(test_fixture, FLAKY_SKIPPED_##test_name)
+    // ReSharper restore CppInconsistentNaming
+#endif
 
 #define ASSERT_SUCCEEDED(ErrCode) ASSERT_TRUE(OPENDAQ_SUCCEEDED(ErrCode))
 

--- a/shared/libraries/testutils/src/CMakeLists.txt
+++ b/shared/libraries/testutils/src/CMakeLists.txt
@@ -5,11 +5,13 @@ set(SRC_Headers bb_memcheck_listener.h
                 memcheck_listener.h
                 ut_logging.h
                 test_comparators.h
+                base_test_listener.h
 )
 
 set(SRC_Cpp bb_memcheck_listener.cpp
             memcheck_listener.cpp
             test_comparators.cpp
+            base_test_listener.cpp
 )
 
 prepend_include(testutils SRC_Headers)

--- a/shared/libraries/testutils/src/base_test_listener.cpp
+++ b/shared/libraries/testutils/src/base_test_listener.cpp
@@ -1,0 +1,18 @@
+#include <testutils/base_test_listener.h>
+
+void BaseTestListener::OnTestStart(const testing::TestInfo& info)
+{
+#ifdef OPENDAQ_SKIP_FLAKY_TESTS
+    const auto testFullName = std::string(info.name());
+    const auto flakyTestPrefix = std::string("FLAKY_SKIPPED_");
+    if (testFullName.find(flakyTestPrefix) == 0)
+    {
+        ::testing::Test::RecordProperty("Flaky test skipped", true);
+        GTEST_SKIP() << "Skipping flaky test: " << info.test_suite_name() << "." << testFullName.substr(flakyTestPrefix.length());
+    }
+#endif
+}
+
+void BaseTestListener::OnTestEnd(const testing::TestInfo& info)
+{
+}

--- a/shared/libraries/testutils/src/memcheck_listener.cpp
+++ b/shared/libraries/testutils/src/memcheck_listener.cpp
@@ -32,6 +32,7 @@ void MemCheckListener::OnTestStart(const testing::TestInfo& info)
     #endif
 #endif
     expectMemoryLeak = false;
+    BaseTestListener::OnTestStart(info);
 }
 
 void MemCheckListener::OnTestEnd(const testing::TestInfo& info)

--- a/shared/libraries/websocket_streaming/tests/CMakeLists.txt
+++ b/shared/libraries/websocket_streaming/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(${TEST_APP}
     test_streaming.cpp
     test_websocket_client_device.cpp
     test_signal_generator.cpp
+    test_app.cpp
 )
 
 if (MSVC)
@@ -18,7 +19,7 @@ target_link_libraries(${TEST_APP} PRIVATE
     daq::opendaq
     daq::opendaq_mocks
     daq::streaming_protocol
-    GTest::GTest GTest::Main
+    ${SDK_TARGET_NAMESPACE}::test_utils
 )
 
 set_target_properties(${TEST_APP} PROPERTIES DEBUG_POSTFIX _debug)

--- a/shared/libraries/websocket_streaming/tests/streaming_test_helpers.h
+++ b/shared/libraries/websocket_streaming/tests/streaming_test_helpers.h
@@ -34,7 +34,7 @@
 // MAC CI issue
 #if !defined(SKIP_TEST_MAC_CI)
 #   if defined(__clang__)
-#       define SKIP_TEST_MAC_CI return
+#       define SKIP_TEST_MAC_CI GTEST_SKIP() << "Skipping test on MacOs"
 #   else
 #       define SKIP_TEST_MAC_CI
 #   endif

--- a/shared/libraries/websocket_streaming/tests/test_app.cpp
+++ b/shared/libraries/websocket_streaming/tests/test_app.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include <testutils/base_test_listener.h>
+
+int main(int argc, char** args)
+{
+    testing::InitGoogleTest(&argc, args);
+
+    testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new BaseTestListener());
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Description:
* Introduces mechanism to skip "flaky" failing tests
* Makes majority of failing test listed in TBBAS-1735 skipped within regular CI test jobs