### PR TITLE
Permission manager optimizations

### DIFF
--- a/core/coreobjects/include/coreobjects/permission_manager_impl.h
+++ b/core/coreobjects/include/coreobjects/permission_manager_impl.h
@@ -29,7 +29,6 @@ class PermissionManagerImpl : public ImplementationOfWeak<IPermissionManager, IP
 {
 public:
     explicit PermissionManagerImpl(const PermissionManagerPtr& parent);
-    explicit PermissionManagerImpl(const PermissionManagerPtr& parent, const PermissionsPtr& defaultPermissions);
     ~PermissionManagerImpl();
 
     ErrCode INTERFACE_FUNC setPermissions(IPermissions* permissions) override;

--- a/core/coreobjects/include/coreobjects/permission_manager_impl.h
+++ b/core/coreobjects/include/coreobjects/permission_manager_impl.h
@@ -29,6 +29,7 @@ class PermissionManagerImpl : public ImplementationOfWeak<IPermissionManager, IP
 {
 public:
     explicit PermissionManagerImpl(const PermissionManagerPtr& parent);
+    explicit PermissionManagerImpl(const PermissionManagerPtr& parent, const PermissionsPtr& defaultPermissions);
     ~PermissionManagerImpl();
 
     ErrCode INTERFACE_FUNC setPermissions(IPermissions* permissions) override;

--- a/core/coreobjects/include/coreobjects/permissions_builder_impl.h
+++ b/core/coreobjects/include/coreobjects/permissions_builder_impl.h
@@ -19,9 +19,9 @@
 #include <coreobjects/permissions_builder.h>
 #include <coreobjects/permissions_ptr.h>
 #include <coreobjects/permission_manager.h>
+#include <coreobjects/object_keys.h>
 
 BEGIN_NAMESPACE_OPENDAQ
-
 class PermissionsBuilderImpl : public ImplementationOf<IPermissionsBuilder>
 {
 public:
@@ -40,9 +40,10 @@ private:
     void deny(IString* groupId, Int permissionFlags);
 
     Bool inherited;
-    DictPtr<IString, Int> allowed;
-    DictPtr<IString, Int> denied;
-    DictPtr<IString, Int> assigned;
+    
+    std::unordered_map<StringPtr, Int, StringHash, StringEqualTo> allowed;
+    std::unordered_map<StringPtr, Int, StringHash, StringEqualTo> denied;
+    std::unordered_map<StringPtr, Int, StringHash, StringEqualTo> assigned;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/permissions_builder_impl.h
+++ b/core/coreobjects/include/coreobjects/permissions_builder_impl.h
@@ -39,6 +39,8 @@ private:
     void allow(IString* groupId, Int permissionFlags);
     void deny(IString* groupId, Int permissionFlags);
 
+    static void InsertOrReplace(const StringPtr& groupId, Int permissionFlag, std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& map);
+
     Bool inherited;
     
     std::unordered_map<StringPtr, Int, StringHash, StringEqualTo> allowed;

--- a/core/coreobjects/include/coreobjects/permissions_impl.h
+++ b/core/coreobjects/include/coreobjects/permissions_impl.h
@@ -40,7 +40,7 @@ public:
     ErrCode INTERFACE_FUNC getAssigned(IDict** permissions) override;
 
 private:
-    static void cloneDict(const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& dict, DictPtr<IString, Int>& target);
+    static void CopyToTarget(const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& dict, DictPtr<IString, Int>& target);
 
     Bool inherited;
     DictPtr<IString, Int> allowed;

--- a/core/coreobjects/include/coreobjects/permissions_impl.h
+++ b/core/coreobjects/include/coreobjects/permissions_impl.h
@@ -20,17 +20,17 @@
 #include <coretypes/dictobject_factory.h>
 #include <coreobjects/permissions_ptr.h>
 #include <coreobjects/permissions_internal.h>
+#include <coreobjects/object_keys.h>
 
 BEGIN_NAMESPACE_OPENDAQ
-
 class PermissionsImpl : public ImplementationOf<IPermissions, IPermissionsInternal>
 {
 public:
     explicit PermissionsImpl();
     explicit PermissionsImpl(Bool inherited,
-                             const DictPtr<IString, Int>& allowed,
-                             const DictPtr<IString, Int>& denied,
-                             const DictPtr<IString, Int>& assigned);
+                             const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& allowed,
+                             const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& denied,
+                             const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& assigned);
 
     ErrCode INTERFACE_FUNC getInherited(Bool* inherited) override;
     ErrCode INTERFACE_FUNC getAllowed(IDict** permissions) override;
@@ -40,7 +40,7 @@ public:
     ErrCode INTERFACE_FUNC getAssigned(IDict** permissions) override;
 
 private:
-    DictPtr<IString, Int> cloneDict(const DictPtr<IString, Int>& dict);
+    static void cloneDict(const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& dict, DictPtr<IString, Int>& target);
 
     Bool inherited;
     DictPtr<IString, Int> allowed;

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -68,7 +68,7 @@ namespace details
         return intfIdToCoreTypeMap.at(intfID);
     }
 
-    static const auto defaultPermissions =
+    static const auto DefaultPermissions =
         PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
 }
 
@@ -310,7 +310,7 @@ public:
     void initDefaultPermissionManager()
     {
         defaultPermissionManager = PermissionManager();
-        defaultPermissionManager.setPermissions(details::defaultPermissions);
+        defaultPermissionManager.setPermissions(details::DefaultPermissions);
     }
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -39,8 +39,10 @@
 #include <coreobjects/errors.h>
 #include <coreobjects/permission_mask_builder_factory.h>
 
-BEGIN_NAMESPACE_OPENDAQ
+// TODO: Add factory instead of impl include
+#include "permission_manager_impl.h"
 
+BEGIN_NAMESPACE_OPENDAQ
 namespace details
 {
     static const std::unordered_map<IntfID, CoreType> intfIdToCoreTypeMap = {
@@ -67,6 +69,9 @@ namespace details
 
         return intfIdToCoreTypeMap.at(intfID);
     }
+
+    static const auto defaultPermissions =
+        PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
 }
 
 class PropertyImpl : public ImplementationOf<IProperty, ISerializable, IPropertyInternal, IOwnable>
@@ -306,11 +311,7 @@ public:
 
     void initDefaultPermissionManager()
     {
-        const auto defaultPermissions =
-            PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
-
-        defaultPermissionManager = PermissionManager();
-        defaultPermissionManager.setPermissions(defaultPermissions);
+        defaultPermissionManager = createWithImplementation<IPermissionManager, PermissionManagerImpl>(nullptr, details::defaultPermissions);
     }
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -67,7 +67,10 @@ namespace details
 
         return intfIdToCoreTypeMap.at(intfID);
     }
