### PR TITLE
Add minimum cmake install rules for bcrypt

### DIFF
--- a/external/bcrypt/CMakeLists.txt
+++ b/external/bcrypt/CMakeLists.txt
@@ -34,3 +34,16 @@ endif()
 if (OPENDAQ_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
+
+include(GNUInstallDirs)
+
+install(TARGETS ${EXTERNAL_LIB} EXPORT ${EXTERNAL_LIB}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+  
+install(
+    DIRECTORY "include/${EXTERNAL_LIB}"
+    DESTINATION include
+)
+


### PR DESCRIPTION
# Type of change:

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

openDAQ SDK depends on bcrypt. openDAQ SDK cmake configuration fails because there is an install rule for openDAQ SDK but none for bcrypt.
