### PR TITLE
Nested property object cleanup

### DIFF
--- a/CMakeBasePresets.json
+++ b/CMakeBasePresets.json
@@ -105,7 +105,8 @@
                 "OPENDAQ_ENABLE_WEBSOCKET_STREAMING": true,
                 "APP_ENABLE_WEBPAGE_EXAMPLES": true,
                 "OPENDAQ_DOCUMENTATION_TESTS": true,
-                "OPENDAQ_ENABLE_NATIVE_STREAMING": true
+                "OPENDAQ_ENABLE_NATIVE_STREAMING": true,
+                "OPENDAQ_ENABLE_OPCUA_INTEGRATION_TESTS": true
             }
         },
         {

--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -64,6 +64,27 @@
 
 ## Required application changes
 
+### [#731](https://github.com/openDAQ/openDAQ/pull/731)
+
+`IPropertyObject::clearPropertyValue(IString* name)` when invoked on an Object-type property, no longer removes the property object and restores it to the default, but instead calls `clearPropertyValue` recursively on the object's properties.
+
+
+```cpp
+auto propObj1 = PropertyObject();
+auto propObj2 = PropertyObject();
+
+propObj1.addProperty(ObjectProperty("Child", propObj2));
+
+auto propObj3 = PropertyObject();
+propObj3.addProperty(IntProperty("IntProp", 0));
+propObj3.setPropertyValue("IntProp", 1);
+propObj1.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("Child", propObj3);
+
+// The below code does not restore "Child" to `propObj2`.
+// It instead sets "Child.IntProp" to its default value of "1".
+propObj1.clearPropertyValue("Child");
+```
+
 ### [#609](https://github.com/openDAQ/openDAQ/pull/609) Relocated module info functions
 
 The following no longer works:

--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -29,6 +29,7 @@
 
 ## Bug fixes
 
+- [#731](https://github.com/openDAQ/openDAQ/pull/731) Fixes nested object access over OPC UA. Object properties original PropertyObject is now stored in PropertyObjectImpl; PropertyImpl now contains the clone.
 - [#719](https://github.com/openDAQ/openDAQ/pull/719) Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).
 - [#703](https://github.com/openDAQ/openDAQ/pull/703) Fixes invalid response of openDAQ mDNS wrapper for unicast queries.
 - [#696](https://github.com/openDAQ/openDAQ/pull/696) Set of LT bugfixes. Keeping sessions alive, raw json values for linear rules, default start value for constant signals, fix IPv4/6 control connection address handling. 

--- a/core/coreobjects/include/coreobjects/property.h
+++ b/core/coreobjects/include/coreobjects/property.h
@@ -193,9 +193,10 @@ struct IPropertyBuilder;
  * the child Property Object to be modified. The same behaviour is applied when a Property Object 
  * is created from a Property Object Class - all Object-type properties of the class are cloned.
  *
- * Notably, a object-type property cannot be replaced via `set property value` (unless using `set protected property value`), but calling
- * `clear property value` will reset all of its properties to their default values. `clear property value`
- * cannot be called of the object-type property is read-only.
+ * Notably, a object-type property cannot be replaced via `set property value` (unless using
+ * `set protected property value`), but calling `clear property value` will call `clear property value`
+ * on all of the object's properties. `clear property value` cannot be called of the object-type
+ * property is read-only.
  *
  * @subsection objects_property_containers Container-type properties
  *

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -817,17 +817,17 @@ public:
 	        });
     }
 
-    ErrCode getStructType(IStructType** structType) override
+    ErrCode INTERFACE_FUNC getStructType(IStructType** structType) override
     {
 	    return getStructTypeInternal(structType, true);
     }
 
-    ErrCode getStructTypeNoLock(IStructType** structType) override
+    ErrCode INTERFACE_FUNC getStructTypeNoLock(IStructType** structType) override
     {
 	    return getStructTypeInternal(structType, false);
     }
 
-    ErrCode getStructTypeInternal(IStructType** structType, bool lock)
+    ErrCode INTERFACE_FUNC getStructTypeInternal(IStructType** structType, bool lock)
     {
 	    OPENDAQ_PARAM_NOT_NULL(structType);
 
@@ -846,7 +846,7 @@ public:
 	        });
     }
     
-    ErrCode overrideDefaultValue(IBaseObject* newDefaultValue)  override
+    ErrCode INTERFACE_FUNC overrideDefaultValue(IBaseObject* newDefaultValue)  override
     {
         defaultValue = newDefaultValue;
         if (defaultValue.supportsInterface<IFreezable>() && !defaultValue.isFrozen())
@@ -854,7 +854,7 @@ public:
         return OPENDAQ_SUCCESS;
     }
 
-    ErrCode getClassOnPropertyValueWrite(IEvent** event) override
+    ErrCode INTERFACE_FUNC getClassOnPropertyValueWrite(IEvent** event) override
     {
         if (event == nullptr)
         {

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -38,9 +38,9 @@
 #include <coreobjects/permission_manager_internal_ptr.h>
 #include <coreobjects/errors.h>
 #include <coreobjects/permission_mask_builder_factory.h>
+#include <coreobjects/property_object_protected.h>
 
 BEGIN_NAMESPACE_OPENDAQ
-
 namespace details
 {
     static const std::unordered_map<IntfID, CoreType> intfIdToCoreTypeMap = {
@@ -817,12 +817,12 @@ public:
 	        });
     }
 
-    ErrCode INTERFACE_FUNC getStructType(IStructType** structType) override
+    ErrCode getStructType(IStructType** structType) override
     {
 	    return getStructTypeInternal(structType, true);
     }
 
-    ErrCode INTERFACE_FUNC getStructTypeNoLock(IStructType** structType) override
+    ErrCode getStructTypeNoLock(IStructType** structType) override
     {
 	    return getStructTypeInternal(structType, false);
     }
@@ -923,6 +923,14 @@ public:
             return OPENDAQ_ERR_NO_OWNER;
 
         return owner.getRef()->setPropertyValue(this->name, value);
+    }
+
+    ErrCode INTERFACE_FUNC setValueProtected(IBaseObject* newValue) override
+    {
+        if (!owner.assigned() || !owner.getRef().assigned())
+            return OPENDAQ_ERR_NO_OWNER;
+
+        return owner.getRef().asPtr<IPropertyObjectProtected>()->setProtectedPropertyValue(this->name, newValue);
     }
 
     ErrCode INTERFACE_FUNC validate()

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -846,20 +846,11 @@ public:
 	        });
     }
     
-    ErrCode cloneDefaultValueAndRelease() override
+    ErrCode overrideDefaultValue(IBaseObject* newDefaultValue)  override
     {
-        const auto cloneable = defaultValue.asPtrOrNull<IPropertyObjectInternal>();
-
-        if (!cloneable.assigned())
-            return this->makeErrorInfo(OPENDAQ_ERR_NOINTERFACE, "Default value of property is not cloneable!");
-
-        PropertyObjectPtr cloned;
-        ErrCode err = cloneable->clone(&cloned);
-        if (OPENDAQ_FAILED(err))
-            return err;
-
-        defaultValue = cloned.detach();
-        defaultValue.freeze();
+        defaultValue = newDefaultValue;
+        if (defaultValue.supportsInterface<IFreezable>() && !defaultValue.isFrozen())
+            defaultValue.freeze();
         return OPENDAQ_SUCCESS;
     }
 

