### PR TITLE
Native streaming performance optimization

### DIFF
--- a/docs/tests/test_modules.cpp
+++ b/docs/tests/test_modules.cpp
@@ -200,6 +200,7 @@ TEST_F(ModulesTest, CreateServer)
     nativeStreamingConfig.setPropertyValue("NativeStreamingPort", 7420);
     nativeStreamingConfig.setPropertyValue("MaxAllowedConfigConnections", 0);
     nativeStreamingConfig.setPropertyValue("StreamingPacketSendTimeout", 0);
+    nativeStreamingConfig.setPropertyValue("StreamingDataPollingPeriod", 20);
     ASSERT_NO_THROW(nativeStreamingServerModule.createServer(nativeStreamingServerType.getId(),
                                                              device,
                                                              nativeStreamingConfig));

--- a/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
+++ b/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
@@ -69,7 +69,7 @@ protected:
     std::thread readThread;
     std::atomic<bool> readThreadActive;
     std::chrono::milliseconds readThreadSleepTime;
-    std::vector<std::pair<SignalPtr, PacketReaderPtr>> signalReaders;
+    std::vector<std::tuple<SignalPtr, std::string, PacketReaderPtr>> signalReaders;
 
     std::shared_ptr<boost::asio::io_context> transportIOContextPtr;
     std::thread transportThread;

--- a/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
+++ b/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
@@ -64,6 +64,8 @@ NativeStreamingServerImpl::NativeStreamingServerImpl(const DevicePtr& rootDevice
 
     this->context.getOnCoreEvent() += event(&NativeStreamingServerImpl::coreEventCallback);
 
+    const uint16_t pollingPeriod = config.getPropertyValue("StreamingDataPollingPeriod");
+    readThreadSleepTime = std::chrono::milliseconds(pollingPeriod);
     startReading();
 }
 
