### PR TITLE
Support  handling Query Multicast in mDNS

### DIFF
--- a/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
+++ b/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
@@ -999,6 +999,39 @@ inline void MDNSDiscoveryClient::sendDiscoveryQuery()
 
     std::vector<int> sockets;
     openClientSockets(sockets);
+
+    {
+        struct sockaddr_in sock_addr;
+        memset(&sock_addr, 0, sizeof(struct sockaddr_in));
+        sock_addr.sin_family = AF_INET;
+#ifdef _WIN32
+        sock_addr.sin_addr = in4addr_any;
+#else
+        sock_addr.sin_addr.s_addr = INADDR_ANY;
+#endif
+        sock_addr.sin_port = htons(MDNS_PORT);
+#ifdef __APPLE__
+        sock_addr.sin_len = sizeof(struct sockaddr_in);
+#endif
+        int sock = mdns_socket_open_ipv4(&sock_addr);
+        if (sock >= 0)
+            sockets.push_back(sock);
+    }
+        
+    {
+        struct sockaddr_in6 sock_addr;
+        memset(&sock_addr, 0, sizeof(struct sockaddr_in6));
+        sock_addr.sin6_family = AF_INET6;
+        sock_addr.sin6_addr = in6addr_any;
+        sock_addr.sin6_port = htons(MDNS_PORT);
+#ifdef __APPLE__
+        sock_addr.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+        int sock = mdns_socket_open_ipv6(&sock_addr);
+        if (sock >= 0)
+            sockets.push_back(sock);
+	}
+
     if (sockets.empty())
         throw std::runtime_error("Failed to open sockets");
 


### PR DESCRIPTION
# Brief

RFC 6762 §5.4 states that a server can respond to an mDNS unicast query with a multicast response, which was not handled in the OpenDAQ wrapper for mDNS. As a result, OpenDAQ could not discover devices using the Avahi server.

This fix resolves the issue by sending the request not only to the network interfaces but also to mDNS itself, allowing it to receive the response correctly.


# Description

(Individual high-level changes)

- Add Python GUI Demo functionality
- Rename a function
- ...

# Usage example
None

# API changes
None

# Required application changes
None

# Required module changes
None
