### PR TITLE
Add disconnection/reconnection detection examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -181,4 +181,16 @@ if (APP_ENABLE_WEBPAGE_EXAMPLES)
     if (OPENDAQ_ENABLE_NATIVE_STREAMING)
         add_dependencies(streaming_configuration_example daq::native_stream_cl_module)
     endif()
+	
+	add_executable(reconnection_example cpp/reconnection_example/reconnection.cpp)
+    target_link_libraries(reconnection_example PRIVATE daq::opendaq)
+    add_dependencies(reconnection_example daq::native_stream_cl_module
+                                          daq::native_stream_srv_module
+	)
+	
+	add_executable(reconnection_example_v3_10 cpp/reconnection_example/reconnection_v3_10.cpp)
+    target_link_libraries(reconnection_example_v3_10 PRIVATE daq::opendaq)
+    add_dependencies(reconnection_example_v3_10 daq::native_stream_cl_module
+                                                daq::native_stream_srv_module
+	)
 endif()

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ option(OPENDAQ_EMPTY_EXAMPLE "Empty example source for user examples." ON)
 option(OPENDAQ_FUNCTION_BLOCK "Function block example using an averager and renderer" ON)
 option(OPENDAQ_CSV_WRITER "Example that connects to availble devices, writing their data to a .csv file" ON)
 option(OPENDAQ_STREAMING_CONFIG "Streaming configuration example that modifies the configuration of OpcUa enabled device" ON)
+option(OPENDAQ_RECONNECTION "Example on how to detect connection loss and reconnection" ON)
 
 if (OPENDAQ_CONSOLE_APP)
   add_subdirectory(console_application)
@@ -81,4 +82,8 @@ endif()
 
 if (OPENDAQ_STREAMING_CONFIG)
   add_subdirectory(streaming_configuration_example)
+endif()
+
+if (OPENDAQ_RECONNECTION)
+  add_subdirectory(reconnection_example)
 endif()

--- a/examples/cpp/reconnection_example/CMakeLists.txt
+++ b/examples/cpp/reconnection_example/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(reconnection VERSION ${OPENDAQ_EXAMPLES_VERSION})
+
+find_package(openDAQ)
+
+add_executable(reconnection reconnection.cpp)
+target_link_libraries(reconnection PRIVATE daq::opendaq)
+
+project(reconnection_v3_10 VERSION ${OPENDAQ_EXAMPLES_VERSION})
+add_executable(reconnection_v3_10 reconnection_v3_10.cpp)
+target_link_libraries(reconnection_v3_10 PRIVATE daq::opendaq)

