### PR TITLE
Python GUI app: attributes dialog, changeable device info, metadata fields fix

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -16,6 +16,7 @@
 
 ## Python
 
+- [#729](https://github.com/openDAQ/openDAQ/pull/729) Improve Python GUI app: attributes dialog update, device info via generic properties treeview, metadata fields fix
 - [#690](https://github.com/openDAQ/openDAQ/pull/690) Enable Python wheels for MacOS
 - [#675](https://github.com/openDAQ/openDAQ/pull/675) Adds a command line option to specify an additional module load path when starting the Python GUI application.
 - [#662](https://github.com/openDAQ/openDAQ/pull/662) Standardizes property modification mechanisms in Python GUI application.

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -56,7 +56,7 @@ class AttributesDialog(Dialog):
                 self.notebook.add(signal_desc_frame, text='Signal Descriptor')
                 if self.node.domain_signal is not None:
                     self.notebook.add(signal_domain_desc_frame,
-                                      text='Signal Domain Descriptor')
+                                      text='Domain Signal Descriptor')
                 self.notebook.bind('<<NotebookTabChanged>>',
                                    self.on_tab_change)
             elif daq.IDevice.can_cast_from(node):

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -1,321 +1,48 @@
-import os
 import tkinter as tk
-from tkinter import ttk, simpledialog
+from tkinter import ttk
 
 import opendaq as daq
 
-from .. import utils
 from ..event_port import EventPort
 from ..app_context import AppContext
 from .dialog import Dialog
-
+from .generic_attributes_treeview import AttributesTreeview
+from .generic_properties_treeview import PropertiesTreeview
+from .data_descriptor_treeview import DataDescriptorTreeview
 
 class AttributesDialog(Dialog):
     def __init__(self, parent, title, node, context: AppContext, **kwargs):
-        Dialog.__init__(self, parent, title, None, **kwargs)
-        self.parent = parent
-        self.node = node
-        self.context = context
+        Dialog.__init__(self, parent, title, context, **kwargs)
         self.event_port = EventPort(parent)
 
         self.geometry(f'{600}x{800}')
         tree_frame = ttk.Frame(self)
-
-        tree = ttk.Treeview(tree_frame, columns=(
-            'value', 'access'), show='tree headings')
-
-        scroll_bar = ttk.Scrollbar(
-            tree_frame, orient=tk.VERTICAL, command=tree.yview)
-        tree.configure(yscrollcommand=scroll_bar.set)
-        scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
-        tree.pack(fill=tk.BOTH, expand=True)
         tree_frame.pack(fill=tk.BOTH, expand=True)
 
-        # define headings
-        tree.heading('#0', anchor=tk.W, text='Name')
-        tree.heading('#1', anchor=tk.W, text='Value')
-        tree.heading('#2', anchor=tk.W, text='Locked')
-        # layout
-        tree.column('#0', anchor=tk.W, minwidth=100, width=100)
-        tree.column('#1', anchor=tk.W, minwidth=100, width=300)
-        tree.column('#2', anchor=tk.W, minwidth=80, width=80)
+        AttributesTreeview(tree_frame, node, context)
 
-        tree.bind('<Double-1>', self.handle_double_click)
-        tree.bind('<Button-3>', lambda event: self.handle_right_click(tree, event))
-
-        self.additional_tree = None
-        self.notebook = None
         if daq.ISignal.can_cast_from(node) or daq.IDevice.can_cast_from(node):
             additional_tree_frame = ttk.Frame(self)
-            if daq.ISignal.can_cast_from(node):
-                self.node = daq.ISignal.cast_from(node)
-                self.notebook = ttk.Notebook(self)
-                self.notebook.pack(fill=tk.BOTH, anchor=tk.W)
-                signal_desc_frame = ttk.Frame(self.notebook)
-                signal_domain_desc_frame = ttk.Frame(self.notebook)
-                self.notebook.add(signal_desc_frame, text='Signal Descriptor')
-                if self.node.domain_signal is not None:
-                    self.notebook.add(signal_domain_desc_frame,
-                                      text='Domain Signal Descriptor')
-                self.notebook.bind('<<NotebookTabChanged>>',
-                                   self.on_tab_change)
-            elif daq.IDevice.can_cast_from(node):
-                self.node = daq.IDevice.cast_from(node)
-                ttk.Label(self, text='Device Info').pack(
-                    anchor=tk.W, pady=5)
-            # additional treeview for specific attributes
-
-            additional_tree = ttk.Treeview(additional_tree_frame, columns=(
-                'value'), show='tree headings')
-
-            scroll_bar = ttk.Scrollbar(
-                additional_tree_frame, orient=tk.VERTICAL, command=additional_tree.yview)
-            additional_tree.configure(yscrollcommand=scroll_bar.set)
-            scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
-            additional_tree.pack(fill=tk.BOTH, expand=True)
             additional_tree_frame.pack(fill=tk.BOTH, expand=True)
+            if daq.ISignal.can_cast_from(node):
+                notebook = ttk.Notebook(additional_tree_frame)
+                notebook.pack(fill=tk.BOTH, expand=True)
 
-            # define headings
-            additional_tree.heading('#0', anchor=tk.W, text='Name')
-            additional_tree.heading('#1', anchor=tk.W, text='Value')
-            # layout
-            additional_tree.column('#0', anchor=tk.W, minwidth=100)
-            additional_tree.column('#1', anchor=tk.W, minwidth=100)
+                signal = daq.ISignal.cast_from(node)
 
-            self.additional_tree = additional_tree
-            additional_tree.bind(
-                '<Button-3>', lambda event: self.handle_right_click(additional_tree, event))
+                signal_desc_frame = ttk.Frame(notebook)
+                signal_desc_frame.pack(fill=tk.BOTH, expand=True)
+                notebook.add(signal_desc_frame, text='Signal Descriptor')
+                DataDescriptorTreeview(signal_desc_frame, signal.descriptor, context)
 
-        self.tree = tree
-        self.initial_update_func = lambda: self.tree_update()
+                if signal.domain_signal is not None:
+                    signal_domain_desc_frame = ttk.Frame(notebook)
+                    signal_domain_desc_frame.pack(fill=tk.BOTH, expand=True)
+                    notebook.add(signal_domain_desc_frame, text='Domain Signal Descriptor')
+                    DataDescriptorTreeview(signal_domain_desc_frame, signal.domain_signal.descriptor, context)
 
-    def get_selected_tab(self):
-        if self.notebook:
-            return self.notebook.index(self.notebook.select())
-        return None
 
-    def on_tab_change(self, event):
-        self.additional_tree_update()
+            elif daq.IDevice.can_cast_from(node):
+                ttk.Label(additional_tree_frame, text='Device Info').pack(anchor=tk.W, pady=5)
+                PropertiesTreeview(additional_tree_frame, daq.IDevice.cast_from(node).info, context)
 
-    def handle_copy(self, tree):
-        sel = utils.treeview_get_first_selection(tree)
-        if not sel:
-            return
-        item = tree.item(sel)
-        value_to_copy = item['values'][0] if item['values'] else ''
-        self.clipboard_clear()
-        self.clipboard_append(value_to_copy)
-
-    def handle_right_click(self, tree, event):
-        utils.treeview_select_item(tree, event)
-
-        menu = tk.Menu(self, tearoff=0)
-        menu.add_command(
-            label='Copy', command=lambda: self.handle_copy(tree))
-        menu.tk_popup(event.x_root, event.y_root)
-
-    def handle_double_click(self, event):
-        node = self.node
-        if not node:
-            return
-
-        sel = utils.treeview_get_first_selection(self.tree)[1:]
-        if sel not in self.attributes:
-            return
-
-        attr_dict = self.attributes[sel]
-
-        if attr_dict['Locked']:
-            return
-
-        if daq.ISignal.can_cast_from(node):
-            node = daq.ISignal.cast_from(node)
-        elif daq.IInputPort.can_cast_from(node):
-            node = daq.IInputPort.cast_from(node)
-
-        new_value = None
-        value = attr_dict['Value']
-        attribute = attr_dict['Attribute']
-
-        prompt = f'Enter the new value for {sel}:'
-
-        if type(value) is bool:
-            new_value = not value
-        elif type(value) is int:
-            self.withdraw()
-            new_value = simpledialog.askinteger(
-                sel, prompt=prompt, initialvalue=value)
-            try:
-                self.deiconify()
-            except tk.TclError:
-                return
-
-        elif type(value) is str:
-            self.withdraw()
-            new_value = simpledialog.askstring(
-                sel, prompt=prompt, initialvalue=value)
-            try:  # handle the case when the main window is closed
-                self.deiconify()
-            except tk.TclError:
-                return
-
-        if new_value is None or new_value == value:
-            return
-
-        setattr(node, attribute, new_value)
-
-        print(f'Value changed for {sel}: {value} -> {new_value}')
-
-        self.tree_update()
-        self.event_port.emit()
-
-    def tree_update(self):
-        self.tree.delete(*self.tree.get_children())
-
-        self.attributes = {}
-        node = self.node
-
-        if node is None:
-            return
-
-        self.attributes['Name'] = {
-            'Value': node.name, 'Locked': False, 'Attribute': 'name'}
-        self.attributes['Description'] = {
-            'Value': node.description, 'Locked': False, 'Attribute': 'description'}
-        self.attributes['Active'] = {'Value': bool(
-            node.active), 'Locked': False, 'Attribute': 'active'}
-        self.attributes['Global ID'] = {
-            'Value': node.global_id, 'Locked': True, 'Attribute': 'global_id'}
-        self.attributes['Local ID'] = {
-            'Value': node.local_id, 'Locked': True, 'Attribute': 'local_id'}
-        self.attributes['Tags'] = {
-            'Value': node.tags.list, 'Locked': False, 'Attribute': 'tags'}
-        self.attributes['Visible'] = {'Value': bool(
-            node.visible), 'Locked': False, 'Attribute': 'visible'}
-
-        if daq.ISignal.can_cast_from(node):
-            signal = daq.ISignal.cast_from(node)
-
-            self.attributes['Public'] = {'Value': bool(
-                signal.public), 'Locked': False, 'Attribute': 'public'}
-            self.attributes['Domain Signal ID'] = {
-                'Value': signal.domain_signal.global_id if signal.domain_signal else '', 'Locked': True,
-                'Attribute': '.domain_signal'}
-            if signal.related_signals:
-                self.attributes['Related Signals IDs'] = {'Value': os.linesep.join(
-                    [s.global_id for s in signal.related_signals]), 'Locked': True, 'Attribute': 'related_signals'}
-            self.attributes['Streamed'] = {'Value': bool(
-                signal.streamed), 'Locked': True, 'Attribute': 'streamed'}
-            self.attributes['Last Value'] = {
-                'Value': utils.get_last_value_for_signal(signal), 'Locked': True, 'Attribute': 'last_value'}
-
-        if daq.IInputPort.can_cast_from(node):
-            input_port = daq.IInputPort.cast_from(node)
-
-            self.attributes['Signal ID'] = {
-                'Value': input_port.signal.global_id if input_port.signal else '', 'Locked': True,
-                'Attribute': 'signal'}
-            self.attributes['Requires Signal'] = {'Value': bool(
-                input_port.requires_signal), 'Locked': True, 'Attribute': 'requires_signal'}
-
-        locked_attributes = node.locked_attributes
-
-        self.attributes['Status'] = {
-            'Value': {}, 'Locked': True, 'Attribute': 'status'}
-        self.attributes['Status']['Value'] = dict(
-            node.status_container.statuses.items()) or None
-
-        for locked_attribute in locked_attributes:
-            if locked_attribute not in self.attributes:
-                continue
-            self.attributes[locked_attribute]['Locked'] = True
-
-        def tree_fill(parent: str, key: str, value: dict, locked_flag: int):
-            locked = utils.yes_no[locked_flag]
-            iid = f'{parent}.{key}'
-            if type(value) is bool:
-                value = utils.yes_no[value]
-            elif type(value) is dict:
-                self.tree.insert(
-                    parent, tk.END, iid=iid, text=key, values=('', locked))
-                for k, v in value.items():
-                    tree_fill(iid, k, v, 1)
-            else:
-                self.tree.insert(
-                    parent, tk.END, iid=iid, text=key, values=(value, locked))
-
-        for attr in self.attributes:
-            locked = self.attributes[attr]['Locked']
-            value = self.attributes[attr]['Value']
-            if type(value) is bool:
-                value = utils.yes_no[value]
-
-            tree_fill('', attr, value, locked)
-
-        if self.additional_tree is not None:
-            self.additional_tree_update()
-
-    def fill_tree(self, tree, key, value, parent='', display_attributes=False):
-
-        display_value = value
-        # for user to see property value without expanding the tree
-        if isinstance(value, daq.IProperty):
-            display_value = value.value
-            if value.value_type == daq.CoreType.ctBool:
-                display_value = utils.yes_no[display_value]
-        else:
-            display_value = utils.metadata_converters[key](
-                value) if key in utils.metadata_converters else value
-        id = tree.insert(
-            parent, tk.END, text=str(key), values=(str(display_value), ))
-
-        # displaying Nones but not traversing further
-        if value is None:
-            return
-
-        if isinstance(value, daq.IPropertyObject):
-            for property in value.all_properties if self.context.view_hidden_components else value.visible_properties:
-                self.fill_tree(tree, property.name, property,
-                               id, display_attributes)
-        elif isinstance(value, daq.IList):
-            try:
-                for i, item in enumerate(value):
-                    self.fill_tree(tree, i, item, id, display_attributes)
-            except Exception:
-                pass
-        elif isinstance(value, daq.IDict):
-            try:
-                for k, v in value.items():
-                    self.fill_tree(tree, k, v, id, display_attributes)
-            except Exception:
-                pass
-        elif issubclass(type(value), daq.IBaseObject) and display_attributes:
-            for name in utils.get_attributes_of_node(value):
-                v = getattr(value, name)
-                self.fill_tree(tree, name, v, id, display_attributes)
-
-    def additional_tree_update_signal(self):
-        signal = daq.ISignal.cast_from(self.node)
-        if self.get_selected_tab() == 0:
-            desc = signal.descriptor
-        else:
-            desc = signal.domain_signal.descriptor
-
-        if desc:
-            for name in utils.get_attributes_of_node(desc):
-                value = getattr(desc, name)
-                self.fill_tree(self.additional_tree, name, value, '', True)
-
-    def additional_tree_update_device(self):
-        device = daq.IDevice.cast_from(self.node)
-        if device.info:
-            for property in self.context.properties_of_component(device.info):
-                self.fill_tree(self.additional_tree,
-                               property.name, property.value)
-
-    def additional_tree_update(self):
-        self.additional_tree.delete(*self.additional_tree.get_children())
-        if daq.ISignal.can_cast_from(self.node):
-            self.additional_tree_update_signal()
-        elif daq.IDevice.can_cast_from(self.node):
-            self.additional_tree_update_device()

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -3,7 +3,6 @@ from tkinter import ttk
 
 import opendaq as daq
 
-from ..event_port import EventPort
 from ..app_context import AppContext
 from .dialog import Dialog
 from .generic_attributes_treeview import AttributesTreeview
@@ -13,13 +12,12 @@ from .data_descriptor_treeview import DataDescriptorTreeview
 class AttributesDialog(Dialog):
     def __init__(self, parent, title, node, context: AppContext, **kwargs):
         Dialog.__init__(self, parent, title, context, **kwargs)
-        self.event_port = EventPort(parent)
 
         self.geometry(f'{600}x{800}')
         tree_frame = ttk.Frame(self)
         tree_frame.pack(fill=tk.BOTH, expand=True)
 
-        AttributesTreeview(tree_frame, node, context)
+        AttributesTreeview(parent, tree_frame, node, context)
 
         if daq.ISignal.can_cast_from(node) or daq.IDevice.can_cast_from(node):
             additional_tree_frame = ttk.Frame(self)

--- a/examples/python/gui_demo/components/attributes_dialog.py
+++ b/examples/python/gui_demo/components/attributes_dialog.py
@@ -201,8 +201,9 @@ class AttributesDialog(Dialog):
             self.attributes['Domain Signal ID'] = {
                 'Value': signal.domain_signal.global_id if signal.domain_signal else '', 'Locked': True,
                 'Attribute': '.domain_signal'}
-            self.attributes['Related Signals IDs'] = {'Value': os.linesep.join(
-                [s.global_id for s in signal.related_signals]), 'Locked': True, 'Attribute': 'related_signals'}
+            if signal.related_signals:
+                self.attributes['Related Signals IDs'] = {'Value': os.linesep.join(
+                    [s.global_id for s in signal.related_signals]), 'Locked': True, 'Attribute': 'related_signals'}
             self.attributes['Streamed'] = {'Value': bool(
                 signal.streamed), 'Locked': True, 'Attribute': 'streamed'}
             self.attributes['Last Value'] = {

--- a/examples/python/gui_demo/components/data_descriptor_treeview.py
+++ b/examples/python/gui_demo/components/data_descriptor_treeview.py
@@ -1,0 +1,72 @@
+import tkinter as tk
+from tkinter import ttk
+
+import opendaq as daq
+
+from .. import utils
+from ..app_context import AppContext
+
+import opendaq
+
+class DataDescriptorTreeview(ttk.Treeview):
+    def __init__(self, parent, data_descriptor : opendaq.IDataDescriptor = None, context: AppContext = None, **kwargs):
+        ttk.Treeview.__init__(self, parent, columns=('value', 'access', *context.metadata_fields), show='tree headings', **kwargs)
+
+        self.context = context
+
+        scroll_bar = ttk.Scrollbar(
+            self, orient=tk.VERTICAL, command=self.yview)
+        self.configure(yscrollcommand=scroll_bar.set)
+        scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
+        scroll_bar_x = ttk.Scrollbar(
+            self, orient=tk.HORIZONTAL, command=self.xview)
+        self.configure(xscrollcommand=scroll_bar_x.set)
+        scroll_bar_x.pack(side=tk.BOTTOM, fill=tk.X)
+        self.pack(fill=tk.BOTH, expand=True)
+
+        # define headings
+        self.heading('#0', anchor=tk.W, text='Name')
+        self.heading('#1', anchor=tk.W, text='Value')
+        # layout
+        self.column('#0', anchor=tk.W, minwidth=100, width=100)
+        self.column('#1', anchor=tk.W, minwidth=100, width=300)
+
+        for name in utils.get_attributes_of_node(data_descriptor):
+            value = getattr(data_descriptor, name)
+            self.fill_tree(name, value, '')
+
+    def fill_tree(self, key, value, parent=''):
+        display_value = value
+        # for user to see property value without expanding the tree
+        if isinstance(value, daq.IProperty):
+            display_value = value.value
+            if value.value_type == daq.CoreType.ctBool:
+                display_value = utils.yes_no[display_value]
+        else:
+            display_value = utils.metadata_converters[key](
+                value) if key in utils.metadata_converters else value
+        id = self.insert(parent, tk.END, text=str(key), values=(str(display_value),))
+
+        # displaying Nones but not traversing further
+        if value is None:
+            return
+
+        if isinstance(value, daq.IPropertyObject):
+            for property in value.all_properties if self.context.view_hidden_components else value.visible_properties:
+                self.fill_tree(property.name, property, id)
+        elif isinstance(value, daq.IList):
+            try:
+                for i, item in enumerate(value):
+                    self.fill_tree(i, item, id)
+            except Exception:
+                pass
+        elif isinstance(value, daq.IDict):
+            try:
+                for k, v in value.items():
+                    self.fill_tree(k, v, id)
+            except Exception:
+                pass
+        elif issubclass(type(value), daq.IBaseObject):
+            for name in utils.get_attributes_of_node(value):
+                v = getattr(value, name)
+                self.fill_tree(name, v, id)

--- a/examples/python/gui_demo/components/data_descriptor_treeview.py
+++ b/examples/python/gui_demo/components/data_descriptor_treeview.py
@@ -6,10 +6,8 @@ import opendaq as daq
 from .. import utils
 from ..app_context import AppContext
 
-import opendaq
-
 class DataDescriptorTreeview(ttk.Treeview):
-    def __init__(self, parent, data_descriptor : opendaq.IDataDescriptor = None, context: AppContext = None, **kwargs):
+    def __init__(self, parent, data_descriptor : daq.IDataDescriptor = None, context: AppContext = None, **kwargs):
         ttk.Treeview.__init__(self, parent, columns=('value', 'access', *context.metadata_fields), show='tree headings', **kwargs)
 
         self.context = context

--- a/examples/python/gui_demo/components/device_info_dialog.py
+++ b/examples/python/gui_demo/components/device_info_dialog.py
@@ -6,89 +6,25 @@ import opendaq as daq
 from .. import utils
 from ..app_context import AppContext
 from .dialog import Dialog
+from .metadata_fields_selector_dialog import MetadataFieldsSelectorDialog
+from .generic_properties_treeview import PropertiesTreeview
 
 
 class DeviceInfoDialog(Dialog):
 
     def __init__(self, parent, node: daq.IDeviceInfo, context: AppContext, title='', **kwargs):
         super().__init__(parent, f'Device {node.name} info', context, **kwargs)
-
-        self.parent = parent
-        self.node = node
         self.context = context
-
         self.geometry(f'{600}x{800}')
-        tree_frame = ttk.Frame(self)
 
-        tree = ttk.Treeview(tree_frame, columns=(
-            'value'), show='tree headings')
+        header_frame = ttk.Frame(self)
 
-        scroll_bar = ttk.Scrollbar(
-            tree_frame, orient=tk.VERTICAL, command=tree.yview)
-        tree.configure(yscrollcommand=scroll_bar.set)
-        scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
-        tree.pack(fill=tk.BOTH, expand=True)
-        tree_frame.pack(fill=tk.BOTH, expand=True)
+        ttk.Label(header_frame, text='Properties').pack(side=tk.LEFT, pady=5)
+        tk.Button(header_frame, text='Edit', image=self.context.icons['settings'], borderwidth=0,
+                  command=lambda: MetadataFieldsSelectorDialog(
+                      self, self.context).show()
+                  ).pack(side=tk.RIGHT, anchor=tk.E)
 
-        # define headings
-        tree.heading('#0', anchor=tk.W, text='Name')
-        tree.heading('value', anchor=tk.W, text='Value')
-        # layout
-        tree.column('#0', anchor=tk.W, minwidth=100, width=150)
-        tree.column('value', anchor=tk.W, minwidth=100, width=300)
+        header_frame.pack(fill=tk.X)
 
-        tree.bind('<Button-3>', self.handle_right_click)
-
-        self.tree = tree
-        self.initial_update_func = self.update
-
-    def update(self):
-        self.tree.delete(*self.tree.get_children())
-
-        def fill_tree(key, value, parent=''):
-
-            display_value = value
-            # for user to see property value without expanding the tree
-            if isinstance(value, daq.IProperty):
-                display_value = value.value
-                if value.value_type == daq.CoreType.ctBool:
-                    display_value = utils.yes_no[display_value]
-            id = self.tree.insert(
-                parent, tk.END, text=str(key), values=(str(display_value), ))
-
-            # displaying Nones but not traversing further
-            if value is None:
-                return
-
-            if isinstance(value, daq.IPropertyObject):
-                for property in value.all_properties if self.context.view_hidden_components else value.visible_properties:
-                    fill_tree(property.name, property, id)
-            elif isinstance(value, daq.IList):
-                try:
-                    for i, item in enumerate(value):
-                        fill_tree(i, item, id)
-                except Exception:
-                    pass
-            elif isinstance(value, daq.IDict):
-                try:
-                    for k, v in value.items():
-                        fill_tree(k, v, id)
-                except Exception:
-                    pass
-
-        for property in self.node.all_properties if self.context.view_hidden_components else self.node.visible_properties:
-            fill_tree(property.name, property, '')
-
-    def handle_copy(self):
-        selected_iid = utils.treeview_get_first_selection(self.tree)
-        if selected_iid is None:
-            return
-        item = self.tree.item(selected_iid)
-        self.clipboard_clear()
-        self.clipboard_append(item['values'][0])
-
-    def handle_right_click(self, event):
-        utils.treeview_select_item(self.tree, event)
-        menu = tk.Menu(self, tearoff=0)
-        menu.add_command(label='Copy', command=self.handle_copy)
-        menu.tk_popup(event.x_root, event.y_root)
+        PropertiesTreeview(self, node, context)

--- a/examples/python/gui_demo/components/device_info_dialog.py
+++ b/examples/python/gui_demo/components/device_info_dialog.py
@@ -3,7 +3,6 @@ from tkinter import ttk
 
 import opendaq as daq
 
-from .. import utils
 from ..app_context import AppContext
 from .dialog import Dialog
 from .metadata_fields_selector_dialog import MetadataFieldsSelectorDialog

--- a/examples/python/gui_demo/components/generic_attributes_treeview.py
+++ b/examples/python/gui_demo/components/generic_attributes_treeview.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 
 import opendaq as daq
+import os
 
 from .. import utils
 from ..app_context import AppContext

--- a/examples/python/gui_demo/components/generic_attributes_treeview.py
+++ b/examples/python/gui_demo/components/generic_attributes_treeview.py
@@ -1,0 +1,229 @@
+import tkinter as tk
+from tkinter import ttk, simpledialog
+
+import opendaq as daq
+
+from .. import utils
+from ..app_context import AppContext
+
+
+class AttributesTreeview(ttk.Treeview):
+    def __init__(self, parent, node=None, context: AppContext = None, **kwargs):
+        ttk.Treeview.__init__(self, parent, columns=('value', 'access', *context.metadata_fields), show='tree headings', **kwargs)
+
+        self.context = context
+        self.node = node
+        self.attributes = None
+
+        scroll_bar = ttk.Scrollbar(
+            self, orient=tk.VERTICAL, command=self.yview)
+        self.configure(yscrollcommand=scroll_bar.set)
+        scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
+        scroll_bar_x = ttk.Scrollbar(
+            self, orient=tk.HORIZONTAL, command=self.xview)
+        self.configure(xscrollcommand=scroll_bar_x.set)
+        scroll_bar_x.pack(side=tk.BOTTOM, fill=tk.X)
+        self.pack(fill=tk.BOTH, expand=True)
+
+        self.tag_configure('readonly', foreground='gray')
+
+        # define headings
+        self.heading('#0', anchor=tk.W, text='Name')
+        self.heading('#1', anchor=tk.W, text='Value')
+        self.heading('#2', anchor=tk.W, text='Locked')
+        # layout
+        self.column('#0', anchor=tk.W, minwidth=100, width=100)
+        self.column('#1', anchor=tk.W, minwidth=100, width=300)
+        self.column('#2', anchor=tk.W, minwidth=80, width=80)
+
+        self.bind('<Double-1>', lambda event: self.handle_double_click())
+        self.bind('<Button-3>', lambda event: self.handle_right_click(event))
+
+        self.tree_update()
+
+    def handle_copy(self):
+        sel = utils.treeview_get_first_selection(self)
+        if not sel:
+            return
+        item = self.item(sel)
+        value_to_copy = item['values'][0] if item['values'] else ''
+        self.clipboard_clear()
+        self.clipboard_append(value_to_copy)
+
+    def handle_right_click(self, event):
+        utils.treeview_select_item(self, event)
+
+        menu = tk.Menu(self, tearoff=0)
+        menu.add_command(label='Copy', command=lambda: self.handle_copy())
+        menu.tk_popup(event.x_root, event.y_root)
+
+    def handle_double_click(self):
+        node = self.node
+        if not node:
+            return
+
+        sel = utils.treeview_get_first_selection(self)[1:]
+        if sel not in self.attributes:
+            return
+
+        attr_dict = self.attributes[sel]
+
+        if attr_dict['Locked']:
+            return
+
+        if daq.ISignal.can_cast_from(node):
+            node = daq.ISignal.cast_from(node)
+        elif daq.IInputPort.can_cast_from(node):
+            node = daq.IInputPort.cast_from(node)
+
+        new_value = None
+        value = attr_dict['Value']
+        attribute = attr_dict['Attribute']
+
+        prompt = f'Enter the new value for {sel}:'
+
+        if type(value) is bool:
+            new_value = not value
+        elif type(value) is int:
+            new_value = simpledialog.askinteger(
+                sel, prompt=prompt, initialvalue=value, parent=self)
+            try:
+                pass
+            except tk.TclError:
+                return
+
+        elif type(value) is str:
+            new_value = simpledialog.askstring(
+                sel, prompt=prompt, initialvalue=value, parent=self)
+            try:  # handle the case when the main window is closed
+                pass
+            except tk.TclError:
+                return
+
+        if new_value is None or new_value == value:
+            return
+
+        setattr(node, attribute, new_value)
+
+        print(f'Value changed for {sel}: {value} -> {new_value}')
+
+        self.tree_update()
+
+    def tree_update(self):
+        self.delete(*self.get_children())
+
+        self.attributes = {}
+        node = self.node
+
+        if node is None:
+            return
+
+        self.attributes['Name'] = {
+            'Value': node.name, 'Locked': False, 'Attribute': 'name'}
+        self.attributes['Description'] = {
+            'Value': node.description, 'Locked': False, 'Attribute': 'description'}
+        self.attributes['Active'] = {'Value': bool(
+            node.active), 'Locked': False, 'Attribute': 'active'}
+        self.attributes['Global ID'] = {
+            'Value': node.global_id, 'Locked': True, 'Attribute': 'global_id'}
+        self.attributes['Local ID'] = {
+            'Value': node.local_id, 'Locked': True, 'Attribute': 'local_id'}
+        self.attributes['Tags'] = {
+            'Value': node.tags.list, 'Locked': False, 'Attribute': 'tags'}
+        self.attributes['Visible'] = {'Value': bool(
+            node.visible), 'Locked': False, 'Attribute': 'visible'}
+
+        if daq.ISignal.can_cast_from(node):
+            signal = daq.ISignal.cast_from(node)
+
+            self.attributes['Public'] = {'Value': bool(
+                signal.public), 'Locked': False, 'Attribute': 'public'}
+            self.attributes['Domain Signal ID'] = {
+                'Value': signal.domain_signal.global_id if signal.domain_signal else '', 'Locked': True,
+                'Attribute': '.domain_signal'}
+            if signal.related_signals:
+                self.attributes['Related Signals IDs'] = {'Value': os.linesep.join(
+                    [s.global_id for s in signal.related_signals]), 'Locked': True, 'Attribute': 'related_signals'}
+            self.attributes['Streamed'] = {'Value': bool(
+                signal.streamed), 'Locked': True, 'Attribute': 'streamed'}
+            self.attributes['Last Value'] = {
+                'Value': utils.get_last_value_for_signal(signal), 'Locked': True, 'Attribute': 'last_value'}
+
+        if daq.IInputPort.can_cast_from(node):
+            input_port = daq.IInputPort.cast_from(node)
+
+            self.attributes['Signal ID'] = {
+                'Value': input_port.signal.global_id if input_port.signal else '', 'Locked': True,
+                'Attribute': 'signal'}
+            self.attributes['Requires Signal'] = {'Value': bool(
+                input_port.requires_signal), 'Locked': True, 'Attribute': 'requires_signal'}
+
+        locked_attributes = node.locked_attributes
+
+        self.attributes['Status'] = {
+            'Value': {}, 'Locked': True, 'Attribute': 'status'}
+        self.attributes['Status']['Value'] = dict(
+            node.status_container.statuses.items()) or None
+
+        for locked_attribute in locked_attributes:
+            if locked_attribute not in self.attributes:
+                continue
+            self.attributes[locked_attribute]['Locked'] = True
+
+        def tree_fill(parent: str, key: str, value: dict, locked_flag: int):
+            locked = utils.yes_no[locked_flag]
+            iid = f'{parent}.{key}'
+            if type(value) is bool:
+                value = utils.yes_no[value]
+            elif type(value) is dict:
+                self.insert(
+                    parent, tk.END, iid=iid, text=key, values=('', locked))
+                for k, v in value.items():
+                    tree_fill(iid, k, v, 1)
+            else:
+                self.insert(
+                    parent, tk.END, iid=iid, text=key, values=(value, locked))
+
+        for attr in self.attributes:
+            locked = self.attributes[attr]['Locked']
+            value = self.attributes[attr]['Value']
+            if type(value) is bool:
+                value = utils.yes_no[value]
+
+            tree_fill('', attr, value, locked)
+
+    def fill_tree(self, key, value, parent='', display_attributes=False):
+        display_value = value
+        # for user to see property value without expanding the tree
+        if isinstance(value, daq.IProperty):
+            display_value = value.value
+            if value.value_type == daq.CoreType.ctBool:
+                display_value = utils.yes_no[display_value]
+        else:
+            display_value = utils.metadata_converters[key](
+                value) if key in utils.metadata_converters else value
+        id = self.insert(parent, tk.END, text=str(key), values=(str(display_value),))
+
+        # displaying Nones but not traversing further
+        if value is None:
+            return
+
+        if isinstance(value, daq.IPropertyObject):
+            for property in value.all_properties if self.context.view_hidden_components else value.visible_properties:
+                self.fill_tree(property.name, property, id, display_attributes)
+        elif isinstance(value, daq.IList):
+            try:
+                for i, item in enumerate(value):
+                    self.fill_tree(i, item, id, display_attributes)
+            except Exception:
+                pass
+        elif isinstance(value, daq.IDict):
+            try:
+                for k, v in value.items():
+                    self.fill_tree(k, v, id, display_attributes)
+            except Exception:
+                pass
+        elif issubclass(type(value), daq.IBaseObject) and display_attributes:
+            for name in utils.get_attributes_of_node(value):
+                v = getattr(value, name)
+                self.fill_tree(name, v, id, display_attributes)

--- a/examples/python/gui_demo/components/generic_attributes_treeview.py
+++ b/examples/python/gui_demo/components/generic_attributes_treeview.py
@@ -64,10 +64,10 @@ class AttributesTreeview(ttk.Treeview):
         if not node:
             return
 
-        sel = utils.treeview_get_first_selection(self)[1:]
+        sel = utils.treeview_get_first_selection(self)
+        sel = sel[1:] if sel else sel
         if sel not in self.attributes:
             return
-
         attr_dict = self.attributes[sel]
 
         if attr_dict['Locked']:

--- a/examples/python/gui_demo/components/generic_attributes_treeview.py
+++ b/examples/python/gui_demo/components/generic_attributes_treeview.py
@@ -6,15 +6,16 @@ import os
 
 from .. import utils
 from ..app_context import AppContext
-
+from ..event_port import EventPort
 
 class AttributesTreeview(ttk.Treeview):
-    def __init__(self, parent, node=None, context: AppContext = None, **kwargs):
-        ttk.Treeview.__init__(self, parent, columns=('value', 'access', *context.metadata_fields), show='tree headings', **kwargs)
+    def __init__(self, parent, frame, node=None, context: AppContext = None, **kwargs):
+        ttk.Treeview.__init__(self, frame, columns=('value', 'access', *context.metadata_fields), show='tree headings', **kwargs)
 
         self.context = context
         self.node = node
         self.attributes = None
+        self.event_port = EventPort(parent)
 
         scroll_bar = ttk.Scrollbar(
             self, orient=tk.VERTICAL, command=self.yview)
@@ -109,6 +110,7 @@ class AttributesTreeview(ttk.Treeview):
         print(f'Value changed for {sel}: {value} -> {new_value}')
 
         self.tree_update()
+        self.event_port.emit()
 
     def tree_update(self):
         self.delete(*self.get_children())

--- a/examples/python/gui_demo/components/input_port_row_view.py
+++ b/examples/python/gui_demo/components/input_port_row_view.py
@@ -88,7 +88,7 @@ class InputPortRowView(ttk.Frame):
             AttributesDialog(self, 'Attributes', self.input_port, self.context).show()
 
     def handle_connect_clicked(self):
-        if (self.selection == 'none'):
+        if self.selection == 'none':
             self.input_port.disconnect()
             self.event_port.emit()
         elif self.selection != '':

--- a/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
+++ b/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
@@ -10,7 +10,7 @@ from .dialog import Dialog
 class MetadataFieldsSelectorDialog(Dialog):
     def __init__(self, parent, context: AppContext):
         Dialog.__init__(self, parent, 'Metadata fields to display', context)
-        self.evet_port = EventPort(parent)
+        self.event_port = EventPort(parent)
         self.fields = []
         try:
             self.fields = utils.get_attributes_of_node(
@@ -60,7 +60,7 @@ class MetadataFieldsSelectorDialog(Dialog):
     def ok(self):
         self.context.metadata_fields = [utils.title_to_snake_case(self.tree.item(
             item, 'text')) for item in self.tree.selection()]
-        self.evet_port.emit()
+        self.event_port.emit()
         self.destroy()
 
     def cancel(self):

--- a/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
+++ b/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from tkinter import ttk
 
-import opendaq
+import opendaq as daq
 
 from .. import utils
 from ..event_port import EventPort
@@ -15,8 +15,8 @@ class MetadataFieldsSelectorDialog(Dialog):
         self.event_port = EventPort(parent)
         self.fields = []
         try:
-            my_prop = opendaq.StringProperty(opendaq.String(
-                'MyString'), opendaq.String('foo'), opendaq.Boolean(True))
+            my_prop = daq.StringProperty(daq.String(
+                'MyString'), daq.String('foo'), daq.Boolean(True))
             self.fields = utils.get_attributes_of_node(my_prop)
             self.fields.remove('name')
             self.fields.remove('value')

--- a/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
+++ b/examples/python/gui_demo/components/metadata_fields_selector_dialog.py
@@ -1,6 +1,8 @@
 import tkinter as tk
 from tkinter import ttk
 
+import opendaq
+
 from .. import utils
 from ..event_port import EventPort
 from ..app_context import AppContext
@@ -13,8 +15,9 @@ class MetadataFieldsSelectorDialog(Dialog):
         self.event_port = EventPort(parent)
         self.fields = []
         try:
-            self.fields = utils.get_attributes_of_node(
-                self.context.instance.all_properties[0])
+            my_prop = opendaq.StringProperty(opendaq.String(
+                'MyString'), opendaq.String('foo'), opendaq.Boolean(True))
+            self.fields = utils.get_attributes_of_node(my_prop)
             self.fields.remove('name')
             self.fields.remove('value')
         except:


### PR DESCRIPTION
# Brief

Improve Python GUI app: attributes dialog update, device info via generic properties treeview, metadata fields fix

# Description

- Attributes dialog update
  - Move all logic for topmost TreeView in `attributes_dialog.py` to `generic_attributes_treeview.py`
  - Use `generic_properties_treeview.py` for `additional_tree_frame` if `daq.IDevice.can_cast_from(node)` allowing for modifications
  - Introduce `data_descriptor_treeview.py` and use it for `additional_tree_frame` if `daq.ISignal.can_cast_from(node)` (it's read only)
  - Set parent for `simpledialog.ask...` to prevent pop-ups under current window
- Enable nested property objects in device info dialog via generic properties treeview
- Fix metadata fields not showing up
- Fix crash if no `related_signals`
- Fix typos, minor fixes