--- a/core/coreobjects/include/coreobjects/property_internal.h
+++ b/core/coreobjects/include/coreobjects/property_internal.h
@@ -140,6 +140,7 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyInternal, IBaseObject)
 
     // Freezes default value
     virtual ErrCode INTERFACE_FUNC overrideDefaultValue(IBaseObject* newDefaultValue) = 0;
+    virtual ErrCode INTERFACE_FUNC setValueProtected(IBaseObject* newValue) = 0;
 };
 /*!@}*/
 

--- a/core/coreobjects/include/coreobjects/property_internal.h
+++ b/core/coreobjects/include/coreobjects/property_internal.h
@@ -137,7 +137,9 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyInternal, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getCoercerNoLock(ICoercer** coercer) = 0;
     virtual ErrCode INTERFACE_FUNC getCallableInfoNoLock(ICallableInfo** callable) = 0;
     virtual ErrCode INTERFACE_FUNC getStructTypeNoLock(IStructType** structType) = 0;
-    virtual ErrCode INTERFACE_FUNC cloneDefaultValueAndRelease() = 0;
+
+    // Freezes default value
+    virtual ErrCode INTERFACE_FUNC overrideDefaultValue(IBaseObject* newDefaultValue) = 0;
 };
 /*!@}*/
 

--- a/core/coreobjects/include/coreobjects/property_internal.h
+++ b/core/coreobjects/include/coreobjects/property_internal.h
@@ -137,6 +137,7 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyInternal, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getCoercerNoLock(ICoercer** coercer) = 0;
     virtual ErrCode INTERFACE_FUNC getCallableInfoNoLock(ICallableInfo** callable) = 0;
     virtual ErrCode INTERFACE_FUNC getStructTypeNoLock(IStructType** structType) = 0;
+    virtual ErrCode INTERFACE_FUNC cloneDefaultValueAndRelease() = 0;
 };
 /*!@}*/
 

--- a/core/coreobjects/include/coreobjects/property_object.h
+++ b/core/coreobjects/include/coreobjects/property_object.h
@@ -175,8 +175,7 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObject, IBaseObject)
      * This function will remove said value from the dictionary. If the tries to obtain the Property value of
      * a property that does not have a set Property value, then the default value is returned.
      *
-     * Importantly, clearing the value of an Object-type property will call `clear` on all the child object's
-     * properties.
+     * Importantly, clearing the value of an Object-type property will call `clear` on all the child object's properties.
      */
     virtual ErrCode INTERFACE_FUNC clearPropertyValue(IString* propertyName) = 0;
 

--- a/core/coreobjects/include/coreobjects/property_object.h
+++ b/core/coreobjects/include/coreobjects/property_object.h
@@ -175,9 +175,8 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObject, IBaseObject)
      * This function will remove said value from the dictionary. If the tries to obtain the Property value of
      * a property that does not have a set Property value, then the default value is returned.
      *
-     * Importantly, clearing the value of an Object-type property will release the reference of the current
-     * Property object value of the property. It will then create a new clone of the Default value and set it
-     * as the value of the property.
+     * Importantly, clearing the value of an Object-type property will call `clear` on all the child object's
+     * properties.
      */
     virtual ErrCode INTERFACE_FUNC clearPropertyValue(IString* propertyName) = 0;
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -1888,8 +1888,8 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
                 {
                     if (protectedAccess)
                     {
-                        auto objProtected = it->second.asPtr<IPropertyObjectProtected>(true);
-                        auto obj = it->second.asPtr<IPropertyObject>(true);
+                        auto objProtected = it->second.template asPtr<IPropertyObjectProtected>(true);
+                        auto obj = it->second.template asPtr<IPropertyObject>(true);
                         for (const auto& childProp: obj.getAllProperties())
                         {
                             objProtected.clearProtectedPropertyValue(childProp.getName());
@@ -1897,7 +1897,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
                     }
                     else
                     {
-                        auto obj = it->second.asPtr<IPropertyObject>(true);
+                        auto obj = it->second.template asPtr<IPropertyObject>(true);
                         for (const auto& childProp: obj.getAllProperties())
                         {
                             obj.clearPropertyValue(childProp.getName());

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -1414,9 +1414,7 @@ PropertyPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkFor
 template <typename PropObjInterface, typename... Interfaces>
 PropertyObjectPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::cloneChildPropertyObject(const PropertyPtr& prop)
 {
-    const auto defaultValue = prop.getDefaultValue();
-    const auto propName = prop.getName();
-    const auto cloneable = defaultValue.asPtrOrNull<IPropertyObjectInternal>();
+    const auto cloneable = prop.getDefaultValue().asPtrOrNull<IPropertyObjectInternal>();
 
     if (!cloneable.assigned())
         return nullptr;

--- a/core/coreobjects/src/property_object_class_builder_impl.cpp
+++ b/core/coreobjects/src/property_object_class_builder_impl.cpp
@@ -4,11 +4,9 @@
 #include <coreobjects/property_object_class_factory.h>
 #include <coreobjects/property_ptr.h>
 #include <coretypes/type_manager_factory.h>
-
 #include <utility>
 
 BEGIN_NAMESPACE_OPENDAQ
-
 PropertyObjectClassBuilderImpl::PropertyObjectClassBuilderImpl(StringPtr name)
     : name(std::move(name))
     , props(Dict<IString, IProperty>())
@@ -84,6 +82,13 @@ ErrCode PropertyObjectClassBuilderImpl::addProperty(IProperty* property)
         if (props.hasKey(p.getName()))
             return makeErrorInfo(OPENDAQ_ERR_ALREADYEXISTS, fmt::format(R"(Property with name {} already exists)", p.getName()));
         props.set(p.getName(), p);
+
+        auto defaultValue = p.asPtr<IPropertyInternal>().getDefaultValueUnresolved();
+        if (auto freezable = defaultValue.asPtrOrNull<IFreezable>(); freezable.assigned())
+        {
+            if (!freezable.isFrozen())
+                freezable.freeze();
+        }
 
         return OPENDAQ_SUCCESS;
     });

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -1600,7 +1600,7 @@ TEST_F(PropertyObjectTest, ObjectPropMetadata)
 
     ASSERT_EQ(propObj.getVisibleProperties().getCount(), 0u);
     ASSERT_THROW(propObj.setPropertyValue("child", PropertyObject()), AccessDeniedException);
-    ASSERT_THROW(childObj.setPropertyValue("Foo", "NotBar"), FrozenException);
+    ASSERT_NO_THROW(childObj.setPropertyValue("Foo", "NotBar"));
 }
 
 TEST_F(PropertyObjectTest, DISABLED_SerializeAndDeserializeEmpty)
@@ -1811,7 +1811,8 @@ TEST_F(PropertyObjectTest, NestedObjectsFrozen)
     const auto propObj = PropertyObject();
     const auto propObj1 = PropertyObject();
     propObj.addProperty(ObjectProperty("Child", propObj1));
-    ASSERT_TRUE(propObj1.isFrozen());
+    ASSERT_FALSE(propObj1.isFrozen());
+    ASSERT_TRUE(propObj.getProperty("Child").getDefaultValue().isFrozen());
 }
 
 TEST_F(PropertyObjectTest, ClonedObjectSet)

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -1802,7 +1802,7 @@ TEST_F(PropertyObjectTest, Clone)
     ASSERT_NO_THROW(propObj.asPtr<IPropertyObjectInternal>().clone());
 
     propObj.setPropertyValue("child.child.foo", "test");
-    ASSERT_EQ(propObj2.getPropertyValue("foo"), "bar");
+    ASSERT_EQ(propObj2.getPropertyValue("foo"), "test");
     ASSERT_EQ(clonedObj2.getPropertyValue("foo"), "test");
 }
 

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -1837,7 +1837,7 @@ TEST_F(PropertyObjectTest, ClonedObjectsClear)
     const auto cloned = propObj.getPropertyValue("Child");
     propObj.setPropertyValue("Child.MyInt", 15);
     propObj.clearPropertyValue("Child");
