### PR TITLE
Component status extension

### DIFF
--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,3 +1,20 @@
+# 5.12.2024:
+## Description
+- Add Component status types to the Type Manager in `context_impl.cpp` ("Ok", "Warning", and "Error")
+- Define `ComponentErrorState` enum in `component.h`
+- Declare and define `initComponentErrorStateStatus`, `setComponentErrorStateStatus`, and `setComponentErrorStateStatusWithMessage` in `component_impl.h`
+- Add `getStatusMessage` in `component_status_container.h`, and `addStatusWithMessage`, `setStatusWithMessage` in `component_status_container_private.h`, implement all three in `component_status_container_impl.h`
+- Use `initComponentErrorStateStatus` and `setComponentErrorStateStatusWithMessage` in all reference Function Blocks
+
+## Required integration changes
+- None, however, developers of Function Blocks are encouraged to use `initComponentErrorStateStatus` and `setComponentErrorStateStatusWithMessage`
+
+```
++ [function] IComponentStatusContainer::getStatusMessage(IString* name, IString** message)
++ [function] IComponentStatusContainerPrivate::addStatusWithMessage(IString* name, IEnumeration* initialValue, IString* message)
++ [function] IComponentStatusContainerPrivate::setStatusWithMessage(IString* name, IEnumeration* value, IString* message)
+```
+
 # 04.12.2024
 ## Description
 - Module-overridable virtual method `ongetLogFileInfos` has been renamed to `onGetLogFileInfos`

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,7 +1,7 @@
 # 5.12.2024
 ## Description
 - Add Component status types to the Type Manager in `context_impl.cpp` ("Ok", "Warning", and "Error")
-- Define `ComponentErrorState` enum in `component.h`
+- Define `ComponentErrorState`
 - Declare and define `initComponentErrorStateStatus`, `setComponentErrorStateStatus`, and `setComponentErrorStateStatusWithMessage` in `component_impl.h`
 - Add `getStatusMessage` in `component_status_container.h`, and `addStatusWithMessage`, `setStatusWithMessage` in `component_status_container_private.h`, implement all three in `component_status_container_impl.h`
 - Use `initComponentErrorStateStatus` and `setComponentErrorStateStatusWithMessage` in all reference Function Blocks

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,4 +1,4 @@
-# 5.12.2024:
+# 5.12.2024
 ## Description
 - Add Component status types to the Type Manager in `context_impl.cpp` ("Ok", "Warning", and "Error")
 - Define `ComponentErrorState` enum in `component.h`
@@ -34,7 +34,7 @@
 + [function] IPropertyObject::getOnAnyPropertyValueRead(IEvent** event)
 ```
 
-# 28.11.2024:
+# 28.11.2024
 ## Description
 - Introduces separate container accessible per device for connection statuses
 - Introduces new core event type "ConnectionStatusChanged" to notify when configuration or streaming connection status of the device changed
@@ -97,7 +97,7 @@
 ## Description
 - Raise minimum required config protocol version to 6 for the following device lockign metods: IDevice::lock(), IDevice::unlock(), IDevice::isLocked(Bool* isLockedOut)
 
-# 12.11.2024:
+# 12.11.2024
 ## Description
 - Improved component updates.
 - Removed generation of local ID for client device in instance.
@@ -131,7 +131,7 @@
 + [function] IUserLock::isLocked(Bool* isLockedOut)
 ```
 
-# 29.10.2024:
+# 29.10.2024
 ## Description
 - Implement thread synchronization mechanism in property objects
 - Provides new internal method to allow for recursive locking in onWrite/onRead events via `GenericPropertyObjectImpl::getRecursiveConfigLock()`

--- a/core/coreobjects/include/coreobjects/core_event_args.h
+++ b/core/coreobjects/include/coreobjects/core_event_args.h
@@ -212,6 +212,7 @@ BEGIN_NAMESPACE_OPENDAQ
  *
  * The event contains the following parameters:
  *  - The new status value encapsulated within an Enumeration object as a value and the status name as a key
