### PR TITLE
[TBBAS-2050] .NET Bindings - Bump-up to .NET 8.0

### DIFF
--- a/bindings/dotnet/openDAQ.Net/README.md
+++ b/bindings/dotnet/openDAQ.Net/README.md
@@ -16,8 +16,8 @@ This project contains the .NET-Bindings to the _openDAQ_ SDK.
 
 
 ## Development environment
-- Visual Studio 2022 (V17.11.x)  
-- TargetFramework: net6.0  
+- Visual Studio 2022 (V17.12.x)  
+- TargetFramework: net8.0  
 - Platform: x64  
 - Language: C#  
 - Test-framework: NUnit  

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.CI.Test/openDAQ.Net.CI.Test.csproj
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.CI.Test/openDAQ.Net.CI.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.NuGet.Test/openDAQ.Net.NuGet.Test.csproj
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.NuGet.Test/openDAQ.Net.NuGet.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/openDAQ.Net.Test.csproj
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/openDAQ.Net.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/coretypes/OpenDaqException.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/coretypes/OpenDaqException.cs
@@ -47,13 +47,26 @@ public class OpenDaqException : Exception
     public OpenDaqException(string message) : base(message) { }
     /// <inheritdoc/>
     public OpenDaqException(string message, Exception inner) : base(message, inner) { }
-    /// <inheritdoc/>
-    protected OpenDaqException(System.Runtime.Serialization.SerializationInfo info,
-                               System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
 
     //openDAQ specific constructors
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenDaqException"/> class with a specified error code.
+    /// </summary>
+    /// <param name="errorCode">The error code.</param>
     public OpenDaqException(ErrorCode errorCode) : this(errorCode, null, null) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenDaqException"/> class with a specified error code and message.
+    /// </summary>
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="message">The message.</param>
     public OpenDaqException(ErrorCode errorCode, string message) : this(errorCode, message, null) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenDaqException"/> class with a specified error code, message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="errorCode">The error code.</param>
+    /// <param name="message">The message.</param>
+    /// <param name="inner">The inner exception that is the cause of this exception.</param>
     public OpenDaqException(ErrorCode errorCode, string message, Exception inner) : base(message, inner)
     {
         this._errorCode = errorCode;

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/media/README.md
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/media/README.md
@@ -10,12 +10,12 @@ the SDK itself.
 
 
 ## Development environment
-- Visual Studio 2022 (V17.11.x when this package has been created)
-- TargetFramework: net6.0
+- Visual Studio 2022 (V17.12.x when this package has been created)
+- TargetFramework: net8.0
 - Platform: x64
 
 ## Prerequisites
-Install this NuGet package for your project using NuGet Manager.  
+Install this NuGet package for your project using NuGet Manager in Visual Studio.  
 On NuGet package restoration all relevant binaries will be copied to the configuration's
 target directory and adapts the file `*.deps.json` to find the libraries since they're
 being structured (e.g. `runtimes/win-x64/native/*`).

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/openDAQ.Net.csproj
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/openDAQ.Net.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <!-- using function pointers (C# 9) and file scoped namespaces (C# 10) so netstandard2.0 not possible (C# 7.3) -->
     <!--<TargetFramework>netstandard2.0</TargetFramework>-->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
     <Platforms>x64;x86</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
# Type of change:

- [x] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

.NET 6.0 has had its end-of-support in November 2024. Switched to the most recent runtime with long-term-support .NET 8.0.