### PR TITLE
Fix getPropertySelectionValue was returning the old value

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -1871,7 +1871,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
         BaseObjectPtr valuePtr;
         PropertyPtr prop;
 
-        getPropertyAndValueInternal(propName, valuePtr, prop, true, true);
+        getPropertyAndValueInternal(propName, valuePtr, prop, true, retrieveUpdatingValue);
 
         if (!prop.assigned())
             throw NotFoundException(R"(Selection property "{}" not found)", propName);

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -337,7 +337,7 @@ protected:
     ErrCode setPropertyValueInternal(IString* name, IBaseObject* value, bool triggerEvent, bool protectedAccess, bool batch, bool isUpdating = false);
     ErrCode clearPropertyValueInternal(IString* name, bool protectedAccess, bool batch, bool isUpdating = false);
     ErrCode getPropertyValueInternal(IString* propertyName, IBaseObject** value, Bool retrieveUpdatingValue = false);
-    ErrCode getPropertySelectionValueInternal(IString* propertyName, IBaseObject** value);
+    ErrCode getPropertySelectionValueInternal(IString* propertyName, IBaseObject** value, Bool retrieveUpdatingValue = false);
     ErrCode checkForReferencesInternal(IProperty* property, Bool* isReferenced);
 
     // Serialization
@@ -1601,14 +1601,14 @@ template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertySelectionValue(IString* propertyName, IBaseObject** value)
 {
     auto lock = getRecursiveConfigLock();
-    return getPropertySelectionValueInternal(propertyName, value);
+    return getPropertySelectionValueInternal(propertyName, value, true);
 }
 
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertySelectionValueNoLock(IString* propertyName,
                                                                                                     IBaseObject** value)
 {
-    return getPropertySelectionValueInternal(propertyName, value);
+    return getPropertySelectionValueInternal(propertyName, value, true);
 }
 
 template <class PropObjInterface, typename... Interfaces>
@@ -1859,7 +1859,8 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyV
 
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertySelectionValueInternal(IString* propertyName,
-                                                                                                      IBaseObject** value)
+                                                                                                      IBaseObject** value,
+                                                                                                      Bool retrieveUpdatingValue)
 {
     if (propertyName == nullptr || value == nullptr)
         return OPENDAQ_ERR_ARGUMENT_NULL;
@@ -1870,7 +1871,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
         BaseObjectPtr valuePtr;
         PropertyPtr prop;
 
-        getPropertyAndValueInternal(propName, valuePtr, prop);
+        getPropertyAndValueInternal(propName, valuePtr, prop, true, true);
 
         if (!prop.assigned())
             throw NotFoundException(R"(Selection property "{}" not found)", propName);

--- a/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
+++ b/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
@@ -466,7 +466,6 @@ TEST_F(ConfigNestedPropertyObjectTest, SyncComponentCustomModeOptions)
 
 TEST_F(ConfigNestedPropertyObjectTest, ModifyOnPropertyWrite)
 {
-
     serverDevice.addProperty(StringProperty("EditableProperty", "defaultValue"));
     serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& /* obj */, PropertyValueEventArgsPtr& arg) 
     {
@@ -479,9 +478,27 @@ TEST_F(ConfigNestedPropertyObjectTest, ModifyOnPropertyWrite)
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), "serverValue");   
 }
 
+TEST_F(ConfigNestedPropertyObjectTest, ModifyOnSelectionPropertyWrite)
+{
+    serverDevice.addProperty(SelectionProperty("EditableProperty", List<IString>("defaultValue", "clientValue", "serverValue"), 0));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
+    {
+        if (arg.getValue() == 1)
+        {
+            ASSERT_EQ(obj.getPropertySelectionValue("EditableProperty"), "clientValue");
+            arg.setValue(2);
+        }
+    };
+
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+    clientDevice.setPropertyValue("EditableProperty", 1);
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "serverValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 2);
+}
+
 TEST_F(ConfigNestedPropertyObjectTest, RestoreOnPropertyWrite)
 {
-
     serverDevice.addProperty(StringProperty("EditableProperty", "defaultValue"));
     serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& /* obj */, PropertyValueEventArgsPtr& arg) 
     {
@@ -493,6 +510,59 @@ TEST_F(ConfigNestedPropertyObjectTest, RestoreOnPropertyWrite)
     clientDevice.setPropertyValue("EditableProperty", "clientValue");
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), "defaultValue");   
 }