+ *  - The new status message under the key "Message"
  *
  * The ID of the event is 120, and the event name is "StatusChanged".
  *

--- a/core/coreobjects/include/coreobjects/core_event_args_impl.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_impl.h
@@ -234,8 +234,6 @@ inline bool CoreEventArgsImpl::validateParameters() const
             return parameters.hasKey("DeviceDomain");
         case CoreEventId::DeviceLockStateChanged:
             return parameters.hasKey("IsLocked");
-        case CoreEventId::StatusChanged:
-            return parameters.getCount() == 2;
         case CoreEventId::ConnectionStatusChanged:
             return parameters.hasKey("StatusName")
                    && parameters.hasKey("StatusValue")

--- a/core/coreobjects/include/coreobjects/core_event_args_impl.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_impl.h
@@ -235,7 +235,7 @@ inline bool CoreEventArgsImpl::validateParameters() const
         case CoreEventId::DeviceLockStateChanged:
             return parameters.hasKey("IsLocked");
         case CoreEventId::StatusChanged:
-            return parameters.getCount() == 1;
+            return parameters.getCount() == 2;
         case CoreEventId::ConnectionStatusChanged:
             return parameters.hasKey("StatusName")
                    && parameters.hasKey("StatusValue")

--- a/core/coretypes/include/coretypes/enumeration.h
+++ b/core/coretypes/include/coretypes/enumeration.h
@@ -34,11 +34,11 @@ BEGIN_NAMESPACE_OPENDAQ
  * @brief Enumerations are immutable objects that encapsulate a value within a predefined set of named integral constants.
  * These constants are predefined in an Enumeration type with the same name as the Enumeration.
  *
- * The Enumeration types are stored within a Type manager. In any given instance of openDAQ, a single Type manager should
+ * The Enumeration types are stored within a Type Manager. In any given Instance of openDAQ, a single Type Manager should
  * exist that is part of its Context.
  *
- * When creating an Enumeration object, the Type manager is used to validate the given enumerator value name against the
- * Enumeration type stored within the manager. If no type with the given Enumeration name is currently stored,
+ * When creating an Enumeration object, the Type Manager is used to validate the given enumerator value name against the
+ * Enumeration type stored within the Manager. If no type with the given Enumeration name is currently stored,
  * construction of the Enumeration object will fail. Similarly, if the provided enumerator value name is not part of
  * the Enumeration type, the construction of the Enumeration object will also fail.
  *

--- a/core/coretypes/src/type_manager_impl.cpp
+++ b/core/coretypes/src/type_manager_impl.cpp
@@ -51,7 +51,7 @@ ErrCode TypeManagerImpl::addType(IType* type)
         {
             if (types.get(typeName) == typePtr)
                 return OPENDAQ_SUCCESS;        // Already exists and is exactly the same, which we don't mind
-            return OPENDAQ_ERR_ALREADYEXISTS;  // Already exists with the same name, but is actually diffrent
+            return OPENDAQ_ERR_ALREADYEXISTS;  // Already exists with the same name, but is actually different
         }
 
         const ErrCode err = types->set(typeName, typePtr);

--- a/core/opendaq/component/include/opendaq/component.h
+++ b/core/opendaq/component/include/opendaq/component.h
@@ -39,13 +39,6 @@ BEGIN_NAMESPACE_OPENDAQ
  * [includeHeader("<coretypes/event_wrapper.h>")]
  */
 
-enum class ComponentErrorState : EnumType
-{
-    Ok = 0,
-    Warning,
-    Error
-};
-
 /*!
  * @brief Acts as a base interface for components, such as device, function block, channel and signal.
  *

--- a/core/opendaq/component/include/opendaq/component.h
+++ b/core/opendaq/component/include/opendaq/component.h
@@ -39,6 +39,12 @@ BEGIN_NAMESPACE_OPENDAQ
  * [includeHeader("<coretypes/event_wrapper.h>")]
  */
 
