### PR TITLE
Upload Python Wheels to S3 even if not `refs/heads/main`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,7 +175,7 @@ jobs:
           aws s3 cp . "s3://${{ env.s3bucket }}/${{ env.s3sdk_path }}/" --recursive --exclude '*' --include "*.exe"
 
       - name: Upload Wheels to S3
-        if: github.ref == 'refs/heads/main' && matrix.cmake_generator_platform != 'Win32'
+        if: matrix.cmake_generator_platform != 'Win32'
         working-directory: ${{ env.wheels_path }}
         run: |
           aws s3 rm "s3://${{ env.s3bucket }}/${{ env.s3wheels_win_amd64_path }}" --recursive --exclude '*' --include '*.whl'
@@ -493,7 +493,6 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload Wheels to S3
-        if: github.ref == 'refs/heads/main'
         working-directory: ${{ env.wheels_path }}
         run: |
           aws s3 rm "s3://${{ env.s3bucket }}/${{ env.s3wheels_linux_x86_64_path }}" --recursive --exclude '*' --include '*.whl'


### PR DESCRIPTION
Enables uploading Python Wheels to S3 from branches other than `refs/heads/main` to be more in line with other files (nuget package, docs, etc.) being uploaded (e.g. via `workflow_dispatch`) for `deploy.yml` workflow.

Noticed the files were missing when I tried deploying files to AWS S3 for "manual" update of  https://docs.opendaq.com to `3.10.2`.