+}
 
+namespace permissions
+{
     static const auto DefaultPermissions =
         PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
 }
@@ -82,8 +85,6 @@ protected:
         , readOnly(false)
     {
         propPtr = this->borrowPtr<PropertyPtr>();
-
-        initDefaultPermissionManager();
     }
 
 public:
@@ -117,7 +118,8 @@ public:
         propPtr = this->borrowPtr<PropertyPtr>();
         owner = nullptr;
 
-        initDefaultPermissionManager();
+        if (this->defaultValue.assigned() && this->defaultValue.supportsInterface<IPropertyObject>())
+            initDefaultPermissionManager();
         checkErrorInfo(validateDuringConstruction());
     }
 
@@ -220,6 +222,7 @@ public:
 
         if (this->defaultValue.assigned())
         {
+            initDefaultPermissionManager();
             auto defaultValueObj = this->defaultValue.asPtr<IPropertyObject>();
             defaultValueObj.getPermissionManager().asPtr<IPermissionManagerInternal>().setParent(this->defaultPermissionManager);
         }
@@ -310,7 +313,7 @@ public:
     void initDefaultPermissionManager()
     {
         defaultPermissionManager = PermissionManager();
-        defaultPermissionManager.setPermissions(details::DefaultPermissions);
+        defaultPermissionManager.setPermissions(permissions::DefaultPermissions);
     }
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -39,10 +39,8 @@
 #include <coreobjects/errors.h>
 #include <coreobjects/permission_mask_builder_factory.h>
 
-// TODO: Add factory instead of impl include
-#include "permission_manager_impl.h"
-
 BEGIN_NAMESPACE_OPENDAQ
+
 namespace details
 {
     static const std::unordered_map<IntfID, CoreType> intfIdToCoreTypeMap = {
@@ -311,7 +309,8 @@ public:
 
     void initDefaultPermissionManager()
     {
-        defaultPermissionManager = createWithImplementation<IPermissionManager, PermissionManagerImpl>(nullptr, details::defaultPermissions);
+        defaultPermissionManager = PermissionManager();
+        defaultPermissionManager.setPermissions(details::defaultPermissions);
     }
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -67,10 +67,10 @@ namespace object_utils
     };
 }
 
-namespace detail
+namespace permissions
 {
-static const auto DefaultPropertyObjectPermissions =
-    PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
+    static const auto DefaultPropertyObjectPermissions =
+        PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
 }
 
 class RecursiveConfigLockGuard : public std::enable_shared_from_this<RecursiveConfigLockGuard>
