### PR TITLE
Fix compiling issue because of  __VA_ARGS__ in macros DAQ_THROW_EXCEPTION

### DIFF
--- a/core/coretypes/include/coretypes/exceptions.h
+++ b/core/coretypes/include/coretypes/exceptions.h
@@ -88,7 +88,7 @@ BEGIN_NAMESPACE_OPENDAQ
 #ifdef NDEBUG
     #define DAQ_THROW_EXCEPTION(OpendaqException, ...) throw OpendaqException(__VA_ARGS__)
 #else
-    #define DAQ_THROW_EXCEPTION(OpendaqException, ...) throw OpendaqException(__LINE__, __FILE__, __VA_ARGS__)
+    #define DAQ_THROW_EXCEPTION(OpendaqException, ...) throw OpendaqException(__LINE__, __FILE__, ##__VA_ARGS__)
 #endif
 
 /*


### PR DESCRIPTION
# Brief

Fixing compile issue by using ##__VA_ARGS__ instead of __VA_ARGS__ in the macros DAQ_THROW_EXCEPTION (introduced in [#721](https://github.com/openDAQ/openDAQ/pull/721)) to remove comma if arguments are empty.