+enum class ComponentErrorState : EnumType
+{
+    Ok = 0,
+    Warning,
+    Error
+};
 
 /*!
  * @brief Acts as a base interface for components, such as device, function block, channel and signal.

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -58,6 +58,13 @@ BEGIN_NAMESPACE_OPENDAQ
 
 #define COMPONENT_AVAILABLE_ATTRIBUTES {"Name", "Description", "Visible", "Active"}
 
+enum class ComponentErrorState : EnumType
+{
+    Ok = 0,
+    Warning,
+    Error
+};
+
 template <class Intf = IComponent, class ... Intfs>
 class ComponentImpl : public GenericPropertyObjectImpl<Intf, IRemovable, IComponentPrivate, IDeserializeComponent, Intfs ...>
 {

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1131,7 +1131,7 @@ template <class Intf, class... Intfs>
 void ComponentImpl<Intf, Intfs...>::initComponentErrorStateStatus() const
 {
     // Component error state status is added ("Ok" when a component is created)
-    const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>();
+    const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>(true);
     const auto componentStatusValue =
         EnumerationWithIntValue("ComponentStatusType", static_cast<Int>(ComponentErrorState::Ok), this->context.getTypeManager());
     statusContainerPrivate.addStatus("ComponentStatus", componentStatusValue);
@@ -1158,7 +1158,7 @@ void ComponentImpl<Intf, Intfs...>::setComponentErrorStateStatusWithMessage(cons
     }
 
     // Set status if initialized
-    const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>();
+    const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>(true);
     const auto componentStatusValue =
         EnumerationWithIntValue("ComponentStatusType", static_cast<Int>(status), this->context.getTypeManager());
     statusContainerPrivate.setStatusWithMessage("ComponentStatus", componentStatusValue, message);

--- a/core/opendaq/component/include/opendaq/component_status_container.h
+++ b/core/opendaq/component/include/opendaq/component_status_container.h
@@ -42,7 +42,7 @@ BEGIN_NAMESPACE_OPENDAQ
 DECLARE_OPENDAQ_INTERFACE(IComponentStatusContainer, IBaseObject)
 {
     /*!
-     * @brief Gets the the current value of Component status with a given name.
+     * @brief Gets the current value of Component status with a given name.
      * @param name The name of Component status.
      * @param[out] value The current value of Component status.
      */
@@ -56,6 +56,13 @@ DECLARE_OPENDAQ_INTERFACE(IComponentStatusContainer, IBaseObject)
      * All objects in the statuses dictionary are key value pairs of <IString, IEnumeration>.
      */
     virtual ErrCode INTERFACE_FUNC getStatuses(IDict** statuses) = 0;
+
+    /*!
+     * @brief Gets the status message of Component status with a given name.
+     * @param name The name of Component status.
+     * @param[out] message The current message of Component status.
+     */
+    virtual ErrCode INTERFACE_FUNC getStatusMessage(IString* name, IString** message) = 0;
 };
 
 OPENDAQ_DECLARE_CLASS_FACTORY(LIBRARY_FACTORY, ComponentStatusContainer)

--- a/core/opendaq/component/include/opendaq/component_status_container_private.h
+++ b/core/opendaq/component/include/opendaq/component_status_container_private.h
@@ -54,6 +54,22 @@ DECLARE_OPENDAQ_INTERFACE(IComponentStatusContainerPrivate, IBaseObject)
      * @param value The new value of the component status.
      */
     virtual ErrCode INTERFACE_FUNC setStatus(IString* name, IEnumeration* value) = 0;
