### PR TITLE
Add RPCs for handling nested function blocks

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -3,6 +3,7 @@
 ## Features
 
 - [#719](https://github.com/openDAQ/openDAQ/pull/719) Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).
+- [#718](https://github.com/openDAQ/openDAQ/pull/718) Adds new Native Configuration Protocol RPCs for handling sub-function blocks (function blocks that are children of other FBs.
 - [#642](https://github.com/openDAQ/openDAQ/pull/642) Introduces mechanisms to modify the IP configuration parameters of openDAQ-compatible devices.
 - [#638](https://github.com/openDAQ/openDAQ/pull/638) Adds a tick tolerance option to the `MultiReader`, allowing for the limitation of inter-sample offsets between read signals.
 - [#631](https://github.com/openDAQ/openDAQ/pull/631) "Any read/write" events are added to property object that are triggered whenever any of the object's property values are read or written.

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -136,7 +136,7 @@ TEST_F(NativeDeviceModulesTest, CheckProtocolVersion)
 
     auto info = client.getDevices()[0].getInfo();
     ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
-    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 8);
+    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 9);
 
     // because info holds a client device as owner, it have to be removed before module manager is destroyed
     // otherwise module of native client device would not be removed
@@ -3031,4 +3031,23 @@ TEST_F(NativeC2DStreamingTest, StreamingData)
     EXPECT_EQ(serverReceivedPackets.getCount(), packetsToRead);
     EXPECT_EQ(clientReceivedPackets.getCount(), packetsToRead);
     EXPECT_TRUE(test_helpers::packetsEqual(clientReceivedPackets, serverReceivedPackets));
+}
+
+TEST_F(NativeDeviceModulesTest, AddNestedFB)
+{
+    const auto server = CreateServerInstance();
+
+    const auto client = Instance();
+    auto dev = client.addDevice("daq.nd://127.0.0.1");
+    auto fb = dev.addFunctionBlock("RefFBModuleStatistics");
+
+    ASSERT_TRUE(fb.getAvailableFunctionBlockTypes().hasKey("RefFBModuleTrigger"));
+
+    FunctionBlockPtr nestedFb;
+    ASSERT_NO_THROW(nestedFb = fb.addFunctionBlock("RefFBModuleTrigger"));
+    ASSERT_TRUE(nestedFb.assigned());
+
+    ASSERT_NO_THROW(fb.removeFunctionBlock(nestedFb));
+    ASSERT_TRUE(nestedFb.isRemoved());
+    ASSERT_EQ(fb.getFunctionBlocks().getCount(), 0u);
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
@@ -179,12 +179,12 @@ public:
 
 inline std::set<uint16_t> GetSupportedConfigProtocolVersions()
 {
-    return {0, 1, 2, 3, 4, 5, 6, 7, 8};
+    return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 }
 
 inline constexpr uint16_t GetLatestConfigProtocolVersion()
 {
-    return 8; // *GetSupportedConfigProtocolVersions().rbegin();
+    return 9; // *GetSupportedConfigProtocolVersions().rbegin();
 }
 
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -79,12 +79,15 @@ public:
     bool isLocked(const std::string& globalId);
     void beginUpdate(const std::string& globalId, const std::string& path = "");
     void endUpdate(const std::string& globalId, const std::string& path = "", const ListPtr<IDict>& props = nullptr);
-    DictPtr<IString, IFunctionBlockType> getAvailableFunctionBlockTypes(const std::string& globalId);
+
+    DictPtr<IString, IFunctionBlockType> getAvailableFunctionBlockTypes(const std::string& globalId, bool isFb = false);
     ComponentHolderPtr addFunctionBlock(const std::string& globalId,
                                         const StringPtr& typeId,
                                         const PropertyObjectPtr& config = nullptr,
-                                        const ComponentPtr& parentComponent = nullptr);
-    void removeFunctionBlock(const std::string& globalId, const StringPtr& functionBlockLocalId);
+                                        const ComponentPtr& parentComponent = nullptr,
+                                        bool isFb = false);
+    void removeFunctionBlock(const std::string& globalId, const StringPtr& functionBlockLocalId, bool isFb = false);
+
     uint64_t getTicksSinceOrigin(const std::string& globalId);
     ListPtr<IDeviceInfo> getAvailableDevices(const std::string& globalId);
     DictPtr<IString, IDeviceType> getAvailableDeviceTypes(const std::string& globalId);

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
@@ -20,6 +20,9 @@
 #include <config_protocol/config_server_access_control.h>
 #include <opendaq/update_parameters_factory.h>
 
+#include "opendaq/component_holder_factory.h"
+#include "opendaq/search_filter_factory.h"
+
 namespace daq::config_protocol
 {
 
@@ -35,6 +38,9 @@ public:
     static BaseObjectPtr endUpdate(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr setAttributeValue(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr update(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
+    static BaseObjectPtr getAvailableFunctionBlockTypes(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
+    static BaseObjectPtr addFunctionBlock(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
+    static BaseObjectPtr removeFunctionBlock(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
 
 private:
     static void applyProps(uint16_t protocolVersion, const PropertyObjectPtr& obj, const ListPtr<IDict>& props);
@@ -280,5 +286,86 @@ inline void ConfigServerComponent::applyProps(uint16_t protocolVersion, const Pr
             obj.clearPropertyValue(name);
     }
 }
+
+inline BaseObjectPtr ConfigServerComponent::getAvailableFunctionBlockTypes(const RpcContext& context,
+                                                                           const ComponentPtr& component,
+                                                                           const ParamsDictPtr& /*params*/)
+{
+    ConfigServerAccessControl::protectObject(component, context.user, Permission::Read);
+
+    BaseObjectPtr fbTypes;
+    if (const auto device = component.asPtrOrNull<IDevice>(true); device.assigned())
+        fbTypes = device.getAvailableFunctionBlockTypes();
+    else if (const auto fb = component.asPtrOrNull<IFunctionBlock>(true); fb.assigned())
+        fbTypes = fb.getAvailableFunctionBlockTypes();
+    else
+        throw InvalidStateException("Component is not a device or function block");
+
+    return fbTypes;
+}
+
+inline BaseObjectPtr ConfigServerComponent::addFunctionBlock(const RpcContext& context,
+                                                             const ComponentPtr& component,
+                                                             const ParamsDictPtr& params)
+{
+    ConfigServerAccessControl::protectLockedComponent(component);
+    ConfigServerAccessControl::protectObject(component, context.user, {Permission::Read, Permission::Write});
+    ConfigServerAccessControl::protectViewOnlyConnection(context.connectionType);
+
+    const auto fbTypeId = params.get("TypeId");
+    PropertyObjectPtr config;
+    if (params.hasKey("Config"))
+        config = params.get("Config");
+
+    BaseObjectPtr fbNested;
+    if (const auto device = component.asPtrOrNull<IDevice>(true); device.assigned())
+        fbNested = device.addFunctionBlock(fbTypeId, config);
+    else if (const auto fb = component.asPtrOrNull<IFunctionBlock>(true); fb.assigned())
+        fbNested = fb.addFunctionBlock(fbTypeId, config);
+    else
+        throw InvalidStateException("Component is not a device or function block");
+
+    return ComponentHolder(fbNested);
+}
+
+inline BaseObjectPtr ConfigServerComponent::removeFunctionBlock(const RpcContext& context,
+                                                                const ComponentPtr& component,
+                                                                const ParamsDictPtr& params)
+{
+    ConfigServerAccessControl::protectLockedComponent(component);
+    ConfigServerAccessControl::protectObject(component, context.user, {Permission::Read, Permission::Write});
+    ConfigServerAccessControl::protectViewOnlyConnection(context.connectionType);
+
+    const auto localId = params.get("LocalId");
+
+    const auto checkFb = [](const ListPtr<IFunctionBlock>& fbs)
+    {
+        if (fbs.getCount() == 0)
+            throw NotFoundException("Function block not found");
+
+        if (fbs.getCount() > 1)
+            throw InvalidStateException("Duplicate function block");
+    };
+
+    ListPtr<IFunctionBlock> fbs;
+    if (const auto device = component.asPtrOrNull<IDevice>(true); device.assigned())
+    {
+        fbs = device.getFunctionBlocks(search::LocalId(localId));
+        checkFb(fbs);
+        device.removeFunctionBlock(fbs[0]);
+        
+    }
+    else if (const auto fb = component.asPtrOrNull<IFunctionBlock>(true); fb.assigned())
+    {
+        fbs = fb.getFunctionBlocks(search::LocalId(localId));
+        checkFb(fbs);
+        fb.removeFunctionBlock(fbs[0]);
+    }
+    else
+        throw InvalidStateException("Component is not a device or function block");
+
+    return nullptr;
+}
+
 
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_device.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_device.h
@@ -27,9 +27,6 @@ namespace daq::config_protocol
 class ConfigServerDevice
 {
 public:
-    static BaseObjectPtr getAvailableFunctionBlockTypes(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params);
-    static BaseObjectPtr addFunctionBlock(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params);
-    static BaseObjectPtr removeFunctionBlock(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params);
     static BaseObjectPtr getInfo(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params);
     static BaseObjectPtr getTicksSinceOrigin(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params);
     static BaseObjectPtr lock(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params);
@@ -45,52 +42,6 @@ public:
     static BaseObjectPtr setPropertyValue(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr setProtectedPropertyValue(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
 };
-
-inline BaseObjectPtr ConfigServerDevice::getAvailableFunctionBlockTypes(const RpcContext& context,
-                                                                        const DevicePtr& device,
-                                                                        const ParamsDictPtr& params)
-{
-    ConfigServerAccessControl::protectObject(device, context.user, Permission::Read);
-
-    const auto fbTypes = device.getAvailableFunctionBlockTypes();
-    return fbTypes;
-}
-
-inline BaseObjectPtr ConfigServerDevice::addFunctionBlock(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params)
-{
-    ConfigServerAccessControl::protectLockedComponent(device);
-    ConfigServerAccessControl::protectObject(device, context.user, {Permission::Read, Permission::Write});
-    ConfigServerAccessControl::protectViewOnlyConnection(context.connectionType);
-
-    const auto fbTypeId = params.get("TypeId");
-    PropertyObjectPtr config;
-    if (params.hasKey("Config"))
-        config = params.get("Config");
-
-    const auto fb = device.addFunctionBlock(fbTypeId, config);
-    return ComponentHolder(fb);
-}
-
-inline BaseObjectPtr ConfigServerDevice::removeFunctionBlock(const RpcContext& context,
-                                                             const DevicePtr& device,
-                                                             const ParamsDictPtr& params)
-{
-    ConfigServerAccessControl::protectLockedComponent(device);
-    ConfigServerAccessControl::protectObject(device, context.user, {Permission::Read, Permission::Write});
-    ConfigServerAccessControl::protectViewOnlyConnection(context.connectionType);
-
-    const auto localId = params.get("LocalId");
-
-    const auto fbs = device.getFunctionBlocks(search::LocalId(localId));
-    if (fbs.getCount() == 0)
-        throw NotFoundException("Function block not found");
-
-    if (fbs.getCount() > 1)
-        throw InvalidStateException("Duplicate function block");
-
-    device.removeFunctionBlock(fbs[0]);
-    return nullptr;
-}
 
 inline BaseObjectPtr ConfigServerDevice::getInfo(const RpcContext& context, const DevicePtr& device, const ParamsDictPtr& params)
 {

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -192,24 +192,28 @@ void ConfigProtocolClientComm::endUpdate(const std::string& globalId, const std:
     parseRpcOrRejectReply(setPropertyValueRpcReplyPacketBuffer.parseRpcRequestOrReply());
 }
 
-DictPtr<IString, IFunctionBlockType> ConfigProtocolClientComm::getAvailableFunctionBlockTypes(const std::string& globalId)
+DictPtr<IString, IFunctionBlockType> ConfigProtocolClientComm::getAvailableFunctionBlockTypes(const std::string& globalId, bool isFb)
 {
-    return sendComponentCommand(globalId, ClientCommand("GetAvailableFunctionBlockTypes"));
+    auto command = isFb ? ClientCommand("GetAvailableFunctionBlockTypes", 9) : ClientCommand("GetAvailableFunctionBlockTypes");
+    return sendComponentCommand(globalId, command);
 }
 
 ComponentHolderPtr ConfigProtocolClientComm::addFunctionBlock(const std::string& globalId,
                                                               const StringPtr& typeId,
                                                               const PropertyObjectPtr& config,
-                                                              const ComponentPtr& parentComponent)
+                                                              const ComponentPtr& parentComponent,
+                                                              bool isFb)
 {
+    auto command = isFb ? ClientCommand("AddFunctionBlock", 9) : ClientCommand("AddFunctionBlock");
     auto params = Dict<IString, IBaseObject>({{"TypeId", typeId}, {"Config", config}});
-    return sendComponentCommand(globalId, ClientCommand("AddFunctionBlock"), params, parentComponent);
+    return sendComponentCommand(globalId, command, params, parentComponent);
 }
 
-void ConfigProtocolClientComm::removeFunctionBlock(const std::string& globalId, const StringPtr& functionBlockLocalId)
+void ConfigProtocolClientComm::removeFunctionBlock(const std::string& globalId, const StringPtr& functionBlockLocalId, bool isFb)
 {
+    auto command = isFb ? ClientCommand("RemoveFunctionBlock", 9) : ClientCommand("RemoveFunctionBlock");
     auto params = Dict<IString, IBaseObject>({{"LocalId", functionBlockLocalId}});
-    sendComponentCommand(globalId, ClientCommand("RemoveFunctionBlock"), params);
+    sendComponentCommand(globalId, command, params);
 }
 
 uint64_t ConfigProtocolClientComm::getTicksSinceOrigin(const std::string& globalId)

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -140,11 +140,12 @@ void ConfigProtocolServer::buildRpcDispatchStructure()
     addHandler<ComponentPtr>("EndUpdate", &ConfigServerComponent::endUpdate);
     addHandler<ComponentPtr>("SetAttributeValue", &ConfigServerComponent::setAttributeValue);
     addHandler<ComponentPtr>("Update", &ConfigServerComponent::update);
+    
+    addHandler<ComponentPtr>("GetAvailableFunctionBlockTypes", &ConfigServerComponent::getAvailableFunctionBlockTypes);
+    addHandler<ComponentPtr>("AddFunctionBlock", &ConfigServerComponent::addFunctionBlock);
+    addHandler<ComponentPtr>("RemoveFunctionBlock", &ConfigServerComponent::removeFunctionBlock);
 
     addHandler<DevicePtr>("GetInfo", &ConfigServerDevice::getInfo);
-    addHandler<DevicePtr>("GetAvailableFunctionBlockTypes", &ConfigServerDevice::getAvailableFunctionBlockTypes);
-    addHandler<DevicePtr>("AddFunctionBlock", &ConfigServerDevice::addFunctionBlock);
-    addHandler<DevicePtr>("RemoveFunctionBlock", &ConfigServerDevice::removeFunctionBlock);
     addHandler<DevicePtr>("GetTicksSinceOrigin", &ConfigServerDevice::getTicksSinceOrigin);
     addHandler<DevicePtr>("Lock", &ConfigServerDevice::lock);
     addHandler<DevicePtr>("Unlock", &ConfigServerDevice::unlock);

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -342,6 +342,23 @@ TEST_F(ConfigProtocolIntegrationTest, AddFunctionBlock)
     ASSERT_EQ(fb.getSignals()[0].getDomainSignal(), fb.getSignals()[2]);
 }
 
+TEST_F(ConfigProtocolIntegrationTest, FunctionBlocksNested)
+{
+    const auto serverSubDevice = serverDevice.getDevices()[0];
+    const auto clientSubDevice = clientDevice.getDevices()[0];
+    const auto config = PropertyObject();
+    config.addProperty(StringPropertyBuilder("Param", "Value").build());
+
+    const auto fb = clientSubDevice.addFunctionBlock("mockfb1", config);
+    auto types = fb.getAvailableFunctionBlockTypes();
+    auto nestedFb = fb.addFunctionBlock(types.getKeyList()[0], config);
+    ASSERT_TRUE(nestedFb.assigned());
+    fb.removeFunctionBlock(nestedFb);
+
+    ASSERT_TRUE(nestedFb.isRemoved());
+    ASSERT_EQ(fb.getFunctionBlocks().getCount(), 0u);
+}
+
 TEST_F(ConfigProtocolIntegrationTest, AddFunctionBlockWithEvent)
 {
     const auto serverSubDevice = serverDevice.getDevices()[0];

--- a/shared/libraries/config_protocol/tests/test_utils.cpp
+++ b/shared/libraries/config_protocol/tests/test_utils.cpp
@@ -183,6 +183,40 @@ MockFb1Impl::MockFb1Impl(const ContextPtr& ctx, const ComponentPtr& parent, cons
     createAndAddInputPort("ip", PacketReadyNotification::None);
 }
 
+DictPtr<IString, IFunctionBlockType> MockFb1Impl::onGetAvailableFunctionBlockTypes()
+{
+       auto fbTypes = Dict<IString, IFunctionBlockType>({{"mockfb1", FunctionBlockType("mockfb1", "MockFB1", "Mock FB1", nullptr)}});
+
+    auto componentTypePrivate = fbTypes.get("mockfb1").asPtr<IComponentTypePrivate>();
+    componentTypePrivate->setModuleInfo(ModuleInfo(VersionInfo(5, 6, 7), "module_name", "module_id"));
+
+    return fbTypes;
+}
+
+FunctionBlockPtr MockFb1Impl::onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config)
+{
+    if (typeId == "mockfb1")
+    {
+        if (!config.assigned())
+            throw InvalidParameterException();
+
+        const StringPtr param = config.getPropertyValue("Param");
+        if (param != "Value")
+            throw InvalidParameterException();
+
+        const auto fb = createWithImplementation<IFunctionBlock, MockFb1Impl>(context, this->functionBlocks, "newFb");
+        addNestedFunctionBlock(fb);
+        return fb;
+    }
+
+    throw NotFoundException();
+}
+
+void MockFb1Impl::onRemoveFunctionBlock(const FunctionBlockPtr& functionBlock)
+{
+    removeNestedFunctionBlock(functionBlock);
+}
+
 MockFb2Impl::MockFb2Impl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
     : FunctionBlock(FunctionBlockType("test_uid", "test_name", "test_description"), ctx, parent, localId, "MockClass")
 {

--- a/shared/libraries/config_protocol/tests/test_utils.h
+++ b/shared/libraries/config_protocol/tests/test_utils.h
@@ -30,6 +30,9 @@ namespace daq::config_protocol::test_utils
     {
     public:
         MockFb1Impl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+        DictPtr<IString, IFunctionBlockType> onGetAvailableFunctionBlockTypes() override;
+        FunctionBlockPtr onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config) override;
+        void onRemoveFunctionBlock(const FunctionBlockPtr& functionBlock) override;
     };
 
     class MockFb2Impl final : public FunctionBlock


### PR DESCRIPTION
# Brief
Adds new Native Configuration Protocol RPCs for handling sub-function blocks (function blocks that are children of other FBs).

# Description
Previously, adding of nested function blocks was possible only locally, as the Native configuration protocol was missing definitions for remote procedure calls that allow for said action. This change enables adding, removing, and checking for available function blocks that can be added as a child of another FB on remote devices using the Native protocol.

This change requires the latest openDAQ version on both the server and client side.