### PR TITLE
Fix selection value dot access

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- [#719](https://github.com/openDAQ/openDAQ/pull/719) Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).
 - [#642](https://github.com/openDAQ/openDAQ/pull/642) Introduces mechanisms to modify the IP configuration parameters of openDAQ-compatible devices.
 - [#638](https://github.com/openDAQ/openDAQ/pull/638) Adds a tick tolerance option to the `MultiReader`, allowing for the limitation of inter-sample offsets between read signals.
 - [#631](https://github.com/openDAQ/openDAQ/pull/631) "Any read/write" events are added to property object that are triggered whenever any of the object's property values are read or written.

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -1897,10 +1897,23 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
         BaseObjectPtr valuePtr;
         PropertyPtr prop;
 
-        getPropertyAndValueInternal(propName, valuePtr, prop, true, retrieveUpdatingValue);
+        StringPtr childName;
+        StringPtr subName;
 
-        if (!prop.assigned())
-            throw NotFoundException(R"(Selection property "{}" not found)", propName);
+        if (isChildProperty(propName, childName, subName))
+        {
+            getProperty(propName, &prop);
+            if (!prop.assigned())
+                throw NotFoundException(R"(Selection property "{}" not found)", propName);
+
+            valuePtr = prop.getValue();
+        }
+        else
+        {
+            getPropertyAndValueInternal(propName, valuePtr, prop, true, retrieveUpdatingValue);
+            if (!prop.assigned())
+                throw NotFoundException(R"(Selection property "{}" not found)", propName);
+        }
 
         const auto propInternal = prop.asPtr<IPropertyInternal>();
         auto values = propInternal.getSelectionValuesNoLock();

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -2112,3 +2112,20 @@ TEST_F(PropertyObjectTest, EnumerationPropertySetGet)
     propObj.setPropertyValue("enumProp", EnumerationWithIntValue("EnumType", 2, objManager));
     ASSERT_EQ(propObj.getPropertyValue("enumProp"), "Option3");
 }
+
+TEST_F(PropertyObjectTest, DotAccessSelectionValue)
+{
+    auto child = PropertyObject();
+    child.addProperty(SelectionProperty("foo", List<IString>("a", "b"), 0));
+
+    auto child1 = PropertyObject();
+    child1.addProperty(ObjectProperty("child", child));
+
+    auto parent = PropertyObject();
+    parent.addProperty(ObjectProperty("child", child1));
+
+    ASSERT_EQ(parent.getPropertyValue("child.child.foo"), 0);
+    ASSERT_EQ(parent.getPropertySelectionValue("child.child.foo"), "a");
+    parent.setPropertyValue("child.child.foo", 1);
+    ASSERT_EQ(parent.getPropertySelectionValue("child.child.foo"), "b");
+}

--- a/core/opendaq/scheduler/tests/test_task_internals.cpp
+++ b/core/opendaq/scheduler/tests/test_task_internals.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <testutils/ut_logging.h>
 
+#include <chrono>
 #include <opendaq/task_flow.h>
 
 using TaskInternalsTest = testing::Test;
@@ -12,7 +13,7 @@ using namespace daq;
 
 TEST_F(TaskInternalsTest, TaskFlowFutureDestructorDoesNotBlock)
 {
-    using namespace std::literals;
+    using namespace std::chrono_literals;
 
     bool finished{false};
     tf::Executor e;

--- a/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
+++ b/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
@@ -107,6 +107,15 @@ TEST_F(ConfigNestedPropertyObjectTest, TestNestedObjectClientGetDotAccess)
     ASSERT_EQ(clientDevice.getPropertyValue("ObjectProperty.child2.child2_1.Ratio"), Ratio(1, 2));
 }
 
+TEST_F(ConfigNestedPropertyObjectTest, TestNestedObjectClientGetSelectionValueDotAccess)
+{
+    ASSERT_EQ(clientDevice.getPropertyValue("ObjectProperty.child1.child1_2.child1_2_1.Selection"), 0);
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("ObjectProperty.child1.child1_2.child1_2_1.Selection"), "a");
+    clientDevice.setPropertyValue("ObjectProperty.child1.child1_2.child1_2_1.Selection", 1);
+    ASSERT_EQ(clientDevice.getPropertyValue("ObjectProperty.child1.child1_2.child1_2_1.Selection"), 1);
+    ASSERT_EQ(clientDevice.getPropertySelectionValue("ObjectProperty.child1.child1_2.child1_2_1.Selection"), "b");
+}
+
 TEST_F(ConfigNestedPropertyObjectTest, TestNestedObjectClientSet)
 {
     const PropertyObjectPtr objectProperty = clientDevice.getPropertyValue("ObjectProperty");

--- a/shared/libraries/config_protocol/tests/test_utils.cpp
+++ b/shared/libraries/config_protocol/tests/test_utils.cpp
@@ -146,6 +146,7 @@ static PropertyObjectPtr createMockNestedPropertyObject()
         });
 
     child1_2_1.addProperty(StringProperty("String", "String"));
+    child1_2_1.addProperty(SelectionProperty("Selection", List<IString>("a", "b"), 0));
     child1_2_1.addProperty(StringPropertyBuilder("ReadOnlyString", "String").setReadOnly(true).build());
     child1_2_1.addProperty(functionProp);
     child1_2_1.addProperty(procedureProp);

--- a/shared/libraries/opcua/opcuaclient/tests/src/test_opcuaasyncexecthread.cpp
+++ b/shared/libraries/opcua/opcuaclient/tests/src/test_opcuaasyncexecthread.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "opcuaclient/opcuaasyncexecthread.h"
+#include <chrono>
 
 BEGIN_NAMESPACE_OPENDAQ_OPCUA
 


### PR DESCRIPTION
# Brief

Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).

# Usage Example

```cpp
auto child = PropertyObject();
child.addProperty(SelectionProperty("foo", List<IString>("a", "b"), 0));

auto parent = PropertyObject();
parent.addProperty(ObjectProperty("child", child))

// Now no longer throws and exception
auto val = parent.getPropertySelectionValue("child.foo");
```
