### PR TITLE
Serialize component name when equal to localID

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1001,7 +1001,7 @@ void ComponentImpl<Intf, Intfs...>::serializeCustomObjectValues(const Serializer
         serializer.writeString(description);
     }
 
-    if (name != localId)
+    if (name != "")
     {
         serializer.key("name");
         serializer.writeString(name);

--- a/core/opendaq/component/tests/test_component.cpp
+++ b/core/opendaq/component/tests/test_component.cpp
@@ -171,6 +171,15 @@ TEST_F(ComponentTest, SerializeAndDeserialize)
     ASSERT_EQ(str1, str2);
 }
 
+TEST_F(ComponentTest, SerializeName)
+{
+    const auto component = Component(NullContext(), nullptr, "Temp");
+    const auto serializer = JsonSerializer(True);
+    component.serialize(serializer);
+    const std::string str = serializer.getOutput();
+    ASSERT_TRUE(str.find("name") != std::string::npos);
+}
+
 TEST_F(ComponentTest, LockedProperties)
 {
     const auto component = Component(NullContext(), nullptr, "Temp");

--- a/modules/tests/test_opendaq_device_modules/test_native_streaming_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_streaming_modules.cpp
@@ -250,17 +250,19 @@ TEST_F(NativeStreamingModulesTest, GetRemoteDeviceObjects)
 
     for (size_t i = 0; i < clientSignals.getCount(); ++i)
     {
-        auto serverDataDescriptor = serverSignals[i].getDescriptor();
-        auto clientDataDescriptor = clientSignals[i].getDescriptor();
+        auto serverSignal = serverSignals[i];
+        auto clientSignal = clientSignals[i];
+        auto serverDataDescriptor = serverSignal.getDescriptor();
+        auto clientDataDescriptor = clientSignal.getDescriptor();
 
         ASSERT_EQ(clientDataDescriptor, serverDataDescriptor);
 
-        //ASSERT_EQ(serverSignals[i].getName(), clientSignals[i].getName());
-        ASSERT_EQ(serverSignals[i].getDescription(), clientSignals[i].getDescription());
+        ASSERT_EQ(serverSignal.getName(), clientSignal.getName());
+        ASSERT_EQ(serverSignal.getDescription(), clientSignal.getDescription());
 
-        auto mirroredSignalPtr = clientSignals[i].asPtr<IMirroredSignalConfig>();
-        ASSERT_GT(mirroredSignalPtr.getStreamingSources().getCount(), 0u) << clientSignals[i].getGlobalId();
-        ASSERT_TRUE(mirroredSignalPtr.getActiveStreamingSource().assigned()) << clientSignals[i].getGlobalId();
+        auto mirroredSignalPtr = clientSignal.asPtr<IMirroredSignalConfig>();
+        ASSERT_GT(mirroredSignalPtr.getStreamingSources().getCount(), 0u) << clientSignal.getGlobalId();
+        ASSERT_TRUE(mirroredSignalPtr.getActiveStreamingSource().assigned()) << clientSignal.getGlobalId();
     }
 
     ASSERT_EQ(serverSignals[0].getName(), clientSignals[0].getName());
@@ -683,8 +685,8 @@ TEST_F(NativeStreamingModulesTest, ProtectedSignals)
         auto client = CreateClientInstance("opendaq", "opendaq");
         auto clientSignals = client.getSignalsRecursive(search::Any());
         ASSERT_EQ(clientSignals.getCount(), 2u);
-        ASSERT_EQ(clientSignals[0].getName(), "*local*Dev*RefDev1*IO*AI*RefCh1*Sig*AI1");
-        ASSERT_EQ(clientSignals[1].getName(), "*local*Dev*RefDev1*IO*AI*RefCh1*Sig*AI1Time");
+        ASSERT_EQ(clientSignals[0].getName(), "AI1");
+        ASSERT_EQ(clientSignals[1].getName(), "AI1Time");
     }
 }
 


### PR DESCRIPTION
# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:

The "Name" attribute was not serialized when equal to the local ID. This caused Native streaming signals to have mangled names, as they would be set to be the same as the client-side signal local IDs (eg. `"mydev*FB*FB1*Sig*Signal1"`)