### PR TITLE
Component status fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,4 @@ Please delete options that are not relevant.
 - [ ] Any dependent changes have been merged and published in downstream modules
 
 # Description:
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ while also embracing existing standards such as MQTT and XCP via Ethernet.
 
 ## Features
 
-- Simple connection to openDAQ-enabled devices, allowing for property visualisation/configuration and data streaming.
+- Simple connection to openDAQ-enabled devices, allowing for property visualization/configuration and data streaming.
 - Simple integration of existing data acquisition devices into the openDAQ ecosystem.
 - SDK that runs the same code on both the device (server) and application (client).
 - Signal processing framework that allows for implementation of custom data processing blocks that run on any SDK instance (device or application).
@@ -126,16 +126,16 @@ documentation can be built with Antora by following the guide found in [docs/Ant
 
 ### Required tools before building
 
- - CMake 3.24 or higher: https://cmake.org/ (might come with development environment like Visual Studio)
- - Git: https://git-scm.com/
- - Compiler:
-   - (msvc) Visual Studio 2017 or higher with installed Workload for C++
-   - (gcc windows) MSYS2: http://www.msys2.org, https://github.com/msys2/msys2/wiki/MSYS2-installation
-   - (gcc) Ninja build system: https://ninja-build.org/
-   - Python3: https://www.python.org/downloads/
- - (optional) Boost C++ Library: https://sourceforge.net/projects/boost/files/boost-binaries/ , http://theboostcpplibraries.com
-   - If installed, set CMake option `OPENDAQ_ALWAYS_FETCH_BOOST=OFF` to allow the SDK to use it.
-   - See also document [BUILD.md](BUILD.md).
+- CMake 3.24 or higher: https://cmake.org/ (might come with development environment like Visual Studio)
+- Git: https://git-scm.com/
+- Compiler:
+  - (msvc) Visual Studio 2017 or higher with installed Workload for C++
+  - (gcc windows) MSYS2: http://www.msys2.org, https://github.com/msys2/msys2/wiki/MSYS2-installation
+  - (gcc) Ninja build system: https://ninja-build.org/
+  - Python3: https://www.python.org/downloads/
+- (optional) Boost C++ Library: https://sourceforge.net/projects/boost/files/boost-binaries/ , http://theboostcpplibraries.com
+  - If installed, set CMake option `OPENDAQ_ALWAYS_FETCH_BOOST=OFF` to allow the SDK to use it.
+  - See also document [BUILD.md](BUILD.md).
    
 ### Building on Windows
 
@@ -168,7 +168,7 @@ cmake --preset "x64/msvc-22/full"
 
 #### 4. Build the project
 
-Open and build `build/x64/msvc-22/full/openDAQ.sln` using Visual Studio (if one ``msvc`` preset had been used above).
+Open and build `build/x64/msvc-22/full/openDAQ.sln` using Visual Studio (if one `msvc` preset had been used above).
 
 Or use command line:
 ```shell
@@ -179,7 +179,7 @@ cd build/x64/msvc-22/full
 cmake --build .
 ```
 
-For other compilers than ``msvc`` one can add parameter ``-j 4`` to the build command to specify the number of parallel builds
+For compilers other than `msvc`, one can add parameter `-j 4` to the build command to specify the number of parallel builds
 (see _cmake.org_: [Build a Project with CMake](https://cmake.org/cmake/help/v3.24/manual/cmake.1.html#build-a-project)).
 
 ### Building on Linux

--- a/changelog/changelog_1.0.0-2.0.0.md
+++ b/changelog/changelog_1.0.0-2.0.0.md
@@ -1,4 +1,4 @@
-# 14.11.2023
+# 2023-11-14
 
 ## Description
 Added Multi-reader support for reading raw signal values (no scaling or conversion)
@@ -6,14 +6,14 @@ Added Multi-reader support for reading raw signal values (no scaling or conversi
 -m enum class ReadMode { Raw, Scaled }
 +m enum class ReadMode { Unscaled, Scaled, RawValue }
 ```
-# 12.10.2023
+# 2023-10-12
 
 ## Description
 Added method to IPropertyInternal
 ```
 +m  [function] IPropertyInternal::getValueTypeUnresolved(CoreType* coreType)
 ```
-# 06.10.2023
+# 2023-10-06
 
 ## Description
 Removed ConfigurationMode from SDK as it was not used anyway.
@@ -23,7 +23,7 @@ Removed ConfigurationMode from SDK as it was not used anyway.
 -m  [function] IUpdatable::update(ConfigurationMode mode, ISerializedObject* update)
 +m  [function] IUpdatable::update(ISerializedObject* update)
 ```
-# 28.9.2023
+# 2023-09-28
 openDAQ Package version: 2.0.0
 
 ## Description
@@ -226,7 +226,7 @@ Main takeaways of the changes:
 + [factory] ScalingPtr Scaling(SampleType inputDataType, ScaledSampleType outputDataType, ScalingType scalingType, const DictPtr<IString, IBaseObject>& params)
 + [factory] StructTypePtr ScalingStructType()
 ```
-# 01.09.2023
+# 2023-09-01
 
 ## Description
 Added unscaled / raw mode option to readers
@@ -251,7 +251,7 @@ Added unscaled / raw mode option to readers
 +m [factory] MultiReaderPtr MultiReader(const ListPtr<ISignal>& signals, SampleType valueReadType, SampleType domainReadType, ReadMode mode = ReadMode::Scaled, ReadTimeoutType timeoutType = ReadTimeoutType::All)
 +  [factory] MultiReaderPtr MultiReader(ListPtr<ISignal> signals, ReadMode mode, ReadTimeoutType timeoutType = ReadTimeoutType::All)
 ```
-# 18.08.2023
+# 2023-08-18
 
 ## Description
 Module Manager is now accessible from within the Context. `createAndAddNestedFunctionBlock` method was added to `SignalContainerImpl`
@@ -286,14 +286,14 @@ allowing for easy creation of nested Function Blocks using other loaded modules.
 -m [factory] DevicePtr Client(const ContextPtr& context, const ModuleManagerPtr& moduleManager, const StringPtr& localId)
 +m [factory] DevicePtr Client(const ContextPtr& context, const StringPtr& localId)
 ```
-# 10.08.2023
+# 2023-08-10
 
 ## Description
 Context is removed from instance interface
 ```
 - [function] IInstance::getContext(IContext** context)
 ```
-# 05.08.2023
+# 2023-08-05
 
 ## Description
 Fixes and improvements for Delphi bindings. 
@@ -308,7 +308,7 @@ Changed `IAllocator::allocate` and `IAllocator::free`
 -  [factory] PropertyWithName(name)
 -  [function] ILoggerComponent.logMessage(ConstCharPtr msg, LogLevel level)
 ```
-# 28.7.2023
+# 2023-07-28
 
 ## Description
 Update to the latest version of the OPC UA model. Signal and Input Port properties are not visible over OPC UA. IComponent methods
@@ -319,7 +319,7 @@ are accessible via OPC UA for all openDAQ components. UserName and location was 
 - [function] IDeviceInfoConfig::setLocation(IString* location)
 - [function] IDeviceInfo::setUserName(IString* userName)
 ```
-# 17.7.2023
+# 2023-07-17
 ff6768d39a76b3b784994f6a17f1d730cb8be639
 
 ## Description
@@ -332,7 +332,7 @@ new event packet type "PropertyChanged" which is sent to connected listeners whe
 
 + [factory] inline EventPacketPtr PropertyChangedEventPacket(const StringPtr& name, const BaseObjectPtr& value)
 ```
-# 11.7.2023
+# 2023-07-11
 70742e4554bbf6f13da11bc782ef7533d8d71795
 
 ## Description
@@ -366,7 +366,7 @@ Name and Description are no longer part of signal/data descriptor
 -m [factory] inline DataPacketPtr DataPacketWithDomain(const DataPacketPtr& domainPacket, const SignalDescriptorPtr& descriptor, uint64_t sampleCount, NumberPtr offset = nullptr, AllocatorPtr allocator = nullptr)
 +m [factory] inline DataPacketPtr DataPacketWithDomain(const DataPacketPtr& domainPacket, const DataDescriptorPtr& descriptor, uint64_t sampleCount, NumberPtr offset = nullptr, AllocatorPtr allocator = nullptr)
 ```
-# 9.6.2023 - 18.7.2023
+# 2023-06-09 - 2023-07-18
 7713cdbb0614b5c073a8d7eb3d834b62e9b1efb4 - 29ee6eb5ebdef33c23b1a7eed4b1e8a064cdb7eb
 ```
 + [interface] IComponentType : public IBaseObject

--- a/changelog/changelog_2.0.0-3.0.0.md
+++ b/changelog/changelog_2.0.0-3.0.0.md
@@ -1,4 +1,4 @@
-# 12.04.2024
+# 2024-04-12
 
 ## Description
 - Implement BlockReaderStatus
@@ -7,7 +7,7 @@
 + [function] IBlockReaderStatus::getReadSamples(SizeT* readSamples)
 + [factory] BlockReaderStatusPtr BlockReaderStatus(const EventPacketPtr& packet = nullptr, Bool valid = true, SizeT readSamples = 0)
 ```
-# 29.03.2024
+# 2024-03-29
 
 ## Description
 - Grouping discovered deivces with IServerCapability
@@ -61,7 +61,7 @@
 +m [function] IModule::createStreaming(IStreaming** streaming, IString* connectionString, IServerCapability* capability)
 ```
 
-# 26.03.2024
+# 2024-03-26
 
 ## Description
 - Implement multi reader builder
@@ -87,7 +87,7 @@
 
 + [factory] MultiReaderPtr MultiReaderFromBuilder(const MultiReaderBuilderPtr& builder)
 ```
-# 26.03.2024:
+# 2024-03-26
 
 ## Description
 - Fix outdated data descriptor before subscription
@@ -107,7 +107,7 @@
 + [function] ErrCode IMirroredSignalPrivate::getMirroredDomainSignal(IMirroredSignalConfig** domainSignals)
 + [function] ErrCode IMirroredSignalPrivate::setMirroredDomainSignal(IMirroredSignalConfig* domainSignal)
 ```
-# 25.04.2024
+# 2024-04-25
 
 ## Description
 - Constant rule rework in openDAQ core and support for native streaming
@@ -118,7 +118,19 @@
 -m [factory] DataPacketPtr DataPacketWithExternalMemory(const DataPacketPtr& domainPacket, const DataDescriptorPtr& descriptor, uint64_t sampleCount, void* data, const DeleterPtr& deleter, NumberPtr offset = nullptr)
 +m [factory] DataPacketPtr DataPacketWithExternalMemory(const DataPacketPtr& domainPacket, const DataDescriptorPtr& descriptor, uint64_t sampleCount, void* data, const DeleterPtr& deleter, NumberPtr offset = nullptr, SizeT bufferSize = std::numeric_limits<SizeT>::max())
 ```
-# 21.03.2024
+
+# 2024-03-22
+
+## Description
+- Add support for multiple module search paths in ModuleManager
+```
++ [factory] ModuleManagerPtr ModuleManagerMultiplePaths(const ListPtr<IString>& paths)
+
++ [function] IInstanceBuilder::addModulePath(IString* path)
++ [function] IInstanceBuilder::getModulePathsList(IList** paths)
+```
+
+# 2024-03-21
 
 ## Description
 - Move create fb/device logic to module manager
@@ -133,7 +145,7 @@
 -m [factory] DevicePtr Client(const ContextPtr& context, const StringPtr& localId, const DeviceInfoPtr& defaultDeviceInfo = nullptr)
 +m [factory] DevicePtr Client(const ContextPtr& context, const StringPtr& localId, const DeviceInfoPtr& defaultDeviceInfo = nullptr, const ComponentPtr& parent = nullptr)
 ```
-# 11.03.2024
+# 2024-03-11
 
 ## Description
 - Make DeviceDomain a standalone object in DeviceImpl
@@ -146,13 +158,13 @@
 + [function] IDevice::getTicksSinceOrigin(UInt* ticks)
 + [factory] CoreEventArgsPtr CoreEventArgsDeviceDomainChanged(const DeviceDomainPtr& deviceDomain)
 ```
-# 11.03.2024
+# 2024-03-11
 
 ## Description
 - Update native transport protocol - initiate streaming only upon client request;
 - New protocol message type added: PAYLOAD_TYPE_STREAMING_PROTOCOL_INIT_REQUEST = 11
 
-# 08.03.2024
+# 2024-03-08
 
 ## Description
 - Propagate server IUpdatable::Update to native protocol clients
@@ -162,14 +174,14 @@
 + [function] ISerializedObject::isRoot(Bool* isRoot)
 + [function] IUpdatable::updateEnded()
 ```
-# 26.02.2024
+# 2024-02-26
 
 ## Description
 - Integrating config provider options in modules
 ```
 + [function] IModule::getId(IString** id)
 ```
-# 26.02.2024
+# 2024-02-26
 
 ## Description
 - Streaming framework refactoring
@@ -188,7 +200,7 @@
 
 + [function] IStreamingPrivate::detachRemovedSignal(const StringPtr& signalRemoteId);
 ```
-# 25.02.2024
+# 2024-02-25
 
 ## Description
 - Readers return IReaderStatus
@@ -237,7 +249,7 @@
 - [factory] inline BlockReaderPtr BlockReaderFromExisting(const BlockReaderPtr& invalidatedReader, SampleType valueReadType, SampleType domainReadType)
 + [factory] inline BlockReaderPtr BlockReaderFromExisting(const BlockReaderPtr& invalidatedReader, SizeT blockSize, SampleType valueReadType, SampleType domainReadType)
 ```
-# 25.02.2024
+# 2024-02-25
 
 ## Description
 - rename search filter search::SearchId to search::InterfaceId
@@ -247,14 +259,14 @@
 +m [factory] SearchFilterPtr InterfaceId(const IntfID& intfId)
 + [factory] SearchFilterPtr LocalId(const StringPtr& localId)
 ```
-# 12.02.2024
+# 2024-02-12
 
 ## Description
 - Add module implementations for device based on the native config protocol
 ```
 + [function] IMirroredSignalPrivate::assignDomainSignal(const SignalPtr& domainSignal);
 ```
-# 06.02.2024
+# 2024-02-06
 
 ## Description
 - Support configuring instance builder from config provider
@@ -272,7 +284,7 @@
 + [factory] ConfigProviderPtr EnvConfigProvider()
 + [factory] ConfigProviderPtr CmdLineArgsConfigProvider(const ListPtr<IString>& args)
 ```
-# 05.02.2024
+# 2024-02-05
 
 ## Description
 - Add core event support to config client
@@ -281,7 +293,7 @@
 +m [function] IComponent::findComponent(IString* id, IComponent** outComponent)
 + [function] ITags::set(IList* tags) = 0;
 ```
-# 5.2.2024
+# 2024-02-05
 
 ## Description
 - Add Component status implementations
@@ -301,7 +313,7 @@
 + [function] IComponentStatusContainer::getOnStatusChanged(IEvent** event)
 + [factory] ComponentStatusContainerPtr ComponentStatusContainer()
 ```
-# 23.01.2024
+# 2024-01-23
 
 ## Description
 - Add debug logger sink for testing purpose
@@ -311,11 +323,11 @@
 + [function] ILastMessageLoggerSinkPrivate::waitForMessage(SizeT timeoutMs, Bool* success)
 + [factory] LoggerSinkPtr LastMessageLoggerSink()
 ```
-# 1.2.2024
+# 2024-02-01
 ```
 +m [function] IMultiReader::skipSamples
 ```
-# 23.1.2024
+# 2024-01-23
 
 ## Description
 - Change ITagsConfig to ITagsPrivate and remove inheritance
@@ -330,7 +342,7 @@
 -m [function] IComponent::getTags(ITagsConfig** tags)
 -m [function] IComponent::getTags(ITags** tags)
 ```
-# 22.1.2024
+# 2024-01-22
 
 ## Description
 - Support for external deserialization factory
@@ -349,7 +361,7 @@
 +  [interface] IComponentDeserializeContext: public IBaseObject
 +  [interface] IDeserializeComponent: public IBaseObject
 ```
-# 16.01.2024
+# 2024-01-16
 
 ## Description
 - Nested object-type property enhancement
@@ -368,7 +380,7 @@
 -m [factory] CoreEventArgsPtr CoreEventArgsPropertyRemoved(const PropertyObjectPtr& propOwner, const StringPtr& propName)
 +m [factory] CoreEventArgsPtr CoreEventArgsPropertyRemoved(const PropertyObjectPtr& propOwner, const StringPtr& propName, const StringPtr& path)
 ```
-# 12.01.2024
+# 2024-01-12
 
 ## Description
 - Search filters, visible flag, component attributes
@@ -446,7 +458,7 @@
 -m [factory] CoreEventArgsPtr CoreEventArgsComponentModified(const DictPtr<IString, IBaseObject>& modifiedAttributes)
 +m [factory] CoreEventArgsPtr CoreEventArgsAttributeChanged(const StringPtr& attributeName, const BaseObjectPtr& attributeValue)
 ```
-# 11.01.2024
+# 2024-01-11
 
 ## Description
 - Add Enumeration Core type implementations
@@ -464,7 +476,7 @@
 + [function] IEnumeration::getValue(IString** value)
 + [factory] EnumerationPtr Enumeration(const StringPtr& typeName, const StringPtr& value, const TypeManagerPtr& typeManager)
 ```
-# 03.01.2024
+# 2024-01-03
 
 ## Description
 - Add method getLastValue in ISignal
@@ -472,7 +484,7 @@
 + [function] ISignal::getLastValue(IBaseObject** value)
 + [function] ISignalPrivate::enableKeepLastValue(Bool enabled)
 ```
-# 18.12.2023
+# 2023-12-18
 
 ## Description
 - Builder pattern implementation for IInstance
@@ -505,7 +517,7 @@
 -m [factory] DevicePtr Client(const ContextPtr& context, const StringPtr& localId)
 +m [factory] DevicePtr Client(const ContextPtr& context, const StringPtr& localId, const DeviceInfoPtr& defaultDeviceInfo)
 ```
-# 13.12.2023
+# 2023-12-13
 
 ## Description
 - Add Core event to Context object that triggers on core changes
@@ -522,7 +534,7 @@
 
 + [function] IContext::getOnCoreEvent(IEvent** event)
 ```
-# 7.12.2023
+# 2023-12-07
 
 ## Description
 - Add Struct Builder for generic struct creation
@@ -541,7 +553,7 @@
 + [factory] StructBuilderPtr StructBuilder(const StringPtr& name, const TypeManagerPtr& typeManager)
 + [factory] StructBuilderPtr StructBuilder(const StructPtr& struct_)
 ```
-# 7.12.2023
+# 2023-12-07
 
 ## Description
 - Add subscribe/unsubscribe completion acknowledgement Events
@@ -558,7 +570,7 @@
 
 + [factory] SubscriptionEventArgsPtr SubscriptionEventArgs(const StringPtr& streamingConnectionString, SubscriptionEventType eventType)
 ```
-# 5.12.2023
+# 2023-12-05
 
 ## Description
 - Expose Origin Epoch and StartOffset the MultiReader aligned all the read signals to
@@ -568,8 +580,7 @@
 + [function] IMultiReader::getOrigin(IString** origin)
 + [function] IMultiReader::getOffset(void* domainStart)
 ```
-# 28.11.2023
-
+# 2023-11-28
 
 ## Description
 - Builder pattern improvement
@@ -643,7 +654,7 @@
 + [function] IScalingBuilder::getParameters(IDict** parameters)
 + [factory] ScalingPtr ScalingFromBuilder(const ScalingBuilderPtr& builder)
 ```
-# 23.11.2023
+# 2023-11-23
 
 
 ## Description
@@ -667,7 +678,7 @@
 -m [factory] inline IoFolderConfigPtr IoFolder(const ContextPtr& context, const ComponentPtr& parent, const StringPtr& localId)
 +m [factory] inline IoFolderConfigPtr IoFolder(const ContextPtr& context, const ComponentPtr& parent, const StringPtr& localId, const ComponentStandardProps propertyMode = ComponentStandardProps::Add)
 ```
-# 17.11.2023
+# 2023-11-17
 
 
 ## Description
@@ -709,14 +720,4 @@
 + [function] ISignal::getStreamed(Bool* streamed)
 + [function] ISignal::setStreamed(Bool streamed)
 ```
-# 22.03.2024
 
-
-## Description
-- Add support for multiple module search paths in ModuleManager
-```
-+ [factory] ModuleManagerPtr ModuleManagerMultiplePaths(const ListPtr<IString>& paths)
-
-+ [function] IInstanceBuilder::addModulePath(IString* path)
-+ [function] IInstanceBuilder::getModulePathsList(IList** paths)
-```

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,4 +1,4 @@
-# 5.12.2024
+# 2024-12-05
 ## Description
 - Add Component status types to the Type Manager in `context_impl.cpp` ("Ok", "Warning", and "Error")
 - Define `ComponentErrorState`
@@ -15,7 +15,7 @@
 + [function] IComponentStatusContainerPrivate::setStatusWithMessage(IString* name, IEnumeration* value, IString* message)
 ```
 
-# 04.12.2024
+# 2024-12-04
 ## Description
 - Module-overridable virtual method `ongetLogFileInfos` has been renamed to `onGetLogFileInfos`
 
@@ -24,8 +24,8 @@
 +m [function] ListPtr<ILogFileInfo> Device::onGetLogFileInfos()
 ```
 
-# 04.12.2024
-##
+# 2024-12-04
+## Description
 - Add "Any read/write" events to property object.
 - These events are triggered whenever any property value is read/written.
 
@@ -34,7 +34,7 @@
 + [function] IPropertyObject::getOnAnyPropertyValueRead(IEvent** event)
 ```
 
-# 03.12.2024
+# 2024-12-03
 ## Description
 - Fixed the issue where property values were written before validation.
 ## Required integration changes
@@ -109,6 +109,7 @@ catch (...)
 assert(propObj.getPropertyValue("prop1") == 0); // prop1 retains its original value
 assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 ```
+
 ```
 + [function] IPropertyValueEventArgs::getOldValue(IBaseObject** value)
 -m[factory] PropertyValueEventArgsPtr PropertyValueEventArgs(const PropertyPtr& propChanged,
@@ -122,7 +123,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
                                                         Bool isUpdating)
 ```
 
-# 28.11.2024
+# 2024-11-28
 ## Description
 - Introduces separate container accessible per device for connection statuses
 - Introduces new core event type "ConnectionStatusChanged" to notify when configuration or streaming connection status of the device changed
@@ -147,7 +148,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] IStreaming::getConnectionStatus(IEnumeration** connectionStatus)
 ```
 
-# 25.11.2024
+# 2024-11-25
 ## Description
 - Delete the fields `id`, `name`, and `versionInfo` from the `IModule` interface and add them to the new `IModuleInfo` interface, which is a new field in the `IModule` interface
 - `IModuleInfo` field is also added to `IComponentType` interface
@@ -171,7 +172,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 - [function] IModule::getId(IVersionInfo** version)
 ```
 
-# 20.11.2024
+# 2024-11-20
 ## Description
 - Support for different client types over the native configuration protocol has been introduced.
 - A ClientType selection property has been added to the general configuration object of the IDevice::addDevice method. Supported values are Control(0), Exclusive Control(1), and View Only(2).
@@ -181,11 +182,11 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 ## Required integration changes
 - None. The default client type is Control(0), which is backward-compatible with previous protocol versions.
 
-# 19.11.2024
+# 2024-11-19
 ## Description
 - Raise minimum required config protocol version to 6 for the following device lockign metods: IDevice::lock(), IDevice::unlock(), IDevice::isLocked(Bool* isLockedOut)
 
-# 12.11.2024
+# 2024-11-12
 ## Description
 - Improved component updates.
 - Removed generation of local ID for client device in instance.
@@ -198,7 +199,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] ISignalPrivate::getSignalSerializeId(IString** serializeId)
 ```
 
-# 08.11.2024
+# 2024-11-08
 ## Description
 - Add support for forcefully unlocking a device over native config protocol
 - Native config protocol bumped to version 6
@@ -219,7 +220,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] IUserLock::isLocked(Bool* isLockedOut)
 ```
 
-# 29.10.2024
+# 2024-10-29
 ## Description
 - Implement thread synchronization mechanism in property objects
 - Provides new internal method to allow for recursive locking in onWrite/onRead events via `GenericPropertyObjectImpl::getRecursiveConfigLock()`
@@ -262,14 +263,14 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] IPropertyObjectInternal::setPropertyValueNoLock(IString* name, IBaseObject* value)
 ```
 
-# 8.11.2024
+# 2024-11-08
 ## Description
 - Block Reader, Tail Reader and Stream Reader now skip events by default in Python
 
 ## Required integration changes
 - In Python, you need to explicitly set `skip_events=False` if you don't want to skip the events in Block, Tail and Stream Reader
 
-# 29.10.2024
+# 2024-10-29
 
 ## Description
 - Support creating readers with connected input port
@@ -282,7 +283,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] IConnectionInternal::enqueueLastDescriptor()
 ```
 
-# 24.10.2024
+# 2024-10-24
 
 ## Description
 - Add a way to view the server protocol version in server capabilities.
@@ -298,7 +299,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] IServerCapabilityConfig::setProtocolVersion(IString* version)
 ```
 
-# 24.10.2024
+# 2024-10-24
 
 ## Description
 - Implement log file info interface
@@ -338,7 +339,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] IDevice::getLog(IString** log, IString* id, Int size = -1, Int offset = 0)
 ```
 
-# 21.10.2024
+# 2024-10-21
 
 ## Description
 - Introduce a new Sample Type "Null"
@@ -353,7 +354,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [factory] DataDescriptorPtr NullDataDescriptor()
 ```
 
-# 11.10.2024
+# 2024-10-11
 
 ## Description
 - Add methods in function block to add/remove nested fb
@@ -374,7 +375,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 + [function] IFunctionBlock::removeFunctionBlock(IFunctionBlock* functionBlock)
 ```
 
-# 10.10.2024
+# 2024-10-10
 
 ## Description
 - Restoring the device while loading the configuration.
@@ -401,7 +402,7 @@ assert(propObj.getPropertyValue("prop2") == -1); // prop2 have a new value
 +m[function] IDevice::loadConfiguration(IString* configuration, IUpdateParameters* config = nullptr)
 ```
 
-# 4.10.2024
+# 2024-10-04
 
 ## Description
 - Adds min read count option to multi reader. Default = 1. Reader will not read less that "min read count". If there are less
@@ -417,21 +418,21 @@ than "min read count" samples in the queue and there's an event after those samp
 +m [factory] MultiReaderPtr MultiReaderEx(const ListPtr<ISignal>& signals, SampleType valueReadType, SampleType domainReadType, ReadMode mode = ReadMode::Scaled, ReadTimeoutType timeoutType = ReadTimeoutType::All, Int requiredCommonSampleRate = -1, bool startOnFullUnitOfDomain = false,  SizeT minReadCount = 1)
 ```
 
-# 03.10.2024
+# 2024-10-03
 
 ## Description
 - Enable concurrent config connections limit for native server using "MaxAllowedConfigConnections" server config property
 - Introduce a new PacketBuffer type ConnectionRejected in the native configuration protocol
 - Native config protocol bumped to version 3
 
-# 03.10.2024
+# 2024-10-03
 
 ## Description
 - Bugfix where onPropertyValueWrite/Read events were available on the native protocol client, but were not fully supported.
 - Said property object events were disabled to reduce probability of misuse.
 - CoreEvents should be used instead of onWrite/Read events where needed.
 
-# 03.10.2024
+# 2024-10-03
 
 ## Description
 - Add support for device locking over native config protocol
@@ -445,7 +446,7 @@ than "min read count" samples in the queue and there's an event after those samp
 
 + [function] IAuthenticationProvider::authenticateAnonymous(IUser** userOut)
 ```
-# 23.09.2024
+# 2024-09-23
 
 ## Description
 - Enable multireader to be manually set inactive to drop data packets
@@ -456,14 +457,14 @@ than "min read count" samples in the queue and there's an event after those samp
 + [function] IMultiReader::setActive(Bool isActive)
 + [function] IMultiReader::getActive(Bool* isActive)
 ```
-# 11.09.2024
+# 2024-09-11
 
 ## Description
 - Enable client-to-device streaming feature within the Native protocol
 - Introduce a new PacketBuffer type NoReplyRpc in the native configuration protocol
 - Native config protocol bumped to version 2
 
-# 11.09.2024
+# 2024-09-11
 
 ## Description
 - Enable openDAQ servers to be added to the component tree under the device
@@ -485,7 +486,7 @@ than "min read count" samples in the queue and there's an event after those samp
 
 + [function] IModuleManagerUtils::createServer(IServer** server, IString* serverTypeId, IDevice* rootDevice, IPropertyObject* serverConfig = nullptr)
 ```
-# 28.08.2024
+# 2024-08-28
 
 ## Description
 - Multi reader returns events on first read
@@ -494,7 +495,7 @@ than "min read count" samples in the queue and there's an event after those samp
 - By default creating block reader with signal had skip events true. Now skip events set to false
 - Multi reader is not losing the first connection event packet. With first read, multi reader now returns event packets which were recieved by signal connection
 
-# 28.08.2024
+# 2024-08-28
 
 ## Description
 - Improving save/load mechanism for restoring input ports connection
@@ -511,7 +512,7 @@ than "min read count" samples in the queue and there's an event after those samp
 +m[function] IUpdatable::updateEnded(IBaseObject* context)
 + [function] IUpdatable::updateInternal(ISerializedObject* update, IBaseObject* context)
 ```
-# 26.08.2024
+# 2024-08-26
 
 ## Description
 - Add OPENDAQ_ERR_CONNECTION_LOST error code and ConnectionLostException exception type.
@@ -519,7 +520,7 @@ than "min read count" samples in the queue and there's an event after those samp
 ## Required integration changes
 - None, however, disconnection errors can now be identified by a specific error type.
 
-#  21.08.2024
+# 2024-08-21
 
 ## Description
 - Reference Domain Info was added as an interface that gives additional information about the reference domain
@@ -570,7 +571,7 @@ than "min read count" samples in the queue and there's an event after those samp
 + [function] IDataDescriptorBuilder::setReferenceDomainInfo(IReferenceDomainInfo* referenceDomainInfo)
 + [function] IDataDescriptorBuilder::getReferenceDomainInfo(IReferenceDomainInfo** referenceDomainInfo)
 ```
-# 12.08.2024
+# 2024-08-12
 
 ## Description
 - Changed logic of IProperty::getOnPropertyValue events.
@@ -581,7 +582,7 @@ than "min read count" samples in the queue and there's an event after those samp
 + [function] IPropertyInternal::getClassOnPropertyValueWriteEvent(IEvent** event)
 + [function] IPropertyInternal::getClassOnPropertyValueReadEvent(IEvent** event)
 ```
-# 12.08.2024
+# 2024-08-12
 
 ## Description
 - Integration the Sync Component
@@ -604,7 +605,7 @@ than "min read count" samples in the queue and there's an event after those samp
 
 + [factory] SyncComponentPtr SyncComponent(const ContextPtr& context, const ComponentPtr& parent, const StringPtr& localId)
 ```
-# 08.08.2024
+# 2024-08-08
 
 ## Description
 - Add get/setValue method to IProperty
@@ -613,7 +614,7 @@ than "min read count" samples in the queue and there's an event after those samp
 + [function] IProperty::getValue(IBaseObject** value)
 + [function] IProperty::setValue(IBaseObject* value)
 ```
-# 26.07.2024
+# 2024-07-26
 
 ## Description
 - Add method to IPropertyObject to detect begin/end update status
@@ -622,7 +623,7 @@ than "min read count" samples in the queue and there's an event after those samp
 ```
 + [function] IPropertyObject::getUpdating(Bool* updating)
 ```
-# 25.07.2024
+# 2024-07-25
 
 ## Description
 - Add user context to json serializer
@@ -630,7 +631,7 @@ than "min read count" samples in the queue and there's an event after those samp
 + [function] ISerializer::getUser(IBaseObject** user)
 + [function] ISerializer::setUser(IBaseObject* user)
 ```
-# 23.07.2024
+# 2024-07-23
 
 ## Description
 - Reader improvement
@@ -726,7 +727,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 + [function] IConnection::hasEventPacket(Bool* hasEventPacket)
 + [function] IConnection::hasGapPacket(Bool* hasGapPacket)
 ```
-# 22.07.2024
+# 2024-07-22
 
 ## Description
 - Standardize cases to PascalCase
@@ -763,7 +764,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 - If relying on string comparison to hardcoded old IDs of things like FB, device, server types, or protocol IDs, those comparisons will need to be updated to match the new IDs, eg. a check like `if (fbType.getId() == "ref_fb_module_renderer")` will never be true
 - Old IDs can still be used when adding new objects to a device via `addDevice`/`addFunctionBlock` or similar calls
 
-# 10.07.2024
+# 2024-07-10
 
 ## Description
 - Add address type and address reachability status to server capability
@@ -781,7 +782,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 + [function] IServerCapabilityConfig::addAddressReachabilityStatus(AddressReachabilityStatus addressReachability)
 + [function] IServerCapabilityConfig::setAddressReachabilityStatus(IList* addressReachability)
 ``` 
-# 04.07.2024
+# 2024-07-04
 
 ## Description
 - Make device connection string prefix mandatory
@@ -798,20 +799,20 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 - [function] IModule::acceptsStreamingConnectionParameters(Bool* accepted, IString* connectionString, IPropertyObject* config = nullptr)
 ```
 
-# 21.06.2024
+# 2024-06-21
 ``` 
 - [function] IDeviceInfoInternal::hasServerCapability(IString* protocolId, Bool* hasCapability)
 + [function] IDeviceInfo::hasServerCapability(IString* protocolId, Bool* hasCapability)
 + [function] IDeviceInfo::getServerCapability(IString* protocolId, IServerCapability** capability)
 ``` 
-# 21.06.2024
+# 2024-06-21
 ``` 
 -m [function] IInstanceBuilder::addDiscoveryService
 +m [function] IInstanceBuilder::addDiscoveryServer
 -m [function] IInstanceBuilder::getDiscoveryServices
 +m [function] IInstanceBuilder::getDiscoveryServers
 ``` 
-# 17.06.2024
+# 2024-06-17
 
 ## Description
 - Add StreamingType object
@@ -831,14 +832,14 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 + [function] IModuleManagerUtils::getAvailableStreamingTypes(IDict** streamingTypes)
 + [function] IModuleManagerUtils::createDefaultAddDeviceConfig(IDict** streamingTypes)
 ``` 
-# 30.05.2024
+# 2024-05-30
 
 ## Description
 - Supporting reading client's connection info in the deviceInfo
 ```
 + [function] IDeviceInfo::getConfigurationConnectionInfo(IServerCapability** connectionInfo)
 ```
-# 27.05.2024
+# 2024-05-27
 
 ## Description
 - Supporting servers to be discovered by mDNS
@@ -869,7 +870,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
                            const DictPtr<IString, IBaseObject> options = Dict<IString, IBaseObject>(),
                            const DictPtr<IString, IDiscoveryServer> discoveryServices = Dict<IString, IDiscoveryServer>())
 ``` 
-# 17.05.2024
+# 2024-05-17
 
 ## Description
 - Add ability to manually connect to streaming for device after device added
@@ -883,7 +884,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 
 + [function] IModule::createConnectionString(IString** connectionString, IServerCapability* serverCapability)
 ``` 
