### PR TITLE
Optimize coretype number casting

### DIFF
--- a/core/coretypes/include/coretypes/number_impl.h
+++ b/core/coretypes/include/coretypes/number_impl.h
@@ -69,14 +69,6 @@ ErrCode NumberImpl<V, Intf>::queryInterface(const IntfID& id, void** intf)
 {
     OPENDAQ_PARAM_NOT_NULL(intf);
 
-    if (id == Intf::Id)
-    {
-        *intf = static_cast<Intf*>(this);
-        this->addRef();
-
-        return OPENDAQ_SUCCESS;
-    }
-
     if (id == INumber::Id)
     {
         *intf = static_cast<INumber*>(this);
@@ -92,13 +84,6 @@ template <class V, class Intf>
 ErrCode NumberImpl<V, Intf>::borrowInterface(const IntfID& id, void** intf) const
 {
     OPENDAQ_PARAM_NOT_NULL(intf);
-
-    if (id == Intf::Id)
-    {
-        *intf = const_cast<Intf*>(static_cast<const Intf*>(this));
-
-        return OPENDAQ_SUCCESS;
-    }
 
     if (id == INumber::Id)
     {

--- a/core/coretypes/include/coretypes/ordinalobject_impl.h
+++ b/core/coretypes/include/coretypes/ordinalobject_impl.h
@@ -29,6 +29,8 @@ template <class V, class Intf, class ... Intfs>
 class OrdinalObjectImpl : public ImplementationOf<Intf, IConvertible, ICoreType, IComparable, ISerializable, Intfs...>
 {
 public:
+    using Super = ImplementationOf<Intf, IConvertible, ICoreType, IComparable, ISerializable, Intfs...>;
+
     OrdinalObjectImpl(V value);
 
     // IBaseObject
@@ -58,6 +60,10 @@ public:
     {
         return OPENDAQ_ERR_NOTIMPLEMENTED;
     }
+
+    // IUnknown
+    ErrCode INTERFACE_FUNC queryInterface(const IntfID& id, void** intf) override;
+    ErrCode INTERFACE_FUNC borrowInterface(const IntfID& id, void** intf) const override;
 
 protected:
     V value;
@@ -222,6 +228,66 @@ template <class V, class Intf, class ... Intfs>
 ErrCode OrdinalObjectImpl<V, Intf, Intfs ...>::serialize(ISerializer* serializer)
 {
     return OPENDAQ_ERR_NOTIMPLEMENTED;
+}
+
+template <class V, class Intf, class ... Intfs>
+ErrCode OrdinalObjectImpl<V, Intf, Intfs ...>::queryInterface(const IntfID& id, void** intf)
+{
+    if (intf == nullptr)
+        return OPENDAQ_ERR_ARGUMENT_NULL;
+
+    if (id == Intf::Id)
+    {
+        *intf = static_cast<Intf*>(this);
+        this->addRef();
+
+        return OPENDAQ_SUCCESS;
+    }
+
+    if (id == ICoreType::Id)
+    {
+        *intf = static_cast<ICoreType*>(this);
+        this->addRef();
+
+        return OPENDAQ_SUCCESS;
+    }
+
+    if (id == IConvertible::Id)
+    {
+        *intf = static_cast<IConvertible*>(this);
+        this->addRef();
+
+        return OPENDAQ_SUCCESS;
+    }
+
+    return Super::queryInterface(id, intf);
+}
+
+template <class V, class Intf, class ... Intfs>
+ErrCode OrdinalObjectImpl<V, Intf, Intfs ...>::borrowInterface(const IntfID& id, void** intf) const
+{
+    if (id == Intf::Id)
+    {
+        *intf = const_cast<Intf*>(static_cast<const Intf*>(this));
+
+        return OPENDAQ_SUCCESS;
+    }
+
+    if (id == ICoreType::Id)
+    {
+        *intf = const_cast<ICoreType*>(static_cast<const ICoreType*>(this));
+
+        return OPENDAQ_SUCCESS;
+    }
+
+    if (id == IConvertible::Id)
+    {
+        *intf = const_cast<IConvertible*>(static_cast<const IConvertible*>(this));
+
+        return OPENDAQ_SUCCESS;
+    }
+
+    return Super::borrowInterface(id, intf);
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/coretypes/tests/test_integer.cpp
+++ b/core/coretypes/tests/test_integer.cpp
@@ -217,3 +217,29 @@ TEST_F(IntegerTest, InterfaceIdString)
 {
     ASSERT_EQ(daqInterfaceIdString<IInteger>(), "{B5C52F78-45F9-5C54-9BC1-CA65A46472CB}");
 }
+
+TEST_F(IntegerTest, QueryInterface)
+{
+    const auto obj = Integer(1);
+    const auto coreType = obj.asPtr<ICoreType>();
+    ASSERT_EQ(coreType, CoreType::ctInt);
+
+    const auto convertible = obj.asPtr<IConvertible>();
+    ASSERT_EQ(1, obj.convertTo(CoreType::ctInt));
+
+    const auto obj1 = obj.asPtr<IInteger>();
+    ASSERT_EQ(1, obj1);
+}
+
+TEST_F(IntegerTest, BorrowInterface)
+{
+    const auto obj = Integer(1);
+    const auto coreType = obj.asPtr<ICoreType>(true);
+    ASSERT_EQ(coreType, CoreType::ctInt);
+
+    const auto convertible = obj.asPtr<IConvertible>(true);
+    ASSERT_EQ(1, obj.convertTo(CoreType::ctInt));
+
+    const auto obj1 = obj.asPtr<IInteger>(true);
+    ASSERT_EQ(1, obj1);
+}


### PR DESCRIPTION
# Brief

Coretype INumber queryInterface & borrow interface optimization



# Description

Optimizes queryInterface and borrowInterface methods for number core types, such as integer and float.
