### PR TITLE
Backport: serialize the Active flag for all Components

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -49,8 +49,6 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-static constexpr int ComponentSerializeFlag_SerializeActiveProp = 1;
-
 // https://developercommunity.visualstudio.com/t/inline-static-destructors-are-called-multiple-time/1157794
 #if defined(_MSC_VER) && _MSC_VER <= 1927
     #define WORKAROUND_MEMBER_INLINE_VARIABLE
@@ -146,7 +144,6 @@ protected:
     ComponentStatusContainerPtr statusContainer;
 
     ErrCode serializeCustomValues(ISerializer* serializer, bool forUpdate) override;
-    virtual int getSerializeFlags();
 
     std::vector<std::pair<std::string, SerializedObjectPtr>> getSerializedItems(const SerializedObjectPtr& object);
 
@@ -934,12 +931,6 @@ ErrCode ComponentImpl<Intf, Intfs...>::serializeCustomValues(ISerializer* serial
         return OPENDAQ_SUCCESS;
     });
 }
- 
-template <class Intf, class... Intfs>
-int ComponentImpl<Intf, Intfs...>::getSerializeFlags()
-{
-    return 0;
-}
 
 template <class Intf, class... Intfs>
 std::vector<std::pair<std::string, SerializedObjectPtr>> ComponentImpl<Intf, Intfs...>::getSerializedItems(const SerializedObjectPtr& object)
@@ -963,8 +954,7 @@ std::vector<std::pair<std::string, SerializedObjectPtr>> ComponentImpl<Intf, Int
 template <class Intf, class... Intfs>
 void ComponentImpl<Intf, Intfs...>::updateObject(const SerializedObjectPtr& obj, const BaseObjectPtr& /* context */)
 {
-    const auto flags = getSerializeFlags();
-    if (flags & ComponentSerializeFlag_SerializeActiveProp && obj.hasKey("active"))
+    if (obj.hasKey("active"))
         active = obj.readBool("active");
 
     if (obj.hasKey("visible"))
@@ -980,9 +970,7 @@ void ComponentImpl<Intf, Intfs...>::updateObject(const SerializedObjectPtr& obj,
 template <class Intf, class... Intfs>
 void ComponentImpl<Intf, Intfs...>::serializeCustomObjectValues(const SerializerPtr& serializer, bool /* forUpdate */)
 {
-    const auto flags = getSerializeFlags();
-
-    if (flags & ComponentSerializeFlag_SerializeActiveProp && !active)
+    if (!active)
     {
         serializer.key("active");
         serializer.writeBool(active);

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -237,6 +237,8 @@ TEST_F(DeviceTest, SerializeAndDeserialize)
 {
     const auto dev = daq::createWithImplementation<daq::IDevice, MockDevice>(daq::NullContext(), nullptr, "dev");
 
+    dev.setActive(daq::False);
+
     const auto serializer = daq::JsonSerializer(daq::True);
     dev.serialize(serializer);
     const auto str1 = serializer.getOutput();
@@ -254,6 +256,8 @@ TEST_F(DeviceTest, SerializeAndDeserialize)
     ASSERT_EQ(str1, str2);
 
     ASSERT_EQ(newDev.getDevices().getElementInterfaceId(), daq::IDevice::Id);
+
+    ASSERT_FALSE(newDev.getActive());
 }
 
 TEST_F(DeviceTest, BeginUpdateEndUpdate)

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -111,7 +111,6 @@ protected:
 
     void serializeCustomObjectValues(const SerializerPtr& serializer, bool forUpdate) override;
     void updateObject(const SerializedObjectPtr& obj, const BaseObjectPtr& context) override;
-    int getSerializeFlags() override;
 
     virtual EventPacketPtr createDataDescriptorChangedEventPacket();
     virtual void onListenedStatusChanged(bool listened);
@@ -1077,12 +1076,6 @@ void SignalBase<TInterface, Interfaces...>::updateObject(const SerializedObjectP
         isPublic = obj.readBool("public");
 
     Super::updateObject(obj, context);
-}
-
-template <typename TInterface, typename... Interfaces>
-int SignalBase<TInterface, Interfaces...>::getSerializeFlags()
-{
-    return ComponentSerializeFlag_SerializeActiveProp;
 }
 
 template <typename TInterface, typename ... Interfaces>


### PR DESCRIPTION
Backport of https://github.com/openDAQ/openDAQ/pull/615 to `3.10`