### PR TITLE
Make attributes editable in Python GUI Demo Application

### DIFF
--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -233,7 +233,7 @@ class AttributesDialog(Dialog):
             locked = utils.yes_no[locked_flag]
             iid = f'{parent}.{key}'
             if type(value) is bool:
-                value = yes_no[value]
+                value = utils.yes_no[value]
             elif type(value) is dict:
                 self.tree.insert(
                     parent, tk.END, iid=iid, text=key, values=('', locked))

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -119,7 +119,7 @@ class AttributesDialog(Dialog):
         if not node:
             return
 
-        sel = utils.treeview_get_first_selection(self.tree)
+        sel = utils.treeview_get_first_selection(self.tree)[1:]
         if sel not in self.attributes:
             return
 


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:

This fixes the issue of attributes not being editable in Python GUI Demo Application
* This works, because there is an unexpected `.` at the beginning of `sel`
* Because the code that handles the logic for this action was already there I'm assuming this either:
  * Never worked as intended
  * Stopped working due to to updates in either Python or tkinter versions (most likely the latter)
    * Tested using:
      * `Python 3.12.8`
      * `tkinter 8.6`
      * `opendaq-3.11.0+301c940-cp312-cp312-win_amd64.whl`
      * Not sure what else could be relevant
* My other worry is that `utils.treeview_get_first_selection` function has the possibility of returning `None`, and, in turn, this generating an error, but I'm guessing `None` was intended for other cases where this function is used