-    ASSERT_NE(cloned, propObj.getPropertyValue("Child"));
+    ASSERT_EQ(cloned, propObj.getPropertyValue("Child"));
     ASSERT_EQ(propObj.getPropertyValue("Child.MyInt"), 10);
 }
 
@@ -1874,6 +1874,7 @@ TEST_F(PropertyObjectTest, BeginEndUpdateClonedClear)
     const auto oldChild = propObj.getPropertyValue("Child");
     const auto newChild = PropertyObject();
     newChild.addProperty(IntProperty("NewInt", 15));
+    newChild.setPropertyValue("NewInt", 10);
     propObj.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("Child", newChild);
 
     propObj.beginUpdate();
@@ -1883,9 +1884,9 @@ TEST_F(PropertyObjectTest, BeginEndUpdateClonedClear)
 
     propObj.endUpdate();
 
-    ASSERT_NE(propObj.getPropertyValue("Child"), newChild);
+    ASSERT_EQ(propObj.getPropertyValue("Child"), newChild);
     ASSERT_NE(propObj.getPropertyValue("Child"), oldChild);
-    ASSERT_EQ(propObj.getPropertyValue("Child.MyString"), "foo");
+    ASSERT_EQ(propObj.getPropertyValue("Child.NewInt"), 15);
 }
 
 TEST_F(PropertyObjectTest, BeginEndUpdateClonedClassObject)
@@ -1911,9 +1912,9 @@ TEST_F(PropertyObjectTest, BeginEndUpdateClonedClassObject)
 
     propObj.endUpdate();
 
-    ASSERT_NE(propObj.getPropertyValue("Child"), newChild);
+    ASSERT_EQ(propObj.getPropertyValue("Child"), newChild);
     ASSERT_NE(propObj.getPropertyValue("Child"), oldChild);
-    ASSERT_EQ(propObj.getPropertyValue("Child.Child.MyString"), "foo");
+    ASSERT_EQ(propObj.getPropertyValue("Child.NewInt"), 15);
 }
 
 TEST_F(PropertyObjectTest, ClonedClassObjects)

--- a/core/coreobjects/tests/test_property_object_update.cpp
+++ b/core/coreobjects/tests/test_property_object_update.cpp
@@ -4,6 +4,7 @@
 #include <coreobjects/property_object_class_factory.h>
 #include <coreobjects/property_factory.h>
 #include <coreobjects/property_object_protected_ptr.h>
+#include <coreobjects/property_object_internal.h>
 
 using namespace daq;
 
@@ -38,16 +39,28 @@ protected:
         child2.addProperty(ObjectProperty("child2_1", child2_1));
         
         parentObj1 = PropertyObject();
-        parentObj1.addProperty(ObjectProperty("child1", child1));
-        parentObj1.addProperty(ObjectProperty("child2", child2));
+
+        PropertyObjectPtr clone1;
+        child1.asPtr<IPropertyObjectInternal>()->clone(&clone1);
+        parentObj1.addProperty(ObjectProperty("child1", clone1));
+
+        child2.asPtr<IPropertyObjectInternal>()->clone(&clone1);
+        parentObj1.addProperty(ObjectProperty("child2", clone1));
 
         parentObj2 = PropertyObject();
-        parentObj2.addProperty(ObjectProperty("child1", child1));
-        parentObj2.addProperty(ObjectProperty("child2", child2));
 
+        child1.asPtr<IPropertyObjectInternal>()->clone(&clone1);
+        parentObj2.addProperty(ObjectProperty("child1", clone1));
+
+        child2.asPtr<IPropertyObjectInternal>()->clone(&clone1);
+        parentObj2.addProperty(ObjectProperty("child2", clone1));
+
+        PropertyObjectPtr clone2;
+        child1.asPtr<IPropertyObjectInternal>()->clone(&clone1);
+        child2.asPtr<IPropertyObjectInternal>()->clone(&clone2);
         PropertyObjectClassPtr objClass = PropertyObjectClassBuilder("TestClass")
-                                              .addProperty(ObjectProperty("child1", child1))
-                                              .addProperty(ObjectProperty("child2", child2))
+                                              .addProperty(ObjectProperty("child1", clone1))
+                                              .addProperty(ObjectProperty("child2", clone2))
                                               .build();
 
         typeManager = TypeManager();

--- a/core/opendaq/opendaq/mocks/CMakeLists.txt
+++ b/core/opendaq/opendaq/mocks/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MOCK_HEADERS mock_device_module.h
                  default_mocks_factory.h
                  mock_fb_dynamic_input_ports.h
                  mock_fb_dynamic_output_ports.h
+                 advanced_components_setup_utils.h
 )
 
 opendaq_prepend_path(include/${SDK_TARGET_NAME}/mock MOCK_HEADERS)
