### PR TITLE
Fix status messages not propagated via native protocol

### DIFF
--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -1347,6 +1347,37 @@ TEST_F(CoreEventTest, StatusChanged)
     ASSERT_EQ(changeCount, 3);
 }
 
+TEST_F(CoreEventTest, StatusAndMsgChanged)
+{
+    const auto typeManager = instance.getContext().getTypeManager();
+    const auto statusType = EnumerationType("StatusType", List<IString>("Status0", "Status1"));
+    typeManager.addType(statusType);
+
+    const auto statusInitValue = Enumeration("StatusType", "Status0", typeManager);
+    const auto statusValue = Enumeration("StatusType", "Status1", typeManager);
+
+    const auto device = instance.getRootDevice();
+    const auto statusContainer = device.getStatusContainer().asPtr<IComponentStatusContainerPrivate>();
+    statusContainer.addStatus("TestStatus", statusInitValue);
+
+    bool eventCalled = false;
+    getOnCoreEvent() += [&](const ComponentPtr& comp, const CoreEventArgsPtr& args)
+    {
+        ASSERT_EQ(comp, instance.getRootDevice());
+        ASSERT_EQ(args.getEventId(), static_cast<int>(CoreEventId::StatusChanged));
+        ASSERT_EQ(args.getEventName(), "StatusChanged");
+        ASSERT_TRUE(args.getParameters().hasKey("TestStatus"));
+        ASSERT_TRUE(args.getParameters().hasKey("Message"));
+        ASSERT_EQ(args.getParameters().get("TestStatus"), statusValue);
+        ASSERT_EQ(args.getParameters().get("Message"), "Msg");
+        eventCalled = true;
+    };
+
+    statusContainer.setStatusWithMessage("TestStatus", statusValue, "Msg");
+
+    ASSERT_TRUE(eventCalled);
+}
+
 TEST_F(CoreEventTest, StatusChangedMuted)
 {
     const auto typeManager = instance.getContext().getTypeManager();

--- a/modules/tests/test_opendaq_device_modules/CMakeLists.txt
+++ b/modules/tests/test_opendaq_device_modules/CMakeLists.txt
@@ -50,6 +50,10 @@ if (OPENDAQ_ENABLE_NATIVE_STREAMING)
     )
 endif()
 
+if (MSVC)
+    target_compile_options(${TEST_APP} PRIVATE /bigobj)
+endif()
+
 add_test(NAME ${TEST_APP}
          COMMAND $<TARGET_FILE_NAME:${TEST_APP}>
          WORKING_DIRECTORY bin

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -285,8 +285,21 @@ void ConfigClientComponentBaseImpl<Impl>::statusChanged(const CoreEventArgsPtr& 
 {
     ComponentStatusContainerPtr statusContainer;
     checkErrorInfo(Impl::getStatusContainer(&statusContainer));
-    DictPtr<IString, IEnumeration> changedStatuses = args.getParameters();
-    for (const auto& st : changedStatuses)
-        statusContainer.asPtr<IComponentStatusContainerPrivate>().setStatus(st.first, st.second);
+
+    auto msg = String("");
+    const DictPtr<IString, IBaseObject> params = args.getParameters();
+    if (params.hasKey("Message"))
+        msg = params.get("Message");
+
+    for (const auto& st : params)
+    {
+        if (st.second.getCoreType() == CoreType::ctEnumeration)
+        {
+            statusContainer.asPtr<IComponentStatusContainerPrivate>().setStatusWithMessage(
+                st.first, st.second.asPtr<IEnumeration>(true), msg);
+            msg = String("");
+        }
+    }
 }
+
 }


### PR DESCRIPTION
Status message is currently not propagated to client, because "message" field is treated as status. This PR is a temporary workaround. I think that original issue is that parameters for status changed are set like this:

```
{
    "StatusName": IEnumeration_StatusValue,
    "Message": "some message"
}

const CoreEventArgsPtr args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
     CoreEventId::StatusChanged, Dict<IString, IBaseObject>({{name, value}, {"Message", message}}));

```

So the problem is that "StatusName" is the key. Probably it was designed like this so that multiple statuses can be reported. But this does not work with messages, as we can have only one message. The full solution would be something like this:

```
{
      "StatusName1": {
        "Value":  IEnumeration_StatusValue
        "Message": "some message"
      },
      "StatusName2": 
      {
        "Value":  IEnumeration_StatusValue
        "Message": "some message"
      }
}
```

I'm just not sure how to handle backwards compatibility