@@ -369,6 +371,15 @@ PropertyObjectPtr NativeStreamingServerImpl::createDefaultConfig(const ContextPt
                                                 .setMinValue(0)
                                                 .build();
     defaultConfig.addProperty(configConnectionsLimitProp);
+
+    const auto pollingPeriodProp = IntPropertyBuilder("StreamingDataPollingPeriod", 20)
+                                       .setMinValue(1)
+                                       .setMaxValue(65535)
+                                       .setDescription("Polling period in milliseconds "
+                                                       "which specifies how often the server collects and sends "
+                                                       "subscribed signals' data to clients")
+                                       .build();
+    defaultConfig.addProperty(pollingPeriodProp);
 
     const auto streamingPacketSendTimeoutPropDescription =
         "Defines the timeout for sending streaming packets, measured in milliseconds. "

--- a/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
+++ b/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
@@ -454,15 +454,16 @@ void NativeStreamingServerImpl::startReadThread()
         {
             std::scoped_lock lock(readersSync);
 
-#if 0
+#if 1
             bool hasPacketsToSend = false;
             for (const auto& [_, signalGlobalId, reader] : signalReaders)
             {
-                auto packets = reader.readAll();
-                if (!packets.empty())
+                PacketPtr packet = reader.read();
+                while (packet.assigned())
                 {
-                    serverHandler->processStreamingPackets(signalGlobalId, std::move(packets));
                     hasPacketsToSend = true;
+                    serverHandler->processStreamingPacket(signalGlobalId, std::move(packet));
+                    packet = reader.read();
                 }
             }
             if (hasPacketsToSend)

--- a/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
+++ b/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
@@ -465,7 +465,6 @@ void NativeStreamingServerImpl::startReadThread()
         {
             std::scoped_lock lock(readersSync);
 
-#if 1
             bool hasPacketsToSend = false;
             for (const auto& [_, signalGlobalId, reader] : signalReaders)
             {
@@ -479,19 +478,6 @@ void NativeStreamingServerImpl::startReadThread()
             }
             if (hasPacketsToSend)
                 serverHandler->scheduleStreamingWriteTasks();
-#else
-            for (const auto& [_, signalGlobalId, reader] : signalReaders)
-            {
-                {
-                    PacketPtr packet = reader.read();
-                    while (packet.assigned())
-                    {
-                        serverHandler->sendPacket(signalGlobalId, std::move(packet));
-                        packet = reader.read();
-                    }
-                }
-            }
-#endif
         }
 
         std::this_thread::sleep_for(readThreadSleepTime);

--- a/modules/native_streaming_server_module/tests/test_native_streaming_server_module.cpp
+++ b/modules/native_streaming_server_module/tests/test_native_streaming_server_module.cpp
@@ -155,6 +155,9 @@ TEST_F(NativeStreamingServerModuleTest, ServerConfig)
 
     ASSERT_TRUE(config.hasProperty("StreamingPacketSendTimeout"));
     ASSERT_EQ(config.getPropertyValue("StreamingPacketSendTimeout"), 0);
+
+    ASSERT_TRUE(config.hasProperty("StreamingDataPollingPeriod"));
+    ASSERT_EQ(config.getPropertyValue("StreamingDataPollingPeriod"), 20);
 }
 
 TEST_F(NativeStreamingServerModuleTest, CreateServer)

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/base_session_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/base_session_handler.h
@@ -44,6 +44,7 @@ public:
     const SessionPtr getSession() const;
     void sendConfigurationPacket(const config_protocol::PacketBuffer& packet);
     void sendPacketBuffer(packet_streaming::PacketBufferPtr&& packetBuffer);
+    void sendPacketBuffers(std::vector<packet_streaming::PacketBufferPtr>&& packetBuffers);
 
     void setConfigPacketReceivedHandler(const ProcessConfigProtocolPacketCb& configPacketReceivedHandler);
     void setPacketBufferReceivedHandler(const OnPacketBufferReceivedCallback& packetBufferReceivedHandler);
@@ -59,9 +60,9 @@ protected:
     daq::native_streaming::ReadTask createReadStopTask();
     daq::native_streaming::ReadTask discardPayload(const void* data, size_t size);
 
-    size_t calculatePayloadSize(const std::vector<daq::native_streaming::WriteTask>& writePayloadTasks);
-    daq::native_streaming::WriteTask createWriteHeaderTask(PayloadType payloadType, size_t payloadSize);
-    daq::native_streaming::WriteTask createWriteStringTask(const std::string& str);
+    static size_t calculatePayloadSize(const std::vector<daq::native_streaming::WriteTask>& writePayloadTasks);
+    static daq::native_streaming::WriteTask createWriteHeaderTask(PayloadType payloadType, size_t payloadSize);
+    static daq::native_streaming::WriteTask createWriteStringTask(const std::string& str);
 
     template<typename T>
     daq::native_streaming::WriteTask createWriteNumberTask(const T& value)
@@ -73,7 +74,9 @@ protected:
     }
 
     static void copyData(void* destination, const void* source, size_t bytesToCopy, size_t sourceOffset, size_t sourceSize);
-    static std::string getStringFromData(const void *source, size_t stringSize, size_t sourceOffset, size_t sourceSize);
+    static std::string getStringFromData(const void* source, size_t stringSize, size_t sourceOffset, size_t sourceSize);
+    static void createAndPushPacketBufferTasks(packet_streaming::PacketBufferPtr&& packetBuffer,
+                                               std::vector<daq::native_streaming::WriteTask>& tasks);
 
     SessionPtr session;
     ProcessConfigProtocolPacketCb configPacketReceivedHandler;

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/base_session_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/base_session_handler.h
@@ -44,7 +44,11 @@ public:
     const SessionPtr getSession() const;
     void sendConfigurationPacket(const config_protocol::PacketBuffer& packet);
     void sendPacketBuffer(packet_streaming::PacketBufferPtr&& packetBuffer);
-    void sendPacketBuffers(std::vector<packet_streaming::PacketBufferPtr>&& packetBuffers);
+
+    void schedulePacketBufferWriteTasks(std::vector<daq::native_streaming::WriteTask>&& tasks,
+                                        std::optional<std::chrono::steady_clock::time_point>&& timeStamp);
+    static void createAndPushPacketBufferTasks(packet_streaming::PacketBufferPtr&& packetBuffer,
+                                               std::vector<daq::native_streaming::WriteTask>& tasks);
 
     void setConfigPacketReceivedHandler(const ProcessConfigProtocolPacketCb& configPacketReceivedHandler);
     void setPacketBufferReceivedHandler(const OnPacketBufferReceivedCallback& packetBufferReceivedHandler);
@@ -75,8 +79,6 @@ protected:
 
     static void copyData(void* destination, const void* source, size_t bytesToCopy, size_t sourceOffset, size_t sourceSize);
     static std::string getStringFromData(const void* source, size_t stringSize, size_t sourceOffset, size_t sourceSize);
-    static void createAndPushPacketBufferTasks(packet_streaming::PacketBufferPtr&& packetBuffer,
-                                               std::vector<daq::native_streaming::WriteTask>& tasks);
 
     SessionPtr session;
     ProcessConfigProtocolPacketCb configPacketReceivedHandler;

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
@@ -56,6 +56,8 @@ public:
     void removeComponentSignals(const StringPtr& componentId);
 
     void sendPacket(const SignalPtr& signal, PacketPtr&& packet);
+    void sendPackets(const SignalPtr& signal, ListPtr<IPacket>&& packet);
+    void sendAllPackets(DictPtr<ISignal, ListPtr<IPacket>>&& allPackets);
 
 protected:
     void initSessionHandler(SessionPtr session);

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
@@ -56,7 +56,7 @@ public:
     void removeComponentSignals(const StringPtr& componentId);
 
     void sendPacket(const std::string& signalId, PacketPtr&& packet);
-    void processStreamingPackets(const std::string& signalId, ListPtr<IPacket>&& packets);
+    void processStreamingPacket(const std::string& signalId, PacketPtr&& packet);
     void scheduleStreamingWriteTasks();
 
 protected:

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
@@ -56,8 +56,8 @@ public:
     void removeComponentSignals(const StringPtr& componentId);
 
     void sendPacket(const SignalPtr& signal, PacketPtr&& packet);
-    void sendPackets(const SignalPtr& signal, ListPtr<IPacket>&& packet);
-    void sendAllPackets(DictPtr<ISignal, ListPtr<IPacket>>&& allPackets);
+    void processStreamingPackets(const std::string& signalId, ListPtr<IPacket>&& packets);
+    void scheduleStreamingWriteTasks();
 
 protected:
     void initSessionHandler(SessionPtr session);

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_server_handler.h
@@ -55,7 +55,7 @@ public:
     void addSignal(const SignalPtr& signal);
     void removeComponentSignals(const StringPtr& componentId);
 
-    void sendPacket(const SignalPtr& signal, PacketPtr&& packet);
+    void sendPacket(const std::string& signalId, PacketPtr&& packet);
     void processStreamingPackets(const std::string& signalId, ListPtr<IPacket>&& packets);
     void scheduleStreamingWriteTasks();
 

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
@@ -47,7 +47,7 @@ public:
                                  PacketPtr&& packet,
                                  const ConsumePacketBufferCallback& consumePacketBufferCb);
 
-    void processPackets(const std::string& signalStringId, ListPtr<IPacket>&& packets);
+    void processPacket(const std::string& signalStringId, PacketPtr&& packet);
 
     void consumeAllPacketBuffers(const std::string& clientId,
                                  std::vector<daq::native_streaming::WriteTask>& tasks,

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
@@ -30,6 +30,8 @@ BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL
 
 using SendPacketBufferCallback = std::function<void(const std::string& subscribedClientId,
                                                     packet_streaming::PacketBufferPtr&& packetBuffer)>;
+using SendPacketBuffersCallback = std::function<void(const std::string& subscribedClientId,
+                                                     std::vector<packet_streaming::PacketBufferPtr>&& packetBuffers)>;
 
 class StreamingManager
 {
@@ -46,6 +48,10 @@ public:
     void sendPacketToSubscribers(const std::string& signalStringId,
                                  PacketPtr&& packet,
                                  const SendPacketBufferCallback& sendPacketBufferCb);
+
+    void sendPacketsToSubscribers(const std::string& signalStringId,
+                                  ListPtr<IPacket>&& packets,
+                                  const SendPacketBuffersCallback& sendPacketBuffersCb);
 
     /// Registers a signal using its global ID as a unique key
     /// and assigns a numeric ID to it.
@@ -131,6 +137,11 @@ private:
                        PacketPtr&& packet,
                        const std::string& clientId,
                        SignalNumericIdType singalNumericId);
+    void sendDaqPackets(const SendPacketBuffersCallback& sendPacketBuffersCb,
+                        const PacketStreamingServerPtr& packetStreamingServerPtr,
+                        ListPtr<IPacket>&& packets,
+                        const std::string& clientId,
+                        SignalNumericIdType singalNumericId);
 
     bool removeSignalSubscriberNoLock(const std::string& signalStringId, const std::string& subscribedClientId);
 

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
@@ -226,13 +226,11 @@ bool NativeStreamingServerHandler::onAuthenticate(const daq::native_streaming::A
     return false;
 }
 
-void NativeStreamingServerHandler::sendPacket(const SignalPtr& signal, PacketPtr&& packet)
+void NativeStreamingServerHandler::sendPacket(const std::string& signalId, PacketPtr&& packet)
 {
-    const auto signalStringId = signal.getGlobalId().toStdString();
-
     // The lambda passed as a parameter will be invoked immediately, making it safe to directly capture this
     streamingManager.sendPacketToSubscribers(
-        signalStringId,
+        signalId,
         std::move(packet),
         [this](const std::string& subscribedClientId, packet_streaming::PacketBufferPtr&& packetBuffer)
         {

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
@@ -239,9 +239,9 @@ void NativeStreamingServerHandler::sendPacket(const std::string& signalId, Packe
     );
 }
 
-void NativeStreamingServerHandler::processStreamingPackets(const std::string& signalId, ListPtr<IPacket>&& packets)
+void NativeStreamingServerHandler::processStreamingPacket(const std::string& signalId, PacketPtr&& packet)
 {
-    streamingManager.processPackets(signalId, std::move(packets));
+    streamingManager.processPacket(signalId, std::move(packet));
 }
 
 void NativeStreamingServerHandler::scheduleStreamingWriteTasks()

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -106,7 +106,6 @@ void StreamingManager::consumeAllPacketBuffers(const std::string& clientId,
 
     if (const auto it = streamingClientsIds.find(clientId); it != streamingClientsIds.end())
     {
-        bool result = false;
         auto& packetStreamingServerPtr = packetStreamingServers.at(clientId);
         tasks.reserve(3 * packetStreamingServerPtr->getAvailableBuffersCount());
 

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -107,7 +107,7 @@ void StreamingManager::consumeAllPacketBuffers(const std::string& clientId,
     if (const auto it = streamingClientsIds.find(clientId); it != streamingClientsIds.end())
     {
         auto& packetStreamingServerPtr = packetStreamingServers.at(clientId);
-        tasks.reserve(3 * packetStreamingServerPtr->getAvailableBuffersCount());
+        tasks.reserve(2 * packetStreamingServerPtr->getAvailableBuffersCount());
 
         while (auto packetBuffer = packetStreamingServerPtr->getNextPacketBuffer())
         {

--- a/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
@@ -143,7 +143,7 @@ public:
         {
             // called only when signal first time subscribed by any client
             if (initialEventPacket.assigned())
-                serverHandler->sendPacket(signal, initialEventPacket);
+                serverHandler->sendPacket(signal.getGlobalId().toStdString(), initialEventPacket);
             signalSubscribedPromise.set_value(signal);
         };
 
@@ -605,7 +605,7 @@ TEST_P(StreamingProtocolTest, InitialEventPacketPostSubscribe)
 
     ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
 
-    serverHandler->sendPacket(serverSignal, firstEventPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), firstEventPacket);
     for (auto& client : clients)
     {
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
@@ -639,7 +639,7 @@ TEST_P(StreamingProtocolTest, SendEventPacket)
 
     ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
 
-    serverHandler->sendPacket(serverSignal, firstEventPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), firstEventPacket);
     for (auto& client : clients)
     {
         ASSERT_EQ(client.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
@@ -654,7 +654,7 @@ TEST_P(StreamingProtocolTest, SendEventPacket)
 
     const auto newValueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Binary).build();
     auto secondEventPacket = DataDescriptorChangedEventPacket(newValueDescriptor, nullptr);
-    serverHandler->sendPacket(serverSignal, secondEventPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), secondEventPacket);
 
     for (auto& client : clients)
     {
@@ -682,7 +682,7 @@ TEST_P(StreamingProtocolTest, SendPacketsNoSubscribers)
     }
 
     auto serverDataPacket = DataPacket(valueDescriptor, 100);
-    serverHandler->sendPacket(serverSignal, serverDataPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), serverDataPacket);
 
     // no subscribers - so packets wont be sent to clients
     for (auto& client : clients)
@@ -728,7 +728,7 @@ TEST_P(StreamingProtocolTest, SendDataPacket)
         client.packetReceivedFuture = client.packetReceivedPromise.get_future();
     }
 
-    serverHandler->sendPacket(serverSignal, serverDataPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), serverDataPacket);
     for (auto& client : clients)
     {
         // wait for data packet

--- a/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
@@ -739,7 +739,7 @@ TEST_P(StreamingProtocolTest, SendDataPacket)
     }
 }
 
-TEST_P(StreamingProtocolTest, SendMultiplePackets)
+TEST_P(StreamingProtocolTest, SendMultipleDataPackets)
 {
     const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
     auto serverEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, NullDataDescriptor());

--- a/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming_server.h
+++ b/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming_server.h
@@ -43,6 +43,7 @@ public:
     void addDaqPacket(const uint32_t signalId, const PacketPtr& packet);
     void addDaqPacket(const uint32_t signalId, PacketPtr&& packet);
     PacketBufferPtr getNextPacketBuffer();
+    size_t getAvailableBuffersCount();
 
     void checkAndSendReleasePacket(bool force);
     void addAlreadySentPacket(uint32_t signalId, Int packetId, Int domainPacketId, bool markForRelease);

--- a/shared/libraries/packet_streaming/src/packet_streaming_server.cpp
+++ b/shared/libraries/packet_streaming/src/packet_streaming_server.cpp
@@ -64,6 +64,11 @@ PacketBufferPtr PacketStreamingServer::getNextPacketBuffer()
     return nullptr;
 }
 
+size_t PacketStreamingServer::getAvailableBuffersCount()
+{
+    return queue.size();
+}
+
 void PacketStreamingServer::addEventPacket(const uint32_t signalId, const EventPacketPtr& packet)
 {
     const auto packetHeader = new GenericPacketHeader();


### PR DESCRIPTION
# Brief
Native streaming packet transmitting performance optimizations

# Description
Optimizes native streaming packet transmitting by:
* merging transport header write task and packet buffer header write task into single task with common contiguous buffer
* writing all available packet buffers per each connected client within a single transport operation

# Usage example
None

# API changes
None

# Required application changes
None

# Required module changes
None