-# 16.05.2024
+# 2024-05-16
 
 ## Description
 - Add functions for sending and dequeueing multiple packets
@@ -898,7 +899,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 + [function] ErrCode IConnection::enqueueMultipleAndStealRef(IList* packets)
 + [function] ErrCode IConnection::dequeueAll(IList** packets)()
 ``` 
-# 26.04.2024
+# 2024-04-26
 
 ## Description
 - Produce gap packets on request
@@ -909,7 +910,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 + [factory] EventPacketPtr ImplicitDomainGapDetectedEventPacket(const NumberPtr& diff)
 + [packet] IMPLICIT_DOMAIN_GAP_DETECTED
 ``` 
-# 26.04.2024
+# 2024-04-26
 
 ## Description
 - Clone property object to create default config from type
@@ -921,7 +922,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 -m [factory] ServerTypePtr ServerType(const StringPtr& id, const StringPtr& name, const StringPtr& description, const FunctionPtr& createDefaultConfigCallback = nullptr)
 +m [factory] ServerTypePtr ServerType(const StringPtr& id, const StringPtr& name, const StringPtr& description, const PropertyObjectPtr& defaultConfig = PropertyObject())
 ``` 
-# 25.04.2024
+# 2024-04-25
 
 ## Description
 - Add mirrored device base implementation as a general approach to manage streaming sources for configuration enabled devices
@@ -933,7 +934,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 + [function] IMirroredDeviceConfig::addStreamingSource(IStreaming* streamingSource)
 + [function] IMirroredDeviceConfig::removeStreamingSource(IString* streamingConnectionString)
 ``` 
