### PR TITLE
Install missing CMake utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,6 +746,21 @@ install(FILES cmake/${SDK_NAME}Utils.cmake
         COMPONENT ${SDK_NAME}_Development
 )
 
+install(FILES cmake/DaqUtils.cmake
+        DESTINATION share/cmake
+        COMPONENT ${SDK_NAME}_Development
+)
+
+install(FILES cmake/DaqInternal.cmake
+        DESTINATION share/cmake
+        COMPONENT ${SDK_NAME}_Development
+)
+
+install(FILES cmake/version/version.h.in cmake/version/version.rc.in
+        DESTINATION share/cmake/version
+        COMPONENT ${SDK_NAME}_Development
+)
+
 install(EXPORT ${SDK_NAME}
         NAMESPACE ${SDK_TARGET_NAMESPACE}::
         FILE ${SDK_NAME}.cmake

--- a/cmake/openDAQConfig.cmake.in
+++ b/cmake/openDAQConfig.cmake.in
@@ -30,3 +30,4 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/openDAQ.cmake)
 include(openDAQUtils)
+include(DaqUtils)

--- a/cmake/openDAQUtils.cmake
+++ b/cmake/openDAQUtils.cmake
@@ -4,6 +4,10 @@ function (opendaq_set_module_properties MODULE_NAME LIB_MAJOR_VERSION)
     set(multiValueArgs "")
     cmake_parse_arguments(OPENDAQ_SET_MODULE_PARAMS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+	if (NOT DEFINED OPENDAQ_MODULE_SUFFIX)
+		set(OPENDAQ_MODULE_SUFFIX ".module${CMAKE_SHARED_LIBRARY_SUFFIX}")
+	endif()
+	
     set_target_properties(${MODULE_NAME} PROPERTIES SUFFIX ${OPENDAQ_MODULE_SUFFIX})
     target_compile_definitions(${MODULE_NAME} PRIVATE BUILDING_SHARED_LIBRARY
                                                       OPENDAQ_TRACK_SHARED_LIB_OBJECT_COUNT


### PR DESCRIPTION
# Brief

Standard example openDAQ modules make use of non-installed openDAQ cmake utilities. This PR adds said cmake utilities to the installed openDAQ package.

# Description

The files DaqUtils.cmake, DaqInternal.cmake, as well as the input templates for version files have been added as targets for openDAQ installation. 

Module examples such as the [Simple FB Module](https://github.com/openDAQ/SimpleFBModule) and [Simple Device Module](https://github.com/openDAQ/SimpleDeviceModule) as of now fail on CMake configure when using an installed version of openDAQ due to the missing cmake utilities.