### PR TITLE
Device info `setName` changed device name + setting owner prevents writing of read-only values

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -5,7 +5,7 @@
 - Enables status messages for connection statuses [#687](https://github.com/openDAQ/openDAQ/pull/687)
 - Fixed an mDNS issue where multiple devices broadcasting with the same IP address were present, but only one could be detected by the client [#689](https://github.com/openDAQ/openDAQ/pull/689)
 - Introduces mechanisms to modify the IP configuration parameters of openDAQ-compatible devices [#642](https://github.com/openDAQ/openDAQ/pull/642)
-- Introduce Changeable Device Info Properties with mDNS Synchronization and Customization [#607](https://github.com/openDAQ/openDAQ/pull/607)
+- Introduce Changeable Device Info Properties with mDNS Synchronization and Customization [#607](https://github.com/openDAQ/openDAQ/pull/607)[#700](https://github.com/openDAQ/openDAQ/pull/700)
 - The "Name" attribute was not serialized when equal to the local ID, causing issues when the localID of a deserialized signal was overridden to be different than the original [#660](https://github.com/openDAQ/openDAQ/pull/660)
 - Fixing building openDAQ on android, by removing multiple coping of loaded library to the final vector in ModuleManager constructor [#569](https://github.com/openDAQ/openDAQ/pull/659)
 - Display time domain signal last value as time in Python GUI demo app [#657](https://github.com/openDAQ/openDAQ/pull/657)
@@ -52,6 +52,32 @@ EnumerationPtr status = instance.getDevices()[0].getConnectionStatusContainer().
 
 
 ## Required module changes
+
+### [#700] https://github.com/openDAQ/openDAQ/pull/700
+
+`IDeviceInfoConfig` setters no longer have protected access once `DeviceInfo` has an owner. To change the value of a read-only 
+device info property `IPropertyObject::setProtectedPropertyValue` must be used. The old setters can still be used as Before
+during info creation. Said behaviour only works locally - when done on a remote device, the setters will fail as before.
+
+Example required changes:
+```cpp
+// Manufacturer is a read-only device info property
+device.getInfo().asPtr<IDeviceInfoConfig>().setManufacturer("openDAQ"); // Fails
+device.getInfo().asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("manufacturer", "openDAQ"); // Works
+
+```
+
+The following still works:
+
+```cpp
+DeviceInfoPtr DeviceImpl::onGetInfo()
+{
+	auto info = DeviceInfo(connStr);
+	info.setManufacturer("openDAQ"); // The `info` object does not yet have an owner
+	return info;
+}
+
+```
 
 ### [#642](https://github.com/openDAQ/openDAQ/pull/642)
 

--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -22,6 +22,19 @@
 - Add support for View Only client to the config protocol [#605](https://github.com/openDAQ/openDAQ/pull/605)
 
 ## Required application changes
+### [#607](https://github.com/openDAQ/openDAQ/pull/607)
+
+The "location" and "userName" properties no longer appear on devices on which said properties are not changeable. Applications should first check whether those properties exist before accessing them, or access them through the  "DeviceInfo" object as is the case for other properties.
+
+```cpp
+if (device.hasProperty("location"))
+	device.setPropertyValue("location", "new_location");
+	
+// Option 2:
+auto locationProp = device.getInfo().getProperty("location");
+if (!location.getReadOnly())
+	location.setValue("new_location");
+```
 
 ### [#606](https://github.com/openDAQ/openDAQ/pull/606)
 
@@ -143,7 +156,22 @@ DeviceInfoPtr ExampleClientModule::populateDiscoveredDevice(const MdnsDiscovered
 
 ### [#630](https://github.com/openDAQ/openDAQ/pull/630)
 
-The `ongetLogFileInfos` function override must be renamed to `onGetLogFileInfos`. This change will cause all modules developed with an older version of openDAQ that override the aforementioned method to no longer compile.
+The `ongetLogFileInfos` function override must be renamed to `onGetLogFileInfos`. This change will cause all modules developed with an older version of openDAQ that override the aforementioned method to no longer compile
+
+### [#607](https://github.com/openDAQ/openDAQ/pull/607)
+
+The "location" and "userName" properties previously always appeared on devices, regardless of whether or not devices used them. A device must explicitly define the "location" and "userName" to be configurable when constructing its DeviceInfo object.
+
+```cpp
+
+DeviceInfoPtr MyDeviceImpl::onGetInfo()
+{
+    auto info = DeviceInfoWithChanegableFields({"userName", "location"});
+	
+	...
+}
+
+```
 
 ### [#606](https://github.com/openDAQ/openDAQ/pull/606)
 

--- a/core/opendaq/device/include/opendaq/device_info_impl.h
+++ b/core/opendaq/device/include/opendaq/device_info_impl.h
@@ -993,6 +993,9 @@ ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::getNetworkInterface(ISt
 template <typename TInterface, typename ... Interfaces>
 ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::setValueInternal(IString* propertyName, IBaseObject* value)
 {
+    if (Super::getPropertyObjectParent().assigned())
+        return Super::setPropertyValue(propertyName, value);
+
     return Super::setProtectedPropertyValue(propertyName, value);
 }
 

--- a/core/opendaq/device/include/opendaq/device_info_impl.h
+++ b/core/opendaq/device/include/opendaq/device_info_impl.h
@@ -275,6 +275,10 @@ DeviceInfoConfigImpl<TInterface, Interfaces...>::DeviceInfoConfigImpl(const List
 template <typename TInterface, typename... Interfaces>
 ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::setName(IString* name)
 {
+    ComponentPtr ownerPtr = Super::getPropertyObjectParent();
+    if (ownerPtr.assigned())
+        return ownerPtr->setName(name);
+
     return setValueInternal(String("name"), name);
 }
 

--- a/core/opendaq/device/tests/test_device_info.cpp
+++ b/core/opendaq/device/tests/test_device_info.cpp
@@ -313,4 +313,25 @@ TEST_F(DeviceInfoTest, OwnerName)
     ASSERT_EQ(info.getName(), "new_id1");
     ASSERT_EQ(component.getName(), "new_id1");
 }
+
+TEST_F(DeviceInfoTest, PropertyWriteAfterOwnerSet)
+{
+    DeviceInfoConfigPtr info = DeviceInfo("", "foo");
+    ComponentPtr component = Component(NullContext(), nullptr, "id");
+
+    ASSERT_NO_THROW(info.setManufacturer("test"));
+    ASSERT_EQ(info.getManufacturer(), "test");
+    
+    ASSERT_NO_THROW(info.setLocation("test"));
+    ASSERT_EQ(info.getLocation(), "test");
+
+    info.asPtr<IOwnable>().setOwner(component);
+    
+    ASSERT_THROW(info.setManufacturer("test1"), AccessDeniedException);
+    ASSERT_EQ(info.getManufacturer(), "test");
+    
+    ASSERT_THROW(info.setLocation("test1"), AccessDeniedException);
+    ASSERT_EQ(info.getLocation(), "test");
+}
+
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/device/tests/test_device_info.cpp
+++ b/core/opendaq/device/tests/test_device_info.cpp
@@ -7,7 +7,9 @@
 #include <opendaq/context_factory.h>
 #include <opendaq/network_interface_factory.h>
 #include <opendaq/module_manager_factory.h>
-#include "testutils/memcheck_listener.h"
+#include <coreobjects/ownable_ptr.h>
+#include <opendaq/component_factory.h>
+#include <testutils/memcheck_listener.h>
 
 using DeviceInfoTest = testing::Test;
 
@@ -292,4 +294,23 @@ TEST_F(DeviceInfoTest, NetworkInterfaces)
     EXPECT_EQ(defaultConfig.getPropertyValue("gateway6"), String(""));
 }
 
+TEST_F(DeviceInfoTest, OwnerName)
+{
+    DeviceInfoConfigPtr info = DeviceInfo("", "foo");
+    ComponentPtr component = Component(NullContext(), nullptr, "id");
+
+    ASSERT_EQ(info.getName(), "foo");
+    info.setName("test");
+    ASSERT_EQ(info.getName(), "test");
+
+    info.asPtr<IOwnable>().setOwner(component);
+
+    ASSERT_EQ(info.getName(), "id");
+    component.setName("new_id");
+    ASSERT_EQ(info.getName(), "new_id");
+
+    info.setName("new_id1");
+    ASSERT_EQ(info.getName(), "new_id1");
+    ASSERT_EQ(component.getName(), "new_id1");
+}
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -404,12 +404,12 @@ ErrCode ModuleManagerImpl::getAvailableDevices(IList** availableDevices)
                         for (const auto & capability : deviceInfo.getServerCapabilities())
                             if (!value.hasServerCapability(capability.getProtocolId()))
                                 valueInternal.addServerCapability(capability);
-                        value.asPtr<IDeviceInfoConfig>().setConnectionString(id);
+                        value.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", id);
                         groupedDevices.set(id, value);
                     }
                     else
                     {
-                        deviceInfo.asPtr<IDeviceInfoConfig>().setConnectionString(id);
+                        deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", id);
                         groupedDevices.set(id, deviceInfo);
                     }
                 }

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -869,7 +869,7 @@ DeviceInfoPtr NativeStreamingClientModule::populateDiscoveredConfigurationDevice
     cap.setProtocolVersion(discoveredDevice.getPropertyOrDefault("protocolVersion", ""));
 
     deviceInfo.asPtr<IDeviceInfoInternal>().addServerCapability(cap);
-    deviceInfo.asPtr<IDeviceInfoConfig>().setConnectionString(cap.getConnectionString());
+    deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", cap.getConnectionString());
     deviceInfo.asPtr<IDeviceInfoConfig>().setDeviceType(createDeviceType());
 
     return deviceInfo;
@@ -887,7 +887,7 @@ DeviceInfoPtr NativeStreamingClientModule::populateDiscoveredStreamingDevice(con
         cap.setPort(discoveredDevice.servicePort);
 
     deviceInfo.asPtr<IDeviceInfoInternal>().addServerCapability(cap);
-    deviceInfo.asPtr<IDeviceInfoConfig>().setConnectionString(cap.getConnectionString());
+    deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", cap.getConnectionString());
     deviceInfo.asPtr<IDeviceInfoConfig>().setDeviceType(createPseudoDeviceType());
 
     return deviceInfo;

--- a/modules/opcua_client_module/src/opcua_client_module_impl.cpp
+++ b/modules/opcua_client_module/src/opcua_client_module_impl.cpp
@@ -13,6 +13,7 @@
 #include <opendaq/device_info_factory.h>
 #include <opendaq/address_info_factory.h>
 #include <coreobjects/property_factory.h>
+#include <coreobjects/property_object_protected_ptr.h>
 #include <opendaq/device_info_internal_ptr.h>
 
 BEGIN_NAMESPACE_OPENDAQ_OPCUA_CLIENT_MODULE
@@ -90,8 +91,8 @@ DevicePtr OpcUaClientModule::onCreateDevice(const StringPtr& connectionString,
     completeServerCapabilities(device, host);
 
     // Set the connection info for the device
-    DeviceInfoConfigPtr deviceInfo = device.getInfo();
-    deviceInfo.setConnectionString(connectionString);
+    DeviceInfoPtr deviceInfo = device.getInfo();
+    deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", connectionString);
     ServerCapabilityConfigPtr connectionInfo = deviceInfo.getConfigurationConnectionInfo();
     
     const auto addressInfo = AddressInfoBuilder().setAddress(host)
@@ -187,7 +188,7 @@ DeviceInfoPtr OpcUaClientModule::populateDiscoveredDevice(const MdnsDiscoveredDe
         cap.setPort(discoveredDevice.servicePort);
 
     deviceInfo.asPtr<IDeviceInfoInternal>().addServerCapability(cap);
-    deviceInfo.asPtr<IDeviceInfoConfig>().setConnectionString(cap.getConnectionString());
+    deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", cap.getConnectionString());
     deviceInfo.asPtr<IDeviceInfoConfig>().setDeviceType(createDeviceType());
 
     return deviceInfo;

--- a/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
+++ b/modules/websocket_streaming_client_module/src/websocket_streaming_client_module_impl.cpp
@@ -329,7 +329,7 @@ DeviceInfoPtr WebsocketStreamingClientModule::populateDiscoveredDevice(const Mdn
         cap.setPort(discoveredDevice.servicePort);
 
     deviceInfo.asPtr<IDeviceInfoInternal>().addServerCapability(cap);
-    deviceInfo.asPtr<IDeviceInfoConfig>().setConnectionString(cap.getConnectionString());
+    deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", cap.getConnectionString());
     deviceInfo.asPtr<IDeviceInfoConfig>().setDeviceType(createWebsocketDeviceType(false));
 
     return deviceInfo;

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -654,22 +654,22 @@ TEST_F(ConfigProtocolIntegrationTest, DeviceInfoNotChangeableField)
         ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("manufacturer", clientDeviceInfo.getManufacturer());
 
-        serverDeviceInfo.asPtr<IDeviceInfoConfig>(true).setManufacturer("server_manufacturer_3");
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
+        ASSERT_ANY_THROW(serverDeviceInfo.asPtr<IDeviceInfoConfig>(true).setManufacturer("server_manufacturer_3"));
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("manufacturer", clientDeviceInfo.getManufacturer());
     }
 
     {
         ASSERT_ANY_THROW(clientDeviceInfo.setPropertyValue("manufacturer", "client_manufacturer"));
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("manufacturer", clientDeviceInfo.getManufacturer());
 
         clientDeviceInfo.asPtr<IPropertyObjectProtected>(true).setProtectedPropertyValue("manufacturer", "client_manufacturer_2");
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("client_manufacturer_2", clientDeviceInfo.getManufacturer());
 
         ASSERT_ANY_THROW(clientDeviceInfo.asPtr<IDeviceInfoConfig>(true).setManufacturer("client_manufacturer_3"));
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("client_manufacturer_2", clientDeviceInfo.getManufacturer());
     }
 }

--- a/shared/libraries/config_protocol/tests/test_utils.h
+++ b/shared/libraries/config_protocol/tests/test_utils.h
@@ -121,7 +121,7 @@ namespace daq::config_protocol::test_utils
             {
                 const auto num = std::to_string(i);
                 const auto deviceInfo = DeviceInfo("mock://available_dev" + num, "AvailableMockDevice" + num);
-                deviceInfo.asPtr<IDeviceInfoConfig>().setManufacturer("Testing");
+                deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("manufacturer","Testing");
                 availableDevices.pushBack(deviceInfo);
             }
             return availableDevices;

--- a/shared/libraries/opcuatms/opcuatms_client/src/tms_client.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/tms_client.cpp
@@ -66,7 +66,7 @@ daq::DevicePtr TmsClient::connect()
     auto device = TmsClientRootDevice(context, parent, rootDeviceBrowseName, tmsClientContext, rootDeviceNodeId);
 
     const auto deviceInfo = device.getInfo();
-    deviceInfo.asPtr<IDeviceInfoConfig>(true).setConnectionString(endpoint.getUrl());
+    deviceInfo.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("connectionString", endpoint.getUrl());
 
     const std::string packageVersion = deviceInfo.getSdkVersion();
     if (!packageVersion.empty() && packageVersion != OPENDAQ_PACKAGE_VERSION)


### PR DESCRIPTION
# Brief
- The `IDeviceInfoConfig::setName` method now also changes the device's name instead of changing an internal, unreadable value once owner is assigned.
- The `IDeviceInfoConfig` setters no longer have protected access to read-only properties after owner is set.

# Description

The `IDeviceInfoConfig::setName` method was previously only useable when creating a DeviceInfo object meant for discovery. If an owner of the device info is assigned (which happens when the info object is obtained via `IDevice::getInfo`), the name of the info object is synced with that of the device. As `IDeviceInfoConfig::setName` previously only modified an internal variable, the function had no effect. With this change, the method now also modified the owner device's name (if the attribute is not locked).

Secondly, the `IDeviceInfoConfig` setters have protected write access to info properties. This is done to enable the pattern of:

```cpp
auto info = DeviceInfo("", "");
info.setManufacturer("openDAQ"); // Manufacturer is read-only
```

This, however, might result in user error when above functions are used when the info object is obtained by `IDevice::getInfo()`. To combat this, after a device takes ownership of the info object, the setters lose privileged access:

```cpp
auto info = device.getInfo();
info.setManufacturer("openDAQ"); // Fails with an access violation exception
```
