### PR TITLE
Fix CMake compile definitions for simulator build

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -8,6 +8,11 @@ if (POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif()
 
+if (DAQSIMULATOR_ENABLE_SIMULATOR_APP)
+    message(NOTICE "Enable simulator support in reference device module.")
+    add_compile_definitions(DAQMODULES_REF_DEVICE_MODULE_SIMULATOR_ENABLED)
+endif()
+
 if (DAQMODULES_OPENDAQ_CLIENT_MODULE)
     message(STATUS "Client modules:")
 


### PR DESCRIPTION
# Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Description:
* Restore CMake compile definitions accidentally removed within merge commit