-# 23.04.2024
+# 2024-04-23
 
 ## Description
 - Adding addresses in ServerCapability
@@ -941,7 +942,7 @@ m [function] IReaderStatus::getOffset(INumber** offset)
 + [function] IServerCapabilityConfig::addAddress(IString* address)
 + [function] IServerCapability::getAddresses(IList** addresses)
 ``` 
-# 22.04.2024
+# 2024-04-22
 
 ## Description
 - Fix reserved keyword clashes with Delphi bindings

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -5,7 +5,7 @@
   - `initComponentErrorStateStatus` to `initComponentStatus`
   - `setComponentErrorStateStatus` to `setComponentStatus`
   - `setComponentErrorStateStatusWithMessage` to `setComponentStatusWithMessage`
-- Fix all reference Function Block implementations by using `setComponentStatusWithMessage` to set the Component Status back to `ComponentStatus::Ok` with appropriate messages where necessary (this prevents Function Blocks to be "stuck" on incorrect Component Status when the user resolves the issue that is causing the Warning or the Error)
+- Fix all reference Function Block implementations by using `setComponent` to set the Component Status back to `ComponentStatus::Ok` where necessary (this prevents Function Blocks to be "stuck" on incorrect Component Status when the user resolves the issue that is causing the Warning or the Error)
   
 ## Required integration changes
 - Requires using the renamed methods and enums in Function Block (Component) implementations (see Description)

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,4 +1,4 @@
-# 2024-12-20
+# 2024-12-27
 ## Description
 - Rename variables containing (for consistency):
   - `ComponentErrorState` to `ComponentStatus`

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,6 +1,6 @@
 # 2024-12-20
 ## Description
-- Rename:
+- Rename variables containing (for consistency):
   - `ComponentErrorState` to `ComponentStatus`
   - `initComponentErrorStateStatus` to `initComponentStatus`
   - `setComponentErrorStateStatus` to `setComponentStatus`

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,3 +1,15 @@
+# 2024-12-20
+## Description
+- Rename:
+  - `ComponentErrorState` to `ComponentStatus`
+  - `initComponentErrorStateStatus` to `initComponentStatus`
+  - `setComponentErrorStateStatus` to `setComponentStatus`
+  - `setComponentErrorStateStatusWithMessage` to `setComponentStatusWithMessage`
+- Fix all reference Function Block implementations by using `setComponentStatusWithMessage` to set the Component Status back to `ComponentStatus::Ok` with appropriate messages where necessary (this prevents Function Blocks to be "stuck" on incorrect Component Status when the user resolves the issue that is causing the Warning or the Error)
+  
+## Required integration changes
+- Requires using the renamed methods and enums in Function Block (Component) implementations (see Description)
+
 # 2024-12-05
 ## Description
 - Add Component status types to the Type Manager in `context_impl.cpp` ("Ok", "Warning", and "Error")

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -180,9 +180,9 @@ protected:
 
     // Initialize component status with "Ok" status
     void initComponentStatus() const;
-    // Set component status with default message (empty string) and log status and message
+    // Set component status with default message (empty string) and log status and message (if different from previous)
     void setComponentStatus(const ComponentStatus& status) const;
-    // Set component status with message and log status and message
+    // Set component status with message and log status and message (if different from previous)
     void setComponentStatusWithMessage(const ComponentStatus& status, const StringPtr& message) const;
 
 private:

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1149,16 +1149,25 @@ void ComponentImpl<Intf, Intfs...>::setComponentStatus(const ComponentStatus& st
 template <class Intf, class... Intfs>
 void ComponentImpl<Intf, Intfs...>::setComponentStatusWithMessage(const ComponentStatus& status, const StringPtr& message) const
 {
+    EnumerationPtr oldStatus;
+    StringPtr oldMessage;
+
     // Fail with explicit message of what happened if not initialized
     try
     {
-        auto dummy = this->statusContainer.getStatus("ComponentStatus");
+        oldStatus = this->statusContainer.getStatus("ComponentStatus");
+        oldMessage = this->statusContainer.getStatusMessage("ComponentStatus");
     }
     catch (const NotFoundException&)
     {
         throw NotFoundException("ComponentStatus has not been added to statusContainer. initComponentStatus needs to be called "
                                 "before setComponentStatus.");
     }
+
+    // Check if status and message are the same as before, if so, return
+    if (status == oldStatus && message == oldMessage)
+        return;
+
     // Set status if initialized
     const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>(true);
     const auto componentStatusValue =

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -180,9 +180,9 @@ protected:
 
     // Initialize component status with "Ok" status
     void initComponentStatus() const;
-    // Set component status with default message (empty string) and log status and message (if different from previous)
+    // Set component status with default message (empty string) and log status and message (if different from previous, and not OK)
     void setComponentStatus(const ComponentStatus& status) const;
-    // Set component status with message and log status and message (if different from previous)
+    // Set component status with message and log status and message (if different from previous, and not OK and empty string)
     void setComponentStatusWithMessage(const ComponentStatus& status, const StringPtr& message) const;
 
 private:
@@ -1163,6 +1163,10 @@ void ComponentImpl<Intf, Intfs...>::setComponentStatusWithMessage(const Componen
         throw NotFoundException("ComponentStatus has not been added to statusContainer. initComponentStatus needs to be called "
                                 "before setComponentStatus.");
     }
+
+    // Check if status and message are the same as before, and also Ok and empty string, and if so, return
+    if (status == oldStatus && status == ComponentStatus::Ok && message == oldMessage && message == "")
+        return;
 
     // Set status if initialized
     const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>(true);

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -58,7 +58,7 @@ BEGIN_NAMESPACE_OPENDAQ
 
 #define COMPONENT_AVAILABLE_ATTRIBUTES {"Name", "Description", "Visible", "Active"}
 
-enum class ComponentErrorState : EnumType
+enum class ComponentStatus : EnumType
 {
     Ok = 0,
     Warning,
@@ -178,9 +178,9 @@ protected:
 
     static bool validateComponentId(const std::string& id);
 
-    void initComponentErrorStateStatus() const;
-    void setComponentErrorStateStatus(const ComponentErrorState& status) const;
-    void setComponentErrorStateStatusWithMessage(const ComponentErrorState& status, const StringPtr& message) const;
+    void initComponentStatus() const;
+    void setComponentStatus(const ComponentStatus& status) const;
+    void setComponentStatusWithMessage(const ComponentStatus& status, const StringPtr& message) const;
 
 private:
     EventEmitter<const ComponentPtr, const CoreEventArgsPtr> componentCoreEvent;
@@ -1128,23 +1128,23 @@ bool ComponentImpl<Intf, Intfs...>::validateComponentId(const std::string& id)
 }
 
 template <class Intf, class... Intfs>
-void ComponentImpl<Intf, Intfs...>::initComponentErrorStateStatus() const
+void ComponentImpl<Intf, Intfs...>::initComponentStatus() const
 {
     // Component error state status is added ("Ok" when a component is created)
     const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>(true);
     const auto componentStatusValue =
-        EnumerationWithIntValue("ComponentStatusType", static_cast<Int>(ComponentErrorState::Ok), this->context.getTypeManager());
+        EnumerationWithIntValue("ComponentStatusType", static_cast<Int>(ComponentStatus::Ok), this->context.getTypeManager());
     statusContainerPrivate.addStatus("ComponentStatus", componentStatusValue);
 }
 
 template <class Intf, class... Intfs>
-void ComponentImpl<Intf, Intfs...>::setComponentErrorStateStatus(const ComponentErrorState& status) const
+void ComponentImpl<Intf, Intfs...>::setComponentStatus(const ComponentStatus& status) const
 {
-    setComponentErrorStateStatusWithMessage(status, "");
+    setComponentStatusWithMessage(status, "");
 }
 
 template <class Intf, class... Intfs>
-void ComponentImpl<Intf, Intfs...>::setComponentErrorStateStatusWithMessage(const ComponentErrorState& status, const StringPtr& message) const
+void ComponentImpl<Intf, Intfs...>::setComponentStatusWithMessage(const ComponentStatus& status, const StringPtr& message) const
 {
     // Fail with explicit message of what happened if not initialized
     try
@@ -1153,8 +1153,8 @@ void ComponentImpl<Intf, Intfs...>::setComponentErrorStateStatusWithMessage(cons
     }
     catch (const NotFoundException&)
     {
-        throw NotFoundException("ComponentStatus has not been added to statusContainer. initComponentErrorStateStatus needs to be called "
-                                "before setComponentErrorStateStatus.");
+        throw NotFoundException("ComponentStatus has not been added to statusContainer. initComponentStatus needs to be called "
+                                "before setComponentStatus.");
     }
 
     // Set status if initialized

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1164,10 +1164,6 @@ void ComponentImpl<Intf, Intfs...>::setComponentStatusWithMessage(const Componen
                                 "before setComponentStatus.");
     }
 
-    // Check if status and message are the same as before, if so, return
-    if (status == oldStatus && message == oldMessage)
-        return;
-
     // Set status if initialized
     const auto statusContainerPrivate = this->statusContainer.template asPtr<IComponentStatusContainerPrivate>(true);
     const auto componentStatusValue =

--- a/core/opendaq/component/include/opendaq/component_status_container_impl.h
+++ b/core/opendaq/component/include/opendaq/component_status_container_impl.h
@@ -197,12 +197,15 @@ inline ErrCode ComponentStatusContainerImpl::setStatusWithMessage(IString* name,
         return OPENDAQ_ERR_NOTFOUND;
 
     const auto valueObj = EnumerationPtr::Borrow(value);
-    const auto oldValue = statuses.get(name);
-    if (valueObj.getEnumerationType() != oldValue.getEnumerationType())
+    const auto oldStatus = statuses.get(name);
+    const auto oldMessage = messages.get(name);
+
+    if (valueObj.getEnumerationType() != oldStatus.getEnumerationType())
         return OPENDAQ_ERR_INVALIDTYPE;
-    if (valueObj == oldValue)
+
+    if (valueObj == oldStatus)
     {
-        if (messages.get(name) == messageObj)
+        if (oldMessage == messageObj)
         {
             // No change in value or message
             return OPENDAQ_IGNORED;
@@ -219,14 +222,14 @@ inline ErrCode ComponentStatusContainerImpl::setStatusWithMessage(IString* name,
         if (OPENDAQ_FAILED(errCode))
             return errCode;
 
-        if (messages.get(name) != messageObj)
+        if (oldMessage != messageObj)
         {
             // Change in message
             errCode = messages->set(name, messageObj);
             if (OPENDAQ_FAILED(errCode))
             {
                 // Rollback
-                statuses.set(name, oldValue);
+                statuses.set(name, oldStatus);
                 // Return error
                 return errCode;
             }

--- a/core/opendaq/component/tests/test_component.cpp
+++ b/core/opendaq/component/tests/test_component.cpp
@@ -256,55 +256,55 @@ public:
     {
     }
 
-    void initComponentErrorStateStatusPublic()
+    void initComponentStatusPublic()
     {
-        this->initComponentErrorStateStatus();
+        this->initComponentStatus();
     }
 
-    void setComponentErrorStateStatusPublic(const ComponentErrorState& status)
+    void setComponentStatusPublic(const ComponentStatus& status)
     {
-        this->setComponentErrorStateStatus(status);
+        this->setComponentStatus(status);
     }
 };
 
-TEST_F(ComponentTest, SetComponentErrorStateStatusWithoutInit)
+TEST_F(ComponentTest, SetComponentStatusWithoutInit)
 {
     auto component = createWithImplementation<IComponent, MyTestComponent>(NullContext(), nullptr);
     auto implPtr = dynamic_cast<MyTestComponent*>(component.getObject());
 
-    ASSERT_THROW_MSG(implPtr->setComponentErrorStateStatusPublic(ComponentErrorState::Error),
+    ASSERT_THROW_MSG(implPtr->setComponentStatusPublic(ComponentStatus::Error),
                      NotFoundException,
-                     "ComponentStatus has not been added to statusContainer. initComponentErrorStateStatus needs to be called before "
-                     "setComponentErrorStateStatus.")
+                     "ComponentStatus has not been added to statusContainer. initComponentStatus needs to be called before "
+                     "setComponentStatus.")
 }
 
-TEST_F(ComponentTest, InitThenSetComponentErrorStateStatus)
+TEST_F(ComponentTest, InitThenSetComponentStatus)
 {
     auto component = createWithImplementation<IComponent, MyTestComponent>(NullContext(), nullptr);
     auto implPtr = dynamic_cast<MyTestComponent*>(component.getObject());
     auto container = component.getStatusContainer();
 
-    implPtr->initComponentErrorStateStatusPublic();
+    implPtr->initComponentStatusPublic();
 
     ASSERT_EQ(
         container.getStatus("ComponentStatus"),
-        EnumerationWithIntValue("ComponentStatusType", static_cast<Int>(ComponentErrorState::Ok), component.getContext().getTypeManager()));
+        EnumerationWithIntValue("ComponentStatusType", static_cast<Int>(ComponentStatus::Ok), component.getContext().getTypeManager()));
 
     ASSERT_EQ(container.getStatus("ComponentStatus"), Enumeration("ComponentStatusType", "Ok", component.getContext().getTypeManager()));
 
-    implPtr->setComponentErrorStateStatusPublic(ComponentErrorState::Error);
+    implPtr->setComponentStatusPublic(ComponentStatus::Error);
 
     ASSERT_EQ(container.getStatus("ComponentStatus"),
               EnumerationWithIntValue(
-                  "ComponentStatusType", static_cast<Int>(ComponentErrorState::Error), component.getContext().getTypeManager()));
+                  "ComponentStatusType", static_cast<Int>(ComponentStatus::Error), component.getContext().getTypeManager()));
 
     ASSERT_EQ(container.getStatus("ComponentStatus"), Enumeration("ComponentStatusType", "Error", component.getContext().getTypeManager()));
 
-    implPtr->setComponentErrorStateStatusPublic(ComponentErrorState::Warning);
+    implPtr->setComponentStatusPublic(ComponentStatus::Warning);
 
     ASSERT_EQ(container.getStatus("ComponentStatus"),
               EnumerationWithIntValue(
-                  "ComponentStatusType", static_cast<Int>(ComponentErrorState::Warning), component.getContext().getTypeManager()));
+                  "ComponentStatusType", static_cast<Int>(ComponentStatus::Warning), component.getContext().getTypeManager()));
 
     ASSERT_EQ(container.getStatus("ComponentStatus"), Enumeration("ComponentStatusType", "Warning", component.getContext().getTypeManager()));
 }

--- a/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
+++ b/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
@@ -168,6 +168,11 @@ private:
 
     sf::Color axisColor;
 
+    ComponentStatus futureComponentStatus;
+    StringPtr futureComponentMessage;
+
+    void logAndSetFutureComponentStatus(ComponentStatus status, StringPtr message);
+
     void updateInputPorts();
     void renderSignals(sf::RenderTarget& renderTarget, const sf::Font& font);
     static sf::Color getColor(const SignalContext& signalContext);

--- a/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -25,7 +25,7 @@ namespace Classifier
 ClassifierFbImpl::ClassifierFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
     : FunctionBlock(CreateType(), ctx, parent, localId)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
     createInputPorts();
     createSignals();
     initProperties();
@@ -97,7 +97,7 @@ void ClassifierFbImpl::readProperties()
 
     if (blockSize == 0)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Classifier property BlockSize must be greater than 0");
+        setComponentStatusWithMessage(ComponentStatus::Error, "Classifier property BlockSize must be greater than 0");
         throw InvalidParameterException("Classifier property BlockSize must be greater than 0");
     }
 
@@ -107,7 +107,7 @@ void ClassifierFbImpl::readProperties()
     }
     else if (customClassList.empty())
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Classifier property CustomClassList is empty");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is empty");
         LOG_W("Classifier property CustomClassList is empty")
     }
     else
@@ -117,7 +117,7 @@ void ClassifierFbImpl::readProperties()
         {
             if (static_cast<Float>(el) < lastValue)
             {
-                setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Classifier property CustomClassList is not incremental");
+                setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is not incremental");
                 LOG_W("Classifier property CustomClassList is not incremental")
                 break;
             }
@@ -149,14 +149,14 @@ void ClassifierFbImpl::configure()
 {
     if (!inputDataDescriptor.assigned())
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "ClassifierFb: Incomplete input data signal descriptor");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "ClassifierFb: Incomplete input data signal descriptor");
         LOG_D("ClassifierFb: Incomplete input data signal descriptor")
         return;
     }
 
     if (!inputDomainDataDescriptor.assigned())
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "ClassifierFb: Incomplete input domain signal descriptor");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "ClassifierFb: Incomplete input domain signal descriptor");
         LOG_D("ClassifierFb: Incomplete input domain signal descriptor")
         return;
     }
@@ -165,7 +165,7 @@ void ClassifierFbImpl::configure()
     {
         if (inputDataDescriptor.getSampleType() == SampleType::Struct || inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Incompatible input value data descriptor");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible input value data descriptor");
             throw std::runtime_error("Incompatible input value data descriptor");
         }
             
@@ -176,20 +176,20 @@ void ClassifierFbImpl::configure()
             inputSampleType != SampleType::UInt8 && inputSampleType != SampleType::UInt16 && inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid sample type");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
         if (inputDomainDataDescriptor.getSampleType() != SampleType::Int64 && inputDomainDataDescriptor.getSampleType() != SampleType::UInt64)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Incompatible domain data sample type");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible domain data sample type");
             throw std::runtime_error("Incompatible domain data sample type");
         }
 
         auto domainUnit = inputDomainDataDescriptor.getUnit();
         if (domainUnit.getSymbol() != "s" && domainUnit.getSymbol() != "seconds")
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Domain unit expected in seconds");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Domain unit expected in seconds");
             throw std::runtime_error("Domain unit expected in seconds");
         }
 
@@ -213,7 +213,7 @@ void ClassifierFbImpl::configure()
 
             if (linearBlockCount == 0)
             {
-                setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Calculation of linearBlockCount failed");
+                setComponentStatusWithMessage(ComponentStatus::Error, "Calculation of linearBlockCount failed");
                 throw std::runtime_error("Calculation of linearBlockCount failed");
             }
         }
@@ -266,7 +266,7 @@ void ClassifierFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Failed to set descriptor for classification signal");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for classification signal");
         LOG_W("ClassifierFb: Failed to set descriptor for classification signal: {}", e.what())
         outputSignal.setDescriptor(nullptr);
     }
@@ -344,7 +344,7 @@ void ClassifierFbImpl::processLinearData(const std::vector<Float>& inputData, co
     auto labels = outputDataDescriptor.getDimensions()[0].getLabels();
     if (labels.getCount() == 0) 
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Classifier labels are not set correctly");
+        setComponentStatusWithMessage(ComponentStatus::Error, "Classifier labels are not set correctly");
         LOG_E("Classifier labels are not set correctly")
         return;
     }
@@ -394,7 +394,7 @@ void ClassifierFbImpl::processExplicitData(Float inputData, UInt inputDomainData
     auto labels = outputDataDescriptor.getDimensions()[0].getLabels();
     if (labels.getCount() == 0) 
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Classifier labels are not set correctly");
+        setComponentStatusWithMessage(ComponentStatus::Error, "Classifier labels are not set correctly");
         LOG_E("Classifier labels are not set correctly")
         packetGap = true;
         return;

--- a/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -124,7 +124,7 @@ void ClassifierFbImpl::readProperties()
             lastValue = el;
         }
     }
-    setComponentStatusWithMessage(ComponentStatus::Ok, "Reading properties successful");
+    setComponentStatus(ComponentStatus::Ok);
 }
 
 FunctionBlockTypePtr ClassifierFbImpl::CreateType()
@@ -271,7 +271,7 @@ void ClassifierFbImpl::configure()
         LOG_W("ClassifierFb: Failed to set descriptor for classification signal: {}", e.what())
         outputSignal.setDescriptor(nullptr);
     }
-    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
+    setComponentStatus(ComponentStatus::Ok);
 }
 
 void ClassifierFbImpl::processData()
@@ -372,7 +372,7 @@ void ClassifierFbImpl::processLinearData(const std::vector<Float>& inputData, co
     outputSignal.sendPacket(outputPacket);
     outputDomainSignal.sendPacket(outputDomainPacket);
 
-    setComponentStatusWithMessage(ComponentStatus::Ok, "Processed linear data");
+    setComponentStatus(ComponentStatus::Ok);
 }
 
 inline UInt ClassifierFbImpl::blockSizeToTimeDuration() 
@@ -443,7 +443,7 @@ void ClassifierFbImpl::processExplicitData(Float inputData, UInt inputDomainData
     outputDomainSignal.sendPacket(outputDomainPacket);
 
     cachedSamples = List<Float>(inputData);
-    setComponentStatusWithMessage(ComponentStatus::Ok, "Processed explicit data");
+    setComponentStatus(ComponentStatus::Ok);
 }
 
 void ClassifierFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -124,6 +124,7 @@ void ClassifierFbImpl::readProperties()
             lastValue = el;
         }
     }
+    setComponentStatusWithMessage(ComponentStatus::Ok, "Reading properties successful");
 }
 
 FunctionBlockTypePtr ClassifierFbImpl::CreateType()
@@ -270,6 +271,7 @@ void ClassifierFbImpl::configure()
         LOG_W("ClassifierFb: Failed to set descriptor for classification signal: {}", e.what())
         outputSignal.setDescriptor(nullptr);
     }
+    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
 }
 
 void ClassifierFbImpl::processData()
@@ -369,6 +371,8 @@ void ClassifierFbImpl::processLinearData(const std::vector<Float>& inputData, co
 
     outputSignal.sendPacket(outputPacket);
     outputDomainSignal.sendPacket(outputDomainPacket);
+
+    setComponentStatusWithMessage(ComponentStatus::Ok, "Processed linear data");
 }
 
 inline UInt ClassifierFbImpl::blockSizeToTimeDuration() 
@@ -439,6 +443,7 @@ void ClassifierFbImpl::processExplicitData(Float inputData, UInt inputDomainData
     outputDomainSignal.sendPacket(outputDomainPacket);
 
     cachedSamples = List<Float>(inputData);
+    setComponentStatusWithMessage(ComponentStatus::Ok, "Processed explicit data");
 }
 
 void ClassifierFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -108,6 +108,7 @@ void ClassifierFbImpl::readProperties()
     else if (customClassList.empty())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is empty");
+        return;
     }
     else
     {
@@ -162,10 +163,8 @@ void ClassifierFbImpl::configure()
     {
         if (inputDataDescriptor.getSampleType() == SampleType::Struct || inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible input value data descriptor");
             throw std::runtime_error("Incompatible input value data descriptor");
         }
-            
 
         auto inputSampleType = inputDataDescriptor.getSampleType();
         if (inputSampleType != SampleType::Float64 && inputSampleType != SampleType::Float32 && inputSampleType != SampleType::Int8 &&
@@ -173,20 +172,17 @@ void ClassifierFbImpl::configure()
             inputSampleType != SampleType::UInt8 && inputSampleType != SampleType::UInt16 && inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
         if (inputDomainDataDescriptor.getSampleType() != SampleType::Int64 && inputDomainDataDescriptor.getSampleType() != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible domain data sample type");
             throw std::runtime_error("Incompatible domain data sample type");
         }
 
         auto domainUnit = inputDomainDataDescriptor.getUnit();
         if (domainUnit.getSymbol() != "s" && domainUnit.getSymbol() != "seconds")
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain unit expected in seconds");
             throw std::runtime_error("Domain unit expected in seconds");
         }
 
@@ -210,7 +206,6 @@ void ClassifierFbImpl::configure()
 
             if (linearBlockCount == 0)
             {
-                setComponentStatusWithMessage(ComponentStatus::Error, "Calculation of linearBlockCount failed");
                 throw std::runtime_error("Calculation of linearBlockCount failed");
             }
         }
@@ -260,14 +255,15 @@ void ClassifierFbImpl::configure()
         
         outputDomainDataDescriptor = DataDescriptorBuilderCopy(inputDomainDataDescriptor).setRule(ExplicitDataRule()).build();
         outputDomainSignal.setDescriptor(outputDomainDataDescriptor);
+
+        setComponentStatus(ComponentStatus::Ok);
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning,
+        setComponentStatusWithMessage(ComponentStatus::Error,
                                       fmt::format("ClassifierFb: Failed to set descriptor for classification signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
-    setComponentStatus(ComponentStatus::Ok);
 }
 
 void ClassifierFbImpl::processData()

--- a/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -108,22 +108,29 @@ void ClassifierFbImpl::readProperties()
     else if (customClassList.empty())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is empty");
-        return;
     }
     else
     {
         Float lastValue = customClassList[0];
+        bool warning = false;
         for (const auto& el : customClassList)
         {
             if (static_cast<Float>(el) < lastValue)
             {
-                setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is not incremental");
+                warning = true;
                 break;
             }
             lastValue = el;
         }
+        if (warning)
+        {
+            setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is not incremental");
+        }
+        else
+        {
+            setComponentStatus(ComponentStatus::Ok);
+        }
     }
-    setComponentStatus(ComponentStatus::Ok);
 }
 
 FunctionBlockTypePtr ClassifierFbImpl::CreateType()

--- a/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -108,7 +108,6 @@ void ClassifierFbImpl::readProperties()
     else if (customClassList.empty())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is empty");
-        LOG_W("Classifier property CustomClassList is empty")
     }
     else
     {
@@ -118,7 +117,6 @@ void ClassifierFbImpl::readProperties()
             if (static_cast<Float>(el) < lastValue)
             {
                 setComponentStatusWithMessage(ComponentStatus::Warning, "Classifier property CustomClassList is not incremental");
-                LOG_W("Classifier property CustomClassList is not incremental")
                 break;
             }
             lastValue = el;
@@ -151,14 +149,12 @@ void ClassifierFbImpl::configure()
     if (!inputDataDescriptor.assigned())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "ClassifierFb: Incomplete input data signal descriptor");
-        LOG_D("ClassifierFb: Incomplete input data signal descriptor")
         return;
     }
 
     if (!inputDomainDataDescriptor.assigned())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "ClassifierFb: Incomplete input domain signal descriptor");
-        LOG_D("ClassifierFb: Incomplete input domain signal descriptor")
         return;
     }
 
@@ -267,8 +263,8 @@ void ClassifierFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for classification signal");
-        LOG_W("ClassifierFb: Failed to set descriptor for classification signal: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Warning,
+                                      fmt::format("ClassifierFb: Failed to set descriptor for classification signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
     setComponentStatus(ComponentStatus::Ok);
@@ -347,7 +343,6 @@ void ClassifierFbImpl::processLinearData(const std::vector<Float>& inputData, co
     if (labels.getCount() == 0) 
     {
         setComponentStatusWithMessage(ComponentStatus::Error, "Classifier labels are not set correctly");
-        LOG_E("Classifier labels are not set correctly")
         return;
     }
 
@@ -399,7 +394,6 @@ void ClassifierFbImpl::processExplicitData(Float inputData, UInt inputDomainData
     if (labels.getCount() == 0) 
     {
         setComponentStatusWithMessage(ComponentStatus::Error, "Classifier labels are not set correctly");
-        LOG_E("Classifier labels are not set correctly")
         packetGap = true;
         return;
     }

--- a/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -179,7 +179,7 @@ void FFTFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("FFT: Failed to set descriptor for signal: {}", e.what()));
+        setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("FFT: Failed to set descriptor for signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
 }

--- a/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -190,6 +190,7 @@ void FFTFbImpl::configure()
         LOG_W("FFT: Failed to set descriptor for signal: {}", e.what())
         outputSignal.setDescriptor(nullptr);
     }
+    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
 }
 
 void FFTFbImpl::processEventPacket(const EventPacketPtr& packet)

--- a/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -186,8 +186,7 @@ void FFTFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for signal");
-        LOG_W("FFT: Failed to set descriptor for signal: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("FFT: Failed to set descriptor for signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
     setComponentStatus(ComponentStatus::Ok);

--- a/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -22,7 +22,7 @@ namespace FFT
 FFTFbImpl::FFTFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
     : FunctionBlock(CreateType(), ctx, parent, localId)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
     initProperties();
     createSignals();
     createInputPorts();
@@ -100,7 +100,7 @@ void FFTFbImpl::configure()
     {
         if (inputDataDescriptor.getSampleType() == SampleType::Struct || inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Incompatible input value data descriptor");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible input value data descriptor");
             throw std::runtime_error("Incompatible input value data descriptor");
         }
             
@@ -117,27 +117,27 @@ void FFTFbImpl::configure()
             inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid sample type");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
         if (inputDomainDataDescriptor.getSampleType() != SampleType::Int64 && inputDomainDataDescriptor.getSampleType() != SampleType::UInt64)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Incompatible domain data sample type");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible domain data sample type");
             throw std::runtime_error("Incompatible domain data sample type");
         }
 
         const auto domainUnit = inputDomainDataDescriptor.getUnit();
         if (domainUnit.getSymbol() != "s" && domainUnit.getSymbol() != "seconds")
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Domain unit expected in seconds");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Domain unit expected in seconds");
             throw std::runtime_error("Domain unit expected in seconds");
         }
 
         const auto domainRule = inputDomainDataDescriptor.getRule();
         if (inputDomainDataDescriptor.getRule().getType() != DataRuleType::Linear)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Domain rule must be linear");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Domain rule must be linear");
             throw std::runtime_error("FFT: Domain rule must be linear");
         }
 
@@ -147,7 +147,7 @@ void FFTFbImpl::configure()
         const auto resolution = inputDomainDataDescriptor.getTickResolution();
         if (!resolution.assigned())
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error,
+            setComponentStatusWithMessage(ComponentStatus::Error,
                                                     "Domain signal descriptor has no Tick resolution configured");
             throw std::runtime_error("FFT: Domain signal descriptor has no Tick resolution configured");
         }
@@ -186,7 +186,7 @@ void FFTFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Failed to set descriptor for signal");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for signal");
         LOG_W("FFT: Failed to set descriptor for signal: {}", e.what())
         outputSignal.setDescriptor(nullptr);
     }

--- a/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -190,7 +190,7 @@ void FFTFbImpl::configure()
         LOG_W("FFT: Failed to set descriptor for signal: {}", e.what())
         outputSignal.setDescriptor(nullptr);
     }
-    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
+    setComponentStatus(ComponentStatus::Ok);
 }
 
 void FFTFbImpl::processEventPacket(const EventPacketPtr& packet)

--- a/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -100,10 +100,8 @@ void FFTFbImpl::configure()
     {
         if (inputDataDescriptor.getSampleType() == SampleType::Struct || inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible input value data descriptor");
             throw std::runtime_error("Incompatible input value data descriptor");
         }
-            
 
         inputSampleType = inputDataDescriptor.getSampleType();
         if (inputSampleType != SampleType::Float64 &&
@@ -117,27 +115,23 @@ void FFTFbImpl::configure()
             inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
         if (inputDomainDataDescriptor.getSampleType() != SampleType::Int64 && inputDomainDataDescriptor.getSampleType() != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible domain data sample type");
             throw std::runtime_error("Incompatible domain data sample type");
         }
 
         const auto domainUnit = inputDomainDataDescriptor.getUnit();
         if (domainUnit.getSymbol() != "s" && domainUnit.getSymbol() != "seconds")
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain unit expected in seconds");
             throw std::runtime_error("Domain unit expected in seconds");
         }
 
         const auto domainRule = inputDomainDataDescriptor.getRule();
         if (inputDomainDataDescriptor.getRule().getType() != DataRuleType::Linear)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain rule must be linear");
             throw std::runtime_error("FFT: Domain rule must be linear");
         }
 
@@ -147,8 +141,6 @@ void FFTFbImpl::configure()
         const auto resolution = inputDomainDataDescriptor.getTickResolution();
         if (!resolution.assigned())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error,
-                                                    "Domain signal descriptor has no Tick resolution configured");
             throw std::runtime_error("FFT: Domain signal descriptor has no Tick resolution configured");
         }
 
@@ -183,13 +175,13 @@ void FFTFbImpl::configure()
         fftOut.resize(blockSize);
 
         configValid = true;
+        setComponentStatus(ComponentStatus::Ok);
     }
     catch (const std::exception& e)
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("FFT: Failed to set descriptor for signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
-    setComponentStatus(ComponentStatus::Ok);
 }
 
 void FFTFbImpl::processEventPacket(const EventPacketPtr& packet)

--- a/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -194,14 +194,12 @@ void PowerFbImpl::checkPacketQueues()
     {
         voltageQueue.pop_back();
         setComponentStatusWithMessage(ComponentStatus::Warning, "Data lost, voltage packets skipped");
-        LOG_W("Data lost, voltage packets skipped")
         synced = false;
     }
     while (currentQueue.size() > 100)
     {
         currentQueue.pop_back();
         setComponentStatusWithMessage(ComponentStatus::Warning, "Data lost, current packets skipped");
-        LOG_W("Data lost, voltage packets skipped")
         synced = false;
     }
 }
@@ -365,7 +363,6 @@ void PowerFbImpl::configure(bool resync)
         !currentDomainDataDescriptor.assigned())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "Incomplete signal descriptors");
-        LOG_D("Incomplete signal descriptors")
         return;
     }
 
@@ -373,27 +370,23 @@ void PowerFbImpl::configure(bool resync)
     {
         if (voltageDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Arrays not supported");
             throw std::runtime_error("Arrays not supported");
         }
 
         if (currentDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample typ");
             throw std::runtime_error("Invalid sample typ");
         }
 
         voltageSampleType = voltageDataDescriptor.getSampleType();
         if (voltageSampleType != SampleType::Float64 && voltageSampleType != SampleType::Float32)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
         currentSampleType = currentDataDescriptor.getSampleType();
         if (currentSampleType != SampleType::Float64 && currentSampleType != SampleType::Float32)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
@@ -411,61 +404,51 @@ void PowerFbImpl::configure(bool resync)
 
         if (voltageDomainDataDescriptor.getOrigin() != currentDomainDataDescriptor.getOrigin())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain mismatch");
             throw std::runtime_error("Domain mismatch");
         }
 
         if (voltageDomainDataDescriptor.getTickResolution() != currentDomainDataDescriptor.getTickResolution())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain tick resolution mismatch");
             throw std::runtime_error("Domain tick resolution mismatch");
         }
 
         if (voltageDomainDataDescriptor.getSampleType() != SampleType::Int64 &&
             voltageDomainDataDescriptor.getSampleType() != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid domain sample type");
             throw std::runtime_error("Invalid domain sample type");
         }
 
         if (currentDomainDataDescriptor.getSampleType() != SampleType::Int64 &&
             currentDomainDataDescriptor.getSampleType() != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid domain sample type");
             throw std::runtime_error("Invalid domain sample type");
         }
 
         if (voltageDomainDataDescriptor.getSampleType() != currentDomainDataDescriptor.getSampleType())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain sample type mismatch");
             throw std::runtime_error("Domain sample type mismatch");
         }
-            
 
         if (currentDomainDataDescriptor.getSampleType() != SampleType::Int64 &&
             currentDomainDataDescriptor.getSampleType() != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid domain sample type");
             throw std::runtime_error("Invalid domain sample type");
         }
 
         if (voltageDomainDataDescriptor.getUnit() != currentDomainDataDescriptor.getUnit())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain unit mismatch");
             throw std::runtime_error("Domain unit mismatch");
         }
 
         const auto voltageDomainRule = voltageDomainDataDescriptor.getRule();
         if (!voltageDomainRule.assigned() || voltageDomainRule.getType() != DataRuleType::Linear)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Linear rule not used");
             throw std::runtime_error("Linear rule not used");
         }
 
         const auto currentDomainRule = currentDomainDataDescriptor.getRule();
         if (!currentDomainRule.assigned() || currentDomainRule.getType() != DataRuleType::Linear)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Linear rule not used");
             throw std::runtime_error("Linear rule not used");
         }
 
@@ -473,7 +456,6 @@ void PowerFbImpl::configure(bool resync)
         const auto currentDomainRuleParams = currentDomainRule.getParameters();
         if (voltageDomainRuleParams != currentDomainRuleParams)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Domain rule mismatch");
             throw std::runtime_error("Domain rule mismatch");
         }
 
@@ -486,8 +468,7 @@ void PowerFbImpl::configure(bool resync)
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for power signal");
-        LOG_W("Failed to set descriptor for power signal: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for power signal: {}", e.what()));
         powerSignal.setDescriptor(nullptr);
     }
     setComponentStatus(ComponentStatus::Ok);

--- a/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -331,7 +331,7 @@ void PowerFbImpl::processPacketTemplated()
         currentPos = 0;
         currentQueue.pop_back();
    }
-   setComponentStatusWithMessage(ComponentStatus::Ok, "Processed packet");
+   setComponentStatus(ComponentStatus::Ok);
 }
 
 RangePtr PowerFbImpl::getValueRange(DataDescriptorPtr voltageDataDescriptor, DataDescriptorPtr currentDataDescriptor)
@@ -490,7 +490,7 @@ void PowerFbImpl::configure(bool resync)
         LOG_W("Failed to set descriptor for power signal: {}", e.what())
         powerSignal.setDescriptor(nullptr);
     }
-    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
+    setComponentStatus(ComponentStatus::Ok);
 }
 
 void PowerFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -465,13 +465,14 @@ void PowerFbImpl::configure(bool resync)
 
         start = voltageDomainRuleParams.get("start");
         delta = voltageDomainRuleParams.get("delta");
+
+        setComponentStatus(ComponentStatus::Ok);
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for power signal: {}", e.what()));
+        setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Failed to set descriptor for power signal: {}", e.what()));
         powerSignal.setDescriptor(nullptr);
     }
-    setComponentStatus(ComponentStatus::Ok);
 }
 
 void PowerFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -193,13 +193,13 @@ void PowerFbImpl::checkPacketQueues()
     while (voltageQueue.size() > 100)
     {
         voltageQueue.pop_back();
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Data lost, voltage packets skipped");
+        LOG_W("Data lost, voltage packets skipped")
         synced = false;
     }
     while (currentQueue.size() > 100)
     {
         currentQueue.pop_back();
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Data lost, current packets skipped");
+        LOG_W("Data lost, current packets skipped")
         synced = false;
     }
 }
@@ -329,7 +329,6 @@ void PowerFbImpl::processPacketTemplated()
         currentPos = 0;
         currentQueue.pop_back();
    }
-   setComponentStatus(ComponentStatus::Ok);
 }
 
 RangePtr PowerFbImpl::getValueRange(DataDescriptorPtr voltageDataDescriptor, DataDescriptorPtr currentDataDescriptor)

--- a/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -2,20 +2,17 @@
 #include <opendaq/function_block_ptr.h>
 #include <opendaq/input_port_factory.h>
 #include <opendaq/data_descriptor_ptr.h>
-
 #include <opendaq/event_packet_ptr.h>
 #include <opendaq/signal_factory.h>
-
 #include <opendaq/custom_log.h>
 #include <opendaq/event_packet_params.h>
-
-#include "coreobjects/unit_factory.h"
-#include "opendaq/data_packet.h"
-#include "opendaq/data_packet_ptr.h"
-#include "opendaq/event_packet_ids.h"
-#include "opendaq/packet_factory.h"
-#include "opendaq/range_factory.h"
-#include "opendaq/sample_type_traits.h"
+#include <coreobjects/unit_factory.h>
+#include <opendaq/data_packet.h>
+#include <opendaq/data_packet_ptr.h>
+#include <opendaq/event_packet_ids.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/range_factory.h>
+#include <opendaq/sample_type_traits.h>
 #include <coreobjects/eval_value_factory.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE

--- a/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -331,6 +331,7 @@ void PowerFbImpl::processPacketTemplated()
         currentPos = 0;
         currentQueue.pop_back();
    }
+   setComponentStatusWithMessage(ComponentStatus::Ok, "Processed packet");
 }
 
 RangePtr PowerFbImpl::getValueRange(DataDescriptorPtr voltageDataDescriptor, DataDescriptorPtr currentDataDescriptor)
@@ -489,6 +490,7 @@ void PowerFbImpl::configure(bool resync)
         LOG_W("Failed to set descriptor for power signal: {}", e.what())
         powerSignal.setDescriptor(nullptr);
     }
+    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
 }
 
 void PowerFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -199,25 +199,21 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
 
         if (this->domainDescriptor == NullDataDescriptor())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Input domain descriptor is not set");
             throw std::runtime_error("Input domain descriptor is not set");
         }
         if (this->voltageDescriptor == NullDataDescriptor())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Input voltage descriptor is not set");
             throw std::runtime_error("Input voltage descriptor is not set");
         }
             
         if (this->currentDescriptor == NullDataDescriptor())
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Input current descriptor is not set");
             throw std::runtime_error("Input current descriptor is not set");
         }
 
         if (this->voltageDescriptor.assigned() && this->voltageDescriptor.getUnit().assigned() &&
             this->voltageDescriptor.getUnit().getSymbol() != "V")
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid voltage signal unit");
             throw std::runtime_error("Invalid voltage signal unit");
         }
 
@@ -240,8 +236,7 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for power signal");
-        LOG_W("Failed to set descriptor for power signal: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for power signal: {}", e.what()));
         reader.setActive(False);
     }
     setComponentStatus(ComponentStatus::Ok);

--- a/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -244,7 +244,7 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
         LOG_W("Failed to set descriptor for power signal: {}", e.what())
         reader.setActive(False);
     }
-    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
+    setComponentStatus(ComponentStatus::Ok);
 }
 
 void PowerReaderFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -244,6 +244,7 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
         LOG_W("Failed to set descriptor for power signal: {}", e.what())
         reader.setActive(False);
     }
+    setComponentStatusWithMessage(ComponentStatus::Ok, "Configuration successful");
 }
 
 void PowerReaderFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -233,13 +233,14 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
 
         powerSignal.setDescriptor(powerDataDescriptor);
         powerDomainSignal.setDescriptor(powerDomainDataDescriptor);
+
+        setComponentStatus(ComponentStatus::Ok);
     }
     catch (const std::exception& e)
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for power signal: {}", e.what()));
         reader.setActive(False);
     }
-    setComponentStatus(ComponentStatus::Ok);
 }
 
 void PowerReaderFbImpl::createInputPorts()

--- a/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -25,7 +25,7 @@ namespace PowerReader
 PowerReaderFbImpl::PowerReaderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
     : FunctionBlock(CreateType(), ctx, parent, localId)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
     createInputPorts();
     createSignals();
     initProperties();
@@ -199,25 +199,25 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
 
         if (this->domainDescriptor == NullDataDescriptor())
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Input domain descriptor is not set");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Input domain descriptor is not set");
             throw std::runtime_error("Input domain descriptor is not set");
         }
         if (this->voltageDescriptor == NullDataDescriptor())
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Input voltage descriptor is not set");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Input voltage descriptor is not set");
             throw std::runtime_error("Input voltage descriptor is not set");
         }
             
         if (this->currentDescriptor == NullDataDescriptor())
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Input current descriptor is not set");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Input current descriptor is not set");
             throw std::runtime_error("Input current descriptor is not set");
         }
 
         if (this->voltageDescriptor.assigned() && this->voltageDescriptor.getUnit().assigned() &&
             this->voltageDescriptor.getUnit().getSymbol() != "V")
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid voltage signal unit");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid voltage signal unit");
             throw std::runtime_error("Invalid voltage signal unit");
         }
 
@@ -240,7 +240,7 @@ void PowerReaderFbImpl::configure(const DataDescriptorPtr& domainDescriptor, con
     }
     catch (const std::exception& e)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Failed to set descriptor for power signal");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for power signal");
         LOG_W("Failed to set descriptor for power signal: {}", e.what())
         reader.setActive(False);
     }

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -1,7 +1,6 @@
 #include <opendaq/function_block_ptr.h>
 #include <ref_fb_module/arial.ttf.h>
 #include <ref_fb_module/renderer_fb_impl.h>
-
 #include <opendaq/event_packet_ids.h>
 #include <opendaq/event_packet_params.h>
 #include <opendaq/event_packet_ptr.h>
@@ -10,9 +9,7 @@
 #include <opendaq/custom_log.h>
 #include <ref_fb_module/dispatch.h>
 #include <coreobjects/eval_value_factory.h>
-
 #include <date/date.h>
-
 #include <iomanip>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
@@ -174,9 +171,7 @@ void RendererFbImpl::readProperties()
     LOG_T("Properties: Custom2dMaxRange {}", custom2dMaxRange);
     if (custom2dMinRange > custom2dMaxRange)
     {
-        setComponentStatusWithMessage(ComponentStatus::Error,
-                                                "Property custom2dMaxRange has to be more than custom2dMinRange");
-        LOG_E("Property custom2dMaxRange has to be more than custom2dMinRange");
+        setComponentStatusWithMessage(ComponentStatus::Error, "Property custom2dMaxRange has to be more than custom2dMinRange");
     }
     else
     {
@@ -933,7 +928,7 @@ void RendererFbImpl::prepareSingleXAxis()
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Unable to configure single X axis: {}", e.what()));
+        setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Unable to configure single X axis: {}", e.what()));
     }
 }
 
@@ -1311,7 +1306,6 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
             }
             catch (const std::exception& e)
             {
-                setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Invalid data rule parameters: {}", e.what()));
                 throw InvalidPropertyException("Invalid data rule parameters: {}", e.what());
             }
             signalContext.isExplicit = false;

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -702,7 +702,6 @@ void RendererFbImpl::updateSingleXAxis() {
             {
                 singleXAxis = false;
                 setComponentStatusWithMessage(ComponentStatus::Warning, "Renderer has multiple input signals with different dimension. Property singleXAxis has turned off");
-                LOG_W("Renderer has multiple input signals with different dimension. Property singleXAxis has turned off")
                 break;
             }
         }
@@ -875,7 +874,6 @@ void RendererFbImpl::prepareSingleXAxis()
         auto sigIt = signalContexts.begin();
         if (!sigIt->valid)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "First signal not valid");
             throw InvalidStateException("First signal not valid");
         }
             
@@ -893,7 +891,6 @@ void RendererFbImpl::prepareSingleXAxis()
 
             if (sigIt->hasTimeOrigin != hasTimeOrigin)
             {
-               setComponentStatusWithMessage(ComponentStatus::Error, "Time origin set on some signals, but not all of them");
                throw InvalidStateException("Time origin set on some signals, but not all of them");
                return;
             }
@@ -902,14 +899,12 @@ void RendererFbImpl::prepareSingleXAxis()
             {
                if (domainUnit != sigIt->domainUnit)
                {
-                   setComponentStatusWithMessage(ComponentStatus::Error, "Domain unit not equal");
                    throw InvalidStateException("Domain unit not equal");
                    return;
                }
 
                if (domainQuantity != sigIt->domainQuantity)
                {
-                   setComponentStatusWithMessage(ComponentStatus::Error, "Domain quantity not equal");
                    throw InvalidStateException("Domain quantity not equal");
                    return;
                }
@@ -938,8 +933,7 @@ void RendererFbImpl::prepareSingleXAxis()
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Unable to configure single X axis");
-        LOG_W("Unable to configure single X axis: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Unable to configure single X axis: {}", e.what()));
     }
 }
 
@@ -1317,7 +1311,7 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
             }
             catch (const std::exception& e)
             {
-                setComponentStatusWithMessage(ComponentStatus::Error, "Invalid data rule parameters");
+                setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Invalid data rule parameters: {}", e.what()));
                 throw InvalidPropertyException("Invalid data rule parameters: {}", e.what());
             }
             signalContext.isExplicit = false;
@@ -1362,8 +1356,7 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
             }
             catch (...)
             {
-                setComponentStatusWithMessage(ComponentStatus::Warning, "Invalid origin, ignored");
-                LOG_W("Invalid origin, ignored: {}", origin)
+                setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Invalid origin, ignored: {}", origin));
             }
         }
 
@@ -1371,7 +1364,6 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
         if (dataDescriptor.getDimensions().getCount() > 1)  // matrix not supported on the input
         {
             setComponentStatusWithMessage(ComponentStatus::Warning, "Matrix signals not supported");
-            LOG_W("Matrix signals not supported")
             return;
         }
         signalContext.sampleType = dataDescriptor.getSampleType();
@@ -1394,8 +1386,7 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Error, "Signal descriptor changed error");
-        LOG_E("Signal descriptor changed error: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Signal descriptor changed error: {}", e.what()));
     }
 }
 
@@ -1511,10 +1502,8 @@ std::chrono::system_clock::time_point RendererFbImpl::timeStrToTimePoint(std::st
     timeStringStream >> date::parse("%FT%T%z", timePoint);
     if (timeStringStream.fail())
     {
-        setComponentStatusWithMessage(ComponentStatus::Error, "Invalid format");
         throw std::runtime_error("Invalid format");
     }
-        
 
     return timePoint;
 }

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -28,7 +28,7 @@ RendererFbImpl::RendererFbImpl(const ContextPtr& ctx, const ComponentPtr& parent
     , inputPortCount(0)
     , axisColor(150, 150, 150)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
     initProperties();
     updateInputPorts();
 
@@ -174,7 +174,7 @@ void RendererFbImpl::readProperties()
     LOG_T("Properties: Custom2dMaxRange {}", custom2dMaxRange);
     if (custom2dMinRange > custom2dMaxRange)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Error,
+        setComponentStatusWithMessage(ComponentStatus::Error,
                                                 "Property custom2dMaxRange have to be more then custom2dMinRange");
         LOG_E("Property custom2dMaxRange have to be more then custom2dMinRange");
     }
@@ -697,7 +697,7 @@ void RendererFbImpl::updateSingleXAxis() {
             if (firstSignalDimension != curSignalDimension) 
             {
                 singleXAxis = false;
-                setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Renderer has multiple input signals with different dimension. Property singleXAxis has turned off");
+                setComponentStatusWithMessage(ComponentStatus::Warning, "Renderer has multiple input signals with different dimension. Property singleXAxis has turned off");
                 LOG_W("Renderer has multiple input signals with different dimension. Property singleXAxis has turned off")
                 break;
             }
@@ -717,7 +717,7 @@ void RendererFbImpl::renderLoop()
     sf::Font font;
     if (!font.loadFromMemory(ARIAL_TTF, sizeof(ARIAL_TTF)))
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Failed to load font");
+        setComponentStatusWithMessage(ComponentStatus::Error, "Failed to load font");
         throw std::runtime_error("Failed to load font");
     }
         
@@ -869,7 +869,7 @@ void RendererFbImpl::prepareSingleXAxis()
         auto sigIt = signalContexts.begin();
         if (!sigIt->valid)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "First signal not valid");
+            setComponentStatusWithMessage(ComponentStatus::Error, "First signal not valid");
             throw InvalidStateException("First signal not valid");
         }
             
@@ -887,7 +887,7 @@ void RendererFbImpl::prepareSingleXAxis()
 
             if (sigIt->hasTimeOrigin != hasTimeOrigin)
             {
-               setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Time origin set on some signals, but not all of them");
+               setComponentStatusWithMessage(ComponentStatus::Error, "Time origin set on some signals, but not all of them");
                throw InvalidStateException("Time origin set on some signals, but not all of them");
                return;
             }
@@ -896,14 +896,14 @@ void RendererFbImpl::prepareSingleXAxis()
             {
                if (domainUnit != sigIt->domainUnit)
                {
-                   setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Domain unit not equal");
+                   setComponentStatusWithMessage(ComponentStatus::Error, "Domain unit not equal");
                    throw InvalidStateException("Domain unit not equal");
                    return;
                }
 
                if (domainQuantity != sigIt->domainQuantity)
                {
-                   setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Domain quantity not equal");
+                   setComponentStatusWithMessage(ComponentStatus::Error, "Domain quantity not equal");
                    throw InvalidStateException("Domain quantity not equal");
                    return;
                }
@@ -932,7 +932,7 @@ void RendererFbImpl::prepareSingleXAxis()
     }
     catch (const std::exception& e)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Unable to configure single X axis");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Unable to configure single X axis");
         LOG_W("Unable to configure single X axis: {}", e.what())
     }
 }
@@ -1311,7 +1311,7 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
             }
             catch (const std::exception& e)
             {
-                setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid data rule parameters");
+                setComponentStatusWithMessage(ComponentStatus::Error, "Invalid data rule parameters");
                 throw InvalidPropertyException("Invalid data rule parameters: {}", e.what());
             }
             signalContext.isExplicit = false;
@@ -1356,7 +1356,7 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
             }
             catch (...)
             {
-                setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Invalid origin, ignored");
+                setComponentStatusWithMessage(ComponentStatus::Warning, "Invalid origin, ignored");
                 LOG_W("Invalid origin, ignored: {}", origin)
             }
         }
@@ -1364,7 +1364,7 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
         const auto dataDescriptor = signalContext.inputDataSignalDescriptor;
         if (dataDescriptor.getDimensions().getCount() > 1)  // matrix not supported on the input
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Matrix signals not supported");
+            setComponentStatusWithMessage(ComponentStatus::Warning, "Matrix signals not supported");
             LOG_W("Matrix signals not supported")
             return;
         }
@@ -1388,7 +1388,7 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
     }
     catch (const std::exception& e)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Signal descriptor changed error");
+        setComponentStatusWithMessage(ComponentStatus::Error, "Signal descriptor changed error");
         LOG_E("Signal descriptor changed error: {}", e.what())
     }
 }
@@ -1505,7 +1505,7 @@ std::chrono::system_clock::time_point RendererFbImpl::timeStrToTimePoint(std::st
     timeStringStream >> date::parse("%FT%T%z", timePoint);
     if (timeStringStream.fail())
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid format");
+        setComponentStatusWithMessage(ComponentStatus::Error, "Invalid format");
         throw std::runtime_error("Invalid format");
     }
         

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -178,6 +178,10 @@ void RendererFbImpl::readProperties()
                                                 "Property custom2dMaxRange has to be more than custom2dMinRange");
         LOG_E("Property custom2dMaxRange has to be more than custom2dMinRange");
     }
+    else
+    {
+        setComponentStatus(ComponentStatus::Ok);
+    }
         
 }
 
@@ -727,6 +731,8 @@ void RendererFbImpl::renderLoop()
     auto waitTime = defaultWaitTime;
     while (!stopRender && window.isOpen())
     {
+        setComponentStatus(ComponentStatus::Ok);
+
         cv.wait_for(lock, waitTime);
         auto t1 = std::chrono::steady_clock::now();
         if (!stopRender && window.isOpen())

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -696,7 +696,7 @@ void RendererFbImpl::updateSingleXAxis() {
             if (firstSignalDimension != curSignalDimension) 
             {
                 singleXAxis = false;
-                setComponentStatusWithMessage(ComponentStatus::Warning, "Renderer has multiple input signals with different dimension. Property singleXAxis has turned off");
+                setComponentStatusWithMessage(ComponentStatus::Warning, "Renderer has multiple input signals with different dimension. Property singleXAxis is turned off");
                 break;
             }
         }
@@ -887,7 +887,6 @@ void RendererFbImpl::prepareSingleXAxis()
             if (sigIt->hasTimeOrigin != hasTimeOrigin)
             {
                throw InvalidStateException("Time origin set on some signals, but not all of them");
-               return;
             }
 
             if (!hasTimeOrigin)
@@ -895,13 +894,11 @@ void RendererFbImpl::prepareSingleXAxis()
                if (domainUnit != sigIt->domainUnit)
                {
                    throw InvalidStateException("Domain unit not equal");
-                   return;
                }
 
                if (domainQuantity != sigIt->domainQuantity)
                {
                    throw InvalidStateException("Domain quantity not equal");
-                   return;
                }
             }
 

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -175,8 +175,8 @@ void RendererFbImpl::readProperties()
     if (custom2dMinRange > custom2dMaxRange)
     {
         setComponentStatusWithMessage(ComponentStatus::Error,
-                                                "Property custom2dMaxRange have to be more then custom2dMinRange");
-        LOG_E("Property custom2dMaxRange have to be more then custom2dMinRange");
+                                                "Property custom2dMaxRange has to be more than custom2dMinRange");
+        LOG_E("Property custom2dMaxRange has to be more than custom2dMinRange");
     }
         
 }

--- a/modules/ref_fb_module/src/scaling_fb_impl.cpp
+++ b/modules/ref_fb_module/src/scaling_fb_impl.cpp
@@ -110,23 +110,21 @@ void ScalingFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inpu
 
 void ScalingFbImpl::configure()
 {
+    setComponentStatus(ComponentStatus::Ok);
     try
     {
         if (inputDomainDataDescriptor == NullDataDescriptor())
         {
-            setComponentStatusWithMessage(ComponentStatus::Warning, "No domain input");
             throw std::runtime_error("No domain input");
         }
 
         if (inputDataDescriptor == NullDataDescriptor())
         {
-            setComponentStatusWithMessage(ComponentStatus::Warning, "No value input");
             throw std::runtime_error("No value input");
         }
 
         if (inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentStatusWithMessage(ComponentStatus::Warning, "Arrays not supported");
             throw std::runtime_error("Arrays not supported");
         }
 
@@ -142,7 +140,6 @@ void ScalingFbImpl::configure()
             inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Warning, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
@@ -177,7 +174,7 @@ void ScalingFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        LOG_W("Failed to set descriptor for output signal: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for output signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
 }

--- a/modules/ref_fb_module/src/scaling_fb_impl.cpp
+++ b/modules/ref_fb_module/src/scaling_fb_impl.cpp
@@ -28,7 +28,7 @@ namespace Scaling
 ScalingFbImpl::ScalingFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
     : FunctionBlock(CreateType(), ctx, parent, localId)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
     createInputPorts();
     createSignals();
     initProperties();
@@ -114,19 +114,19 @@ void ScalingFbImpl::configure()
     {
         if (inputDomainDataDescriptor == NullDataDescriptor())
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "No domain input");
+            setComponentStatusWithMessage(ComponentStatus::Warning, "No domain input");
             throw std::runtime_error("No domain input");
         }
 
         if (inputDataDescriptor == NullDataDescriptor())
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "No value input");
+            setComponentStatusWithMessage(ComponentStatus::Warning, "No value input");
             throw std::runtime_error("No value input");
         }
 
         if (inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Arrays not supported");
+            setComponentStatusWithMessage(ComponentStatus::Warning, "Arrays not supported");
             throw std::runtime_error("Arrays not supported");
         }
 
@@ -142,7 +142,7 @@ void ScalingFbImpl::configure()
             inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Invalid sample type");
+            setComponentStatusWithMessage(ComponentStatus::Warning, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 

--- a/modules/ref_fb_module/src/scaling_fb_impl.cpp
+++ b/modules/ref_fb_module/src/scaling_fb_impl.cpp
@@ -2,13 +2,10 @@
 #include <ref_fb_module/dispatch.h>
 #include <opendaq/input_port_factory.h>
 #include <opendaq/data_descriptor_ptr.h>
-
 #include <opendaq/event_packet_ptr.h>
 #include <opendaq/signal_factory.h>
-
 #include <opendaq/custom_log.h>
 #include <opendaq/event_packet_params.h>
-
 #include "coreobjects/unit_factory.h"
 #include "opendaq/data_packet.h"
 #include "opendaq/data_packet_ptr.h"
@@ -18,7 +15,6 @@
 #include "opendaq/sample_type_traits.h"
 #include <coreobjects/eval_value_factory.h>
 #include <opendaq/reusable_data_packet_ptr.h>
-#include <opendaq/component_status_container_private_ptr.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
@@ -110,7 +106,6 @@ void ScalingFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inpu
 
 void ScalingFbImpl::configure()
 {
-    setComponentStatus(ComponentStatus::Ok);
     try
     {
         if (inputDomainDataDescriptor == NullDataDescriptor())
@@ -171,10 +166,12 @@ void ScalingFbImpl::configure()
         outputDataDescriptor = outputDataDescriptorBuilder.build();
         outputSignal.setDescriptor(outputDataDescriptor);
         outputDomainSignal.setDescriptor(inputDomainDataDescriptor);
+
+        setComponentStatus(ComponentStatus::Ok);
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for output signal: {}", e.what()));
+        setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Failed to set descriptor for output signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
 }

--- a/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -206,8 +206,7 @@ void StatisticsFbImpl::configure()
 
     const auto outputRmsDataDescriptor = DataDescriptorBuilderCopy(inputValueDataDescriptor)
                                              .setName(static_cast<std::string>(inputValueDataDescriptor.getName() + "/Rms"))
-                                             .setPostScaling(nullptr)
-                                             .setValueRange(Range(0, inputValueDataDescriptor.getValueRange().getHighValue()));
+                                             .setPostScaling(nullptr);
     this->outputRmsDataDescriptor = outputRmsDataDescriptor.build();
 
     rmsSignal.setDescriptor(this->outputRmsDataDescriptor);

--- a/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -71,6 +71,7 @@ FunctionBlockPtr StatisticsFbImpl::onAddFunctionBlock(const StringPtr& typeId, c
         if (typeId != "RefFBModuleTrigger")
         {
             setComponentStatusWithMessage(ComponentStatus::Error, "Statistics function block only supports nested trigger function block");
+            throw InvalidParameterException("Statistics function block only supports nested trigger function block");
         }
 
         PropertyObjectPtr triggerConfig = config;

--- a/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -80,7 +80,7 @@ FunctionBlockPtr StatisticsFbImpl::onAddFunctionBlock(const StringPtr& typeId, c
             triggerConfig = PropertyObject();
             triggerConfig.addProperty(BoolProperty("UseMultiThreadedScheduler", packetReadyNotification != PacketReadyNotification::SameThread));
         }
-        nestedFunctionBlock = createAndAddNestedFunctionBlock(typeId, "nfbt", triggerConfig);
+        nestedFunctionBlock = createAndAddNestedFunctionBlock(typeId, "NestedTriggerFunctionBlock", triggerConfig);
     }
 
     triggerInput.connect(nestedFunctionBlock.getSignals()[0]);

--- a/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -15,7 +15,7 @@ StatisticsFbImpl::StatisticsFbImpl(const ContextPtr& ctx,
                                    const PropertyObjectPtr& config)
     : FunctionBlock(CreateType(), ctx, parent, localId)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
     initProperties();
 
     avgSignal = createAndAddSignal("avg");
@@ -63,14 +63,14 @@ FunctionBlockPtr StatisticsFbImpl::onAddFunctionBlock(const StringPtr& typeId, c
         auto lock = this->getAcquisitionLock();
         if (this->functionBlocks.getItems().getCount())
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Only one nested function block is supported");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Only one nested function block is supported");
             throw AlreadyExistsException("Only one nested function block is supported");
         }
             
         
         if (typeId != "RefFBModuleTrigger")
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error,
+            setComponentStatusWithMessage(ComponentStatus::Error,
                                                     "Statistics function block only supports nested trigger function block");
             LOG_E("Statistics function block only supports nested trigger function block")
         }
@@ -133,14 +133,14 @@ void StatisticsFbImpl::configure()
     valid = false;
     if (!inputValueDataDescriptor.assigned() || !inputDomainDataDescriptor.assigned())
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Incomplete input signal descriptors");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Incomplete input signal descriptors");
         LOG_W("Incomplete input signal descriptors")
         return;
     }
 
     if (inputDomainDataDescriptor.getSampleType() != SampleType::Int64 && inputDomainDataDescriptor.getSampleType() != SampleType::UInt64)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Incompatible domain data sample type");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Incompatible domain data sample type");
         LOG_W("Incompatible domain data sample type {}", convertSampleTypeToString(inputDomainDataDescriptor.getSampleType()))
         return;
     }
@@ -148,7 +148,7 @@ void StatisticsFbImpl::configure()
     const auto domainRule = inputDomainDataDescriptor.getRule();
     if (domainRule.getType() != DataRuleType::Linear)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Domain rule type is not Linear");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Domain rule type is not Linear");
         LOG_W("Domain rule type is not Linear")
         return;
     }
@@ -183,7 +183,7 @@ void StatisticsFbImpl::configure()
     if (inputValueDataDescriptor.getSampleType() == SampleType::Struct ||
         inputValueDataDescriptor.getDimensions().getCount() > 0)  // arrays not supported on the input
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Incompatible input value data descriptor");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Incompatible input value data descriptor");
         LOG_W("Incompatible input value data descriptor")
         return;
     }
@@ -191,7 +191,7 @@ void StatisticsFbImpl::configure()
     sampleType = inputValueDataDescriptor.getSampleType();
     if (!acceptSampleType(sampleType))
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Invalid sample type");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Invalid sample type");
         LOG_W("Incompatible input data sample type {}", convertSampleTypeToString(sampleType))
         return;
     }
@@ -310,7 +310,7 @@ void StatisticsFbImpl::validateTriggerDescriptors(const DataDescriptorPtr& value
         const auto type = valueDataDescriptor.getSampleType();
         if (acceptSampleType(type))
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Invalid nested trigger value sample type");
+            setComponentStatusWithMessage(ComponentStatus::Warning, "Invalid nested trigger value sample type");
             LOG_W("Invalid nested trigger value sample type")
             return;
         }
@@ -319,7 +319,7 @@ void StatisticsFbImpl::validateTriggerDescriptors(const DataDescriptorPtr& value
     {
         if (domainDataDescriptor.getSampleType() != SampleType::Int64)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Invalid nested trigger domain sample type");
+            setComponentStatusWithMessage(ComponentStatus::Warning, "Invalid nested trigger domain sample type");
             LOG_W("Invalid nested trigger domain sample type")
             return;
         }
@@ -581,7 +581,7 @@ void StatisticsFbImpl::calculate(
                     calcUntyped<SampleType::Int64, SampleType::Invalid>(data, firstTick, outAvgData, outRmsData, outDomainData, avgCount);
                     break;
                 default:
-                    setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Incompatible domain sample type");
+                    setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible domain sample type");
                     LOG_C("Incompatible domain sample type {}", convertSampleTypeToString(sampleType))
                     assert(false);
             }
@@ -620,7 +620,7 @@ void StatisticsFbImpl::calculate(
                     calcUntyped<SampleType::Int64, SampleType::Int64>(data, firstTick, outAvgData, outRmsData, outDomainData, avgCount);
                     break;
                 default:
-                    setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Incompatible domain sample type");
+                    setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible domain sample type");
                     LOG_C("Incompatible domain sample type {}", convertSampleTypeToString(sampleType))
                     assert(false);
             }
@@ -669,7 +669,7 @@ void StatisticsFbImpl::calculate(
                         data, firstTick, outAvgData, outRmsData, outDomainData, avgCount);
                     break;
                 default:
-                    setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Incompatible domain sample type");
+                    setComponentStatusWithMessage(ComponentStatus::Error, "Incompatible domain sample type");
                     LOG_C("Incompatible domain sample type {}", convertSampleTypeToString(sampleType))
                     assert(false);
             }

--- a/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -58,7 +58,6 @@ DictPtr<IString, IFunctionBlockType> StatisticsFbImpl::onGetAvailableFunctionBlo
 
 FunctionBlockPtr StatisticsFbImpl::onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config)
 {
-    setComponentStatus(ComponentStatus::Ok);
     FunctionBlockPtr nestedFunctionBlock;
     {
         auto lock = this->getAcquisitionLock();
@@ -84,6 +83,9 @@ FunctionBlockPtr StatisticsFbImpl::onAddFunctionBlock(const StringPtr& typeId, c
     }
 
     triggerInput.connect(nestedFunctionBlock.getSignals()[0]);
+
+    setComponentStatus(ComponentStatus::Ok);
+
     return nestedFunctionBlock;
 }
 

--- a/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
+++ b/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
@@ -48,8 +48,6 @@ void StructDecoderFbImpl::processSignalDescriptorsChangedEventPacket(const Event
 
 void StructDecoderFbImpl::configure()
 {
-    setComponentStatus(ComponentStatus::Ok);
-
     if (!inputDataDescriptor.assigned() || !inputDomainDataDescriptor.assigned())
     {
         configured = false;
@@ -105,6 +103,7 @@ void StructDecoderFbImpl::configure()
 
         configured = true;
         setInputStatus(InputConnected);
+        setComponentStatus(ComponentStatus::Ok);
     }
     catch (const std::exception& e)
     {

--- a/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
+++ b/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
@@ -24,7 +24,7 @@ StructDecoderFbImpl::StructDecoderFbImpl(const ContextPtr& ctx, const ComponentP
     : FunctionBlock(CreateType(), ctx, parent, localId)
     , configured(false)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
     createInputPorts();
     initStatuses();
 }
@@ -59,14 +59,14 @@ void StructDecoderFbImpl::configure()
     {
         if (inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Arrays not supported");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Arrays not supported");
             throw std::runtime_error("Arrays not supported");
         }
 
         const auto inputSampleType = inputDataDescriptor.getSampleType();
         if (inputSampleType != SampleType::Struct)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid sample type");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
@@ -94,7 +94,7 @@ void StructDecoderFbImpl::configure()
             const auto fieldSampleType = field.getSampleType();
             if (std::find(validFieldTypes.begin(), validFieldTypes.end(), fieldSampleType) == validFieldTypes.end())
             {
-                setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Field has invalid sample type");
+                setComponentStatusWithMessage(ComponentStatus::Error, "Field has invalid sample type");
                 throw std::runtime_error(fmt::format("Field \"{}\" has invalid sample type", field.getName()));
             }
 
@@ -111,7 +111,7 @@ void StructDecoderFbImpl::configure()
     {
         configured = false;
         setInputStatus(InputInvalid);
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Failed to configure output signals");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to configure output signals");
         LOG_W("Failed to configure output signals: {}", e.what())
         signals.clear();
     }
@@ -261,13 +261,13 @@ void StructDecoderFbImpl::initStatuses() const
     }
     catch (const std::exception& e)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Couldn't add type to type manager");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Couldn't add type to type manager");
         const auto loggerComponent = this->context.getLogger().getOrAddComponent("ScalingFunctionBlock");
         LOG_W("Couldn't add type {} to type manager: {}", inputStatusType.getName(), e.what());
     }
     catch (...)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Couldn't add type to type manager");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Couldn't add type to type manager");
         const auto loggerComponent = this->context.getLogger().getOrAddComponent("ScalingFunctionBlock");
         LOG_W("Couldn't add type {} to type manager!", inputStatusType.getName());
     }

--- a/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
+++ b/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
@@ -109,7 +109,7 @@ void StructDecoderFbImpl::configure()
     {
         configured = false;
         setInputStatus(InputInvalid);
-        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to configure output signals: {}", e.what()));
+        setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Failed to configure output signals: {}", e.what()));
         signals.clear();
     }
 }

--- a/modules/ref_fb_module/src/trigger_fb_impl.cpp
+++ b/modules/ref_fb_module/src/trigger_fb_impl.cpp
@@ -12,7 +12,7 @@ namespace Trigger
 TriggerFbImpl::TriggerFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config)
     : FunctionBlock(CreateType(), ctx, parent, localId)
 {
-    initComponentErrorStateStatus();
+    initComponentStatus();
 
     state = false;
 
@@ -68,7 +68,7 @@ void TriggerFbImpl::configure()
 {
     if (!inputDataDescriptor.assigned() || !inputDomainDataDescriptor.assigned())
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Incomplete signal descriptors");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Incomplete signal descriptors");
         LOG_D("Incomplete signal descriptors")
         return;
     }
@@ -77,7 +77,7 @@ void TriggerFbImpl::configure()
     {
         if (inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Arrays not supported");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Arrays not supported");
             throw std::runtime_error("Arrays not supported");
         }
 
@@ -87,7 +87,7 @@ void TriggerFbImpl::configure()
             inputSampleType != SampleType::UInt8 && inputSampleType != SampleType::UInt16 && inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentErrorStateStatusWithMessage(ComponentErrorState::Error, "Invalid sample type");
+            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
@@ -99,7 +99,7 @@ void TriggerFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        setComponentErrorStateStatusWithMessage(ComponentErrorState::Warning, "Failed to set descriptor for trigger signal");
+        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for trigger signal");
         LOG_W("Failed to set descriptor for trigger signal: {}", e.what())
         outputSignal.setDescriptor(nullptr);
     }

--- a/modules/ref_fb_module/src/trigger_fb_impl.cpp
+++ b/modules/ref_fb_module/src/trigger_fb_impl.cpp
@@ -66,10 +66,11 @@ void TriggerFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inpu
 
 void TriggerFbImpl::configure()
 {
+    setComponentStatus(ComponentStatus::Ok);
+
     if (!inputDataDescriptor.assigned() || !inputDomainDataDescriptor.assigned())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "Incomplete signal descriptors");
-        LOG_D("Incomplete signal descriptors")
         return;
     }
 
@@ -77,7 +78,6 @@ void TriggerFbImpl::configure()
     {
         if (inputDataDescriptor.getDimensions().getCount() > 0)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Arrays not supported");
             throw std::runtime_error("Arrays not supported");
         }
 
@@ -87,7 +87,6 @@ void TriggerFbImpl::configure()
             inputSampleType != SampleType::UInt8 && inputSampleType != SampleType::UInt16 && inputSampleType != SampleType::UInt32 &&
             inputSampleType != SampleType::UInt64)
         {
-            setComponentStatusWithMessage(ComponentStatus::Error, "Invalid sample type");
             throw std::runtime_error("Invalid sample type");
         }
 
@@ -99,8 +98,7 @@ void TriggerFbImpl::configure()
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, "Failed to set descriptor for trigger signal");
-        LOG_W("Failed to set descriptor for trigger signal: {}", e.what())
+        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for trigger signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
 }

--- a/modules/ref_fb_module/src/trigger_fb_impl.cpp
+++ b/modules/ref_fb_module/src/trigger_fb_impl.cpp
@@ -66,8 +66,6 @@ void TriggerFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inpu
 
 void TriggerFbImpl::configure()
 {
-    setComponentStatus(ComponentStatus::Ok);
-
     if (!inputDataDescriptor.assigned() || !inputDomainDataDescriptor.assigned())
     {
         setComponentStatusWithMessage(ComponentStatus::Warning, "Incomplete signal descriptors");
@@ -95,10 +93,12 @@ void TriggerFbImpl::configure()
 
         outputDomainDataDescriptor = DataDescriptorBuilderCopy(inputDomainDataDescriptor).setRule(ExplicitDataRule()).build();
         outputDomainSignal.setDescriptor(outputDomainDataDescriptor);
+
+        setComponentStatus(ComponentStatus::Ok);
     }
     catch (const std::exception& e)
     {
-        setComponentStatusWithMessage(ComponentStatus::Warning, fmt::format("Failed to set descriptor for trigger signal: {}", e.what()));
+        setComponentStatusWithMessage(ComponentStatus::Error, fmt::format("Failed to set descriptor for trigger signal: {}", e.what()));
         outputSignal.setDescriptor(nullptr);
     }
 }

--- a/modules/ref_fb_module/tests/test_fb_trigger.cpp
+++ b/modules/ref_fb_module/tests/test_fb_trigger.cpp
@@ -352,9 +352,9 @@ TEST_F(TriggerTest, TriggerTestErrorStateStatus)
     // Set new status via ...
     auto signal = Signal(context, nullptr, "ID");
     fb.getInputPorts()[0].connect(signal);
-    // Assert that now status is now "Warning"
+    // Assert that now status is now "Error"
     ASSERT_EQ(comp.getStatusContainer().getStatus("ComponentStatus"),
-              Enumeration("ComponentStatusType", "Warning", context.getTypeManager()));
+              Enumeration("ComponentStatusType", "Error", context.getTypeManager()));
     // Assert that message is "Failed to set descriptor for trigger signal!"
     ASSERT_EQ(comp.getStatusContainer().getStatusMessage("ComponentStatus"), "Failed to set descriptor for trigger signal: Invalid sample type");
 }

--- a/modules/ref_fb_module/tests/test_fb_trigger.cpp
+++ b/modules/ref_fb_module/tests/test_fb_trigger.cpp
@@ -356,5 +356,5 @@ TEST_F(TriggerTest, TriggerTestErrorStateStatus)
     ASSERT_EQ(comp.getStatusContainer().getStatus("ComponentStatus"),
               Enumeration("ComponentStatusType", "Warning", context.getTypeManager()));
     // Assert that message is "Failed to set descriptor for trigger signal!"
-    ASSERT_EQ(comp.getStatusContainer().getStatusMessage("ComponentStatus"), "Failed to set descriptor for trigger signal");
+    ASSERT_EQ(comp.getStatusContainer().getStatusMessage("ComponentStatus"), "Failed to set descriptor for trigger signal: Invalid sample type");
 }

--- a/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -396,7 +396,7 @@ TEST_F(OpcuaDeviceModulesTest, ChangePropAfterRemove)
 {
     auto loggerSink = LastMessageLoggerSink();
     loggerSink.setLevel(LogLevel::Warn);
-    auto debugSink = loggerSink.asPtrOrNull<ILastMessageLoggerSinkPrivate>();
+    auto privateSink = loggerSink.asPtrOrNull<ILastMessageLoggerSinkPrivate>();
 
     auto sinks = DefaultSinks(nullptr);
     sinks.pushBack(loggerSink);
@@ -413,12 +413,13 @@ TEST_F(OpcuaDeviceModulesTest, ChangePropAfterRemove)
     ASSERT_TRUE(mirroredRefDevice.isRemoved());
 
     // reset messages
-    debugSink.waitForMessage(0);
+    // ReSharper disable once CppExpressionWithoutSideEffects
+    privateSink.waitForMessage(0);
 
     ASSERT_NO_THROW(mirroredRefDevice.setPropertyValue("NumberOfChannels", 1));
     logger.flush();
-    ASSERT_TRUE(debugSink.waitForMessage(2000));
-    ASSERT_EQ(debugSink.getLastMessage(), "Failed to set value for property \"NumberOfChannels\" on OpcUA client property object: Writing property value");
+    ASSERT_TRUE(privateSink.waitForMessage(2000));
+    ASSERT_EQ(privateSink.getLastMessage(), "Failed to set value for property \"NumberOfChannels\" on OpcUA client property object: Writing property value");
 }
 
 TEST_F(OpcuaDeviceModulesTest, RemoteGlobalIds)
@@ -443,7 +444,7 @@ TEST_F(OpcuaDeviceModulesTest, GetSetDeviceProperties)
     SKIP_TEST_MAC_CI;
     auto loggerSink = LastMessageLoggerSink();
     loggerSink.setLevel(LogLevel::Warn);
-    auto debugSink = loggerSink.asPtrOrNull<ILastMessageLoggerSinkPrivate>();
+    auto sinkPrivate = loggerSink.asPtrOrNull<ILastMessageLoggerSinkPrivate>();
 
     auto sinks = DefaultSinks(nullptr);
     sinks.pushBack(loggerSink);
@@ -471,11 +472,12 @@ TEST_F(OpcuaDeviceModulesTest, GetSetDeviceProperties)
     auto oldProperties = refDevice.getAllProperties();
 
     // reset messages
-    debugSink.waitForMessage(0);
+    // ReSharper disable once CppExpressionWithoutSideEffects
+    sinkPrivate.waitForMessage(0);
     ASSERT_ANY_THROW(refDevice.setPropertyValue("InvalidProp", 100));
     logger.flush();
-    ASSERT_TRUE(debugSink.waitForMessage(2000));
-    ASSERT_EQ(debugSink.getLastMessage(), "Failed to set value for property \"InvalidProp\" on OpcUA client property object: Property not found");
+    ASSERT_TRUE(sinkPrivate.waitForMessage(2000));
+    ASSERT_EQ(sinkPrivate.getLastMessage(), "Failed to set value for property \"InvalidProp\" on OpcUA client property object: Property not found");
 
     auto properties = refDevice.getAllProperties();
     ASSERT_EQ(properties.getCount(), oldProperties.getCount());
@@ -689,7 +691,7 @@ TEST_F(OpcuaDeviceModulesTest, FunctionBlockProperties)
 {
     auto loggerSink = LastMessageLoggerSink();
     loggerSink.setLevel(LogLevel::Warn);
-    auto debugSink = loggerSink.asPtrOrNull<ILastMessageLoggerSinkPrivate>();
+    auto privateSink = loggerSink.asPtrOrNull<ILastMessageLoggerSinkPrivate>();
 
     auto sinks = DefaultSinks(nullptr);
     sinks.pushBack(loggerSink);
@@ -710,11 +712,12 @@ TEST_F(OpcuaDeviceModulesTest, FunctionBlockProperties)
     ASSERT_EQ(fb.getPropertyValue("DomainSignalType"), serverFb.getPropertyValue("DomainSignalType"));
 
     // reset messages
-    debugSink.waitForMessage(0);
+    // ReSharper disable once CppExpressionWithoutSideEffects
+    privateSink.waitForMessage(0);
     ASSERT_NO_THROW(fb.setPropertyValue("DomainSignalType" , 1000));
     logger.flush();
-    ASSERT_TRUE(debugSink.waitForMessage(2000));
-    ASSERT_EQ(debugSink.getLastMessage(), "Failed to set value for property \"DomainSignalType\" on OpcUA client property object: Writing property value");
+    ASSERT_TRUE(privateSink.waitForMessage(2000));
+    ASSERT_EQ(privateSink.getLastMessage(), "Failed to set value for property \"DomainSignalType\" on OpcUA client property object: Writing property value");
 }
 
 TEST_F(OpcuaDeviceModulesTest, DISABLED_InputPort)

--- a/modules/tests/test_ref_modules/test_ref_modules.cpp
+++ b/modules/tests/test_ref_modules/test_ref_modules.cpp
@@ -1121,13 +1121,13 @@ TEST_F(RefModulesTest, ScalingFbStatuses)
     // Incomplete descriptors - domain signal not assigned
     scalingFb.getInputPorts()[0].connect(signal);
     ASSERT_EQ(scalingFb.getStatusContainer().getStatus("ComponentStatus"),
-              Enumeration("ComponentStatusType", "Warning", instance.getContext().getTypeManager()));
+              Enumeration("ComponentStatusType", "Error", instance.getContext().getTypeManager()));
     ASSERT_EQ(scalingFb.getStatusContainer().getStatusMessage("ComponentStatus"),
               "Failed to set descriptor for output signal: No domain input");
 
     logger.flush();
     ASSERT_TRUE(privateSink.waitForMessage(100));
-    ASSERT_EQ(privateSink.getLastMessage(), "Component RefFBModuleScaling_1 status changed to Warning with message: Failed to set descriptor for output signal: No domain input");
+    ASSERT_EQ(privateSink.getLastMessage(), "Component RefFBModuleScaling_1 status changed to Error with message: Failed to set descriptor for output signal: No domain input");
 }
 
 TEST_F(RefModulesTest, DISABLED_RunDeviceScalingPerformanceTest)


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Description:

Component status fixes:
* Streamline naming for Component Status building blocks:
  * `ComponentErrorStateStatus` to `ComponentStatus` (all variable names)
  * `ComponentErrorState` to `ComponentStatus` (enum)
* Equip all existing Function Block implementations  with additional `setComponentStatus` calls, setting the Component Status back to `ComponentStatus::Ok`
* Avoid redundant code in Function Block implementations and improve logging:
  * `LOG_` (`W`/`E`/`I` for Warning/Error/Ok) on each `setComponentStatusWithMessage`
  * Delete all "manual" `LOG_` calls in Function Block implementations adjacent/related to `setComponentStatus`/`setComponentStatusWithMessage`
* Improve Component Status messages (and thereby log messages) in reference Function Blocks with additional info wherever possible
* Add comments to `initComponentStatus`, `setComponentStatus`, and `setComponentStatusWithMessage` in `component_impl.h` that hopefully show up in users' IDEs (works in Visual Studio Community 2022)
* Supplement unit tests

Unrelated changes:
* Change all changelog dates to ISO 8601
* Make minor cosmetic/grammar changes to `README.md`
* Fix typos, minor changes