+
+    /*!
+     * @brief Adds the new status with given name, initial value, and message.
+     * @param name The name of the component status.
+     * @param initialValue The initial value of the component status.
+     * @param message The message of the component status.
+     */
+    virtual ErrCode INTERFACE_FUNC addStatusWithMessage(IString* name, IEnumeration* initialValue, IString* message) = 0;
+
+    /*!
+     * @brief Sets the value for the existing component status with a message.
+     * @param name The name of the component status.
+     * @param value The new value of the component status.
+     * @param message The new message of the component status.
+     */
+    virtual ErrCode INTERFACE_FUNC setStatusWithMessage(IString* name, IEnumeration* value, IString* message) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/component/tests/test_component.cpp
+++ b/core/opendaq/component/tests/test_component.cpp
@@ -13,8 +13,7 @@
 #include <opendaq/component_status_container_private_ptr.h>
 #include <opendaq/component_exceptions.h>
 #include <opendaq/component_impl.h>
-
-#include "testutils/testutils.h"
+#include <testutils/testutils.h>
 
 using namespace daq;
 using namespace testing;

--- a/core/opendaq/component/tests/test_component_status_container.cpp
+++ b/core/opendaq/component/tests/test_component_status_container.cpp
@@ -4,8 +4,7 @@
 #include <opendaq/component_status_container_private_ptr.h>
 #include <opendaq/context_factory.h>
 #include <opendaq/component_deserialize_context_factory.h>
-
-#include "opendaq/instance_factory.h"
+#include <opendaq/instance_factory.h>
 
 using namespace daq;
 using namespace testing;

