### PR TITLE
Return a copy of internal dictionary of current statuses instead of original

### DIFF
--- a/core/opendaq/component/include/opendaq/component_status_container_impl.h
+++ b/core/opendaq/component/include/opendaq/component_status_container_impl.h
@@ -81,7 +81,16 @@ ErrCode StatusContainerBase<TInterface, Interfaces...>::getStatuses(IDict** stat
 
     std::scoped_lock lock(sync);
 
-    *statuses = this->statuses.addRefAndReturn();
+    auto dict = Dict<IString, IEnumeration>();
+
+    for (const auto& [name, value]: this->statuses)
+    {
+        dict.set(name, value);
+    }
+
+    dict.freeze();
+
+    *statuses = dict.detach();
     return OPENDAQ_SUCCESS;
 }
 


### PR DESCRIPTION
The current implementation returns an internal dictionary of statuses, which is not thread-safe and potentially dangerous because one thread can update the status. At the same time, the other reads the statuses via the dictionary, which is not under lock.