### PR TITLE
Optimize global ID access in native streaming server

### DIFF
--- a/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
+++ b/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
@@ -69,7 +69,7 @@ protected:
     std::thread readThread;
     std::atomic<bool> readThreadActive;
     std::chrono::milliseconds readThreadSleepTime;
-    std::vector<std::pair<SignalPtr, PacketReaderPtr>> signalReaders;
+    std::vector<std::tuple<SignalPtr, std::string, PacketReaderPtr>> signalReaders;
 
     std::shared_ptr<boost::asio::io_context> transportIOContextPtr;
     std::thread transportThread;

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
@@ -55,7 +55,7 @@ public:
     void addSignal(const SignalPtr& signal);
     void removeComponentSignals(const StringPtr& componentId);
 
-    void sendPacket(const SignalPtr& signal, PacketPtr&& packet);
+    void sendPacket(const std::string& globalId, PacketPtr&& packet);
 
 protected:
     void initSessionHandler(SessionPtr session);

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
@@ -226,13 +226,11 @@ bool NativeStreamingServerHandler::onAuthenticate(const daq::native_streaming::A
     return false;
 }
 
-void NativeStreamingServerHandler::sendPacket(const SignalPtr& signal, PacketPtr&& packet)
+void NativeStreamingServerHandler::sendPacket(const std::string& globalId, PacketPtr&& packet)
 {
-    const auto signalStringId = signal.getGlobalId().toStdString();
-
     // The lambda passed as a parameter will be invoked immediately, making it safe to directly capture this
     streamingManager.sendPacketToSubscribers(
-        signalStringId,
+        globalId,
         std::move(packet),
         [this](const std::string& subscribedClientId, packet_streaming::PacketBufferPtr&& packetBuffer)
         {

--- a/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
@@ -143,7 +143,7 @@ public:
         {
             // called only when signal first time subscribed by any client
             if (initialEventPacket.assigned())
-                serverHandler->sendPacket(signal, initialEventPacket);
+                serverHandler->sendPacket(signal.getGlobalId(), initialEventPacket);
             signalSubscribedPromise.set_value(signal);
         };
 
@@ -605,7 +605,7 @@ TEST_P(StreamingProtocolTest, InitialEventPacketPostSubscribe)
 
     ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
 
-    serverHandler->sendPacket(serverSignal, firstEventPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId(), firstEventPacket);
     for (auto& client : clients)
     {
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
@@ -639,7 +639,7 @@ TEST_P(StreamingProtocolTest, SendEventPacket)
 
     ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
 
-    serverHandler->sendPacket(serverSignal, firstEventPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId(), firstEventPacket);
     for (auto& client : clients)
     {
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
@@ -654,7 +654,7 @@ TEST_P(StreamingProtocolTest, SendEventPacket)
 
     const auto newValueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Binary).build();
     auto secondEventPacket = DataDescriptorChangedEventPacket(newValueDescriptor, nullptr);
-    serverHandler->sendPacket(serverSignal, secondEventPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId(), secondEventPacket);
 
     for (auto& client : clients)
     {
@@ -682,7 +682,7 @@ TEST_P(StreamingProtocolTest, SendPacketsNoSubscribers)
     }
 
     auto serverDataPacket = DataPacket(valueDescriptor, 100);
-    serverHandler->sendPacket(serverSignal, serverDataPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId(), serverDataPacket);
 
     // no subscribers - so packets wont be sent to clients
     for (auto& client : clients)
@@ -728,7 +728,7 @@ TEST_P(StreamingProtocolTest, SendDataPacket)
         client.packetReceivedFuture = client.packetReceivedPromise.get_future();
     }
 
-    serverHandler->sendPacket(serverSignal, serverDataPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId(), serverDataPacket);
     for (auto& client : clients)
     {
         // wait for data packet


### PR DESCRIPTION
# Brief

Optimize native streaming server with signal global id caching

# Description

Small optimization of native streaming server by caching global ID of subscribed signals. It avoids unnecessary heap allocations.