### PR TITLE
Initialize `futureComponentStatus` and `futureComponentMessage` in `renderer_fb_impl.cpp`, thereby preventing unwarranted crashes

### DIFF
--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -26,6 +26,8 @@ RendererFbImpl::RendererFbImpl(const ContextPtr& ctx, const ComponentPtr& parent
     , axisColor(150, 150, 150)
 {
     initComponentStatus();
+    futureComponentStatus = ComponentStatus::Ok;
+    futureComponentMessage = "";
     initProperties();
     updateInputPorts();
 


### PR DESCRIPTION
I think this should fix [TBBAS-2070] as well (must be tested to confirm)