--- a/core/opendaq/functionblock/include/opendaq/function_block.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block.h
@@ -110,13 +110,13 @@ DECLARE_OPENDAQ_INTERFACE(IFunctionBlock, IFolder)
 
     // [templateType(functionBlockTypes, IString, IFunctionBlockType)]
     /*!
-     * @brief Gets all neasted function block types that are supported, containing their description.
+     * @brief Gets all nested function block types that are supported, containing their description.
      * @param[out] functionBlockTypes A dictionary of available function block types.
      */
     virtual ErrCode INTERFACE_FUNC getAvailableFunctionBlockTypes(IDict** functionBlockTypes) = 0;
 
     /*!
-     * @brief Creates and adds a function block as the neasted of current function block with the provided unique ID and returns it.
+     * @brief Creates and adds a function block as the nested of current function block with the provided unique ID and returns it.
      * @param[out] functionBlock The added function block.
      * @param typeId The unique ID of the function block. Can be obtained from its corresponding Function Block Info
      * object.

--- a/core/opendaq/modulemanager/src/context_impl.cpp
+++ b/core/opendaq/modulemanager/src/context_impl.cpp
@@ -34,15 +34,6 @@ ContextImpl::ContextImpl(SchedulerPtr scheduler,
     if (!this->typeManager.assigned())
         this->typeManager = TypeManager();
 
-    if (!this->typeManager.hasType("ConnectionStatusType"))
-    {
-        const auto statusType = EnumerationType("ConnectionStatusType", List<IString>("Connected",
-                                                                                      "Reconnecting",
-                                                                                      "Unrecoverable",
-                                                                                      "Removed"));
-        this->typeManager.addType(statusType);
-    }
-
     if (!this->authenticationProvider.assigned())
         this->authenticationProvider = AuthenticationProvider();
 
@@ -308,6 +299,9 @@ void ContextImpl::registerOpenDaqTypes()
     // Add component status types to the type manager
     const auto componentStatusType = EnumerationType("ComponentStatusType", List<IString>("Ok", "Warning", "Error"));
     typeManager->addType(componentStatusType);
+
+    const auto connectionStatusType = EnumerationType("ConnectionStatusType", List<IString>("Connected", "Reconnecting", "Unrecoverable", "Removed"));
+    typeManager.addType(connectionStatusType);
 }
 
 OPENDAQ_DEFINE_CLASS_FACTORY(

--- a/core/opendaq/modulemanager/src/context_impl.cpp
+++ b/core/opendaq/modulemanager/src/context_impl.cpp
@@ -304,6 +304,10 @@ void ContextImpl::registerOpenDaqTypes()
                                     .build();
 
     typeManager->addType(ptpSyncInterface);
+
+    // Add component status types to the type manager
+    const auto componentStatusType = EnumerationType("ComponentStatusType", List<IString>("Ok", "Warning", "Error"));
+    typeManager->addType(componentStatusType);
 }
 
 OPENDAQ_DEFINE_CLASS_FACTORY(

--- a/docs/Antora/modules/knowledge_base/pages/components.adoc
+++ b/docs/Antora/modules/knowledge_base/pages/components.adoc
@@ -89,7 +89,7 @@ folders.
 
 Each component within the openDAQ(TM) tree may have one or more implementation-specific predefined statuses.
 Each status is uniquely named within the component's scope and is assigned an openDAQ(TM) enumeration type value.
-An example of such a status is the "InputStatus" of the xref:function_blocks.adoc#scaling_fb[Scaling Function Block]:
+All components have a predefined status named "ComponentStatus" that is used, for example, by all reference Function Block implementations, such as the xref:function_blocks.adoc#scaling_fb[Scaling Function Block]:
 
 [cols="1,3"]
 |===
@@ -97,20 +97,19 @@ An example of such a status is the "InputStatus" of the xref:function_blocks.ado
 | **Status value**
 | **Description**
 
-| "Disconnected"
-| No xref:signals.adoc[Signal] is connected to the xref:function_blocks.adoc#input_port[Input Port] of the Function block
+| "Ok"
+| Everything is working fine. This is the initial state.
 
-| "Invalid"
-| A Signal is connected to the Input Port of Function block, but scaling is not possible because its xref:signals.adoc#data_descriptor[DataDescriptor]
-does not fulfill the scaling conditions, or the xref:signals.adoc#domain_signal[Domain Signal] is not assigned
+| "Warning"
+| There's a warning.
 
-| "Connected"
-| The connected signal is valid and can be scaled
+| "Error"
+| Something went wrong.
 
 |===
 
 This example code snippet showcases the addition of the Scaling Function Block and the printing of
-all its statuses names along with the current value of "InputStatus":
+all its statuses names along with the current value ("Ok" by default) and message (empty string by default) of "ComponentStatus":
 
 [tabs]
 ====
@@ -123,8 +122,11 @@ std::cout << "The Scaling Function Block available statuses: ";
 for (const auto& [name, _] : scalingFb.getStatusContainer().getStatuses())
     std::cout << "\"" << name << "\"; ";
 std::cout << std::endl
-          << "The Scaling Function Block \"InputStatus\" is "
-          << scalingFb.getStatusContainer().getStatus("InputStatus")
+          << "The Scaling Function Block \"ComponentStatus\" is "
+          << scalingFb.getStatusContainer().getStatus("ComponentStatus")
+          << std::endl
+          << "The message is "
+          << scalingFb.getStatusContainer().getStatusMessage("ComponentStatus")
           << std::endl;
 ----
 C#::
@@ -136,8 +138,10 @@ Console.WriteLine("The Scaling Function Block available statuses: ");
 foreach (string statusName in functionBlock.StatusContainer.Statuses.Keys)
     Console.WriteLine($"\"{statusName}\"");
 Console.WriteLine();
-Console.WriteLine("The Scaling Function Block \"InputStatus\" is {0}",
-                  scalingFb.StatusContainer.GetStatus("InputStatus"));
+Console.WriteLine("The Scaling Function Block \"ComponentStatus\" is {0}",
+                  scalingFb.StatusContainer.GetStatus("ComponentStatus"));
+Console.WriteLine("The message is {0}",
+                  scalingFb.StatusContainer.GetStatusMessage("ComponentStatus"));
 ----
 ====
 

--- a/docs/tests/test_components.cpp
+++ b/docs/tests/test_components.cpp
@@ -47,12 +47,17 @@ TEST_F(ComponentsTest, DeviceFolderTypes)
 TEST_F(ComponentsTest, ComponentStatuses)
 {
     auto instance = docs_test_helpers::setupInstance();
+
     const auto scalingFb = instance.addFunctionBlock("RefFBModuleScaling");
     auto statuses = scalingFb.getStatusContainer().getStatuses();
 
-    ASSERT_GT(statuses.getCount(), 0u);
-    ASSERT_TRUE(statuses.hasKey("InputStatus"));
-    ASSERT_EQ(scalingFb.getStatusContainer().getStatus("InputStatus"), "Disconnected");
+    auto status = scalingFb.getStatusContainer().getStatus("ComponentStatus");
+    auto message = scalingFb.getStatusContainer().getStatusMessage("ComponentStatus");
+
+    ASSERT_GT(statuses.getCount(), 0);
+    ASSERT_TRUE(status == Enumeration("ComponentStatusType", "Ok", instance.getContext().getTypeManager()));
+    ASSERT_EQ(status, Enumeration("ComponentStatusType", "Ok", instance.getContext().getTypeManager()));
+    ASSERT_EQ(message, "");
 }
 
 END_NAMESPACE_OPENDAQ

--- a/modules/ref_fb_module/include/ref_fb_module/scaling_fb_impl.h
+++ b/modules/ref_fb_module/include/ref_fb_module/scaling_fb_impl.h
@@ -67,7 +67,6 @@ private:
 
     void processEventPacket(const EventPacketPtr& packet);
     void onPacketReceived(const InputPortPtr& port) override;
-    void onDisconnected(const InputPortPtr& port) override;
 
     void processSignalDescriptorChanged(const DataDescriptorPtr& inputDataDescriptor,
                                         const DataDescriptorPtr& inputDomainDataDescriptor);
@@ -77,9 +76,6 @@ private:
     void initProperties();
     void propertyChanged(bool configure);
     void readProperties();
-
-    void initStatuses();
-    void setInputStatus(const StringPtr& value);
 };
 
 }

--- a/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -25,6 +25,7 @@ namespace PowerReader
 PowerReaderFbImpl::PowerReaderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
     : FunctionBlock(CreateType(), ctx, parent, localId)
 {
+    initComponentErrorStateStatus();
     createInputPorts();
     createSignals();
     initProperties();
@@ -197,16 +198,28 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
             this->currentDescriptor = currentDescriptor;
 
         if (this->domainDescriptor == NullDataDescriptor())
+        {
+            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Input domain descriptor is not set");
             throw std::runtime_error("Input domain descriptor is not set");
+        }
         if (this->voltageDescriptor == NullDataDescriptor())
+        {
+            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Input voltage descriptor is not set");
             throw std::runtime_error("Input voltage descriptor is not set");
+        }
+            
         if (this->currentDescriptor == NullDataDescriptor())
+        {
+            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Input current descriptor is not set");
             throw std::runtime_error("Input current descriptor is not set");
+        }
 
-        if (this->voltageDescriptor.assigned() &&
-            this->voltageDescriptor.getUnit().assigned() &&
+        if (this->voltageDescriptor.assigned() && this->voltageDescriptor.getUnit().assigned() &&
             this->voltageDescriptor.getUnit().getSymbol() != "V")
+        {
+            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid voltage signal unit");
             throw std::runtime_error("Invalid voltage signal unit");
+        }
 
         const auto powerDataDescriptorBuilder =
             DataDescriptorBuilder().setSampleType(SampleType::Float64).setUnit(Unit("W", -1, "watt", "power"));
@@ -227,6 +240,7 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
     }
     catch (const std::exception& e)
     {
+        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Failed to set descriptor for power signal");
         LOG_W("Failed to set descriptor for power signal: {}", e.what())
         reader.setActive(False);
     }

--- a/modules/ref_fb_module/tests/test_fb_statistics.cpp
+++ b/modules/ref_fb_module/tests/test_fb_statistics.cpp
@@ -46,7 +46,7 @@ public:
         // Create logger, module manager, context and module
         const auto logger = Logger();
         moduleManager = ModuleManager("[[none]]");
-        context = Context(Scheduler(logger), logger, nullptr, moduleManager, nullptr);
+        context = Context(Scheduler(logger), logger, TypeManager(), moduleManager, nullptr);
         createModule(&module, context);
         moduleManager.addModule(module);
         moduleManager = context.asPtr<IContextInternal>().moveModuleManager();

--- a/modules/ref_fb_module/tests/test_fb_trigger.cpp
+++ b/modules/ref_fb_module/tests/test_fb_trigger.cpp
@@ -27,7 +27,7 @@ public:
     {
         // Create logger, context and module
         auto logger = Logger();
-        context = Context(Scheduler(logger), logger, nullptr, nullptr, nullptr);
+        context = Context(Scheduler(logger), logger, TypeManager(), nullptr, nullptr);
         createModule(&module, context);
 
         this->rule = rule;
@@ -333,4 +333,28 @@ TEST_F(TriggerTest, TriggerTestIntLinearThresholdChanged)
                                     {},
                                     newThresholds);
     helper.run();
+}
+
+TEST_F(TriggerTest, TriggerTestErrorStateStatus)
+{
+    // Create context and module
+    auto context = NullContext();
+    ModulePtr module;
+    createModule(&module, context);
+    // Create function block
+    auto fb = module.createFunctionBlock("RefFBModuleTrigger", nullptr, "fb");
+    // Cast to component
+    auto comp = fb.asPtr<IComponent>();
+    // Assert that initial status is "Ok"
+    ASSERT_EQ(comp.getStatusContainer().getStatus("ComponentStatus"), Enumeration("ComponentStatusType", "Ok", context.getTypeManager()));
+    // Assert that initial message is an empty string
+    ASSERT_EQ(comp.getStatusContainer().getStatusMessage("ComponentStatus"), "");
+    // Set new status via ...
+    auto signal = Signal(context, nullptr, "ID");
+    fb.getInputPorts()[0].connect(signal);
+    // Assert that now status is now "Warning"
+    ASSERT_EQ(comp.getStatusContainer().getStatus("ComponentStatus"),
+              Enumeration("ComponentStatusType", "Warning", context.getTypeManager()));
+    // Assert that message is "Failed to set descriptor for trigger signal!"
+    ASSERT_EQ(comp.getStatusContainer().getStatusMessage("ComponentStatus"), "Failed to set descriptor for trigger signal");
 }

--- a/modules/ref_fb_module/tests/test_ref_fb_module.cpp
+++ b/modules/ref_fb_module/tests/test_ref_fb_module.cpp
@@ -93,7 +93,7 @@ static ModulePtr CreateModule()
 {
     ModulePtr module;
     auto logger = Logger();
-    createModule(&module, Context(Scheduler(logger), logger, nullptr, nullptr, nullptr));
+    createModule(&module, Context(Scheduler(logger), logger, TypeManager(), nullptr, nullptr));
     return module;
 }
 


### PR DESCRIPTION
# Type of change:

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:

* Add Component status types to the Type Manager in `context_impl.cpp` ("Ok", "Warning", and "Error")
* Define `ComponentErrorState`
* Declare and define `initComponentErrorStateStatus`, `setComponentErrorStateStatus`, and `setComponentErrorStateStatusWithMessage` in `component_impl.h`
* Add `getStatusMessage` in `component_status_container.h`, and `addStatusWithMessage`, `setStatusWithMessage` in `component_status_container_private.h` , implement all three in `component_status_container_impl.h`, and make other appropriate changes wherever necessary
* Use `initComponentErrorStateStatus` and `setComponentErrorStateStatusWithMessage` in all reference Function Blocks
* Add appropriate tests and supplement existing ones
* Modify Doxygen and Antora docs
* Fix typos, and other minor issues, etc. (unrelated)