### PR TITLE
TBBAS-2047 MultiReader crash after some time

### DIFF
--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -664,6 +664,10 @@ SizeT MultiReaderImpl::getMinSamplesAvailable(bool acrossDescriptorChanges) cons
     for (const auto& signal : signals)
     {
         auto sigSamples = signal.getAvailable(acrossDescriptorChanges);
+
+        if (!signal.info.dataPacket.assigned())
+             sigSamples = 0;
+
         if (sigSamples < min)
         {
             min = sigSamples;


### PR DESCRIPTION
# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
There was a race between two consecutive calls - first one check if there is packet in connection queue and cache it, the second one - checked how many data available in connection. If a packet arrived in between, that situatuion leads to crash.