@@ -34,6 +35,7 @@ set(MOCK_SOURCES mock_device_module.cpp
                  default_mocks.cpp
                  mock_fb_dynamic_input_ports.cpp
                  mock_fb_dynamic_output_ports.cpp
+                 advanced_components_setup_utils.cpp
 )
 
 source_group("mock" FILES ${MOCK_HEADERS}

--- a/core/opendaq/opendaq/mocks/advanced_components_setup_utils.cpp
+++ b/core/opendaq/opendaq/mocks/advanced_components_setup_utils.cpp
@@ -118,7 +118,7 @@ ComponentPtr createAdvancedPropertyComponent(const ContextPtr& ctx, const Compon
     return component;
 }
 
-static PropertyObjectPtr createMockNestedPropertyObject()
+PropertyObjectPtr createMockNestedPropertyObject()
 {
     PropertyObjectPtr parent = PropertyObject();
     PropertyObjectPtr child1 = PropertyObject();

--- a/core/opendaq/opendaq/mocks/advanced_components_setup_utils.cpp
+++ b/core/opendaq/opendaq/mocks/advanced_components_setup_utils.cpp
@@ -1,4 +1,4 @@
-#include "test_utils.h"
+#include "opendaq/mock/advanced_components_setup_utils.h"
 #include "coreobjects/argument_info_factory.h"
 #include "coreobjects/callable_info_factory.h"
 #include "coreobjects/coercer_factory.h"
@@ -13,7 +13,7 @@
 #include "opendaq/mock/mock_device_module.h"
 #include "opendaq/mock/mock_physical_device.h"
 
-namespace daq::config_protocol::test_utils
+namespace daq::test_utils
 {
 
 DevicePtr createTestDevice(const std::string& localId)

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/advanced_components_setup_utils.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/advanced_components_setup_utils.h
@@ -130,7 +130,7 @@ namespace daq::test_utils
             return availableDevices;
         }
 
-        DevicePtr onAddDevice(const StringPtr& connectionString, const PropertyObjectPtr& config = nullptr) override
+        DevicePtr onAddDevice(const StringPtr& connectionString, const PropertyObjectPtr& /*config*/ = nullptr) override
         {
             if (connectionString == "mock://test")
             {

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/advanced_components_setup_utils.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/advanced_components_setup_utils.h
@@ -25,6 +25,7 @@ namespace daq::test_utils
 {
     DevicePtr createTestDevice(const std::string& localId = "root_dev");
     ComponentPtr createAdvancedPropertyComponent(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    PropertyObjectPtr createMockNestedPropertyObject();
 
     class MockFb1Impl final : public FunctionBlock
     {

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/advanced_components_setup_utils.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/advanced_components_setup_utils.h
@@ -21,7 +21,7 @@
 #include <opendaq/channel_impl.h>
 #include <opendaq/server_impl.h>
 
-namespace daq::config_protocol::test_utils
+namespace daq::test_utils
 {
     DevicePtr createTestDevice(const std::string& localId = "root_dev");
     ComponentPtr createAdvancedPropertyComponent(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -136,7 +136,7 @@ TEST_F(NativeDeviceModulesTest, CheckProtocolVersion)
 
     auto info = client.getDevices()[0].getInfo();
     ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
-    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 9);
+    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 10);
 
     // because info holds a client device as owner, it have to be removed before module manager is destroyed
     // otherwise module of native client device would not be removed

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -261,10 +261,15 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::clearPropertyValue(IString* pr
 template <class Impl>
 ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::clearProtectedPropertyValue(IString* propertyName)
 {
+    OPENDAQ_PARAM_NOT_NULL(propertyName);
     if (!deserializationComplete)
         return Impl::clearProtectedPropertyValue(propertyName);
 
-    return OPENDAQ_ERR_INVALID_OPERATION;
+    const auto propertyNamePtr = StringPtr::Borrow(propertyName);
+    return daqTry([this, &propertyNamePtr]()
+    {
+        clientComm->clearProtectedPropertyValue(remoteGlobalId, propertyNamePtr);
+    });
 }
 
 template <class Impl>

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
@@ -179,12 +179,12 @@ public:
 
 inline std::set<uint16_t> GetSupportedConfigProtocolVersions()
 {
-    return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 }
 
 inline constexpr uint16_t GetLatestConfigProtocolVersion()
 {
-    return 9; // *GetSupportedConfigProtocolVersions().rbegin();
+    return 10; // *GetSupportedConfigProtocolVersions().rbegin();
 }
 
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -69,6 +69,7 @@ public:
     void setProtectedPropertyValue(const std::string& globalId, const std::string& propertyName, const BaseObjectPtr& propertyValue);
     BaseObjectPtr getPropertyValue(const std::string& globalId, const std::string& propertyName);
     void clearPropertyValue(const std::string& globalId, const std::string& propertyName);
+    void clearProtectedPropertyValue(const std::string& globalId, const std::string& propertyName);
     void update(const std::string& globalId, const std::string& serialized, const std::string& path);
     BaseObjectPtr callProperty(const std::string& globalId, const std::string& propertyName, const BaseObjectPtr& params);
     void setAttributeValue(const std::string& globalId, const std::string& attributeName, const BaseObjectPtr& attributeValue);

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
@@ -33,6 +33,7 @@ public:
     static BaseObjectPtr setPropertyValue(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr setProtectedPropertyValue(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr clearPropertyValue(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
+    static BaseObjectPtr clearProtectedPropertyValue(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr callProperty(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr beginUpdate(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr endUpdate(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
@@ -130,6 +131,23 @@ inline BaseObjectPtr ConfigServerComponent::clearPropertyValue(const RpcContext&
     ConfigServerAccessControl::protectObject(propertyParent, context.user, {Permission::Read, Permission::Write});
 
     component.clearPropertyValue(propertyName);
+
+    return nullptr;
+}
+
+inline BaseObjectPtr ConfigServerComponent::clearProtectedPropertyValue(const RpcContext& context,
+                                                                        const ComponentPtr& component,
+                                                                        const ParamsDictPtr& params)
+{
+    ConfigServerAccessControl::protectLockedComponent(component);
+    ConfigServerAccessControl::protectViewOnlyConnection(context.connectionType);
+
+    const auto propertyName = static_cast<std::string>(params["PropertyName"]);
+    const auto propertyParent = ConfigServerAccessControl::getFirstPropertyParent(component, propertyName);
+
+    ConfigServerAccessControl::protectObject(propertyParent, context.user, {Permission::Read, Permission::Write});
+
+    component.asPtr<IPropertyObjectProtected>().clearProtectedPropertyValue(propertyName);
 
     return nullptr;
 }

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -120,6 +120,20 @@ void ConfigProtocolClientComm::clearPropertyValue(
     parseRpcOrRejectReply(clearPropertyValueRpcReplyPacketBuffer.parseRpcRequestOrReply());
 }
 
+void ConfigProtocolClientComm::clearProtectedPropertyValue(const std::string& globalId, const std::string& propertyName)
+{
+    requireMinServerVersion(ClientCommand("ClearProtectedPropertyValue", 10));
+
+    auto dict = Dict<IString, IBaseObject>();
+    dict.set("ComponentGlobalId", String(globalId));
+    dict.set("PropertyName", String(propertyName));
+    auto clearPropertyValueRpcRequestPacketBuffer = createRpcRequestPacketBuffer(generateId(), "ClearProtectedPropertyValue", dict);
+    const auto clearPropertyValueRpcReplyPacketBuffer = sendRequestCallback(clearPropertyValueRpcRequestPacketBuffer);
+
+    // ReSharper disable once CppExpressionWithoutSideEffects
+    parseRpcOrRejectReply(clearPropertyValueRpcReplyPacketBuffer.parseRpcRequestOrReply());
+}
+
 void ConfigProtocolClientComm::update(const std::string& globalId, const std::string& serialized, const std::string& path)
 {
     auto dict = Dict<IString, IBaseObject>();

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -135,6 +135,7 @@ void ConfigProtocolServer::buildRpcDispatchStructure()
     addHandler<ComponentPtr>("GetPropertyValue", &ConfigServerComponent::getPropertyValue);
     addHandler<ComponentPtr>("SetProtectedPropertyValue", &ConfigServerComponent::setProtectedPropertyValue);
     addHandler<ComponentPtr>("ClearPropertyValue", &ConfigServerComponent::clearPropertyValue);
+    addHandler<ComponentPtr>("ClearProtectedPropertyValue", &ConfigServerComponent::clearProtectedPropertyValue);
     addHandler<ComponentPtr>("CallProperty", &ConfigServerComponent::callProperty);
     addHandler<ComponentPtr>("BeginUpdate", &ConfigServerComponent::beginUpdate);
     addHandler<ComponentPtr>("EndUpdate", &ConfigServerComponent::endUpdate);

--- a/shared/libraries/config_protocol/tests/CMakeLists.txt
+++ b/shared/libraries/config_protocol/tests/CMakeLists.txt
@@ -16,8 +16,6 @@ add_executable(${TEST_APP}
     test_nested_property_objects.cpp
     test_remote_update.cpp
     test_c2d_streaming.cpp
-    test_utils.h
-    test_utils.cpp
 )
 
 target_link_libraries(${TEST_APP} PRIVATE

--- a/shared/libraries/config_protocol/tests/test_c2d_streaming.cpp
+++ b/shared/libraries/config_protocol/tests/test_c2d_streaming.cpp
@@ -8,7 +8,7 @@
 #include <opendaq/packet_factory.h>
 #include <future>
 #include <queue>
-#include "test_utils.h"
+#include "opendaq/mock/advanced_components_setup_utils.h"
 
 #include <coreobjects/user_factory.h>
 #include <opendaq/event_packet_utils.h>

--- a/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_access_control.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 #include <opendaq/instance_factory.h>
 
-#include "test_utils.h"
+#include <opendaq/mock/advanced_components_setup_utils.h>
 #include <config_protocol/config_protocol_server.h>
 #include <config_protocol/config_protocol_client.h>
 #include <config_protocol/config_client_device_impl.h>

--- a/shared/libraries/config_protocol/tests/test_config_protocol_device_locking.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_device_locking.cpp
@@ -7,7 +7,7 @@
 #include <config_protocol/config_client_device_impl.h>
 #include <coreobjects/callable_info_factory.h>
 #include <coreobjects/argument_info_factory.h>
-#include "test_utils.h"
+#include <opendaq/mock/advanced_components_setup_utils.h>
 
 
 using namespace daq;
@@ -23,7 +23,7 @@ public:
 
     DevicePtr createDevice()
     {
-        return daq::config_protocol::test_utils::createTestDevice();
+        return test_utils::createTestDevice();
     }
 
     void setupServerAndClient(const DevicePtr& device, const UserPtr& user)

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -6,7 +6,7 @@
 #include <gmock/gmock.h>
 #include <config_protocol/config_protocol_server.h>
 #include <config_protocol/config_protocol_client.h>
-#include "test_utils.h"
+#include <opendaq/mock/advanced_components_setup_utils.h>
 #include <coreobjects/argument_info_factory.h>
 #include <coreobjects/callable_info_factory.h>
 #include <opendaq/context_factory.h>

--- a/shared/libraries/config_protocol/tests/test_config_protocol_view_only_client.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_view_only_client.cpp
@@ -7,7 +7,7 @@
 #include <gmock/gmock.h>
 #include <opendaq/device_private_ptr.h>
 #include <opendaq/device_ptr.h>
-#include "test_utils.h"
+#include <opendaq/mock/advanced_components_setup_utils.h>
 
 using namespace daq;
 using namespace testing;
@@ -19,7 +19,7 @@ public:
 
     DevicePtr createDevice()
     {
-        return daq::config_protocol::test_utils::createTestDevice();
+        return test_utils::createTestDevice();
     }
 
     void setupServerAndClient(ClientType connectionType)

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -16,7 +16,7 @@
 #include <opendaq/component_status_container_ptr.h>
 #include <opendaq/device_domain_factory.h>
 #include <coreobjects/property_object_factory.h>
-#include "test_utils.h"
+#include <opendaq/mock/advanced_components_setup_utils.h>
 #include "config_protocol/config_protocol_server.h"
 #include "config_protocol/config_protocol_client.h"
 #include "config_protocol/config_client_device_impl.h"

--- a/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
+++ b/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
@@ -16,7 +16,7 @@
 #include <coreobjects/property_object_factory.h>
 #include <opendaq/sync_component_ptr.h>
 #include <opendaq/sync_component_private_ptr.h>
-#include "test_utils.h"
+#include <opendaq/mock/advanced_components_setup_utils.h>
 #include "config_protocol/config_protocol_server.h"
 #include "config_protocol/config_protocol_client.h"
 #include "config_protocol/config_client_device_impl.h"

--- a/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
+++ b/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
@@ -179,7 +179,7 @@ TEST_F(ConfigNestedPropertyObjectTest, TestNestedObjectClientClear)
     clientDevice.setPropertyValue("ObjectProperty.child1.child1_2.Int", 2);
     clientDevice.setPropertyValue("ObjectProperty.child2.child2_1.Ratio", Ratio(1, 5));
 
-    clientDevice.clearPropertyValue("ObjectProperty");
+    clientDevice.asPtr<IPropertyObjectProtected>().clearProtectedPropertyValue("ObjectProperty");
 
     ASSERT_EQ(serverDevice.getPropertyValue("ObjectProperty.child1.child1_2.child1_2_1.String"), "String");
     ASSERT_DOUBLE_EQ(serverDevice.getPropertyValue("ObjectProperty.child1.child1_1.Float"), 1.1);
@@ -196,7 +196,7 @@ TEST_F(ConfigNestedPropertyObjectTest, TestNestedObjectClientClear)
     clientDevice.setPropertyValue("ObjectProperty.child1.child1_2.Int", 2);
     clientDevice.setPropertyValue("ObjectProperty.child2.child2_1.Ratio", Ratio(1, 5));
     
-    clientDevice.clearPropertyValue("ObjectProperty.child1");
+    clientDevice.asPtr<IPropertyObjectProtected>().clearProtectedPropertyValue("ObjectProperty.child1");
 
     ASSERT_EQ(serverDevice.getPropertyValue("ObjectProperty.child1.child1_2.child1_2_1.String"), "String");
     ASSERT_DOUBLE_EQ(serverDevice.getPropertyValue("ObjectProperty.child1.child1_1.Float"), 1.1);
@@ -267,7 +267,7 @@ TEST_F(ConfigNestedPropertyObjectTest, TestNestedObjectServerClearObject)
     ASSERT_EQ(clientDevice.getPropertyValue("ObjectProperty.child1.child1_2.Int"), 2);
     ASSERT_EQ(clientDevice.getPropertyValue("ObjectProperty.child2.child2_1.Ratio"), Ratio(1, 5));
 
-    serverDevice.clearPropertyValue("ObjectProperty");
+    serverDevice.asPtr<IPropertyObjectProtected>().clearProtectedPropertyValue("ObjectProperty");
 
     ASSERT_EQ(clientDevice.getPropertyValue("ObjectProperty.child1.child1_2.child1_2_1.String"), "String");
     ASSERT_DOUBLE_EQ(clientDevice.getPropertyValue("ObjectProperty.child1.child1_1.Float"), 1.1);
@@ -279,7 +279,7 @@ TEST_F(ConfigNestedPropertyObjectTest, TestNestedObjectServerClearObject)
     serverDevice.setPropertyValue("ObjectProperty.child1.child1_2.Int", 2);
     serverDevice.setPropertyValue("ObjectProperty.child2.child2_1.Ratio", Ratio(1, 5));
 
-    serverDevice.clearPropertyValue("ObjectProperty.child1");
+    serverDevice.asPtr<IPropertyObjectProtected>().clearProtectedPropertyValue("ObjectProperty.child1");
     
     ASSERT_EQ(clientDevice.getPropertyValue("ObjectProperty.child1.child1_2.child1_2_1.String"), "String");
     ASSERT_DOUBLE_EQ(clientDevice.getPropertyValue("ObjectProperty.child1.child1_1.Float"), 1.1);

--- a/shared/libraries/config_protocol/tests/test_remote_update.cpp
+++ b/shared/libraries/config_protocol/tests/test_remote_update.cpp
@@ -5,7 +5,7 @@
 #include <coreobjects/property_object_internal_ptr.h>
 #include <opendaq/mock/mock_fb_module.h>
 #include <opendaq/data_descriptor_factory.h>
-#include "test_utils.h"
+#include <opendaq/mock/advanced_components_setup_utils.h>
 #include "config_protocol/config_protocol_server.h"
 #include "config_protocol/config_protocol_client.h"
 #include "config_protocol/config_client_device_impl.h"

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
@@ -155,7 +155,7 @@ protected:
     PropertyPtr addVariableBlockProperty(const StringPtr& propName, const OpcUaNodeId& propNodeId);
     void browseRawProperties();
     bool isIgnoredMethodProperty(const std::string& browseName);
-    void cloneAndSetChildPropertyObject(const PropertyPtr& prop) override;
+    PropertyObjectPtr cloneChildPropertyObject(const PropertyPtr& prop) override;
 
 private:
     bool isBasePropertyObject(const PropertyObjectPtr& propObj);

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_property_object_impl.h
@@ -143,7 +143,8 @@ protected:
     std::map<std::string, std::string> propBrowseName;
     opcua::OpcUaNodeId methodParentNodeId;
     LoggerComponentPtr loggerComponent;
-
+    
+    ErrCode setOPCUAPropertyValueInternal(IString* propertyName, IBaseObject* value, bool protectedWrite);
     void addProperties(const OpcUaNodeId& parentId,
                        std::map<uint32_t, PropertyPtr>& orderedProperties,
                        std::vector<PropertyPtr>& unorderedProperties);
@@ -153,8 +154,12 @@ protected:
                              std::unordered_map<std::string, BaseObjectPtr>& functionPropValues);
     PropertyPtr addVariableBlockProperty(const StringPtr& propName, const OpcUaNodeId& propNodeId);
     void browseRawProperties();
-    bool isIgnoredMethodPeoperty(const std::string& browseName);
-    virtual ErrCode INTERFACE_FUNC setPropertyValueInternal(IString* propertyName, IBaseObject* value, bool protectedWrite);
+    bool isIgnoredMethodProperty(const std::string& browseName);
+    void cloneAndSetChildPropertyObject(const PropertyPtr& prop) override;
+
+private:
+    bool isBasePropertyObject(const PropertyObjectPtr& propObj);
 };
+
 
 END_NAMESPACE_OPENDAQ_OPCUA_TMS

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_sync_component_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_sync_component_impl.h
@@ -34,10 +34,6 @@ public:
                                const opcua::OpcUaNodeId& nodeId)
         : Super(ctx, parent, localId, clientContext, nodeId)
     {
-        StringPtr propertyName = "Interfaces";
-        BaseObjectPtr interfacesValue;
-        checkErrorInfo(getPropertyValue(propertyName, &interfacesValue));
-        checkErrorInfo(Impl::setProtectedPropertyValue(propertyName, interfacesValue));
     }
 
     ErrCode INTERFACE_FUNC getSyncLocked(Bool* synchronizationLocked) override

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -553,7 +553,7 @@ bool TmsClientPropertyObjectBaseImpl<Impl>::isIgnoredMethodProperty(const std::s
 }
 
 template <class Impl>
-void TmsClientPropertyObjectBaseImpl<Impl>::cloneAndSetChildPropertyObject(const PropertyPtr& prop)
+PropertyObjectPtr TmsClientPropertyObjectBaseImpl<Impl>::cloneChildPropertyObject(const PropertyPtr& prop)
 {
     const auto propPtrInternal = prop.asPtr<IPropertyInternal>();
     if (propPtrInternal.assigned() && propPtrInternal.getValueTypeUnresolved() == ctObject && prop.getDefaultValue().assigned())
@@ -561,27 +561,22 @@ void TmsClientPropertyObjectBaseImpl<Impl>::cloneAndSetChildPropertyObject(const
         const auto propName = prop.getName();
         const auto defaultValueObj = prop.getDefaultValue().asPtrOrNull<IPropertyObject>();
         if (!defaultValueObj.assigned())
-            return;
+            return nullptr;
 
         if (!isBasePropertyObject(defaultValueObj))
         {
-            auto clonedValue = defaultValueObj.asPtr<IPropertyObjectInternal>(true).clone();
-            this->writeLocalValue(propName, clonedValue);
-            this->configureClonedObj(propName, clonedValue);
-            return;
+            return defaultValueObj.asPtr<IPropertyObjectInternal>(true).clone();
         }
 
         if (const auto& objIt = objectTypeIdMap.find(propName); objIt != objectTypeIdMap.cend())
         {
-            auto clientObj = TmsClientPropertyObject(daqContext, clientContext, objIt->second);
-            this->writeLocalValue(propName, clientObj);
-            this->configureClonedObj(propName, clientObj);
+            return TmsClientPropertyObject(daqContext, clientContext, objIt->second);
         }
-        else
-        {
-            throw NotFoundException{"Object property with name {} not found", propName};
-        }
+        
+        throw NotFoundException{"Object property with name {} not found", propName};
     }
+
+    return nullptr;
 }
 
 template <class Impl>

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -167,11 +167,6 @@ ErrCode INTERFACE_FUNC TmsClientPropertyObjectBaseImpl<Impl>::getPropertyValue(I
             const auto refProp = this->objPtr.getProperty(propertyName).getReferencedProperty();
             return getPropertyValue(refProp.getName(), value);
         }
-        //else if (const auto& objIt = objectTypeIdMap.find(propertyNamePtr); objIt != objectTypeIdMap.cend())
-        //{
-        //    *value = TmsClientPropertyObject(daqContext, clientContext, objIt->second).detach();
-        //    return OPENDAQ_SUCCESS;
-        //}
 
         return Impl::getPropertyValue(propertyName, value);
     });

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -47,7 +47,8 @@ ErrCode TmsClientPropertyObjectBaseImpl<Impl>::setOPCUAPropertyValueInternal(ISt
 
         if (!prop.assigned())
             throw NotFoundException(R"(Child property "{}" not found)", propertyNamePtr);
-
+        if (protectedWrite)
+            return prop.asPtr<IPropertyInternal>()->setValueProtected(value);
         return prop->setValue(value);
     }
 

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -27,7 +27,7 @@ namespace detail
 }
 
 template <class Impl>
-ErrCode TmsClientPropertyObjectBaseImpl<Impl>::setPropertyValueInternal(IString* propertyName, IBaseObject* value, bool protectedWrite)
+ErrCode TmsClientPropertyObjectBaseImpl<Impl>::setOPCUAPropertyValueInternal(IString* propertyName, IBaseObject* value, bool protectedWrite)
 {
     if (propertyName == nullptr)
     {
@@ -35,6 +35,21 @@ ErrCode TmsClientPropertyObjectBaseImpl<Impl>::setPropertyValueInternal(IString*
         return OPENDAQ_SUCCESS;
     }
     auto propertyNamePtr = StringPtr::Borrow(propertyName);
+
+    StringPtr childName;
+    StringPtr subName;
+    if (this->isChildProperty(propertyNamePtr, childName, subName))
+    {
+        PropertyPtr prop;
+        ErrCode err = getProperty(propertyNamePtr, &prop);
+        if (OPENDAQ_FAILED(err))
+            return err;
+
+        if (!prop.assigned())
+            throw NotFoundException(R"(Child property "{}" not found)", propertyNamePtr);
+
+        return prop->setValue(value);
+    }
 
     StringPtr lastProcessDescription = "";
     ErrCode errCode = daqTry(
@@ -103,13 +118,13 @@ void TmsClientPropertyObjectBaseImpl<Impl>::init()
 template <typename Impl>
 ErrCode INTERFACE_FUNC TmsClientPropertyObjectBaseImpl<Impl>::setPropertyValue(IString* propertyName, IBaseObject* value)
 {
-    return setPropertyValueInternal(propertyName, value, false);
+    return setOPCUAPropertyValueInternal(propertyName, value, false);
 }
 
 template <typename Impl>
 ErrCode INTERFACE_FUNC TmsClientPropertyObjectBaseImpl<Impl>::setProtectedPropertyValue(IString* propertyName, IBaseObject* value)
 {
-    return setPropertyValueInternal(propertyName, value, true);
+    return setOPCUAPropertyValueInternal(propertyName, value, true);
 }
 
 template <typename Impl>
@@ -121,6 +136,21 @@ ErrCode INTERFACE_FUNC TmsClientPropertyObjectBaseImpl<Impl>::getPropertyValue(I
         return OPENDAQ_SUCCESS;
     }
     auto propertyNamePtr = StringPtr::Borrow(propertyName);
+
+    StringPtr childName;
+    StringPtr subName;
+    if (this->isChildProperty(propertyNamePtr, childName, subName))
+    {
+        PropertyPtr prop;
+        ErrCode err = getProperty(propertyNamePtr, &prop);
+        if (OPENDAQ_FAILED(err))
+            return err;
+
+        if (!prop.assigned())
+            throw NotFoundException(R"(Child property "{}" not found)", propertyNamePtr);
+
+        return prop->getValue(value);
+    }
 
     StringPtr lastProccessDescription = "";
     ErrCode errCode = daqTry([&]
@@ -136,11 +166,11 @@ ErrCode INTERFACE_FUNC TmsClientPropertyObjectBaseImpl<Impl>::getPropertyValue(I
             const auto refProp = this->objPtr.getProperty(propertyName).getReferencedProperty();
             return getPropertyValue(refProp.getName(), value);
         }
-        else if (const auto& objIt = objectTypeIdMap.find(propertyNamePtr); objIt != objectTypeIdMap.cend())
-        {
-            *value = TmsClientPropertyObject(daqContext, clientContext, objIt->second).detach();
-            return OPENDAQ_SUCCESS;
-        }
+        //else if (const auto& objIt = objectTypeIdMap.find(propertyNamePtr); objIt != objectTypeIdMap.cend())
+        //{
+        //    *value = TmsClientPropertyObject(daqContext, clientContext, objIt->second).detach();
+        //    return OPENDAQ_SUCCESS;
+        //}
 
         return Impl::getPropertyValue(propertyName, value);
     });
@@ -332,7 +362,14 @@ void TmsClientPropertyObjectBaseImpl<Impl>::addProperties(const OpcUaNodeId& par
             try
             {
                 if (!hasProp)
+                {
                     prop = addVariableBlockProperty(propName, childNodeId);
+                }
+                else if (this->objPtr.template supportsInterface<ISyncComponent>())
+                {
+                    Impl::removeProperty(propName);
+                    prop = addVariableBlockProperty(propName, childNodeId);
+                }
 
                 objectTypeIdMap.emplace(propName, childNodeId);
             }
@@ -371,7 +408,7 @@ void TmsClientPropertyObjectBaseImpl<Impl>::addMethodProperties(const OpcUaNodeI
         const auto typeId = OpcUaNodeId(ref->typeDefinition.nodeId);
         const auto propName = String(utils::ToStdString(ref->browseName.name));
 
-        if (isIgnoredMethodPeoperty(propName))
+        if (isIgnoredMethodProperty(propName))
             continue;
 
         Bool hasProp;
@@ -510,9 +547,48 @@ void TmsClientPropertyObjectBaseImpl<Impl>::browseRawProperties()
 }
 
 template <class Impl>
-bool TmsClientPropertyObjectBaseImpl<Impl>::isIgnoredMethodPeoperty(const std::string& browseName)
+bool TmsClientPropertyObjectBaseImpl<Impl>::isIgnoredMethodProperty(const std::string& browseName)
 {
     return browseName == "BeginUpdate" || browseName == "EndUpdate" || browseName == "GetErrorInformation";
+}
+
+template <class Impl>
+void TmsClientPropertyObjectBaseImpl<Impl>::cloneAndSetChildPropertyObject(const PropertyPtr& prop)
+{
+    const auto propPtrInternal = prop.asPtr<IPropertyInternal>();
+    if (propPtrInternal.assigned() && propPtrInternal.getValueTypeUnresolved() == ctObject && prop.getDefaultValue().assigned())
+    {
+        const auto propName = prop.getName();
+        const auto defaultValueObj = prop.getDefaultValue().asPtrOrNull<IPropertyObject>();
+        if (!defaultValueObj.assigned())
+            return;
+
+        if (!isBasePropertyObject(defaultValueObj))
+        {
+            auto clonedValue = defaultValueObj.asPtr<IPropertyObjectInternal>(true).clone();
+            this->writeLocalValue(propName, clonedValue);
+            this->configureClonedObj(propName, clonedValue);
+            return;
+        }
+
+        if (const auto& objIt = objectTypeIdMap.find(propName); objIt != objectTypeIdMap.cend())
+        {
+            auto clientObj = TmsClientPropertyObject(daqContext, clientContext, objIt->second);
+            this->writeLocalValue(propName, clientObj);
+            this->configureClonedObj(propName, clientObj);
+        }
+        else
+        {
+            throw NotFoundException{"Object property with name {} not found", propName};
+        }
+    }
+}
+
+template <class Impl>
+bool TmsClientPropertyObjectBaseImpl<Impl>::isBasePropertyObject(const PropertyObjectPtr& propObj)
+{
+    return !propObj.supportsInterface<IServerCapabilityConfig>() 
+            && !propObj.supportsInterface<IAddressInfo>();
 }
 
 template class TmsClientPropertyObjectBaseImpl<PropertyObjectImpl>;

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
@@ -581,22 +581,22 @@ TEST_F(TmsDeviceTest, DeviceInfoNotChangeableField)
         ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("manufacturer", clientDeviceInfo.getManufacturer());
 
-        serverDeviceInfo.asPtr<IDeviceInfoConfig>(true).setManufacturer("server_manufacturer_3");
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
+        ASSERT_ANY_THROW(serverDeviceInfo.asPtr<IDeviceInfoConfig>(true).setManufacturer("server_manufacturer_3"));
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("manufacturer", clientDeviceInfo.getManufacturer());
     }
 
     {
         ASSERT_ANY_THROW(clientDeviceInfo.setPropertyValue("manufacturer", "client_manufacturer"));
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("manufacturer", clientDeviceInfo.getManufacturer());
 
-        clientDeviceInfo.asPtr<IPropertyObjectProtected>(true).setProtectedPropertyValue("manufacturer", "client_manufacturer_2");
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
-        ASSERT_EQ("client_manufacturer_2", clientDeviceInfo.getManufacturer());
+        clientDeviceInfo.asPtr<IPropertyObjectProtected>(true).setProtectedPropertyValue("manufacturer", "client_manufacturer_3");
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
+        ASSERT_EQ("client_manufacturer_3", clientDeviceInfo.getManufacturer());
 
-        clientDeviceInfo.asPtr<IDeviceInfoConfig>(true).setManufacturer("client_manufacturer_3");
-        ASSERT_EQ("server_manufacturer_3", serverDeviceInfo.getManufacturer());
+        ASSERT_ANY_THROW(clientDeviceInfo.asPtr<IDeviceInfoConfig>(true).setManufacturer("client_manufacturer_3"));
+        ASSERT_EQ("server_manufacturer_2", serverDeviceInfo.getManufacturer());
         ASSERT_EQ("client_manufacturer_3", clientDeviceInfo.getManufacturer());
     }
 }

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_property_object.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_property_object.cpp
@@ -10,6 +10,7 @@
 #include "tms_object_integration_test.h"
 #include <opcuatms_client/objects/tms_client_property_object_factory.h>
 #include <coreobjects/property_object_class_factory.h>
+#include <opendaq/mock/advanced_components_setup_utils.h>
 
 #include <coreobjects/callable_info_factory.h>
 #include <opendaq/context_factory.h>

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_property_object.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_property_object.cpp
@@ -543,10 +543,7 @@ TEST_F(TmsNestedPropertyObjectTest, TestNestedObjectServerClearIndividual)
     ASSERT_EQ(clientObj.getPropertyValue("child2.child2_1.Ratio"), Ratio(1, 2));
 }
 
-// BUG: Clearing the server side value of an object-type property makes the TMS server property object
-//      hold a pointer to the old object instead of the newly created one post-clear.
-
-TEST_F(TmsNestedPropertyObjectTest, DISABLED_TestNestedObjectServerClearObject)
+TEST_F(TmsNestedPropertyObjectTest, TestNestedObjectServerClearObject)
 {
     serverObj.setPropertyValue("child1.child1_2.child1_2_1.String", "new_string");
     serverObj.setPropertyValue("child1.child1_1.Float", 2.1);
@@ -559,7 +556,7 @@ TEST_F(TmsNestedPropertyObjectTest, DISABLED_TestNestedObjectServerClearObject)
     ASSERT_EQ(clientObj.getPropertyValue("child2.child2_1.Ratio"), Ratio(1, 5));
 
     for (const auto& prop : serverObj.getAllProperties())
-        serverObj.clearPropertyValue(prop.getName());
+        serverObj.asPtr<IPropertyObjectProtected>().clearProtectedPropertyValue(prop.getName());
     
     ASSERT_EQ(serverObj.getPropertyValue("child1.child1_2.child1_2_1.String"), "String");
     ASSERT_DOUBLE_EQ(serverObj.getPropertyValue("child1.child1_1.Float"), 1.1);
@@ -576,7 +573,7 @@ TEST_F(TmsNestedPropertyObjectTest, DISABLED_TestNestedObjectServerClearObject)
     serverObj.setPropertyValue("child1.child1_2.Int", 2);
     serverObj.setPropertyValue("child2.child2_1.Ratio", Ratio(1, 5));
 
-    serverObj.clearPropertyValue("child1");
+    serverObj.asPtr<IPropertyObjectProtected>().clearProtectedPropertyValue("child1");
     
     ASSERT_EQ(clientObj.getPropertyValue("child1.child1_2.child1_2_1.String"), "String");
     ASSERT_DOUBLE_EQ(clientObj.getPropertyValue("child1.child1_1.Float"), 1.1);


### PR DESCRIPTION
# Brief
Fixes nested object access over OPC UA. Object properties original `PropertyObject` is now stored in `PropertyObjectImpl`; `PropertyImpl` now contains the clone.

# Description

- OPC UA nested objects have been fixed. Previously, when creating client-side nested objects, a local copy was created instead of a mirrored one.
- OPC UA dot access for nested objects now works.
- Previously `PropertyImpl` held the original object with which Object-type properties were constructed, whereas the dictionary of local values inside the owner `PropertyObjectImpl` contained a clone. This has now been switched. The Property default value clone is a always a frozen instance of `PropertyObjectImpl`.
- Adds `clearProtectedPropertyValue` RPC to native config protocol.
- `clearPropertyValue` on object-type properties no longer removes the object from the local values dictionary. Instead of replacing it with the default value clone, it now calls `clearPropertyValue` recursively on all of the properties of the child object.

# Usage Examples

## OPC UA client

```cpp
// Device at address 127.0.0.1 has an OPC UA server and a nested
// object-type proerty named "child" with a "foo" string property.

auto instance = Instance();
auto dev = instance.addDevice("daq.opcua://127.0.0.1");

StringPtr val = dev.getPropertyValue("child.foo"); // Gets the old property value
dev.setPropertyValue("child.foo", "bar"); // Sets the server property value to "foo"
dev.getPropertyValue("child.foo"); // Returns "bar"
```

## Using object-type property default values

Previously, after using a  `PropertyObject` to create an `Object-type property`, after calling `addProperty`, the object used to create the property could no longer be used. It was frozen and kept as the default value of the property, where the `PropertyObject` that is the owner of the property, held a cloned, modifiable object.

With this change, the owner now holds the original, and the `Property` default value is a clone of the object.

After this change the following now works:

```cpp
auto obj = PropertyObject();
auto obj2 = PropertyObject();

obj2.addProperty(StringProperty("foo", "bar"));
obj.addProperty(ObjectProperty("child", obj2);

// This previously failed, as `obj2` was frozen. 
// To change the value of "foo", the cloned had to first be obtained via `obj.getPropertyValue("child")`
obj2.setPropertyValue("foo", "bar1");
```

# Required Application Changes

`IPropertyObject::clearPropertyValue(IString* name)` when invoked on an Object-type property, no longer removes the property object and restores it to the default, but instead calls `clearPropertyValue` recursively on the object's properties.


```cpp
auto propObj1 = PropertyObject();
auto propObj2 = PropertyObject();

propObj1.addProperty(ObjectProperty("Child", propObj2));

auto propObj3 = PropertyObject();
propObj3.addProperty(IntProperty("IntProp", 0));
propObj3.setPropertyValue("IntProp", 1);
propObj1.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("Child", propObj3);

// The below code does not restore "Child" to `propObj2`.
// It instead sets "Child.IntProp" to its default value of "1".
propObj1.clearPropertyValue("Child");
```

# API changes

```diff
+ ErrCode IPropertyInternal::overrideDefaultValue(IBaseObject* newDefaultValue);
+ ErrCode IPropertyInternal::setValueProtected(IBaseObject* newValue);
```