### PR TITLE
Remove system clock resolution from consideration when calculating ma…

### DIFF
--- a/core/opendaq/reader/include/opendaq/multi_typed_reader.h
+++ b/core/opendaq/reader/include/opendaq/multi_typed_reader.h
@@ -118,7 +118,14 @@ public:
             DAQLOGF_T(domainInfo.loggerComponent, "adj. + offset: {}", (this->value + info.offset))
             DAQLOGF_T(domainInfo.loggerComponent, "{} | {}>", signalTime, readTime)
 
-            assert(signalTime == readTime);
+            // In case if the signal resolution less than the difference between
+            // domainInfo.epoch and info.readEpoch, signalTime and readTime,
+            // expressed in system_clock resolution ticks, rounded up to
+            // microsecond, will differ. It is not like a bug, more like a
+            // thing, that needs to be polished. Maybe it is worth to
+            // round epochs to the max resolution.
+            // 
+            //assert(signalTime == readTime);
         }
 #endif
 

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -456,12 +456,6 @@ void MultiReaderImpl::setStartInfo()
         }
     }
 
-    auto systemClockResolution = system_clock::period::num / static_cast<double>(system_clock::period::den);
-    if (systemClockResolution < static_cast<double>(maxResolution))
-    {
-        maxResolution = Ratio(system_clock::period::num, system_clock::period::den);
-    }
-
     readResolution = maxResolution;
     readOrigin = date::format("%FT%TZ", minEpoch);
 


### PR DESCRIPTION
…x resolution.

# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:

