### PR TITLE
Connection status messages

### DIFF
--- a/bindings/python/opendaq/generated/device/py_connection_status_container_private.cpp
+++ b/bindings/python/opendaq/generated/device/py_connection_status_container_private.cpp
@@ -76,4 +76,13 @@ void defineIConnectionStatusContainerPrivate(pybind11::module_ m, PyDaqIntf<daq:
         },
         py::arg("connection_string"), py::arg("value"), py::arg("streaming_object"),
         "Updates the value of an existing connection status.");
+    cls.def("update_connection_status_with_message",
+        [](daq::IConnectionStatusContainerPrivate *object, std::variant<daq::IString*, py::str, daq::IEvalValue*>& connectionString, daq::IEnumeration* value, daq::IStreaming* streamingObject, std::variant<daq::IString*, py::str, daq::IEvalValue*>& message)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::ConnectionStatusContainerPrivatePtr::Borrow(object);
+            objectPtr.updateConnectionStatusWithMessage(getVariantValue<daq::IString*>(connectionString), value, streamingObject, getVariantValue<daq::IString*>(message));
+        },
+        py::arg("connection_string"), py::arg("value"), py::arg("streaming_object"), py::arg("message"),
+        "Updates the value of an existing connection status with a message.");
 }

--- a/changelog/changelog_3.0.0-4.0.0.md
+++ b/changelog/changelog_3.0.0-4.0.0.md
@@ -1,3 +1,30 @@
+# 2025-01-31
+## Description
+- Enables status messages for connection statuses
+- Introduces additional "Message" parameter of string-object-type within "ConnectionStatusChanged" core event arguments
+
+## Required integration changes
+- Breaks binary compatibility
+
+## Example
+To update existing connection status with status message:
+```cpp
+const auto typeManager = client.getDevices()[0].getContext().getTypeManager();
+const StringPtr statusMessage = "Network connection interrupted or closed by the remote device";
+const EnumerationPtr statusValue = Enumeration("ConnectionStatusType", "Reconnecting", typeManager);
+const auto connectionStatusContainer = client.getDevices()[0].getConnectionStatusContainer();
+connectionStatusContainer.asPtr<IConnectionStatusContainerPrivate>().updateConnectionStatusWithMessage(connectionString, statusValue, nullptr, statusMessage);
+```
+To get the status message of connection status:
+```cpp
+StringPtr message = client.getDevices()[0].getConnectionStatusContainer().getStatusMessage("ConfigurationStatus");
+```
+
+## API changes
+```
++ [function] IConnectionStatusContainerPrivate::updateConnectionStatusWithMessage(IString* connectionString, IEnumeration* value, IStreaming* streamingObject, IString* message)
+```
+
 # 2025-01-24
 ## Description
 - Introduces mechanisms to modify the IP configuration parameters of openDAQ-compatible devices.
@@ -37,6 +64,7 @@ and the implementation of onGetAvailableDevices in client modules.
 
 + [function] IModuleManagerUtils::changeIpConfig(IString* iface, IString* manufacturer, IString* serialNumber, IPropertyObject* config)
 + [function] IModuleManagerUtils::requestIpConfig(IString* iface, IString* manufacturer, IString* serialNumber, IPropertyObject** config)
+```
 
 # 2025-01-21
 ## Description

--- a/core/coreobjects/include/coreobjects/core_event_args.h
+++ b/core/coreobjects/include/coreobjects/core_event_args.h
@@ -260,6 +260,7 @@ BEGIN_NAMESPACE_OPENDAQ
  *  3 - ConfigurationAndStreaming) under the key "ProtocolType"
  *  - The Streaming object associated with connection under the key "StreamingObject", the parameter is nullptr if connection
  *  is of configuration type or the corresponding streaming connection has been removed
+ *  - The new status message under the key "Message", the parameter is nullptr if the corresponding connection has been removed
  *
  * The ID of the event is 170, and the event name is "ConnectionStatusChanged".
  *

--- a/core/coreobjects/include/coreobjects/core_event_args_impl.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_impl.h
@@ -239,7 +239,8 @@ inline bool CoreEventArgsImpl::validateParameters() const
                    && parameters.hasKey("StatusValue")
                    && parameters.hasKey("ConnectionString")
                    && parameters.hasKey("ProtocolType")
-                   && parameters.hasKey("StreamingObject");
+                   && parameters.hasKey("StreamingObject")
+                   && parameters.hasKey("Message");
         default:
             break;
     }

--- a/core/opendaq/device/include/opendaq/connection_status_container_impl.h
+++ b/core/opendaq/device/include/opendaq/connection_status_container_impl.h
@@ -40,12 +40,14 @@ public:
     // IComponentStatusContainer
     ErrCode INTERFACE_FUNC getStatus(IString* name, IEnumeration** value) override;
     ErrCode INTERFACE_FUNC getStatuses(IDict** statuses) override;
+    ErrCode INTERFACE_FUNC getStatusMessage(IString* name, IString** message) override;
 
     // IConnectionStatusContainerPrivate
     ErrCode INTERFACE_FUNC addConfigurationConnectionStatus(IString* connectionString, IEnumeration* initialValue) override;
     ErrCode INTERFACE_FUNC addStreamingConnectionStatus(IString* connectionString, IEnumeration* initialValue, IStreaming* streamingObject) override;
     ErrCode INTERFACE_FUNC removeStreamingConnectionStatus(IString* connectionString) override;
     ErrCode INTERFACE_FUNC updateConnectionStatus(IString* connectionString, IEnumeration* value, IStreaming* streamingObject) override;
+    ErrCode INTERFACE_FUNC updateConnectionStatusWithMessage(IString* connectionString, IEnumeration* value, IStreaming* streamingObject, IString* message) override;
 
     // ISerializable
     ErrCode INTERFACE_FUNC serialize(ISerializer* serializer) override;
@@ -99,6 +101,29 @@ inline ErrCode ConnectionStatusContainerImpl::getStatus(IString* name, IEnumerat
     return OPENDAQ_ERR_NOTFOUND;
 }
 
+inline ErrCode ConnectionStatusContainerImpl::getStatusMessage(IString* name, IString** message)
+{
+    OPENDAQ_PARAM_NOT_NULL(name);
+    OPENDAQ_PARAM_NOT_NULL(message);
+
+    const auto nameObj = StringPtr::Borrow(name);
+    if (nameObj == "")
+        return OPENDAQ_ERR_INVALIDPARAMETER;
+
+    std::scoped_lock lock(sync);
+
+    for (const auto& [connectionString, nameAlias] : statusNameAliases)
+    {
+        if (nameAlias == nameObj && messages.hasKey(connectionString))
+        {
+            *message = messages.get(connectionString).addRefAndReturn();
+            return OPENDAQ_SUCCESS;
+        }
+    }
+
+    return OPENDAQ_ERR_NOTFOUND;
+}
+
 inline ErrCode ConnectionStatusContainerImpl::getStatuses(IDict** statuses)
 {
     OPENDAQ_PARAM_NOT_NULL(statuses);
@@ -128,10 +153,12 @@ inline ErrCode ConnectionStatusContainerImpl::addConfigurationConnectionStatus(I
 
     std::scoped_lock lock(sync);
 
-    if (configConnectionStatusAdded || statuses.hasKey(connectionStringObj))
+    if (configConnectionStatusAdded || statuses.hasKey(connectionStringObj) || messages.hasKey(connectionStringObj))
         return OPENDAQ_ERR_ALREADYEXISTS;
 
+    const auto message = String("");
     statuses[connectionStringObj] = initialValue;
+    messages[connectionStringObj] = message;
     statusNameAliases[connectionStringObj] = ConfigurationConnectionStatusAlias;
     configConnectionStatusAdded = true;
 
@@ -143,7 +170,8 @@ inline ErrCode ConnectionStatusContainerImpl::addConfigurationConnectionStatus(I
                                         {"StatusValue", initialValue},
                                         {"ConnectionString", connectionStringObj},
                                         {"ProtocolType", Integer((Int)ProtocolType::Configuration)},
-                                        {"StreamingObject", nullptr}}));
+                                        {"StreamingObject", nullptr},
+                                        {"Message", message}}));
         triggerCoreEvent(args);
     }
 
@@ -161,11 +189,13 @@ inline ErrCode ConnectionStatusContainerImpl::addStreamingConnectionStatus(IStri
 
     std::scoped_lock lock(sync);
 
-    if (statuses.hasKey(connectionStringObj))
+    if (statuses.hasKey(connectionStringObj) || messages.hasKey(connectionStringObj))
         return OPENDAQ_ERR_ALREADYEXISTS;
 
     ++streamingConnectionsCounter;
+    const auto message = String("");
     statuses[connectionStringObj] = initialValue;
+    messages[connectionStringObj] = message;
     const StringPtr statusNameAlias = getStreamingStatusNameAlias(connectionStringObj);
     statusNameAliases[connectionStringObj] = statusNameAlias;
 
@@ -177,7 +207,8 @@ inline ErrCode ConnectionStatusContainerImpl::addStreamingConnectionStatus(IStri
                                         {"StatusValue", initialValue},
                                         {"ConnectionString", connectionStringObj},
                                         {"ProtocolType", Integer((Int)ProtocolType::Streaming)},
-                                        {"StreamingObject", streamingObject}}));
+                                        {"StreamingObject", streamingObject},
+                                        {"Message", message}}));
         triggerCoreEvent(args);
     }
 
@@ -190,7 +221,7 @@ inline ErrCode ConnectionStatusContainerImpl::removeStreamingConnectionStatus(IS
 
     std::scoped_lock lock(sync);
 
-    if (!statuses.hasKey(connectionString))
+    if (!statuses.hasKey(connectionString) || !messages.hasKey(connectionString))
         return OPENDAQ_ERR_NOTFOUND;
 
     const StringPtr statusNameAlias =
@@ -198,6 +229,7 @@ inline ErrCode ConnectionStatusContainerImpl::removeStreamingConnectionStatus(IS
             ? statusNameAliases.remove(connectionString)
             : nullptr;
 
+    messages.remove(connectionString);
     auto value = statuses.remove(connectionString);
     value = "Removed";
 
@@ -209,7 +241,8 @@ inline ErrCode ConnectionStatusContainerImpl::removeStreamingConnectionStatus(IS
                                         {"StatusValue", value},
                                         {"ConnectionString", connectionString},
                                         {"ProtocolType", Integer((Int)ProtocolType::Streaming)},
-                                        {"StreamingObject", nullptr}}));
+                                        {"StreamingObject", nullptr},
+                                        {"Message", nullptr}}));
         triggerCoreEvent(args);
     }
 
@@ -218,26 +251,39 @@ inline ErrCode ConnectionStatusContainerImpl::removeStreamingConnectionStatus(IS
 
 inline ErrCode ConnectionStatusContainerImpl::updateConnectionStatus(IString* connectionString, IEnumeration* value, IStreaming* streamingObject)
 {
+    return updateConnectionStatusWithMessage(connectionString, value, streamingObject, String(""));
+}
+
+inline ErrCode ConnectionStatusContainerImpl::updateConnectionStatusWithMessage(IString* connectionString, IEnumeration* value, IStreaming* streamingObject, IString* message)
+{
     OPENDAQ_PARAM_NOT_NULL(connectionString);
     OPENDAQ_PARAM_NOT_NULL(value);
+    OPENDAQ_PARAM_NOT_NULL(message);
 
     const auto connectionStringObj = StringPtr::Borrow(connectionString);
     if (connectionStringObj == "")
         return OPENDAQ_ERR_INVALIDPARAMETER;
+    const auto messageObj = StringPtr::Borrow(message);
 
     std::scoped_lock lock(sync);
 
-    if (!statuses.hasKey(connectionStringObj))
+    if (!statuses.hasKey(connectionStringObj) || !messages.hasKey(connectionStringObj))
         return OPENDAQ_ERR_NOTFOUND;
 
     const auto valueObj = EnumerationPtr::Borrow(value);
     const auto oldValue = statuses.get(connectionStringObj);
+    const auto oldMessage = messages.get(connectionStringObj);
+
     if (valueObj.getEnumerationType() != oldValue.getEnumerationType())
         return OPENDAQ_ERR_INVALIDTYPE;
-    if (valueObj == oldValue)
+    if (valueObj == oldValue && oldMessage == messageObj)
         return OPENDAQ_IGNORED;
 
     auto errCode = statuses->set(connectionStringObj, value);
+    if (OPENDAQ_FAILED(errCode))
+        return errCode;
+
+    errCode = messages->set(connectionStringObj, message);
     if (OPENDAQ_FAILED(errCode))
         return errCode;
 
@@ -259,7 +305,8 @@ inline ErrCode ConnectionStatusContainerImpl::updateConnectionStatus(IString* co
                                         {"StatusValue", value},
                                         {"ConnectionString", connectionStringObj},
                                         {"ProtocolType", connectionType},
-                                        {"StreamingObject", streamingObject}}));
+                                        {"StreamingObject", streamingObject},
+                                        {"Message", message}}));
         triggerCoreEvent(args);
     }
 
@@ -271,14 +318,16 @@ inline ErrCode ConnectionStatusContainerImpl::serialize(ISerializer* serializer)
     OPENDAQ_PARAM_NOT_NULL(serializer);
 
     serializer->startTaggedObject(this);
-    {
-        serializer->key("connectionStatuses");
-        statuses.serialize(serializer);
-    }
-    {
-        serializer->key("statusNames");
-        statusNameAliases.serialize(serializer);
-    }
+
+    serializer->key("connectionStatuses");
+    statuses.serialize(serializer);
+
+    serializer->key("statusNames");
+    statusNameAliases.serialize(serializer);
+
+    serializer->key("messages");
+    messages.serialize(serializer);
+
     serializer->endObject();
 
     return OPENDAQ_SUCCESS;
@@ -319,6 +368,11 @@ inline ErrCode ConnectionStatusContainerImpl::Deserialize(ISerializedObject* ser
     DictPtr<IString, IEnumeration> statuses = serializedObj.readObject("connectionStatuses", context, factoryCallback);
     DictPtr<IString, IString> statusNameAliases = serializedObj.readObject("statusNames", context, factoryCallback);
 
+    // Supports backwards compatibility without messages
+    DictPtr<IString, IString> messages = Dict<IString, IString>();
+    if (serializedObj.hasKey("messages"))
+        messages = serializedObj.readObject("messages", context, factoryCallback);
+
     for (const auto& [connString, nameAlias] : statusNameAliases)
     {
         if (nameAlias == ConfigurationConnectionStatusAlias && statuses.hasKey(connString))
@@ -326,6 +380,12 @@ inline ErrCode ConnectionStatusContainerImpl::Deserialize(ISerializedObject* ser
             errCode = statusContainer->addConfigurationConnectionStatus(connString, statuses.get(connString));
             if (OPENDAQ_FAILED(errCode))
                 return errCode;
+            if (messages.hasKey(connString))
+            {
+                errCode = statusContainer->updateConnectionStatusWithMessage(connString, statuses.get(connString), nullptr, messages.get(connString));
+                if (OPENDAQ_FAILED(errCode))
+                    return errCode;
+            }
             break;
         }
     }

--- a/core/opendaq/device/include/opendaq/connection_status_container_private.h
+++ b/core/opendaq/device/include/opendaq/connection_status_container_private.h
@@ -79,6 +79,16 @@ DECLARE_OPENDAQ_INTERFACE(IConnectionStatusContainerPrivate, IBaseObject)
      * Set to nullptr for configuration connections.
      */
     virtual ErrCode INTERFACE_FUNC updateConnectionStatus(IString* connectionString, IEnumeration* value, IStreaming* streamingObject) = 0;
+
+    /*!
+     * @brief Updates the value of an existing connection status with a message.
+     * @param connectionString The connection string identifying the status to update.
+     * @param value The new value of the status.
+     * @param streamingObject The streaming object associated with the connection, used in triggered Core events.
+     * Set to nullptr for configuration connections.
+     * @param message The new message of the connection status. Usually describes last reconnect attempt failure.
+     */
+    virtual ErrCode INTERFACE_FUNC updateConnectionStatusWithMessage(IString* connectionString, IEnumeration* value, IStreaming* streamingObject, IString* message) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/streaming.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/streaming.h
@@ -51,11 +51,11 @@ struct MockStreaming : daq::StreamingImpl<IMockStreaming>
 
     void triggerReconnectionStart() override
     {
-        updateConnectionStatus(Enumeration("ConnectionStatusType", "Reconnecting", this->context.getTypeManager()));
+        updateConnectionStatus(Enumeration("ConnectionStatusType", "Reconnecting", this->context.getTypeManager()), "");
     }
     void triggerReconnectionCompletion() override
     {
-        updateConnectionStatus(Enumeration("ConnectionStatusType", "Connected", this->context.getTypeManager()));
+        updateConnectionStatus(Enumeration("ConnectionStatusType", "Connected", this->context.getTypeManager()), "");
     }
 
     daq::MirroredSignalConfigPtr signal;

--- a/core/opendaq/streaming/include/opendaq/streaming_impl.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_impl.h
@@ -69,7 +69,7 @@ protected:
     void addToAvailableSignals(const StringPtr& signalStreamingId);
     void removeFromAvailableSignals(const StringPtr& signalStreamingId);
 
-    virtual void updateConnectionStatus(const EnumerationPtr& status);
+    virtual void updateConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage);
 
     /*!
      * @brief A function called when the active state of the Streaming is changed.
@@ -724,7 +724,7 @@ void StreamingImpl<Interfaces...>::triggerSubscribeAck(const StringPtr& signalSt
 }
 
 template <typename... Interfaces>
-void StreamingImpl<Interfaces...>::updateConnectionStatus(const EnumerationPtr& status)
+void StreamingImpl<Interfaces...>::updateConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage)
 {
     std::scoped_lock lock(sync);
 
@@ -738,10 +738,11 @@ void StreamingImpl<Interfaces...>::updateConnectionStatus(const EnumerationPtr& 
     auto device = this->ownerDeviceRef.assigned() ? this->ownerDeviceRef.getRef() : nullptr;
     if (device.assigned())
     {
-        device.getConnectionStatusContainer().template asPtr<IConnectionStatusContainerPrivate>().updateConnectionStatus(
+        device.getConnectionStatusContainer().template asPtr<IConnectionStatusContainerPrivate>().updateConnectionStatusWithMessage(
             this->connectionString,
             connectionStatus,
-            this->template borrowPtr<StreamingPtr>()
+            this->template borrowPtr<StreamingPtr>(),
+            statusMessage
         );
     }
 }

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -60,7 +60,7 @@ public:
     void closeConnectionOnRemoval();
 
 private:
-    void connectionStatusChangedHandler(const EnumerationPtr& status);
+    void transportConnectionStatusChangedHandler(const EnumerationPtr& status, const StringPtr& statusMessage);
     config_protocol::PacketBuffer doConfigRequestAndGetReply(const config_protocol::PacketBuffer& reqPacket);
     void doConfigNoReplyRequest(const config_protocol::PacketBuffer& reqPacket);
     void sendConfigRequest(const config_protocol::PacketBuffer& reqPacket);
@@ -74,7 +74,7 @@ private:
     void enableStreamingForComponent(const ComponentPtr& component);
     void tryAddSignalToStreaming(const SignalPtr& signal, const StreamingPtr& streaming);
     void setSignalActiveStreamingSource(const SignalPtr& signal, const StreamingPtr& streaming);
-    void updateConnectionStatus(const EnumerationPtr& status);
+    void updateConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage);
     void tryConfigProtocolReconnect();
 
     std::shared_ptr<boost::asio::io_context> processingIOContextPtr;
@@ -99,7 +99,7 @@ private:
 
 DECLARE_OPENDAQ_INTERFACE(INativeDevicePrivate, IBaseObject)
 {
-    virtual void INTERFACE_FUNC publishConnectionStatus(const EnumerationPtr& status) = 0;
+    virtual void INTERFACE_FUNC publishConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage) = 0;
     virtual void INTERFACE_FUNC completeInitialization(std::shared_ptr<NativeDeviceHelper> deviceHelper, const StringPtr& connectionString) = 0;
     virtual void INTERFACE_FUNC updateDeviceInfo(const StringPtr& connectionString) = 0;
 };
@@ -118,7 +118,7 @@ public:
     ~NativeDeviceImpl() override;
 
     // INativeDevicePrivate
-    void INTERFACE_FUNC publishConnectionStatus(const EnumerationPtr& status) override;
+    void INTERFACE_FUNC publishConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage) override;
     void INTERFACE_FUNC completeInitialization(std::shared_ptr<NativeDeviceHelper> deviceHelper, const StringPtr& connectionString) override;
     void INTERFACE_FUNC updateDeviceInfo(const StringPtr& connectionString) override;
 

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -46,7 +46,8 @@ public:
                                 std::shared_ptr<boost::asio::io_context> processingIOContextPtr,
                                 std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr,
                                 std::thread::id reconnectionProcessingThreadId,
-                                const StringPtr& connectionString);
+                                const StringPtr& connectionString,
+                                Int reconnectionPeriod);
     ~NativeDeviceHelper();
 
     void setupProtocolClients(const ContextPtr& context);
@@ -73,6 +74,8 @@ private:
     void enableStreamingForComponent(const ComponentPtr& component);
     void tryAddSignalToStreaming(const SignalPtr& signal, const StreamingPtr& streaming);
     void setSignalActiveStreamingSource(const SignalPtr& signal, const StreamingPtr& streaming);
+    void updateConnectionStatus(const EnumerationPtr& status);
+    void tryConfigProtocolReconnect();
 
     std::shared_ptr<boost::asio::io_context> processingIOContextPtr;
     std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr;
@@ -89,6 +92,9 @@ private:
     Bool restoreClientConfigOnReconnect;
     const StringPtr connectionString;
     std::mutex sync;
+
+    std::shared_ptr<boost::asio::steady_timer> configProtocolReconnectionRetryTimer;
+    std::chrono::milliseconds reconnectionPeriod;
 };
 
 DECLARE_OPENDAQ_INTERFACE(INativeDevicePrivate, IBaseObject)

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_device_impl.h
@@ -42,7 +42,7 @@ protected:
 
     void signalAvailableHandler(const StringPtr& signalStringId, const StringPtr& serializedSignal);
     void signalUnavailableHandler(const StringPtr& signalStringId);
-    void connectionStatusChangedHandler(const EnumerationPtr& status);
+    void connectionStatusChangedHandler(const EnumerationPtr& status, const StringPtr& statusMessage);
     void publishConnectionStatus();
     void createNativeStreaming(opendaq_native_streaming_protocol::NativeStreamingClientHandlerPtr transportProtocolClient,
                                std::shared_ptr<boost::asio::io_context> processingIOContextPtr,

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_streaming_impl.h
@@ -58,13 +58,14 @@ protected:
     void signalAvailableHandler(const StringPtr& signalStringId, const StringPtr& serializedSignal);
     void signalUnavailableHandler(const StringPtr& signalStringId);
 
-    void updateConnectionStatus(const EnumerationPtr& status) override;
-    void processConnectionStatus(const EnumerationPtr& status);
+    void updateConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage) override;
+    void processTransportConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage);
 
     void initClientHandlerCallbacks();
     void upgradeClientHandlerCallbacks();
 
     void stopProcessingOperations();
+    void requestStreamingOnReconnection();
 
     opendaq_native_streaming_protocol::NativeStreamingClientHandlerPtr transportClientHandler;
 

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -23,7 +23,8 @@ NativeDeviceHelper::NativeDeviceHelper(const ContextPtr& context,
                                        std::shared_ptr<boost::asio::io_context> processingIOContextPtr,
                                        std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr,
                                        std::thread::id reconnectionProcessingThreadId,
-                                       const StringPtr& connectionString)
+                                       const StringPtr& connectionString,
+                                       Int reconnectionPeriod)
     : processingIOContextPtr(processingIOContextPtr)
     , reconnectionProcessingIOContextPtr(reconnectionProcessingIOContextPtr)
     , reconnectionProcessingThreadId(reconnectionProcessingThreadId)
@@ -34,11 +35,14 @@ NativeDeviceHelper::NativeDeviceHelper(const ContextPtr& context,
     , configProtocolRequestTimeout(std::chrono::milliseconds(configProtocolRequestTimeout))
     , restoreClientConfigOnReconnect(restoreClientConfigOnReconnect)
     , connectionString(connectionString)
+    , configProtocolReconnectionRetryTimer(std::make_shared<boost::asio::steady_timer>(*reconnectionProcessingIOContextPtr))
+    , reconnectionPeriod(std::chrono::milliseconds(reconnectionPeriod))
 {
 }
 
 NativeDeviceHelper::~NativeDeviceHelper()
 {
+    configProtocolReconnectionRetryTimer->cancel();
     closeConnectionOnRemoval();
 }
 
@@ -66,6 +70,8 @@ void NativeDeviceHelper::unsubscribeFromCoreEvent(const ContextPtr& context)
 
 void NativeDeviceHelper::closeConnectionOnRemoval()
 {
+    configProtocolReconnectionRetryTimer->cancel();
+
     if (transportClientHandler)
     {
         transportClientHandler->resetConfigHandlers();
@@ -259,25 +265,51 @@ void NativeDeviceHelper::connectionStatusChangedHandler(const EnumerationPtr& st
 {
     if (status == "Connected")
     {
-        try
-        {
-            acceptNotificationPackets = true;
-            configProtocolClient->reconnect(restoreClientConfigOnReconnect);
-        }
-        catch(const std::exception& e)
-        {
-            acceptNotificationPackets = false;
-            LOG_W("Reconnection failed: {}", e.what());
-            return;
-        }
+        tryConfigProtocolReconnect();
     }
     else
     {
+        configProtocolReconnectionRetryTimer->cancel();
         acceptNotificationPackets = false;
         cancelPendingConfigRequests(ConnectionLostException());
         configProtocolClient->disconnectExternalSignals();
+
+        updateConnectionStatus(status);
+    }
+}
+
+void NativeDeviceHelper::tryConfigProtocolReconnect()
+{
+    try
+    {
+        acceptNotificationPackets = true;
+        configProtocolClient->reconnect(restoreClientConfigOnReconnect);
+    }
+    catch(const std::exception& e)
+    {
+        acceptNotificationPackets = false;
+        LOG_E("Configuration protocol reconnection failed: {}.", e.what());
+
+        configProtocolReconnectionRetryTimer->expires_from_now(reconnectionPeriod);
+        configProtocolReconnectionRetryTimer->async_wait(
+            [this, weak_self = weak_from_this()](const boost::system::error_code& ec)
+            {
+                if (ec)
+                    return;
+                if (auto shared_self = weak_self.lock())
+                    this->tryConfigProtocolReconnect();
+            }
+        );
+        return;
     }
 
+    auto tmpStatusValue = connectionStatus;
+    tmpStatusValue = "Connected";
+    updateConnectionStatus(tmpStatusValue);
+}
+
+void NativeDeviceHelper::updateConnectionStatus(const EnumerationPtr& status)
+{
     connectionStatus = status;
 
     auto device = deviceRef.assigned() ? deviceRef.getRef() : nullptr;

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -261,7 +261,7 @@ void NativeDeviceHelper::coreEventCallback(ComponentPtr& sender, CoreEventArgsPt
     }
 }
 
-void NativeDeviceHelper::connectionStatusChangedHandler(const EnumerationPtr& status)
+void NativeDeviceHelper::transportConnectionStatusChangedHandler(const EnumerationPtr& status, const StringPtr& statusMessage)
 {
     if (status == "Connected")
     {
@@ -274,7 +274,7 @@ void NativeDeviceHelper::connectionStatusChangedHandler(const EnumerationPtr& st
         cancelPendingConfigRequests(ConnectionLostException());
         configProtocolClient->disconnectExternalSignals();
 
-        updateConnectionStatus(status);
+        updateConnectionStatus(status, statusMessage);
     }
 }
 
@@ -288,7 +288,10 @@ void NativeDeviceHelper::tryConfigProtocolReconnect()
     catch(const std::exception& e)
     {
         acceptNotificationPackets = false;
-        LOG_E("Configuration protocol reconnection failed: {}.", e.what());
+        const auto statusMessage = String(fmt::format("Configuration protocol reconnection failed: {}.", e.what()));
+        LOG_E("{}", statusMessage);
+
+        updateConnectionStatus(connectionStatus, statusMessage);
 
         configProtocolReconnectionRetryTimer->expires_from_now(reconnectionPeriod);
         configProtocolReconnectionRetryTimer->async_wait(
@@ -303,19 +306,20 @@ void NativeDeviceHelper::tryConfigProtocolReconnect()
         return;
     }
 
+    // use tmp var to implicitly copy the enumeration type
     auto tmpStatusValue = connectionStatus;
     tmpStatusValue = "Connected";
-    updateConnectionStatus(tmpStatusValue);
+    updateConnectionStatus(tmpStatusValue, "");
 }
 
-void NativeDeviceHelper::updateConnectionStatus(const EnumerationPtr& status)
+void NativeDeviceHelper::updateConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage)
 {
     connectionStatus = status;
 
     auto device = deviceRef.assigned() ? deviceRef.getRef() : nullptr;
     if (!device.assigned())
         return;
-    device.asPtr<INativeDevicePrivate>()->publishConnectionStatus(connectionStatus);
+    device.asPtr<INativeDevicePrivate>()->publishConnectionStatus(connectionStatus, statusMessage);
 }
 
 void NativeDeviceHelper::setupProtocolClients(const ContextPtr& context)
@@ -358,21 +362,21 @@ void NativeDeviceHelper::setupProtocolClients(const ContextPtr& context)
         );
     };
 
-    OnConnectionStatusChangedCallback connectionStatusChangedCb =
-        [this](const EnumerationPtr& status)
+    OnConnectionStatusChangedCallback transportConnectionStatusChangedCb =
+        [this](const EnumerationPtr& status, const StringPtr& statusMessage)
     {
         boost::asio::dispatch(
             *reconnectionProcessingIOContextPtr,
-            [this, status, weak_self = weak_from_this()]()
+            [this, status, statusMessage, weak_self = weak_from_this()]()
             {
                 if (auto shared_self = weak_self.lock())
-                    this->connectionStatusChangedHandler(status);
+                    this->transportConnectionStatusChangedHandler(status, statusMessage);
             }
         );
     };
 
     transportClientHandler->setConfigHandlers(receiveConfigPacketCb,
-                                              connectionStatusChangedCb);
+                                              transportConnectionStatusChangedCb);
 }
 
 PacketBuffer NativeDeviceHelper::doConfigRequestAndGetReply(const PacketBuffer& reqPacket)
@@ -519,10 +523,10 @@ NativeDeviceImpl::~NativeDeviceImpl()
 }
 
 // INativeDevicePrivate
-void NativeDeviceImpl::publishConnectionStatus(const EnumerationPtr& status)
+void NativeDeviceImpl::publishConnectionStatus(const EnumerationPtr& status, const StringPtr& statusMessage)
 {
-    this->statusContainer.asPtr<IComponentStatusContainerPrivate>().setStatus("ConnectionStatus", status);
-    this->connectionStatusContainer.updateConnectionStatus(deviceInfo.getConnectionString(), status, nullptr);
+    this->statusContainer.asPtr<IComponentStatusContainerPrivate>().setStatusWithMessage("ConnectionStatus", status, statusMessage);
+    this->connectionStatusContainer.updateConnectionStatusWithMessage(deviceInfo.getConnectionString(), status, nullptr, statusMessage);
 }
 
 void NativeDeviceImpl::completeInitialization(std::shared_ptr<NativeDeviceHelper> deviceHelper, const StringPtr& connectionString)

--- a/modules/native_streaming_client_module/src/native_streaming_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_device_impl.cpp
@@ -69,9 +69,9 @@ void NativeStreamingDeviceImpl::createNativeStreaming(NativeStreamingClientHandl
                   });
 
     OnConnectionStatusChangedCallback onConnectionStatusChangedCallback =
-        [this](const EnumerationPtr& status)
+        [this](const EnumerationPtr& status, const StringPtr& statusMessage)
         {
-            connectionStatusChangedHandler(status);
+            connectionStatusChangedHandler(status, statusMessage);
         };
 
     nativeStreaming =
@@ -239,7 +239,7 @@ void NativeStreamingDeviceImpl::signalUnavailableHandler(const StringPtr& signal
     deviceSignals.erase(signalStringId);
 }
 
-void NativeStreamingDeviceImpl::connectionStatusChangedHandler(const EnumerationPtr& status)
+void NativeStreamingDeviceImpl::connectionStatusChangedHandler(const EnumerationPtr& status, const StringPtr& statusMessage)
 {
     if (status == "Connected")
     {
@@ -261,7 +261,7 @@ void NativeStreamingDeviceImpl::connectionStatusChangedHandler(const Enumeration
     }
     connectionStatus = status;
 
-    this->statusContainer.asPtr<IComponentStatusContainerPrivate>().setStatus("ConnectionStatus", connectionStatus);
+    this->statusContainer.asPtr<IComponentStatusContainerPrivate>().setStatusWithMessage("ConnectionStatus", connectionStatus, statusMessage);
 }
 
 END_NAMESPACE_OPENDAQ_NATIVE_STREAMING_CLIENT_MODULE

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -428,11 +428,12 @@ void GenericConfigClientDeviceImpl<TDeviceBase>::connectionStatusChanged(const C
     const StringPtr connectionString = parameters.get("ConnectionString");
     const StringPtr statusName = parameters.get("StatusName");
     const EnumerationPtr value = parameters.get("StatusValue");
+    const StringPtr message = parameters.get("Message");
     const auto addedStatuses = connectionStatusContainer.getStatuses();
 
     // ignores status change if it was not added initially
     if (addedStatuses.hasKey(statusName))
-        connectionStatusContainer.asPtr<IConnectionStatusContainerPrivate>().updateConnectionStatus(connectionString, value, nullptr);
+        connectionStatusContainer.asPtr<IConnectionStatusContainerPrivate>().updateConnectionStatusWithMessage(connectionString, value, nullptr, message);
 }
 
 template <class TDeviceBase>

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -423,7 +423,7 @@ BaseObjectPtr ConfigProtocolServer::acceptsSignal(const RpcContext& context, con
 
 void ConfigProtocolServer::coreEventCallback(ComponentPtr& component, CoreEventArgsPtr& eventArgs)
 {
-    if (streamingConsumer.isForwardedCoreEvent(component, eventArgs))
+    if (isForwardedCoreEvent(component, eventArgs))
     {
         const auto packed = packCoreEvent(component, eventArgs);
         sendNotification(packed);

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -860,9 +860,19 @@ TEST_F(ConfigCoreEventTest, StatusChanged)
         ASSERT_EQ(args.getEventId(), static_cast<int>(CoreEventId::StatusChanged));
         ASSERT_EQ(args.getEventName(), "StatusChanged");
         ASSERT_TRUE(args.getParameters().hasKey("TestStatus"));
+        ASSERT_TRUE(args.getParameters().hasKey("Message"));
         ASSERT_EQ(comp, clientDevice);
 
-        if (changeCount % 2 == 0)
+        if (changeCount != 3)
+        {
+            ASSERT_EQ(args.getParameters().get("Message"), "");
+        }
+        else
+        {
+            ASSERT_EQ(args.getParameters().get("Message"), "Msg");
+        }
+
+        if (changeCount != 1)
         {
             ASSERT_EQ(args.getParameters().get("TestStatus"), statusValue);
             ASSERT_EQ(args.getParameters().get("TestStatus"), "Status1");
@@ -881,8 +891,9 @@ TEST_F(ConfigCoreEventTest, StatusChanged)
     statusContainer.setStatus("TestStatus", statusValue);
     statusContainer.setStatus("TestStatus", statusInitValue);
     statusContainer.setStatus("TestStatus", statusValue);
+    statusContainer.setStatusWithMessage("TestStatus", statusValue, "Msg");
 
-    ASSERT_EQ(changeCount, 3);
+    ASSERT_EQ(changeCount, 4);
 }
 
 TEST_F(ConfigCoreEventTest, ConnectionStatusChanged)
@@ -912,7 +923,18 @@ TEST_F(ConfigCoreEventTest, ConnectionStatusChanged)
         ASSERT_EQ(comp, clientDevice);
 
         ASSERT_TRUE(args.getParameters().hasKey("StatusValue"));
-        if (changeCount % 2 == 0)
+        ASSERT_TRUE(args.getParameters().hasKey("Message"));
+        ASSERT_TRUE(args.getParameters().get("Message").assigned());
+        if (changeCount != 3)
+        {
+            ASSERT_EQ(args.getParameters().get("Message"), "");
+        }
+        else
+        {
+            ASSERT_EQ(args.getParameters().get("Message"), "Msg");
+        }
+
+        if (changeCount != 1)
         {
             ASSERT_EQ(args.getParameters().get("StatusValue"), statusValue);
             ASSERT_EQ(args.getParameters().get("StatusValue"), "Reconnecting");
@@ -931,13 +953,15 @@ TEST_F(ConfigCoreEventTest, ConnectionStatusChanged)
     connectionStatusContainer.updateConnectionStatus("ConfigConnStr", statusValue, nullptr);
     connectionStatusContainer.updateConnectionStatus("ConfigConnStr", statusInitValue, nullptr);
     connectionStatusContainer.updateConnectionStatus("ConfigConnStr", statusValue, nullptr);
+    connectionStatusContainer.updateConnectionStatusWithMessage("ConfigConnStr", statusValue, nullptr, "Msg");
 
     // core events with streaming connection status change are not forwarded to client
     connectionStatusContainer.updateConnectionStatus("StreamingConnStr", statusValue, mockStreaming);
     connectionStatusContainer.updateConnectionStatus("StreamingConnStr", statusInitValue, mockStreaming);
     connectionStatusContainer.updateConnectionStatus("StreamingConnStr", statusValue, mockStreaming);
+    connectionStatusContainer.updateConnectionStatusWithMessage("StreamingConnStr", statusValue, mockStreaming, "Msg");
 
-    ASSERT_EQ(changeCount, 3);
+    ASSERT_EQ(changeCount, 4);
 }
 
 TEST_F(ConfigCoreEventTest, TypeAdded)

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_client_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_client_handler.h
@@ -39,7 +39,7 @@ using OnSignalAvailableCallback = std::function<void(const StringPtr& signalStri
 using OnSignalUnavailableCallback = std::function<void(const StringPtr& signalStringId)>;
 using OnPacketCallback = std::function<void(const StringPtr& signalStringId, const PacketPtr& packet)>;
 using OnSignalSubscriptionAckCallback = std::function<void(const StringPtr& signalStringId, bool subscribed)>;
-using OnConnectionStatusChangedCallback = std::function<void(const EnumerationPtr& status)>;
+using OnConnectionStatusChangedCallback = std::function<void(const EnumerationPtr& status, const StringPtr& statusMessage)>;
 
 class NativeStreamingClientHandler;
 using NativeStreamingClientHandlerPtr = std::shared_ptr<NativeStreamingClientHandler>;
@@ -92,7 +92,7 @@ protected:
 
     void checkReconnectionResult(const boost::system::error_code& ec);
     void tryReconnect();
-    void connectionStatusChanged(const EnumerationPtr& status);
+    void connectionStatusChanged(const EnumerationPtr& status, const StringPtr& statusMessage);
 
     enum class ConnectionResult
     {

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -149,7 +149,7 @@ ListPtr<ISignal> StreamingManager::unregisterClient(const std::string& clientId)
     }
     else
     {
-        LOG_I("Client was not registered");
+        LOG_I("Client {} was not registered as streaming client", clientId);
         return List<ISignal>();
     }
 

--- a/shared/libraries/native_streaming_protocol/tests/test_base.h
+++ b/shared/libraries/native_streaming_protocol/tests/test_base.h
@@ -51,6 +51,7 @@ public:
 
     static daq::PropertyObjectPtr createTransportLayerConfig()
     {
+        static size_t clientId = 123456;
         auto config = daq::PropertyObject();
 
         config.addProperty(daq::BoolProperty("MonitoringEnabled", daq::True));
@@ -59,7 +60,7 @@ public:
         config.addProperty(daq::IntProperty("ConnectionTimeout", 1000));
         config.addProperty(daq::IntProperty("StreamingInitTimeout", 1000));
         config.addProperty(daq::IntProperty("ReconnectionPeriod", 1000));
-        config.addProperty(daq::StringProperty("ClientId", "123456"));
+        config.addProperty(daq::StringProperty("ClientId", std::to_string(clientId++)));
 
         return config;
     }

--- a/shared/libraries/native_streaming_protocol/tests/test_client_to_dev_streaming.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_client_to_dev_streaming.cpp
@@ -19,7 +19,7 @@ public:
             clientContext, ClientAttributesBase::createTransportLayerConfig(), ClientAttributesBase::createAuthenticationConfig());
 
         clientHandler->setConfigHandlers([](config_protocol::PacketBuffer&&) {},
-                                         [](const EnumerationPtr&) {});
+                                         [](const EnumerationPtr&, const StringPtr&) {});
     }
 
     void tearDown()

--- a/shared/libraries/native_streaming_protocol/tests/test_config_packets.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_config_packets.cpp
@@ -118,7 +118,7 @@ public:
             configProtocolHandler->receivePacket(std::move(packetBuffer));
         };
 
-        connectionStatusChangedHandler = [this](const EnumerationPtr& status)
+        connectionStatusChangedHandler = [this](const EnumerationPtr& status, const StringPtr& statusMessage)
         {
             connectionStatusPromise.set_value(status);
         };

--- a/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
@@ -117,7 +117,7 @@ public:
                 unsubscribedAckPromise.set_value(signalStringId);
         };
 
-        connectionStatusChangedHandler = [this](const EnumerationPtr& status)
+        connectionStatusChangedHandler = [this](const EnumerationPtr& status, const StringPtr& statusMessage)
         {
             connectionStatusPromise.set_value(status);
         };


### PR DESCRIPTION
# Brief
Enables status messages for connection statuses

> [!CAUTION]
> Breaks binary compatibility

# Description
* Enables status messages for connection statuses
* Introduces additional "Message" parameter of string-object-type within "ConnectionStatusChanged" core event arguments

# Usage example
To update existing connection status with status message:
```cpp
const auto typeManager = client.getDevices()[0].getContext().getTypeManager();
const StringPtr statusMessage = "Network connection interrupted or closed by the remote device";
const EnumerationPtr statusValue = Enumeration("ConnectionStatusType", "Reconnecting", typeManager);
const auto connectionStatusContainer = client.getDevices()[0].getConnectionStatusContainer();
connectionStatusContainer.asPtr<IConnectionStatusContainerPrivate>().updateConnectionStatusWithMessage(connectionString, statusValue, nullptr, statusMessage);
```
or directly from device implementation:
```cpp
...
this->connectionStatusContainer.updateConnectionStatusWithMessage(connectionString, statusValue, nullptr, statusMessage);
```

To get the status message of connection status:
```cpp
StringPtr message = client.getDevices()[0].getConnectionStatusContainer().getStatusMessage("ConfigurationStatus");
```

# Required integration changes

## Breaking application changes
None.

## Breaking module changes
None.

# API changes
```diff
+ [function] IConnectionStatusContainerPrivate::updateConnectionStatusWithMessage(IString* connectionString, IEnumeration* value, IStreaming* streamingObject, IString* message)
```