### PR TITLE
Fix a broken string in python gui_demo

### DIFF
--- a/examples/python/gui_demo/components/add_device_dialog.py
+++ b/examples/python/gui_demo/components/add_device_dialog.py
@@ -162,8 +162,7 @@ class AddDeviceDialog(Dialog):
                 self.select_parent_device(device.global_id)
                 self.event_port.emit()
             except RuntimeError as e:
-                utils.show_error('Error adding device', f'{
-                                 connection_string}: {e}', self)
+                utils.show_error('Error adding device', f'{connection_string}: {e}', self)
                 return
 
     def handle_add_device(self):


### PR DESCRIPTION
At least in python 3.10 you get the following error at the start of `py -m opendaq`:
```
SyntaxError: unterminated string literal (detected at line 165)
```

Seems like python doesn't appreciate the line break there.