### PR TITLE
Fix/reconnect exclusive client

### DIFF
--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -46,7 +46,8 @@ public:
                                 std::shared_ptr<boost::asio::io_context> processingIOContextPtr,
                                 std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr,
                                 std::thread::id reconnectionProcessingThreadId,
-                                const StringPtr& connectionString);
+                                const StringPtr& connectionString,
+                                Int reconnectionPeriod);
     ~NativeDeviceHelper();
 
     void setupProtocolClients(const ContextPtr& context);
@@ -73,6 +74,8 @@ private:
     void enableStreamingForComponent(const ComponentPtr& component);
     void tryAddSignalToStreaming(const SignalPtr& signal, const StreamingPtr& streaming);
     void setSignalActiveStreamingSource(const SignalPtr& signal, const StreamingPtr& streaming);
+    void updateConnectionStatus(opendaq_native_streaming_protocol::ClientConnectionStatus status);
+    void tryConfigProtocolReconnect();
 
     std::shared_ptr<boost::asio::io_context> processingIOContextPtr;
     std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr;
@@ -89,6 +92,9 @@ private:
     Bool restoreClientConfigOnReconnect;
     const StringPtr connectionString;
     std::mutex sync;
+
+    std::shared_ptr<boost::asio::steady_timer> configProtocolReconnectionRetryTimer;
+    std::chrono::milliseconds reconnectionPeriod;
 };
 
 DECLARE_OPENDAQ_INTERFACE(INativeDevicePrivate, IBaseObject)

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -456,7 +456,7 @@ PropertyObjectPtr NativeStreamingClientModule::createTransportLayerDefaultConfig
 {
     auto transportLayerConfig = daq::PropertyObject();
 
-    transportLayerConfig.addProperty(daq::BoolProperty("MonitoringEnabled", daq::False));
+    transportLayerConfig.addProperty(daq::BoolProperty("MonitoringEnabled", daq::True));
     transportLayerConfig.addProperty(daq::IntProperty("HeartbeatPeriod", 1000));
     transportLayerConfig.addProperty(daq::IntProperty("InactivityTimeout", 1500));
     transportLayerConfig.addProperty(daq::IntProperty("ConnectionTimeout", 1000));


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Pull request title reflects its content
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description:
## TBBAS-2072:
* The config protocol client now attempts to reconnect limitlessly if the server rejects the reconnection (unless the device is removed from the openDAQ tree). Previously, it only tried once and stopped if rejected.
* The native connection activity monitoring now is enabled by default. 
