### PR TITLE
Disable scanning for devices on add for non-smart connection strings

### DIFF
--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -466,18 +466,19 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
 
         if (!connectionStringPtr.assigned() || connectionStringPtr.getLength() == 0)
             return this->makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Connection string is not set or empty");
+        
+        // Connection strings with the "daq" prefix automatically choose the best method of connection
+        const bool useSmartConnection = connectionStringPtr.toStdString().find("daq://") == 0;
 
         // Scan for devices if not yet done so
         // TODO: Should we re-scan after a timeout?
-        if (!availableDevicesGroup.assigned())
+        if (useSmartConnection && !availableDevicesGroup.assigned())
         {
             const auto errCode = getAvailableDevices(&ListPtr<IDeviceInfo>());
             if (OPENDAQ_FAILED(errCode))
                 return this->makeErrorInfo(errCode, "Failed getting available devices");
         }
 
-        // Connection strings with the "daq" prefix automatically choose the best method of connection
-        const bool useSmartConnection = connectionStringPtr.toStdString().find("daq://") == 0;
         const auto discoveredDeviceInfo = getDiscoveredDeviceInfo(connectionStringPtr, useSmartConnection);
         if (useSmartConnection)
             connectionStringPtr = resolveSmartConnectionString(connectionStringPtr, discoveredDeviceInfo, config, loggerComponent);


### PR DESCRIPTION
# Brief

Disables scanning for devices before creating a device when not using a smart connection strings ("daq://" prefix) to speed up device creation. 

# Description

Previously, when adding devices, if no device scan via `getAvailableDevices()` has been done, the module manager first scanned for devices to gather the information on server capabilities of each device. This is only required when connecting via the "daq://" prefix and can be skipped when connecting directly via a connection string.

# Usage example

No changes in usage.

# Required integration changes

## Breaking application changes

None.

## Breaking module changes

None.

# API changes

None.
