### PR TITLE
<TBBAS-2120> Add cmake option to disable access control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ option(OPENDAQ_THREAD_SAFE "Enable thread-safe implementations where available" 
 option(OPENDAQ_MIMALLOC_SUPPORT "Enable MiMalloc-based packet allocator" OFF)
 option(OPENDAQ_ENABLE_NATIVE_STREAMING "Enable ${SDK_NAME} native streaming" OFF)
 option(OPENDAQ_ALWAYS_FETCH_DEPENDENCIES "Ignore any installed libraries and always build all dependencies from source" ON)
+option(OPENDAQ_ENABLE_ACCESS_CONTROL "Enable object-level access control" ON)
 
 option(OPENDAQ_ENABLE_OPCUA "Enable OpcUa" OFF)
 cmake_dependent_option(OPCUA_ENABLE_ENCRYPTION "Enable OpcUa encryption" OFF "OPENDAQ_ENABLE_OPCUA" OFF)
@@ -658,6 +659,13 @@ if (OPENDAQ_ENABLE_NATIVE_STREAMING)
     add_compile_definitions(OPENDAQ_ENABLE_NATIVE_STREAMING)
 else()
     message(STATUS "Native streaming disabled")
+endif()
+
+if (OPENDAQ_ENABLE_ACCESS_CONTROL)
+    message(STATUS "Access control enabled")
+    add_compile_definitions(OPENDAQ_ENABLE_ACCESS_CONTROL)
+else()
+    message(STATUS "Access control disabled")
 endif()
 
 use_compiler_cache()

--- a/core/coreobjects/include/coreobjects/permission_manager.h
+++ b/core/coreobjects/include/coreobjects/permission_manager.h
@@ -59,4 +59,12 @@ DECLARE_OPENDAQ_INTERFACE(IPermissionManager, IBaseObject)
  */
 OPENDAQ_DECLARE_CLASS_FACTORY(LIBRARY_FACTORY, PermissionManager, IPermissionManager*, parent)
 
+/*!
+ * @brief Creates a permission manager which never restricts any access to any object.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(LIBRARY_FACTORY,
+                                                            DisabledPermissionManager,
+                                                            IPermissionManager,
+                                                            createDisabledPermissionManager)
+
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/permission_manager_factory.h
+++ b/core/coreobjects/include/coreobjects/permission_manager_factory.h
@@ -43,6 +43,15 @@ inline PermissionManagerPtr PermissionManager(const PermissionManagerPtr& parent
     return obj;
 }
 
+/*!
+ * @brief Creates a permission manager which never restricts any access to any object.
+ */
+inline PermissionManagerPtr DisabledPermissionManager()
+{
+    PermissionManagerPtr obj(DisabledPermissionManager_Create());
+    return obj;
+}
+
 /*!@}*/
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/permission_manager_impl.h
+++ b/core/coreobjects/include/coreobjects/permission_manager_impl.h
@@ -25,6 +25,8 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
+// PermissionManagerImpl
+
 class PermissionManagerImpl : public ImplementationOfWeak<IPermissionManager, IPermissionManagerInternal, ICloneable>
 {
 public:
@@ -50,6 +52,25 @@ private:
     std::unordered_set<IPermissionManager*> children;
     PermissionsPtr permissions;
     PermissionsPtr localPermissions;
+};
+
+// DisabledPermissionManagerImpl
+
+class DisabledPermissionManagerImpl : public ImplementationOfWeak<IPermissionManager, IPermissionManagerInternal, ICloneable>
+{
+public:
+    explicit DisabledPermissionManagerImpl();
+
+    ErrCode INTERFACE_FUNC setPermissions(IPermissions* permissions) override;
+    ErrCode INTERFACE_FUNC isAuthorized(IUser* user, Permission permission, Bool* authorizedOut) override;
+    ErrCode INTERFACE_FUNC clone(IBaseObject** cloneOut) override;
+
+protected:
+    ErrCode INTERFACE_FUNC setParent(IPermissionManager* parentManager) override;
+    ErrCode INTERFACE_FUNC addChildManager(IPermissionManager* childManager) override;
+    ErrCode INTERFACE_FUNC removeChildManager(IPermissionManager* childManager) override;
+    ErrCode INTERFACE_FUNC getPermissions(IPermissions** permisisonConfigOut) override;
+    ErrCode INTERFACE_FUNC updateInheritedPermissions() override;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -306,11 +306,15 @@ public:
 
     void initDefaultPermissionManager()
     {
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
         const auto defaultPermissions =
             PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
 
         defaultPermissionManager = PermissionManager();
         defaultPermissionManager.setPermissions(defaultPermissions);
+#else
+        defaultPermissionManager = DisabledPermissionManager();
+#endif
     }
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -495,15 +495,19 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
     , updateCount(0)
     , coreEventMuted(true)
     , path("")
-    , permissionManager(PermissionManager())
     , className(nullptr)
     , objectClass(nullptr)
 {
     this->internalAddRef();
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
 
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
+    this->permissionManager = PermissionManager();
     this->permissionManager.setPermissions(
         PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build());
+#else
+    this->permissionManager = DisabledPermissionManager();
+#endif
 }
 
 template <typename PropObjInterface, typename... Interfaces>

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -9,6 +9,8 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
+// PermissionManagerImpl
+
 PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent)
     : permissions(PermissionsBuilder().inherit(true).build())
     , localPermissions(PermissionsBuilder().inherit(true).build())
@@ -157,8 +159,63 @@ PermissionManagerInternalPtr PermissionManagerImpl::getParentManager()
     return parent.getRef().asPtr<IPermissionManagerInternal>();
 }
 
