### PR TITLE
Allow for conversion between development and release version

### DIFF
--- a/docs/Antora-specs/antora.yml
+++ b/docs/Antora-specs/antora.yml
@@ -1,12 +1,12 @@
 name: opendaq-specs
 title: openDAQ protocols specification
-version: 3.11.0
+version: dev
 start_page: ROOT:overview.adoc
 asciidoc:
   attributes:
     page-toclevels: 3@
     experimental: true
-    version: 3.11.0
+    version: dev
 nav:
   - modules/packet_streaming/nav-packet-streaming.adoc
   - modules/native_communication_protocol/nav-native-communication-protocol.adoc

--- a/docs/Antora/antora.yml
+++ b/docs/Antora/antora.yml
@@ -1,12 +1,12 @@
 name: opendaq
 title: openDAQ Documentation
-version: 3.11.0
+version: dev
 start_page: ROOT:introduction.adoc
 asciidoc:
   attributes:
     page-toclevels: 3@
     experimental: true
-    version: 3.11.0
+    version: dev
 nav:
 - modules/getting_started/nav-getting_started.adoc
 - modules/howto_guides/nav-howto-guides.adoc

--- a/opendaq_version_bump.py
+++ b/opendaq_version_bump.py
@@ -1,26 +1,37 @@
-import sys
-
 def read_file(filename):
-    with open(filename, "r") as file:
-        content = file.read()
-        return content
-    
+    with open(filename, 'r') as file:
+        return file.read()
+
 def write_file(filename, content):
-    with open(filename, "w") as file:
+    with open(filename, 'w') as file:
         file.write(content)
 
-def read_and_replace(filename):
-    new = read_file(filename).replace(version, new_version)
-    write_file(filename, new)
+def read_and_replace(filename, string, new_string):
+    write_file(filename, read_file(filename).replace(string, new_string))
+    print('Wrote `' + new_string + '` instead of `' + string + '` in `' +  filename + '`')
 
-# this code is used to increase openDAQ version
+def parse_yml(filename, key):
+    file = read_file(filename)
+    start = file.find(':', file.find(key)) + 1
+    finish = file.find('\n', start)
+    return file[start:finish].strip()
 
-version = read_file("opendaq_version").strip()
-print("Current version: " + version)
-new_version = input("New version: ").strip()
+# this code is used to bump openDAQ version
 
-read_and_replace("docs/Antora/antora.yml")
-read_and_replace("docs/Antora-specs/antora.yml")
-read_and_replace("opendaq_version")
-
-print("Version bump was successful!")
+print()
+old_version = read_file('opendaq_version').strip()
+print('Current version (`MAJOR.MINOR.PATCH`): `' + old_version + '`')
+old_antora_version = parse_yml('docs/Antora/antora.yml', 'version:')
+print('Current Antora version: `' + old_antora_version + '`')
+print()
+print('Bump for release or development (latest main)?')
+print('(Release will write `dev` in Antora docs version, development  will write `MAJOR.MINOR`)')
+is_release = input('R/D: ').strip().lower() == 'r'
+new_version = input('New version (`MAJOR.MINOR.PATCH`): ').strip()
+print()
+new_antora_version =  'dev' if not is_release else new_version[:new_version.rindex('.')]
+read_and_replace("opendaq_version", old_version, new_version)
+read_and_replace("docs/Antora/antora.yml", old_antora_version, new_antora_version)
+read_and_replace("docs/Antora-specs/antora.yml", old_antora_version, new_antora_version)
+print('Version bump finished!')
+print()


### PR DESCRIPTION
# Brief
Allow for conversion between development and release version via `opendaq_version_bump.py` script and vice versa

# Description

* Always write `MAJOR.MINOR.PATCH` to `opendaq_version` file
* Write `MAJOR.MINOR` to `docs/Antora/antora.yml` and `docs/Antora-specs/antora.yml` in case of release
* Write `dev` to `docs/Antora/antora.yml` and `docs/Antora-specs/antora.yml` in case of development (latest main)
* Rename version to `dev` in Antora

# Usage example

In terminal use:

```shell
python opendaq_version_bump.py
```

from openDAQ root directory and follow the onscreen instructions to bump the version and select development/release mode.

Example terminal output when converting from `3.11.0`, `dev` to `3.12.0`, `release`:
```
Current version (`MAJOR.MINOR.PATCH`): `3.11.0`
Current Antora version: `dev`

Bump for release or development (latest main)?
(Release will write `dev` in Antora docs version, development  will write `MAJOR.MINOR`)
R/D: r
New version (`MAJOR.MINOR.PATCH`): 3.12.0

Wrote `3.12.0` instead of `3.11.0` in `opendaq_version`
Wrote `3.12` instead of `dev` in `docs/Antora/antora.yml`
Wrote `3.12` instead of `dev` in `docs/Antora-specs/antora.yml`
Version bump finished!
```

# Required integration changes

## Breaking application changes

None.

## Breaking module changes

None.

# API changes

None.