### PR TITLE
Properly set component status on reconnect

### DIFF
--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -67,6 +67,13 @@ static InstancePtr CreateUpdatedServerInstance()
     const auto testType = EnumerationType("TestEnumType", List<IString>("TestValue1", "TestValue2"));
     instance.getContext().getTypeManager().addType(testType);
 
+    const auto statusType = EnumerationType("StatusType", List<IString>("Off", "On"));
+    typeManager.addType(statusType);
+    const auto statusValue = Enumeration("StatusType", "Off", typeManager);
+
+    instance.getStatusContainer().asPtr<IComponentStatusContainerPrivate>().addStatusWithMessage("TestStatus", statusValue, "MsgOff");
+
+
     return instance;
 }
 
@@ -1743,6 +1750,8 @@ TEST_F(NativeDeviceModulesTest, Reconnection)
         }
     };
 
+    ASSERT_EQ(client.getDevices()[0].getStatusContainer().getStatus("TestStatus").getValue(), "On");
+
     // destroy server to emulate disconnection
     server.release();
     ASSERT_TRUE(connectionOldStatusFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
@@ -1787,6 +1796,9 @@ TEST_F(NativeDeviceModulesTest, Reconnection)
 
     ASSERT_TRUE(client.getContext().getTypeManager().hasType("TestEnumType"));
 
+    ASSERT_EQ(client.getDevices()[0].getStatusContainer().getStatus("TestStatus").getValue(), "Off");
+    ASSERT_EQ(client.getDevices()[0].getStatusContainer().getStatusMessage("TestStatus"), "MsgOff");
+
     auto signals = client.getSignals(search::Recursive(search::Any()));
     for (const auto& signal : signals)
     {
@@ -1828,6 +1840,8 @@ TEST_F(NativeDeviceModulesTest, ReconnectionRestoreClientConfig)
             }
         }
     };
+
+    ASSERT_EQ(client.getDevices()[0].getStatusContainer().getStatus("TestStatus").getValue(), "On");
 
     // destroy server to emulate disconnection
     server.release();
@@ -1878,6 +1892,9 @@ TEST_F(NativeDeviceModulesTest, ReconnectionRestoreClientConfig)
     ASSERT_TRUE(info.assigned());
     ASSERT_EQ(info.getConnectionString(), "daq.nd://127.0.0.1");
     ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
+
+    ASSERT_EQ(client.getDevices()[0].getStatusContainer().getStatus("TestStatus").getValue(), "Off");
+    ASSERT_EQ(client.getDevices()[0].getStatusContainer().getStatusMessage("TestStatus"), "MsgOff");
 }
 
 TEST_F(NativeDeviceModulesTest, Update)

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -54,6 +54,7 @@ protected:
                                                     const FunctionPtr& factoryCallback);
 
     void handleRemoteCoreObjectInternal(const ComponentPtr& sender, const CoreEventArgsPtr& args) override;
+    void remoteUpdateStatuses(const SerializedObjectPtr& serializedStatuses);
     void onRemoteUpdate(const SerializedObjectPtr& serialized) override;
 
 private:
@@ -194,6 +195,40 @@ void ConfigClientComponentBaseImpl<Impl>::handleRemoteCoreObjectInternal(const C
 }
 
 template <class Impl>
+void ConfigClientComponentBaseImpl<Impl>::remoteUpdateStatuses(const SerializedObjectPtr& serializedStatuses)
+{
+    if (serializedStatuses.hasKey("statuses"))
+    {
+        const auto deserializeContext = createWithImplementation<IComponentDeserializeContext, ConfigProtocolDeserializeContextImpl>(
+            this->clientComm, std::string{}, this->context, nullptr, nullptr, nullptr, nullptr);
+
+        DictPtr<IString, IString> messagesDict;
+        if (serializedStatuses.hasKey("messages"))
+            messagesDict = serializedStatuses.readObject("messages", deserializeContext, nullptr);
+        else
+            messagesDict = Dict<IString, IString>();
+
+        const DictPtr<IString, IEnumeration> statusDict = serializedStatuses.readObject("statuses", deserializeContext, nullptr);
+        const auto statuses = this->statusContainer.getStatuses();
+        const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>(true);
+
+        for (const auto& [name, value] : statusDict)
+        {
+            StringPtr msg;
+            if (messagesDict.hasKey(name))
+                msg = messagesDict.get(name);
+            else
+                msg = String("");
+
+            if (statuses.hasKey(name))
+                statusContainerPrivate.setStatusWithMessage(name, value, msg);
+            else
+                statusContainerPrivate.addStatusWithMessage(name, value, msg);
+        }
+    }
+}
+
+template <class Impl>
 void ConfigClientComponentBaseImpl<Impl>::onRemoteUpdate(const SerializedObjectPtr& serialized)
 {
     ConfigClientPropertyObjectBaseImpl<Impl>::onRemoteUpdate(serialized);
@@ -209,6 +244,12 @@ void ConfigClientComponentBaseImpl<Impl>::onRemoteUpdate(const SerializedObjectP
 
     if (serialized.hasKey("name"))
        this->name = serialized.readString("name");
+
+    if (serialized.hasKey("statuses"))
+    {
+        const auto serializedStatuses = serialized.readSerializedObject("statuses");
+        remoteUpdateStatuses(serializedStatuses);
+    }
 }
 
 template <class Impl>


### PR DESCRIPTION
Component status was not a part of remote-update on configuration client objects.

Slightly off-topic, I don't like the way we have deserialization/update implemented on remote objects. Every change applied on openDAQ components must be applied to configuration client remote objects. I prefer the remote update to be implemented on the components themselves.