-// Factory
+// DisabledPermissionManagerImpl
+
+DisabledPermissionManagerImpl::DisabledPermissionManagerImpl()
+{
+}
+
+ErrCode DisabledPermissionManagerImpl::setPermissions(IPermissions* permissions)
+{
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DisabledPermissionManagerImpl::isAuthorized(IUser* user, Permission permission, Bool* authorizedOut)
+{
+    OPENDAQ_PARAM_NOT_NULL(authorizedOut);
+    *authorizedOut = true;
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DisabledPermissionManagerImpl::clone(IBaseObject** cloneOut)
+{
+    auto manager = DisabledPermissionManager();
+    *cloneOut = manager.addRefAndReturn();
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DisabledPermissionManagerImpl::setParent(IPermissionManager* parentManager)
+{
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DisabledPermissionManagerImpl::addChildManager(IPermissionManager* childManager)
+{
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DisabledPermissionManagerImpl::removeChildManager(IPermissionManager* childManager)
+{
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DisabledPermissionManagerImpl::getPermissions(IPermissions** permisisonConfigOut)
+{
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode DisabledPermissionManagerImpl::updateInheritedPermissions()
+{
+    return OPENDAQ_SUCCESS;
+}
+
+// Factories
 
 OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, PermissionManager, IPermissionManager*, parent)
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(LIBRARY_FACTORY,
+                                                               DisabledPermissionManagerImpl,
+                                                               IPermissionManager,
+                                                               createDisabledPermissionManager)
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/tests/test_permission_manager.cpp
+++ b/core/coreobjects/tests/test_permission_manager.cpp
@@ -279,3 +279,18 @@ TEST_F(PermissionManagerTest, AssignAddPermission)
     ASSERT_TRUE(manager.isAuthorized(admin, Permission::Execute));
 }
 
+TEST_F(PermissionManagerTest, CreateDisabledPermissionManager)
+{
+    auto admin = User("admin", "password", List<IString>("admin"));
+
+    auto permissionManager = DisabledPermissionManager();
+    permissionManager.setPermissions(nullptr);
+
+    ASSERT_TRUE(permissionManager.isAuthorized(admin, Permission::Read));
+    ASSERT_TRUE(permissionManager.isAuthorized(admin, Permission::Write));
+    ASSERT_TRUE(permissionManager.isAuthorized(admin, Permission::Execute));
+
+    ASSERT_TRUE(permissionManager.isAuthorized(nullptr, Permission::Read));
+    ASSERT_TRUE(permissionManager.isAuthorized(nullptr, Permission::Write));
+    ASSERT_TRUE(permissionManager.isAuthorized(nullptr, Permission::Execute));
+}

--- a/core/opendaq/opendaq/tests/CMakeLists.txt
+++ b/core/opendaq/opendaq/tests/CMakeLists.txt
@@ -9,10 +9,13 @@ set(TEST_SOURCES test_factories.cpp
                  test_instance.cpp
                  test_core_events.cpp
                  test_config_provider.cpp
-                 test_access_control.cpp
                  test_module_callbacks.cpp
                  ${TEST_HEADERS}
 )
+
+if (OPENDAQ_ENABLE_ACCESS_CONTROL)
+    list(APPEND TEST_SOURCES test_access_control.cpp)
+endif()
 
 opendaq_prepare_test_runner(TEST_APP FOR ${MODULE_NAME}
                        SOURCES

--- a/docs/tests/CMakeLists.txt
+++ b/docs/tests/CMakeLists.txt
@@ -17,11 +17,14 @@ set(TEST_SOURCES docs_test_helpers.h
                  test_config_provider.cpp
                  test_get_last_value.cpp
                  test_howto_configure_instance.cpp
-                 test_howto_access_control.cpp
 )
 
 if (OPENDAQ_ENABLE_NATIVE_STREAMING AND OPENDAQ_ENABLE_WEBSOCKET_STREAMING)
     list(APPEND TEST_SOURCES test_streaming_config.cpp)
+endif()
+
+if (OPENDAQ_ENABLE_ACCESS_CONTROL)
+    list(APPEND TEST_SOURCES test_howto_access_control.cpp)
 endif()
 
 add_executable(${TEST_APP} ${TEST_SOURCES}

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -454,7 +454,12 @@ TEST_F(NativeDeviceModulesTest, PartialSerialization)
     ASSERT_TRUE(device.assigned());
 
     auto clientChannels = device.getChannelsRecursive();
+
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
     ASSERT_EQ(clientChannels.getCount(), 1u);
+#else
+    ASSERT_EQ(clientChannels.getCount(), 2u);
+#endif
 }
 
 TEST_F(NativeDeviceModulesTest, PartialSerializationPropertyObjectClass)

--- a/modules/tests/test_opendaq_device_modules/test_native_streaming_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_streaming_modules.cpp
@@ -654,9 +654,14 @@ TEST_F(NativeStreamingModulesTest, ProtectedSignals)
     {
         auto client = CreateClientInstance("opendaq", "opendaq");
         auto clientSignals = client.getSignalsRecursive(search::Any());
+
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
         ASSERT_EQ(clientSignals.getCount(), 2u);
         ASSERT_EQ(clientSignals[0].getName(), "*local*Dev*RefDev1*IO*AI*RefCh1*Sig*AI1");
         ASSERT_EQ(clientSignals[1].getName(), "*local*Dev*RefDev1*IO*AI*RefCh1*Sig*AI1Time");
+#else
+        ASSERT_EQ(clientSignals.getCount(), 5u);
+#endif
     }
 }
 
@@ -678,7 +683,12 @@ TEST_F(NativeStreamingModulesTest, ProtectedSignalSubscribeDenied)
     test_helpers::setupSubscribeAckHandler(signalSubscribePromise, signalSubscribeFuture, signal);
 
     auto reader = daq::StreamReader<double, uint64_t>(signal, ReadTimeoutType::Any);
+
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
     ASSERT_FALSE(test_helpers::waitForAcknowledgement(signalSubscribeFuture, std::chrono::seconds(1)));
+#else
+    ASSERT_TRUE(test_helpers::waitForAcknowledgement(signalSubscribeFuture, std::chrono::seconds(1)));
+#endif
 }
 
 
@@ -742,5 +752,10 @@ TEST_F(NativeStreamingModulesTest, ProtectedSignalUnsubscribeDenied)
     test_helpers::setupUnsubscribeAckHandler(signalUnsubscribePromise, signalUnsubscribeFuture, signal);
 
     reader.release();
+
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
     ASSERT_FALSE(test_helpers::waitForAcknowledgement(signalUnsubscribeFuture, std::chrono::seconds(1)));
+#else
+    ASSERT_TRUE(test_helpers::waitForAcknowledgement(signalUnsubscribeFuture, std::chrono::seconds(1)));
+#endif
 }

--- a/shared/libraries/config_protocol/tests/CMakeLists.txt
+++ b/shared/libraries/config_protocol/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ set(BASE_NAME config_protocol)
 set(MODULE_NAME ${SDK_TARGET_NAME}_${BASE_NAME})
 set(TEST_APP test_${MODULE_NAME})
 
-add_executable(${TEST_APP}
+set(TEST_SOURCES
     test_config_packet.cpp
     test_config_client_server.cpp
     test_config_protocol_integration.cpp
@@ -18,6 +18,12 @@ add_executable(${TEST_APP}
     test_utils.h
     test_utils.cpp
 )
+
+if (OPENDAQ_ENABLE_ACCESS_CONTROL)
+    list(APPEND TEST_SOURCES test_config_protocol_access_control.cpp)
+endif()
+
+add_executable(${TEST_APP} ${TEST_SOURCES})
 
 target_link_libraries(${TEST_APP} PRIVATE
     ${SDK_TARGET_NAMESPACE}::${BASE_NAME}


### PR DESCRIPTION
# Brief

Add a CMake option to disable access control at compile time. Disabling access control can improve the startup performance of a device while its structure is being built.

# Usage example

In Cmake use `OPENDAQ_ENABLE_ACCESS_CONTROL=OFF` to disable access control. By default this option is set to `ON` to ensure backwards compatibility.

# Required application changes

By default, access control is enabled, so no integration changes are required. If you disable access control, the PermissionManager object will always allow unrestricted access to all users for all property objects.