### PR TITLE
Add scan timeout in `createDevice`

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -2,7 +2,6 @@
 
 ## Features
 
-- [#719](https://github.com/openDAQ/openDAQ/pull/719) Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).
 - [#718](https://github.com/openDAQ/openDAQ/pull/718) Adds new Native Configuration Protocol RPCs for handling sub-function blocks (function blocks that are children of other FBs.
 - [#642](https://github.com/openDAQ/openDAQ/pull/642) Introduces mechanisms to modify the IP configuration parameters of openDAQ-compatible devices.
 - [#638](https://github.com/openDAQ/openDAQ/pull/638) Adds a tick tolerance option to the `MultiReader`, allowing for the limitation of inter-sample offsets between read signals.
@@ -29,6 +28,7 @@
 
 ## Bug fixes
 
+- [#719](https://github.com/openDAQ/openDAQ/pull/719) Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).
 - [#703](https://github.com/openDAQ/openDAQ/pull/703) Fixes invalid response of openDAQ mDNS wrapper for unicast queries.
 - [#696](https://github.com/openDAQ/openDAQ/pull/696) Set of LT bugfixes. Keeping sessions alive, raw json values for linear rules, default start value for constant signals, fix IPv4/6 control connection address handling. 
 - [#693](https://github.com/openDAQ/openDAQ/pull/693) Standard example openDAQ modules make use of non-installed openDAQ cmake utilities. Adds said utilities openDAQ packages.
@@ -47,7 +47,7 @@
 
 ## Misc
 
-- [#728](https://github.com/openDAQ/openDAQ/pull/726) Add timeout on to re-scan after for available devices after 5s in the module manager call `createDevice`.
+- [#728](https://github.com/openDAQ/openDAQ/pull/728) Add timeout on to re-scan after for available devices after 5s in the module manager call `createDevice`.
 - [#714](https://github.com/openDAQ/openDAQ/pull/714) Set of permission manager optimizations that reduce the number of Dictionary object creations on Property/PropertyObject construction.
 - [#706](https://github.com/openDAQ/openDAQ/pull/706) Limit reference device channel count to min/max values.
 - [#702](https://github.com/openDAQ/openDAQ/pull/702) Native streaming packet transmission performance optimizations.

--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -47,6 +47,7 @@
 
 ## Misc
 
+- [#728](https://github.com/openDAQ/openDAQ/pull/726) Add timeout on to re-scan after for available devices after 5s in the module manager call `createDevice`.
 - [#714](https://github.com/openDAQ/openDAQ/pull/714) Set of permission manager optimizations that reduce the number of Dictionary object creations on Property/PropertyObject construction.
 - [#706](https://github.com/openDAQ/openDAQ/pull/706) Limit reference device channel count to min/max values.
 - [#702](https://github.com/openDAQ/openDAQ/pull/702) Native streaming packet transmission performance optimizations.

--- a/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
@@ -125,10 +125,10 @@ private:
 
     DictPtr<IString, IDeviceInfo> availableDevicesWithIpConfig;
     discovery::DiscoveryClient discoveryClient; // for discovering devices which has IP modification feature enabled
-
+    ContextPtr context;
 
     std::chrono::time_point<std::chrono::steady_clock> lastScanTime;
-    std::chrono::seconds scanTimeout;
+    std::chrono::milliseconds rescanTimer;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_manager_impl.h
@@ -125,6 +125,10 @@ private:
 
     DictPtr<IString, IDeviceInfo> availableDevicesWithIpConfig;
     discovery::DiscoveryClient discoveryClient; // for discovering devices which has IP modification feature enabled
+
+
+    std::chrono::time_point<std::chrono::steady_clock> lastScanTime;
+    std::chrono::seconds scanTimeout;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -39,6 +39,7 @@ using namespace std::chrono_literals;
 
 static OrphanedModules orphanedModules;
 
+static constexpr std::chrono::milliseconds DefaultrescanTimer = 5000ms;
 static constexpr char createModuleFactory[] = "createModule";
 static constexpr char checkDependenciesFunc[] = "checkDependencies";
 
@@ -47,7 +48,7 @@ static void GetModulesPath(std::vector<fs::path>& modulesPath, const LoggerCompo
 ModuleManagerImpl::ModuleManagerImpl(const BaseObjectPtr& path)
     : modulesLoaded(false)
     , work(ioContext.get_executor())
-    , scanTimeout(5s)
+    , rescanTimer(DefaultrescanTimer)
 {
     if (const StringPtr pathStr = path.asPtrOrNull<IString>(true); pathStr.assigned())
     {
@@ -144,10 +145,20 @@ ErrCode ModuleManagerImpl::loadModules(IContext* context)
     if (modulesLoaded)
         return OPENDAQ_SUCCESS;
     
-    const auto contextPtr = ContextPtr::Borrow(context);
-    logger = contextPtr.getLogger();
+    this->context = ContextPtr::Borrow(context);
+    logger = this->context.getLogger();
     if (!logger.assigned())
         return makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Logger must not be null");
+
+    auto options = this->context.getOptions();
+    if (options.hasKey("ModuleManager"))
+    {
+        DictPtr<IString, IBaseObject> inner = options.get("ModuleManager");
+        if (inner.hasKey("AddDeviceRescanTimer"))
+        {
+            this->rescanTimer = std::chrono::milliseconds(static_cast<int>(inner.get("AddDeviceRescanTimer")));
+        }
+    }
 
     loggerComponent = this->logger.getOrAddComponent("ModuleManager");
 
@@ -499,10 +510,9 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
         if (!connectionStringPtr.assigned() || connectionStringPtr.getLength() == 0)
             return this->makeErrorInfo(OPENDAQ_ERR_ARGUMENT_NULL, "Connection string is not set or empty");
 
-        // Scan for devices if not yet done so
-        // TODO: Should we re-scan after a timeout?
+        // Scan for devices if not yet done so, or timeout is exceeded
         auto currentTime = std::chrono::steady_clock::now();
-        if (!availableDevicesGroup.assigned() || currentTime - lastScanTime > scanTimeout)
+        if (!availableDevicesGroup.assigned() || currentTime - lastScanTime > rescanTimer)
         {
             const auto errCode = getAvailableDevices(&ListPtr<IDeviceInfo>());
             if (OPENDAQ_FAILED(errCode))

--- a/core/opendaq/modulemanager/tests/module_manager_test.cpp
+++ b/core/opendaq/modulemanager/tests/module_manager_test.cpp
@@ -2,11 +2,15 @@
 #include <opendaq/module_manager_factory.h>
 #include <opendaq/context_factory.h>
 #include <opendaq/logger_factory.h>
-
 #include "mock/mock_module.h"
 
 #include <chrono>
 #include <thread>
+
+#include <opendaq/component_type_builder_factory.h>
+#include <opendaq/device_info_config_ptr.h>
+#include <opendaq/device_info_factory.h>
+#include <opendaq/module_manager_utils_ptr.h>
 
 using namespace daq;
 
@@ -139,4 +143,81 @@ TEST_F(ModuleManagerTest, RegisterDaqTypes)
     ASSERT_TRUE(typeManager.hasType("PtpSyncInterface"));
     ASSERT_TRUE(typeManager.hasType("SyncInterfaceBase"));
     ASSERT_TRUE(typeManager.hasType("InterfaceClockSync"));
+}
+
+class MockModuleInternal : public MockModuleImpl
+{
+public:
+    MockModuleInternal();
+
+    daq::ErrCode INTERFACE_FUNC getAvailableDevices(daq::IList** availableDevices) override;
+    daq::ErrCode INTERFACE_FUNC getAvailableDeviceTypes(daq::IDict** deviceTypes) override;
+    daq::ErrCode INTERFACE_FUNC createDevice(daq::IDevice** device, daq::IString* connectionString, daq::IComponent* parent, daq::IPropertyObject* config) override;
+
+    DeviceInfoConfigPtr info;
+    DeviceTypePtr type;
+    int scanCount = 0;
+};
+
+MockModuleInternal::MockModuleInternal()
+{
+    info = DeviceInfo("daqmock://dev");
+    type = DeviceTypeBuilder().setConnectionStringPrefix("daqmock").setId("daqmock").build();
+}
+
+daq::ErrCode MockModuleInternal::getAvailableDevices(daq::IList** availableDevices)
+{
+    scanCount++;
+    *availableDevices = List<IDeviceInfo>(info).detach();
+    return OPENDAQ_SUCCESS;
+}
+
+daq::ErrCode MockModuleInternal::getAvailableDeviceTypes(daq::IDict** deviceTypes)
+{
+    *deviceTypes = Dict<IString, IDeviceType>({{type.getId(), type}}).detach();
+    return OPENDAQ_SUCCESS;
+}
+
+daq::ErrCode MockModuleInternal::createDevice(daq::IDevice** device,
+                                              daq::IString* /*connectionString*/,
+                                              daq::IComponent* /*parent*/,
+                                              daq::IPropertyObject* /*config*/)
+{
+    *device = DevicePtr();
+    return OPENDAQ_SUCCESS;
+}
+
+// Disabled, as test is not deterministic on devices where calls between creates take longer than 5s
+TEST_F(ModuleManagerTest, DISABLED_TestScanTimeout1)
+{
+    auto manager = ModuleManager("[[none]]");
+    auto module = createWithImplementation<IModule, MockModuleInternal>();
+
+    manager.addModule(module);
+    auto impl = reinterpret_cast<MockModuleInternal*>(module.getObject());
+
+    auto utils = manager.asPtr<IModuleManagerUtils>();
+    auto dev = utils.createDevice("daqmock", nullptr);
+    ASSERT_EQ(impl->scanCount, 1);
+    dev = utils.createDevice("daqmock", nullptr);
+    ASSERT_EQ(impl->scanCount, 1);
+}
+
+// Disabled to not significantly increase test suite runtime
+TEST_F(ModuleManagerTest, DISABLED_TestScanTimeout2)
+{
+    auto manager = ModuleManager("[[none]]");
+    auto module = createWithImplementation<IModule, MockModuleInternal>();
+
+    manager.addModule(module);
+    auto impl = reinterpret_cast<MockModuleInternal*>(module.getObject());
+
+    auto utils = manager.asPtr<IModuleManagerUtils>();
+    auto dev = utils.createDevice("daqmock", nullptr);
+    ASSERT_EQ(impl->scanCount, 1);
+
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(6s);
+    dev = utils.createDevice("daqmock", nullptr);
+    ASSERT_EQ(impl->scanCount, 2);
 }

--- a/core/opendaq/opendaq/src/instance_builder_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_builder_impl.cpp
@@ -7,25 +7,22 @@
 #include <coreobjects/authentication_provider_factory.h>
 
 BEGIN_NAMESPACE_OPENDAQ
-
 DictPtr<IString, IBaseObject> InstanceBuilderImpl::GetDefaultOptions()
 {
-    return Dict<IString, IBaseObject>({
-        {"ModuleManager", Dict<IString, IBaseObject>({
-                {"ModulesPaths", List<IString>(""),
-                }
-            })},
-        {"Scheduler", Dict<IString, IBaseObject>({
-                {"WorkersNum", 0}
-            })},
-        {"Logging", Dict<IString, IBaseObject>({
-                {"GlobalLogLevel", OPENDAQ_LOG_LEVEL_DEFAULT}
-            })},
-        {"RootDevice", Dict<IString, IBaseObject>({
-                {"DefaultLocalId", ""},
-                {"ConnectionString", ""}
-            })},   
-        {"Modules", Dict<IString, IBaseObject>()}
+    return Dict<IString, IBaseObject>({{"ModuleManager", Dict<IString, IBaseObject>({
+                                            {"ModulesPaths", List<IString>("")}, {"AddDeviceRescanTimer", 5000}
+                                        })},
+                                       {"Scheduler", Dict<IString, IBaseObject>({
+                                            {"WorkersNum", 0}
+                                        })},
+                                       {"Logging", Dict<IString, IBaseObject>({
+                                            {"GlobalLogLevel", OPENDAQ_LOG_LEVEL_DEFAULT}
+                                        })},
+                                       {"RootDevice", Dict<IString, IBaseObject>({
+                                            {"DefaultLocalId", ""},
+                                            {"ConnectionString", ""}
+                                        })},
+                                       {"Modules", Dict<IString, IBaseObject>()}
     });
 }
 


### PR DESCRIPTION
# Brief
Add timeout on to re-scan after for available devices after 5s in the module manager call `createDevice`.

# Description
The openDAQ module manager scans for available devices before attempting to create a device. This is done to gather all device capabilities for configuration/streaming, and to allow adding a device via the connection string format "daq://Manufacturer_SerialNumber".

This was only done if `getAvailableDevices` has not been called at all in the lifetime of the module manager. This PR changes said behaviour by introducing a 5s  timeout post `getAvailableDevices`. If a device is created after said timeout, the module manager now re-scans before creating the device.

# Usage example

When re-booting a device with manufacturer "openDAQ" and serial "SN123",  the following code snippet previously never connected, if the device was not yet discoverable during the first loop iteration:

```cpp
bool connected = false;
while (!connected)
{
    try
    {
        auto dev = instance.addDevice("daq://openDAQ_SN123")
        connected = dev.assigned();
    }
    catch(...)
    {
        using namespace std::chrono_literals;
        std::cout << "Failed to connect, retrying..." << std::endl;
        std::this_tread::sleep_for(0.5s);
    }
}
```

