### PR TITLE
TBBAS-2071 Setting Number of Channels for Reference Device

### DIFF
--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -292,7 +292,12 @@ void RefDeviceImpl::initProperties(const PropertyObjectPtr& config)
     if (numberOfChannels < 1 || numberOfChannels > 4096)
         throw InvalidParameterException("Invalid number of channels");
 
-    objPtr.addProperty(IntProperty("NumberOfChannels", numberOfChannels));
+    auto numberOfChannelsProp = IntPropertyBuilder("NumberOfChannels", numberOfChannels)
+                                    .setMinValue(1)
+                                    .setMaxValue(4096)
+                                    .build();
+
+    objPtr.addProperty(numberOfChannelsProp);
     objPtr.getOnPropertyValueWrite("NumberOfChannels") +=
         [this](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& args) { updateNumberOfChannels(); };
 


### PR DESCRIPTION
# Brief

Bounds property to min/max values

# Description

Channel numbers now could be only between 1 and 4096