+
+TEST_F(ConfigNestedPropertyObjectTest, RestoreSelectionOnPropertyWrite)
+{
+    serverDevice.addProperty(SelectionProperty("EditableProperty", List<IString>("defaultValue", "clientValue", "serverValue"), 0));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
+    {
+        if (arg.getValue() == 1)
+        {
+            ASSERT_EQ(obj.getPropertySelectionValue("EditableProperty"), "clientValue");
+            arg.setValue(0);
+        }
+    };
+
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+    clientDevice.setPropertyValue("EditableProperty", 1);
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+}
+
+TEST_F(ConfigNestedPropertyObjectTest, RestoreOnPropertyWrite2)
+{
+    serverDevice.addProperty(StringProperty("EditableProperty", "defaultValue"));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& /* obj */, PropertyValueEventArgsPtr& arg) 
+    {
+        if (arg.getValue() == "clientValue")
+            arg.setValue(arg.getOldValue());
+    };
+
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), "defaultValue");
+    clientDevice.setPropertyValue("EditableProperty", "clientValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), "defaultValue");   
+}
+
+TEST_F(ConfigNestedPropertyObjectTest, RestoreSelectionOnPropertyWrite2)
+{
+    serverDevice.addProperty(SelectionProperty("EditableProperty", List<IString>("defaultValue", "clientValue", "serverValue"), 0));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
+    {
+        if (arg.getValue() == 1)
+        {
+            ASSERT_EQ(obj.getPropertySelectionValue("EditableProperty"), "clientValue");
+            arg.setValue(arg.getOldValue());
+        }
+    };
+
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+    clientDevice.setPropertyValue("EditableProperty", 1);
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+}
+
 
 TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueInsideCallback)
 {
@@ -506,6 +576,22 @@ TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueInsideCallback)
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
     clientDevice.setPropertyValue("EditableProperty", 1);
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);   
+}
+
+TEST_F(ConfigNestedPropertyObjectTest, SetSelectionPropertyValueInsideCallback)
+{
+    serverDevice.addProperty(SelectionProperty("EditableProperty", List<IString>("defaultValue", "clientValue", "serverValue"), 0));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
+    {
+        if ((Int)arg.getValue() > 0)
+            obj.asPtr<IPropertyObjectProtected>(true).setProtectedPropertyValue("EditableProperty", 0);
+    };
+
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+    clientDevice.setPropertyValue("EditableProperty", 1);
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
 }
 
 TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueCallbackFailed)
@@ -522,6 +608,22 @@ TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueCallbackFailed)
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);   
 }
 
+TEST_F(ConfigNestedPropertyObjectTest, SetSelectionPropertyValueCallbackFailed)
+{
+    serverDevice.addProperty(SelectionProperty("EditableProperty", List<IString>("defaultValue", "clientValue", "serverValue"), 0));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
+    {
+        if ((Int)arg.getValue() > 0)
+            throw InvalidParameterException("Invalid value");
+    };
+
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+    ASSERT_THROW(clientDevice.setPropertyValue("EditableProperty", 1), InvalidParameterException);
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+}
+  
 TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueCallbackIgnoreValue)
 {
     serverDevice.addProperty(IntProperty("EditableProperty", 0));
@@ -534,6 +636,22 @@ TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueCallbackIgnoreValue)
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
     ASSERT_NO_THROW(clientDevice.setPropertyValue("EditableProperty", 1));
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);   
+}
+
+TEST_F(ConfigNestedPropertyObjectTest, SetSelectionPropertyValueCallbackIgnoreValue)
+{
+    serverDevice.addProperty(SelectionProperty("EditableProperty", List<IString>("defaultValue", "clientValue", "serverValue"), 0));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
+    {
+        if ((Int)arg.getValue() > 0)
+            arg.setValue(0);
+    };
+
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+    ASSERT_NO_THROW(clientDevice.setPropertyValue("EditableProperty", 1));
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
 }
 
 TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueCallbackNestead)
@@ -549,6 +667,23 @@ TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueCallbackNestead)
     ASSERT_NO_THROW(clientDevice.setPropertyValue("EditableProperty", 1));
     ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 10);   
 }
+
+TEST_F(ConfigNestedPropertyObjectTest, SetSelectionPropertyValueCallbackNestead)
+{
+    serverDevice.addProperty(SelectionProperty("EditableProperty", List<IString>("defaultValue", "clientValue", "serverValue"), 0));
+    serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
+    {
+        if ((Int)arg.getValue() < 2)
+            obj.setPropertyValue("EditableProperty", arg.getValue() + 1);
+    };
+
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 0);
+    ASSERT_NO_THROW(clientDevice.setPropertyValue("EditableProperty", 1));
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "serverValue");
+    ASSERT_EQ(clientDevice.getPropertyValue("EditableProperty"), 2);
+}
+
 
 TEST_F(ConfigNestedPropertyObjectTest, SetPropertyValueCallbackDependencies)
 {

--- a/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
+++ b/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
@@ -584,7 +584,10 @@ TEST_F(ConfigNestedPropertyObjectTest, SetSelectionPropertyValueInsideCallback)
     serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
     {
         if ((Int)arg.getValue() > 0)
+        {
+            ASSERT_NE(obj.getPropertySelectionValue("EditableProperty"), "defaultValue");
             obj.asPtr<IPropertyObjectProtected>(true).setProtectedPropertyValue("EditableProperty", 0);
+        }
     };
 
     ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
@@ -614,7 +617,10 @@ TEST_F(ConfigNestedPropertyObjectTest, SetSelectionPropertyValueCallbackFailed)
     serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
     {
         if ((Int)arg.getValue() > 0)
+        {
+            ASSERT_NE(obj.getPropertySelectionValue("EditableProperty"), "defaultValue");
             throw InvalidParameterException("Invalid value");
+        }
     };
 
     ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");
@@ -644,7 +650,10 @@ TEST_F(ConfigNestedPropertyObjectTest, SetSelectionPropertyValueCallbackIgnoreVa
     serverDevice.getOnPropertyValueWrite("EditableProperty") += [](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& arg) 
     {
         if ((Int)arg.getValue() > 0)
+        {
+            ASSERT_NE(obj.getPropertySelectionValue("EditableProperty"), "defaultValue");
             arg.setValue(0);
+        }
     };
 
     ASSERT_EQ(clientDevice.getPropertySelectionValue("EditableProperty"), "defaultValue");


### PR DESCRIPTION
# Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Pull request title reflects its content
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description:

