### PR TITLE
Automatically populate default config in module implementation

### DIFF
--- a/core/coreobjects/include/coreobjects/component_type_impl.h
+++ b/core/coreobjects/include/coreobjects/component_type_impl.h
@@ -124,7 +124,7 @@ ErrCode GenericComponentTypeImpl<Intf, Interfaces...>::createDefaultConfig(IProp
     if (this->defaultConfig.assigned())
         return this->defaultConfig.template asPtr<IPropertyObjectInternal>()->clone(defaultConfig);
 
-    *defaultConfig = nullptr;
+    *defaultConfig = PropertyObject().detach();
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/coreobjects/include/coreobjects/component_type_impl.h
+++ b/core/coreobjects/include/coreobjects/component_type_impl.h
@@ -19,7 +19,7 @@
 #include <coretypes/string_ptr.h>
 #include <coretypes/function_ptr.h>
 #include <coretypes/validation.h>
-#include <coreobjects/property_object_ptr.h>
+#include <coreobjects/property_object_factory.h>
 #include <coretypes/struct_impl.h>
 #include <coretypes/struct_type_factory.h>
 #include <coreobjects/property_object_internal_ptr.h>

--- a/core/opendaq/modulemanager/include/opendaq/module_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_impl.h
@@ -225,8 +225,8 @@ public:
             return errCode;
         
         ComponentTypePtr type;
-        if (types.assigned() && types.hasKey(id))
-            type = types.get(id);
+        if (types.assigned() && types.hasKey(serverTypeId))
+            type = types.get(serverTypeId);
 
         ServerPtr serverInstance;
         errCode = wrapHandlerReturn(this, &Module::onCreateServer, serverInstance, serverTypeId, mergeConfig(config, type), rootDevice);
@@ -437,7 +437,7 @@ private:
                     if (userProp.getValueType() == ctObject)
                         populateDefaultConfig(defaultProp.getValue(), userProp.getValue());
                     else
-                        defaultObj.setPropertyValue(propName, userInput.getPropertyValue(propName));
+                        defaultObj.setPropertyValue(propName, userProp.getValue());
                 }
             }
     }

--- a/core/opendaq/modulemanager/include/opendaq/module_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_impl.h
@@ -129,11 +129,11 @@ public:
         const StringPtr prefix = getPrefixFromConnectionString(connectionString);
         if (prefix.assigned() && prefix.getLength() != 0)
         {
-            for (const auto& type : types)
+            for (const auto& [_, type] : types)
             {
-                if (type.second.getConnectionStringPrefix() == prefix)
+                if (type.getConnectionStringPrefix() == prefix)
                 {
-                    deviceType = type.second;
+                    deviceType = type;
                     break;
                 }
             }
@@ -256,11 +256,11 @@ public:
         const StringPtr prefix = getPrefixFromConnectionString(connectionString);
         if (prefix.assigned() && prefix.getLength() != 0)
         {
-            for (const auto& type : types)
+            for (const auto& [_, type] : types)
             {
-                if (type.second.getConnectionStringPrefix() == prefix)
+                if (type.getConnectionStringPrefix() == prefix)
                 {
-                    streamingType = type.second;
+                    streamingType = type;
                     break;
                 }
             }

--- a/core/opendaq/modulemanager/include/opendaq/module_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_impl.h
@@ -420,12 +420,6 @@ private:
         return "";
     }
 
-    template <typename T>
-    ComponentTypePtr getTypeFromConnectionString(const StringPtr& connectionString, const DictPtr<IString, IComponentType> types)
-    {
-        
-    }
-
     static void populateDefaultConfig(const PropertyObjectPtr& defaultObj, const PropertyObjectPtr& userInput)
     {
         for (const auto& prop : defaultObj.getAllProperties())

--- a/core/opendaq/opendaq/tests/CMakeLists.txt
+++ b/core/opendaq/opendaq/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SOURCES test_factories.cpp
                  test_core_events.cpp
                  test_config_provider.cpp
                  test_access_control.cpp
+                 test_module_callbacks.cpp
                  ${TEST_HEADERS}
 )
 

--- a/core/opendaq/opendaq/tests/test_module_callbacks.cpp
+++ b/core/opendaq/opendaq/tests/test_module_callbacks.cpp
@@ -1,0 +1,150 @@
+#include "test_helpers.h"
+#include <gtest/gtest.h>
+#include <opendaq/module_impl.h>
+#include <opendaq/instance_factory.h>
+#include <opendaq/device_type_factory.h>
+#include <opendaq/function_block_type_factory.h>
+#include <opendaq/server_type_factory.h>
+#include <opendaq/streaming_type_factory.h>
+
+using ModuleCallbacksTest = testing::Test;
+
+BEGIN_NAMESPACE_OPENDAQ
+
+class TestModuleImpl final : public Module
+{
+public:
+
+    static PropertyObjectPtr CreatePartialConfigObject()
+    {
+        PropertyObjectPtr partial = PropertyObject();
+        auto childObj1 = PropertyObject();
+        childObj1.addProperty(StringProperty("foo", "bar"));
+        partial.addProperty(ObjectProperty("child", childObj1));
+        return partial;
+    }
+
+    static PropertyObjectPtr CreateInvalidConfigObject()
+    {
+        PropertyObjectPtr invalid = PropertyObject();
+        auto childObj1 = PropertyObject();
+        invalid.addProperty(BoolProperty("foo", false));
+        childObj1.addProperty(IntProperty("foo", 1));
+        childObj1.addProperty(StringProperty("invalid", "bar"));
+        invalid.addProperty(ObjectProperty("invalidchild", childObj1));
+        return invalid;
+    }
+
+    TestModuleImpl()
+        : Module("name", VersionInfo(1, 0, 0), NullContext(), "id")
+    {
+        obj = PropertyObject();
+        obj.addProperty(StringProperty("foo", "bar"));
+
+        auto childObj1 = PropertyObject();
+        childObj1.addProperty(StringProperty("foo", "bar"));
+
+        auto childObj2 = PropertyObject();
+        childObj2.addProperty(StringProperty("foo", "bar"));
+
+        childObj1.addProperty(ObjectProperty("child", childObj2));
+        obj.addProperty(ObjectProperty("child", childObj1));
+    }
+
+    void configValid(const PropertyObjectPtr& config, const PropertyObjectPtr& reference) 
+    {
+        ASSERT_EQ(config.getAllProperties().getCount(), reference.getAllProperties().getCount());
+        for (const auto& prop : reference.getAllProperties())
+        {
+            const auto name = prop.getName();
+            ASSERT_TRUE(config.hasProperty(name));
+            if (prop.getValueType() == ctObject)
+                configValid(config.getPropertyValue(name), reference.getPropertyValue(name));
+        }
+    }
+
+    DictPtr<IString, IDeviceType> onGetAvailableDeviceTypes() override
+    {
+        return Dict<IString, IDeviceType>({{"id", DeviceType("id", "name", "desc", "daqtest", obj)}});
+    }
+
+    DevicePtr onCreateDevice(const StringPtr& connectionString, const ComponentPtr& parent, const PropertyObjectPtr& config) override
+    {
+        configValid(config, obj);
+        return {};
+    }
+
+    DictPtr<IString, IFunctionBlockType> onGetAvailableFunctionBlockTypes() override
+    {
+        return Dict<IString, IServerType>({{"id", ServerType("id", "name", "desc", obj)}});
+    }
+
+    FunctionBlockPtr onCreateFunctionBlock(const StringPtr& id, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config) override
+    {
+        configValid(config, obj);
+        return {};
+    }
+
+    DictPtr<IString, IServerType> onGetAvailableServerTypes() override
+    {
+        return Dict<IString, IServerType>({{"id", ServerType("id", "name", "desc", obj)}});
+    }
+
+    ServerPtr onCreateServer(const StringPtr& serverType, const PropertyObjectPtr& serverConfig, const DevicePtr& rootDevice) override
+    {
+        configValid(serverConfig, obj);
+        return {};
+    }
+
+    DictPtr<IString, IStreamingType> onGetAvailableStreamingTypes() override
+    {
+        return Dict<IString, IStreamingType>({{"id", StreamingType("id", "name", "desc", "daqtest", obj)}});
+    }
+
+    StreamingPtr onCreateStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config) override
+    {
+        configValid(config, obj);
+        return {};
+    }
+
+    PropertyObjectPtr obj;
+};
+
+
+TEST_F(ModuleCallbacksTest, TestDeviceCallback)
+{
+    const auto _module = createWithImplementation<IModule, TestModuleImpl>();
+
+    ASSERT_FALSE(_module.createDevice("daqtest://", nullptr, nullptr).assigned());
+    ASSERT_FALSE(_module.createDevice("daqtest://", nullptr, PropertyObject()).assigned());
+    ASSERT_FALSE(_module.createDevice("daqtest://", nullptr, TestModuleImpl::CreatePartialConfigObject()).assigned());
+    ASSERT_FALSE(_module.createDevice("daqtest://", nullptr, TestModuleImpl::CreateInvalidConfigObject()).assigned());
+}
+
+TEST_F(ModuleCallbacksTest, TestFBCallback)
+{
+    const auto _module = createWithImplementation<IModule, TestModuleImpl>();
+    ASSERT_FALSE(_module.createFunctionBlock("id", nullptr, "", nullptr).assigned());
+    ASSERT_FALSE(_module.createFunctionBlock("id", nullptr, "", PropertyObject()).assigned());
+    ASSERT_FALSE(_module.createFunctionBlock("id", nullptr, "", TestModuleImpl::CreatePartialConfigObject()).assigned());
+    ASSERT_FALSE(_module.createFunctionBlock("id", nullptr, "", TestModuleImpl::CreateInvalidConfigObject()).assigned());
+}
+
+TEST_F(ModuleCallbacksTest, TestServerCallback)
+{
+    const auto _module = createWithImplementation<IModule, TestModuleImpl>();
+    ASSERT_FALSE(_module.createServer("id", nullptr, nullptr).assigned());
+    ASSERT_FALSE(_module.createServer("id", nullptr, PropertyObject()).assigned());
+    ASSERT_FALSE(_module.createServer("id", nullptr, TestModuleImpl::CreatePartialConfigObject()).assigned());
+    ASSERT_FALSE(_module.createServer("id", nullptr, TestModuleImpl::CreateInvalidConfigObject()).assigned());
+}
+
+TEST_F(ModuleCallbacksTest, TestStreamingCallback)
+{
+    const auto _module = createWithImplementation<IModule, TestModuleImpl>();
+    ASSERT_FALSE(_module.createStreaming("daqtest://", nullptr).assigned());
+    ASSERT_FALSE(_module.createStreaming("daqtest://", PropertyObject()).assigned());
+    ASSERT_FALSE(_module.createStreaming("daqtest://", TestModuleImpl::CreatePartialConfigObject()).assigned());
+    ASSERT_FALSE(_module.createStreaming("daqtest://", TestModuleImpl::CreateInvalidConfigObject()).assigned());
+}
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/server/tests/test_server_type.cpp
+++ b/core/opendaq/server/tests/test_server_type.cpp
@@ -38,7 +38,8 @@ TEST_F(ServerTypeTest, ServerTypeFactoryWithDefaultConfig)
 TEST_F(ServerTypeTest, DefaultConfigNullValue)
 {
     ServerTypePtr serverType = ServerType("test_uid", "", "", nullptr);
-    ASSERT_FALSE(serverType.createDefaultConfig().assigned());
+    ASSERT_TRUE(serverType.createDefaultConfig().assigned());
+    ASSERT_EQ(serverType.createDefaultConfig().getAllProperties().getCount(), 0);
 }
 
 TEST_F(ServerTypeTest, ServerTypeStructType)

--- a/docs/tests/test_examples.cpp
+++ b/docs/tests/test_examples.cpp
@@ -97,7 +97,7 @@ TEST_F(ExamplesTest, Client)
     DevicePtr device = instance.addDevice("daq.opcua://127.0.0.1");
 
     DeviceInfoPtr info = device.getInfo();
-    ASSERT_EQ(info.getName(), "Device 1");
+    ASSERT_EQ(info.getName(), "RefDev1");
 
     StreamReaderPtr reader = StreamReader<double, uint64_t>(device.getSignals(search::Recursive(search::Any()))[0], ReadTimeoutType::Any);
     

--- a/docs/tests/test_quick_start.cpp
+++ b/docs/tests/test_quick_start.cpp
@@ -33,7 +33,7 @@ TEST_F(QuickStartTest, QuickStartAppConnect)
     daq::DevicePtr device = instance.addDevice("daq.opcua://127.0.0.1");
     ASSERT_TRUE(device.assigned());
 
-    ASSERT_EQ(device.getInfo().getName(), "Device 1");
+    ASSERT_EQ(device.getInfo().getName(), "RefDev1");
 }
 
 // Corresponding document: Antora/modules/quick_start/pages/quick_start_application.adoc

--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -33,17 +33,17 @@ RefDeviceImpl::RefDeviceImpl(size_t id, const PropertyObjectPtr& config, const C
                           ? this->logger.getOrAddComponent(REF_MODULE_NAME)
                           : throw ArgumentNullException("Logger must not be null"))
 {
-    if (config.assigned())
+    if (config.assigned() && config.hasProperty("SerialNumber"))
     {
-        if (config.hasProperty("SerialNumber"))
-            serialNumber = config.getPropertyValue("SerialNumber");
+        const StringPtr serialTemp = config.getPropertyValue("SerialNumber");
+        serialNumber = serialTemp.getLength() ? serialTemp : serialNumber;
     }
 
     const auto options = this->context.getModuleOptions(REF_MODULE_NAME);
-    if (options.assigned())
+    if (options.assigned() && options.hasKey("SerialNumber"))
     {
-        if (options.hasKey("SerialNumber"))
-            serialNumber = options.get("SerialNumber");
+        const StringPtr serialTemp = config.getPropertyValue("SerialNumber");
+        serialNumber = serialTemp.getLength() ? serialTemp : serialNumber;
     }
 
     initIoFolder();
@@ -90,6 +90,7 @@ DeviceTypePtr RefDeviceImpl::CreateType()
     defaultConfig.addProperty(StringProperty("SerialNumber", ""));
     defaultConfig.addProperty(BoolProperty("EnableLogging", False));
     defaultConfig.addProperty(StringProperty("LoggingPath", "ref_device_simulator.log"));
+    defaultConfig.addProperty(StringProperty("Name", ""));
 
     return DeviceType("daqref",
                       "Reference device",

--- a/modules/ref_device_module/src/ref_device_module_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_module_impl.cpp
@@ -88,17 +88,29 @@ DevicePtr RefDeviceModule::onCreateDevice(const StringPtr& connectionString,
     if (config.assigned())
     {
         if (config.hasProperty("LocalId"))
-            localId = config.getPropertyValue("LocalId");
+        {
+            StringPtr localIdTemp = config.getPropertyValue("LocalId");
+            localId = localIdTemp.getLength() ? localIdTemp : nullptr;
+        }
         if (config.hasProperty("Name"))
-            name = config.getPropertyValue("Name");
+        {
+            StringPtr nameTemp = config.getPropertyValue("Name");
+            name = nameTemp.getLength() ? nameTemp : nullptr;
+        }
     }
 
     if (options.assigned())
     {
         if (options.hasKey("LocalId"))
-            localId = options.get("LocalId");
+        {
+            StringPtr localIdTemp = options.get("LocalId");
+            localId = localIdTemp.getLength() ? localIdTemp : nullptr;
+        }
         if (options.hasKey("Name"))
-            name = options.get("Name");
+        {
+            StringPtr nameTemp = options.get("Name");
+            name = nameTemp.getLength() ? nameTemp : nullptr;
+        }
     }
 
     if (!localId.assigned())

--- a/modules/ref_device_module/tests/test_ref_device_module.cpp
+++ b/modules/ref_device_module/tests/test_ref_device_module.cpp
@@ -881,7 +881,7 @@ TEST_F(RefDeviceModuleTestConfig, DeviceModuleJsonConfigEmptyString)
     createModule(&module, context);
 
     DevicePtr ptr;
-    ASSERT_THROW(ptr = module.createDevice("daqref://device1", nullptr), GeneralErrorException);
+    ASSERT_NO_THROW(ptr = module.createDevice("daqref://device1", nullptr), GeneralErrorException);
 }
 
 TEST_F(RefDeviceModuleTest, AddRemoveAddDevice)

--- a/modules/ref_device_module/tests/test_ref_device_module.cpp
+++ b/modules/ref_device_module/tests/test_ref_device_module.cpp
@@ -881,7 +881,7 @@ TEST_F(RefDeviceModuleTestConfig, DeviceModuleJsonConfigEmptyString)
     createModule(&module, context);
 
     DevicePtr ptr;
-    ASSERT_NO_THROW(ptr = module.createDevice("daqref://device1", nullptr), GeneralErrorException);
+    ASSERT_NO_THROW(ptr = module.createDevice("daqref://device1", nullptr));
 }
 
 TEST_F(RefDeviceModuleTest, AddRemoveAddDevice)

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -972,7 +972,7 @@ TEST_F(NativeDeviceModulesTest, DeviceInfo)
     ASSERT_EQ(info.getServerCapabilities()[1].getProtocolId(), "OpenDAQNativeConfiguration");
 
     auto subDeviceInfo = client.getDevices()[0].getDevices()[0].getInfo();
-    ASSERT_EQ(subDeviceInfo.getName(), "Device 0");
+    ASSERT_EQ(subDeviceInfo.getName(), "RefDev0");
     ASSERT_EQ(subDeviceInfo.getConnectionString(), "daqref://device0");
     ASSERT_EQ(subDeviceInfo.getModel(), "Reference device");
     ASSERT_EQ(subDeviceInfo.getSerialNumber(), "DevSer0");


### PR DESCRIPTION
# Type of change:

- [x] New feature (non-breaking change which adds functionality)

# Description:

Automatically populate user config object before passing it to the module callbacks (`onCreateDevice`, `onCreateServer`...) 