### PR TITLE
Remove root device on instance destruction

### DIFF
--- a/core/opendaq/opendaq/include/opendaq/instance_impl.h
+++ b/core/opendaq/opendaq/include/opendaq/instance_impl.h
@@ -168,7 +168,7 @@ private:
 
     bool rootDeviceSet;
 
-    void stopAndRemoveServers();
+    void stopAndRemoveServers() const;
     DevicePtr createDevice(const StringPtr& connectionString, const PropertyObjectPtr& config = nullptr);
 
     template<class F>

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -64,6 +64,7 @@ InstanceImpl::InstanceImpl(IInstanceBuilder* instanceBuilder)
 InstanceImpl::~InstanceImpl()
 {
     stopAndRemoveServers();
+    rootDevice.remove();
     rootDevice.release();
 }
 
@@ -132,8 +133,11 @@ static ContextPtr ContextFromInstanceBuilder(IInstanceBuilder* instanceBuilder)
     return Context(scheduler, logger, typeManager, moduleManager, authenticationProvider, options, discoveryServers);
 }
 
-void InstanceImpl::stopAndRemoveServers()
+void InstanceImpl::stopAndRemoveServers() const
 {
+    if (rootDevice.isRemoved())
+        return;
+
     for (const auto& server : rootDevice.getServers())
     {
         server.stop();

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -945,4 +945,47 @@ TEST_F(InstanceTest, DISABLED_SaveLoadServers)
     ASSERT_EQ(servers[0].getId(), serverId);
 }
 
+TEST_F(InstanceTest, TestRemoved1)
+{
+    auto instance = test_helpers::setupInstance();
+    instance.addFunctionBlock("mock_fb_uid");
+    instance.addDevice("daqmock://client_device");
+    instance.addDevice("daqmock://phys_device");
+
+    const ListPtr<IComponent> components = instance.getItems(search::Recursive(search::Any()));
+
+    const auto root = instance.getRootDevice();
+    root.remove();
+
+    Bool removed = false;
+    root.asPtr<IRemovable>()->isRemoved(&removed);
+    ASSERT_TRUE(removed);
+
+    for (const auto& component : components)
+    {
+        component.asPtr<IRemovable>()->isRemoved(&removed);
+        ASSERT_TRUE(removed);
+    }
+}
+
+TEST_F(InstanceTest, TestRemoved2)
+{
+    auto instance = test_helpers::setupInstance();
+    instance.addFunctionBlock("mock_fb_uid");
+    instance.addDevice("daqmock://client_device");
+    instance.addDevice("daqmock://phys_device");
+
+    ListPtr<IComponent> components = instance.getItems(search::Recursive(search::Any()));
+    components.pushBack(instance.getRootDevice());
+
+    instance.release();
+
+    Bool removed = false;
+    for (const auto& component : components)
+    {
+        component.asPtr<IRemovable>()->isRemoved(&removed);
+        ASSERT_TRUE(removed);
+    }
+}
+
 END_NAMESPACE_OPENDAQ


### PR DESCRIPTION
# Type of change:

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Description:

- `rootDevice.remove()` is now called on instance destruction.
- openDAQ components can hook onto the `onRemoved()` that will be called when the openDAQ program terminates.