--- a/examples/cpp/reconnection_example/reconnection.cpp
+++ b/examples/cpp/reconnection_example/reconnection.cpp
@@ -1,0 +1,145 @@
+#include <opendaq/opendaq.h>
+#include <coreobjects/core_event_args_ids.h>
+#include <iostream>
+#include <condition_variable>
+
+using namespace daq;
+using namespace std::chrono_literals;
+
+/*
+ * Exampling highlighting how to detect connection loss and reconnection when connected via the
+ * openDAQ Native Protocol. This example works on openDAQ versions 3.11 and newer.
+ */
+
+InstancePtr createServerInstance()
+{
+    auto instance = InstanceBuilder().setGlobalLogLevel(LogLevel::Critical).build();
+    instance.addServer("OpenDAQNativeStreaming", nullptr);
+    return instance;
+}
+
+// Creates an `AddDeviceConfig` object with monitoring enabled. Monitoring enables a heartbeat mechanism
+// that can detect connection loss when the device does not gracefully disconnect.
+PropertyObjectPtr createConfigWithMonitoring(const InstancePtr& instance)
+{
+    auto config = instance.createDefaultAddDeviceConfig();
+    PropertyObjectPtr deviceConfig = config.getPropertyValue("Device");
+    PropertyObjectPtr nativeDeviceConfig = deviceConfig.getPropertyValue("OpenDAQNativeConfiguration");
+    PropertyObjectPtr transportLayerConfig = nativeDeviceConfig.getPropertyValue("TransportLayerConfig");
+    transportLayerConfig.setPropertyValue("MonitoringEnabled", True);
+
+    return config;
+}
+
+InstancePtr createClientInstance()
+{
+    auto instance = InstanceBuilder().setGlobalLogLevel(LogLevel::Critical).build();
+    instance.addDevice("daq.nd://127.0.0.1", createConfigWithMonitoring(instance));
+    return instance;
+}
+
+std::string protocolTypeToString(Int typeId)
+{
+    const ProtocolType type = static_cast<ProtocolType>(typeId);
+    switch (type)
+    {
+        case ProtocolType::Unknown:
+            return "Unknown";
+        case ProtocolType::Configuration:
+            return "Configuration";
+        case ProtocolType::Streaming:
+            return "Streaming";
+        case ProtocolType::ConfigurationAndStreaming:
+            return "ConfigurationAndStreaming";
+    }
+
+    return "";
+}
+
+int main()
+{
+    auto serverInstance = createServerInstance();
+    auto clientInstance = createClientInstance();
+    auto clientDevice = clientInstance.getDevices()[0];
+
+    // Get the connection status of the configuration and streaming connections.
+    auto connectionStatusContainer = clientDevice.getConnectionStatusContainer();
+    auto configurationStatus = connectionStatusContainer.getStatus("ConfigurationStatus");
+    auto streamingStatus = connectionStatusContainer.getStatus("StreamingStatus_OpenDAQNativeStreaming_1");
+
+    std::cout << "=====================\n";
+    std::cout << "Configuration connection status: " << configurationStatus.getValue() << "\n";
+    std::cout << "Native streaming connection status: " << streamingStatus.getValue() << "\n";
+    std::cout << "=====================\n\n";
+
+    std::condition_variable cv;
+    std::mutex m;
+    int connectionChangedCount = 0;
+    bool ready = false;
+
+    // Listen for connection status changes when the state changes to "Connected" or "Reconnecting".
+    clientDevice.getOnComponentCoreEvent() += [&] (ComponentPtr&, CoreEventArgsPtr& args)
+    {
+        if (args.getEventId() == static_cast<Int>(CoreEventId::ConnectionStatusChanged))
+        {
+            const EnumerationPtr value = args.getParameters().get("StatusValue");
+            if (value != "Connected" && value != "Reconnecting")
+                return;
+
+            std::unique_lock lk(m);
+            cv.wait(lk, [&ready] { return ready; });
+
+            std::cout << "=====================\n";
+            std::cout << "Connection status name: " << args.getParameters().get("StatusName") << "\n";
+            std::cout << "Connection string: " << args.getParameters().get("ConnectionString") << "\n";
+            std::cout << "Connection status value: " << args.getParameters().get("StatusValue") << "\n";
+            std::cout << "Connection status Protocol Type: " << protocolTypeToString(args.getParameters().get("ProtocolType")) << "\n";
+            std::cout << "=====================\n\n";
+
+            ready = false;
+            connectionChangedCount++;
+            cv.notify_one();
+        }
+    };
+
+    {
+        // Simulate a connection loss.
+        std::lock_guard lk(m);
+        serverInstance.release();
+        ready = true;
+        cv.notify_one();
+    }
+
+    // Wait for both the configuration and streaming connection to start reconnection.
+    for (int i = 0; i < 2; i++)
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&connectionChangedCount, i] { return connectionChangedCount > i; });
+        ready = true;
+        cv.notify_one();
+    }
+
+    std::this_thread::sleep_for(1000ms);
+
+    {
+        // Simulate a reconnection.
+        std::lock_guard lk(m);
+        ready = false;
+        serverInstance = createServerInstance();
+        ready = true;
+        cv.notify_one();
+    }
+    
+    // Wait for both the configuration and streaming connection to be re-established.
+    for (int i = 2; i < 4; i++)
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&connectionChangedCount, i] { return connectionChangedCount > i; });
+        ready = true;
+        cv.notify_one();
+    }
+
+    std::cout << "Press \"enter\" to exit the application..." << "\n";
+    std::cin.get();
+    return 0;
+}

--- a/examples/cpp/reconnection_example/reconnection_v3_10.cpp
+++ b/examples/cpp/reconnection_example/reconnection_v3_10.cpp
@@ -1,0 +1,113 @@
+#include <opendaq/opendaq.h>
+#include <coreobjects/core_event_args_ids.h>
+#include <iostream>
+#include <condition_variable>
+
+using namespace daq;
+using namespace std::chrono_literals;
+
+/*
+ * Exampling highlighting how to detect connection loss and reconnection when connected via the
+ * openDAQ Native Protocol. This example works on both the latest and the 3.10 version of
+ * openDAQ. Newer versions provide a more streamlined way of handling disconnection/reconn
+ * detection.
+ */
+
+InstancePtr createServerInstance()
+{
+    auto instance = InstanceBuilder().setGlobalLogLevel(LogLevel::Critical).build();
+    instance.addServer("OpenDAQNativeStreaming", nullptr);
+    return instance;
+}
+
+// Creates an `AddDeviceConfig` object with monitoring enabled. Monitoring enables a heartbeat mechanism
+// that can detect connection loss when the device does not gracefully disconnect.
+PropertyObjectPtr createConfigWithMonitoring(const InstancePtr& instance)
+{
+    auto config = instance.createDefaultAddDeviceConfig();
+    PropertyObjectPtr deviceConfig = config.getPropertyValue("Device");
+    PropertyObjectPtr nativeDeviceConfig = deviceConfig.getPropertyValue("OpenDAQNativeConfiguration");
+    PropertyObjectPtr transportLayerConfig = nativeDeviceConfig.getPropertyValue("TransportLayerConfig");
+    transportLayerConfig.setPropertyValue("MonitoringEnabled", True);
+
+    return config;
+}
+
+InstancePtr createClientInstance()
+{
+    auto instance = InstanceBuilder().setGlobalLogLevel(LogLevel::Critical).build();
+    instance.addDevice("daq.nd://127.0.0.1", createConfigWithMonitoring(instance));
+    return instance;
+}
+
+int main()
+{
+    auto serverInstance = createServerInstance();
+    auto clientInstance = createClientInstance();
+    auto clientDevice = clientInstance.getDevices()[0];
+
+    // Get the connection status of the configuration connection
+    auto statusContainer = clientDevice.getStatusContainer();
+    auto connectionStatus = statusContainer.getStatus("ConnectionStatus");
+
+    std::cout << "=====================\n";
+    std::cout << "Connection status: " << connectionStatus.getValue() << "\n";
+    std::cout << "=====================\n\n";
+    
+    std::condition_variable cv;
+    std::mutex m;
+    int connectionChangedCount = 0;
+    bool ready = false;
+    
+    // Listen for connection status changes via the "StatusChanged" core event.
+    clientDevice.getOnComponentCoreEvent() += [&] (ComponentPtr&, CoreEventArgsPtr& args)
+    {
+        if (args.getEventId() == static_cast<Int>(CoreEventId::StatusChanged) && args.getParameters().hasKey("ConnectionStatus"))
+        {
+            std::unique_lock lk(m);
+            cv.wait(lk, [&ready] { return ready; });
+
+            std::cout << "=====================\n";
+            std::cout << "Connection status changed: " << args.getParameters().get("ConnectionStatus") << "\n";
+            std::cout << "=====================\n\n";
+
+            ready = false;
+            connectionChangedCount++;
+            cv.notify_one();
+        }
+    };
+
+    {
+        // Simulate a connection loss.
+        std::lock_guard lk(m);
+        serverInstance.release();
+        ready = true;
+        cv.notify_one();
+    }
+
+    {
+        // Wait for the configuration connection to start reconnection.
+        std::unique_lock lk(m);
+        cv.wait(lk, [&connectionChangedCount] { return connectionChangedCount > 0; });
+    }
+
+    std::this_thread::sleep_for(1000ms);
+
+    {
+        // Simulate a reconnection.
+        std::lock_guard lk(m);
+        serverInstance = createServerInstance();
+        ready = true;
+        cv.notify_one();
+    }
+
+    {
+        // Wait for the configuration connection to be re-established.
+        std::unique_lock lk(m);
+        cv.wait(lk, [&connectionChangedCount] { return connectionChangedCount > 1; });
+    }
+
+    std::cout << "Press \"enter\" to exit the application..." << "\n";
+    std::cin.get();
+    return 0;
+}


### PR DESCRIPTION
# Description:

Adds examples highlighting how disconnection/reconnection can be detected on the 3.10 release, as well as on versions newer than 3.11.