@@ -514,7 +514,7 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
     this->internalAddRef();
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
 
-    this->permissionManager.setPermissions(detail::DefaultPropertyObjectPermissions);
+    this->permissionManager.setPermissions(permissions::DefaultPropertyObjectPermissions);
 
     PropertyValueEventEmitter readEmitter;
     PropertyValueEventEmitter writeEmitter;

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -67,6 +67,12 @@ namespace object_utils
     };
 }
 
+namespace detail
+{
+static const auto DefaultPropertyObjectPermissions =
+    PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
+}
+
 class RecursiveConfigLockGuard : public std::enable_shared_from_this<RecursiveConfigLockGuard>
 {
 public:
@@ -508,8 +514,7 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
     this->internalAddRef();
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
 
-    this->permissionManager.setPermissions(
-        PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build());
+    this->permissionManager.setPermissions(detail::DefaultPropertyObjectPermissions);
 
     PropertyValueEventEmitter readEmitter;
     PropertyValueEventEmitter writeEmitter;

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -11,12 +11,12 @@ BEGIN_NAMESPACE_OPENDAQ
 
 namespace detail
 {
-    static const auto defaultPermissions = PermissionsBuilder().inherit(true).build();
+    static const auto DefaultPermissions = PermissionsBuilder().inherit(true).build();
 }
 
 PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent)
-    : permissions(detail::defaultPermissions)
-    , localPermissions(detail::defaultPermissions)
+    : permissions(detail::DefaultPermissions)
+    , localPermissions(detail::DefaultPermissions)
 {
     if (parent.assigned())
         setParent(parent);
@@ -95,7 +95,7 @@ ErrCode INTERFACE_FUNC PermissionManagerImpl::clone(IBaseObject** cloneOut)
 {
     PermissionManagerPtr cloneParent = getParentManager();
     auto manager = PermissionManager(cloneParent);
-    manager.setPermissions(PermissionsBuilder().inherit(localPermissions.getInherited()).extend(localPermissions).build());
+    manager.setPermissions(localPermissions);
     *cloneOut = manager.addRefAndReturn();
     return OPENDAQ_SUCCESS;
 }

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -9,16 +9,15 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent)
-    : permissions(PermissionsBuilder().inherit(true).build())
-    , localPermissions(PermissionsBuilder().inherit(true).build())
+namespace detail
 {
-    setParent(parent);
+    static const auto defaultPermissions = PermissionsBuilder().inherit(true).build();
 }
 
-PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent, const PermissionsPtr& defaultPermissions)
+PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent)
+    : permissions(detail::defaultPermissions)
+    , localPermissions(detail::defaultPermissions)
 {
-    localPermissions = defaultPermissions;
     if (parent.assigned())
         setParent(parent);
 }

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -16,6 +16,13 @@ PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent)
     setParent(parent);
 }
 
+PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent, const PermissionsPtr& defaultPermissions)
+{
+    localPermissions = defaultPermissions;
+    if (parent.assigned())
+        setParent(parent);
+}
+
 PermissionManagerImpl::~PermissionManagerImpl()
 {
     if (const auto parent = getParentManager(); parent.assigned())
@@ -28,19 +35,23 @@ PermissionManagerImpl::~PermissionManagerImpl()
 ErrCode INTERFACE_FUNC PermissionManagerImpl::setPermissions(IPermissions* permissions)
 {
     localPermissions = permissions;
-    auto builder = PermissionsBuilder();
 
     if (localPermissions.getInherited())
     {
+        auto builder = PermissionsBuilder();
         if (const auto parent = getParentManager(); parent.assigned())
         {
             const auto parentConfig = parent.getPermissions();
             builder.inherit(true).extend(parentConfig);
         }
-    }
 
-    builder.extend(localPermissions);
-    this->permissions = builder.build();
+        builder.extend(localPermissions);
+        this->permissions = builder.build();
+    }
+    else
+    {
+        this->permissions = localPermissions;
+    }
 
     updateChildPermissions();
     return OPENDAQ_SUCCESS;

--- a/core/coreobjects/src/permissions_builder_impl.cpp
+++ b/core/coreobjects/src/permissions_builder_impl.cpp
@@ -88,9 +88,10 @@ ErrCode INTERFACE_FUNC PermissionsBuilderImpl::build(IPermissions** configOut)
 void PermissionsBuilderImpl::assign(IString* groupId, Int permissionFlags)
 {
     StringPtr groupIdPtr = groupId;
-    assigned.insert(std::make_pair(groupIdPtr, permissionFlags));
-    allowed.insert(std::make_pair(groupIdPtr, permissionFlags));
-    denied.insert(std::make_pair(groupIdPtr, permissionFlags));
+
+    InsertOrReplace(groupIdPtr, permissionFlags, assigned);
+    InsertOrReplace(groupIdPtr, permissionFlags, allowed);
+    InsertOrReplace(groupIdPtr, 0, denied);
 }
 
 void PermissionsBuilderImpl::allow(IString* groupId, Int permissionFlags)
@@ -101,9 +102,9 @@ void PermissionsBuilderImpl::allow(IString* groupId, Int permissionFlags)
 
     allowMask |= permissionFlags;
     denyMask &= ~permissionFlags;
-
-    allowed.insert(std::make_pair(groupIdPtr, allowMask));
-    denied.insert(std::make_pair(groupIdPtr, denyMask));
+    
+    InsertOrReplace(groupIdPtr, denyMask, denied);
+    InsertOrReplace(groupIdPtr, allowMask, allowed);
 }
 
 void PermissionsBuilderImpl::deny(IString* groupId, Int permissionFlags)
@@ -114,9 +115,19 @@ void PermissionsBuilderImpl::deny(IString* groupId, Int permissionFlags)
 
     denyMask |= permissionFlags;
     allowMask &= ~permissionFlags;
-    
-    denied.insert(std::make_pair(groupIdPtr, denyMask));
-    allowed.insert(std::make_pair(groupIdPtr, allowMask));
+
+    InsertOrReplace(groupIdPtr, denyMask, denied);
+    InsertOrReplace(groupIdPtr, allowMask, allowed);
+}
+
+void PermissionsBuilderImpl::InsertOrReplace(const StringPtr& groupId,
+                                             Int permissionFlag,
+                                             std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& map)
+{
+    if (map.count(groupId))
+        map[groupId] = permissionFlag;
+    else
+        map.insert(std::make_pair(groupId, permissionFlag));
 }
 
 // Factory

--- a/core/coreobjects/src/permissions_builder_impl.cpp
+++ b/core/coreobjects/src/permissions_builder_impl.cpp
@@ -2,7 +2,6 @@
 #include <coretypes/validation.h>
 #include <coreobjects/permissions_impl.h>
 #include <coreobjects/permission_mask_builder_ptr.h>
-#include <coreobjects/permission_mask_builder_factory.h>
 #include <coreobjects/permissions_internal_ptr.h>
 
 BEGIN_NAMESPACE_OPENDAQ
@@ -24,7 +23,9 @@ ErrCode INTERFACE_FUNC PermissionsBuilderImpl::assign(IString* groupId, IPermiss
     OPENDAQ_PARAM_NOT_NULL(groupId);
 
     Int permissionFlags;
-    permissions->build(&permissionFlags);
+    ErrCode err = permissions->build(&permissionFlags);
+    if (OPENDAQ_FAILED(err))
+        return err;
 
     assign(groupId, permissionFlags);
     return OPENDAQ_SUCCESS;
@@ -36,7 +37,9 @@ ErrCode INTERFACE_FUNC PermissionsBuilderImpl::allow(IString* groupId, IPermissi
     OPENDAQ_PARAM_NOT_NULL(groupId);
 
     Int permissionFlags;
-    permissions->build(&permissionFlags);
+    ErrCode err = permissions->build(&permissionFlags);
+    if (OPENDAQ_FAILED(err))
+        return err;
 
     allow(groupId, permissionFlags);
     return OPENDAQ_SUCCESS;
@@ -48,7 +51,9 @@ ErrCode INTERFACE_FUNC PermissionsBuilderImpl::deny(IString* groupId, IPermissio
     OPENDAQ_PARAM_NOT_NULL(groupId);
 
     Int permissionFlags;
-    permissions->build(&permissionFlags);
+    ErrCode err = permissions->build(&permissionFlags);
+    if (OPENDAQ_FAILED(err))
+        return err;
 
     deny(groupId, permissionFlags);
     return OPENDAQ_SUCCESS;

--- a/core/coreobjects/src/permissions_impl.cpp
+++ b/core/coreobjects/src/permissions_impl.cpp
@@ -11,14 +11,17 @@ PermissionsImpl::PermissionsImpl()
 }
 
 PermissionsImpl::PermissionsImpl(Bool inherited,
-                                 const DictPtr<IString, Int>& allowed,
-                                 const DictPtr<IString, Int>& denied,
-                                 const DictPtr<IString, Int>& assigned)
+                                 const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& allowed,
+                                 const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& denied,
+                                 const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& assigned)
     : inherited(inherited)
-    , allowed(cloneDict(allowed))
-    , denied(cloneDict(denied))
-    , assigned(cloneDict(assigned))
+    , allowed(Dict<IString, Int>())
+    , denied(Dict<IString, Int>())
+    , assigned(Dict<IString, Int>())
 {
+    cloneDict(allowed, this->allowed);
+    cloneDict(denied, this->denied);
+    cloneDict(assigned, this->assigned);
 }
 
 ErrCode INTERFACE_FUNC PermissionsImpl::getInherited(Bool* inherited)
@@ -53,14 +56,10 @@ ErrCode INTERFACE_FUNC PermissionsImpl::getAssigned(IDict** permissions)
     return OPENDAQ_SUCCESS;
 }
 
-DictPtr<IString, Int> PermissionsImpl::cloneDict(const DictPtr<IString, Int>& dict)
+void PermissionsImpl::cloneDict(const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& dict, DictPtr<IString, Int>& target)
 {
-    auto clone = Dict<IString, Int>();
-
     for (const auto& [key, val] : dict)
-        clone.set(key, val);
-
-    return clone;
+        target.set(key, val);
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/src/permissions_impl.cpp
+++ b/core/coreobjects/src/permissions_impl.cpp
@@ -19,9 +19,9 @@ PermissionsImpl::PermissionsImpl(Bool inherited,
     , denied(Dict<IString, Int>())
     , assigned(Dict<IString, Int>())
 {
-    cloneDict(allowed, this->allowed);
-    cloneDict(denied, this->denied);
-    cloneDict(assigned, this->assigned);
+    CopyToTarget(allowed, this->allowed);
+    CopyToTarget(denied, this->denied);
+    CopyToTarget(assigned, this->assigned);
 }
 
 ErrCode INTERFACE_FUNC PermissionsImpl::getInherited(Bool* inherited)
@@ -56,7 +56,7 @@ ErrCode INTERFACE_FUNC PermissionsImpl::getAssigned(IDict** permissions)
     return OPENDAQ_SUCCESS;
 }
 
-void PermissionsImpl::cloneDict(const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& dict, DictPtr<IString, Int>& target)
+void PermissionsImpl::CopyToTarget(const std::unordered_map<StringPtr, Int, StringHash, StringEqualTo>& dict, DictPtr<IString, Int>& target)
 {
     for (const auto& [key, val] : dict)
         target.set(key, val);

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -58,7 +58,7 @@ BEGIN_NAMESPACE_OPENDAQ
 
 #define COMPONENT_AVAILABLE_ATTRIBUTES {"Name", "Description", "Visible", "Active"}
 
-namespace detail
+namespace permissions
 {
     static const auto DefaultComponentPermissions = PermissionsBuilder().inherit(true).build();
 }
@@ -253,7 +253,7 @@ ComponentImpl<Intf, Intfs...>::ComponentImpl(
 
     if (parent.assigned())
     {
-        this->permissionManager.setPermissions(detail::DefaultComponentPermissions);
+        this->permissionManager.setPermissions(permissions::DefaultComponentPermissions);
         const auto parentManager = parent.getPermissionManager();
         this->permissionManager.template asPtr<IPermissionManagerInternal>(true).setParent(parentManager);
     }

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -58,6 +58,11 @@ BEGIN_NAMESPACE_OPENDAQ
 
 #define COMPONENT_AVAILABLE_ATTRIBUTES {"Name", "Description", "Visible", "Active"}
 
+namespace detail
+{
+    static const auto DefaultComponentPermissions = PermissionsBuilder().inherit(true).build();
+}
+
 enum class ComponentStatus : EnumType
 {
     Ok = 0,
@@ -248,7 +253,7 @@ ComponentImpl<Intf, Intfs...>::ComponentImpl(
 
     if (parent.assigned())
     {
-        this->permissionManager.setPermissions(PermissionsBuilder().inherit(true).build());
+        this->permissionManager.setPermissions(detail::DefaultComponentPermissions);
         const auto parentManager = parent.getPermissionManager();
         this->permissionManager.template asPtr<IPermissionManagerInternal>(true).setParent(parentManager);
     }


### PR DESCRIPTION
# Brief

Set of permission manager optimizations that reduce the number of Dictionary object creations on `Property`/`PropertyObject` construction.

# Description

- Define static permission objects for default initializations of the permission managers of `PropertyObject`, `Property`, and Component
- Replace `PermissionBuilder` dictionaries with `std::map`
- Only create `PermissionManager` on `Property` creation when creating an object-type `Property`
