### PR TITLE
Add element IntfID to list/dict serialization + Serialization versioning

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -29,6 +29,7 @@
 
 ## Bug fixes
 
+- [#733](https://github.com/openDAQ/openDAQ/pull/733) Fixes list/dictionary deserialization not containing key/value/item interface IDs. Requires server-side update.
 - [#719](https://github.com/openDAQ/openDAQ/pull/719) Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).
 - [#703](https://github.com/openDAQ/openDAQ/pull/703) Fixes invalid response of openDAQ mDNS wrapper for unicast queries.
 - [#696](https://github.com/openDAQ/openDAQ/pull/696) Set of LT bugfixes. Keeping sessions alive, raw json values for linear rules, default start value for constant signals, fix IPv4/6 control connection address handling. 

--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- [#733](https://github.com/openDAQ/openDAQ/pull/733) Introduces serializer versioning; openDAQ list objects are now serialized as objects instead of JSON arrays.
 - [#718](https://github.com/openDAQ/openDAQ/pull/718) Adds new Native Configuration Protocol RPCs for handling sub-function blocks (function blocks that are children of other FBs.
 - [#642](https://github.com/openDAQ/openDAQ/pull/642) Introduces mechanisms to modify the IP configuration parameters of openDAQ-compatible devices.
 - [#638](https://github.com/openDAQ/openDAQ/pull/638) Adds a tick tolerance option to the `MultiReader`, allowing for the limitation of inter-sample offsets between read signals.

--- a/core/corecontainers/include/coretypes/listobject_impl.h
+++ b/core/corecontainers/include/coretypes/listobject_impl.h
@@ -23,12 +23,15 @@
 #include <coretypes/cloneable.h>
 #include <coretypes/iterable.h>
 #include <coretypes/list_element_type.h>
-
+#include <coretypes/deserializer.h>
+#include <coretypes/serialized_object.h>
 #include <vector>
 
 BEGIN_NAMESPACE_OPENDAQ
 
 class ListIteratorImpl;
+
+ErrCode INTERFACE_FUNC deserializeList(ISerializedObject* ser, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 
 class ListImpl : public ImplementationOf<IList, IIterable, ISerializable, IListElementType, ICoreType, ICloneable, IFreezable>
 {
@@ -71,6 +74,12 @@ public:
     // ISerializable
     ErrCode INTERFACE_FUNC serialize(ISerializer* serializer) override;
     ErrCode INTERFACE_FUNC getSerializeId(ConstCharPtr* id) const override;
+    
+    static ConstCharPtr SerializeId();
+    static ErrCode Deserialize(ISerializedObject* ser, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj)
+    {
+        return deserializeList(ser, context, factoryCallback, obj);
+    }
 
     // IBaseObject
     ErrCode INTERFACE_FUNC toString(CharPtr* str) override;
@@ -96,5 +105,7 @@ private:
 
     void releaseRefOnChildren();
 };
+
+OPENDAQ_REGISTER_DESERIALIZE_FACTORY(ListImpl)
 
 END_NAMESPACE_OPENDAQ

--- a/core/corecontainers/src/listobject_impl.cpp
+++ b/core/corecontainers/src/listobject_impl.cpp
@@ -508,7 +508,7 @@ ConstCharPtr ListImpl::SerializeId()
 
 ErrCode INTERFACE_FUNC deserializeList(ISerializedObject* ser, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj)
 {
-    Bool hasKey;
+    Bool hasKey = false;
     IntfID id = IUnknown::Id;
     ser->hasKey(String("itemIntfID"), &hasKey);
     if (hasKey)

--- a/core/coreobjects/src/user_impl.cpp
+++ b/core/coreobjects/src/user_impl.cpp
@@ -91,7 +91,10 @@ ErrCode INTERFACE_FUNC UserImpl::serialize(ISerializer* serializer)
     if (groups.assigned())
     {
         serializer->key("groups");
-        groups.serialize(serializer);
+        serializer->startList();
+        for (const auto& group : groups)
+            group.serialize(serializer);
+        serializer->endList();
     }
 
     serializer->endObject();

--- a/core/coreobjects/tests/test_property.cpp
+++ b/core/coreobjects/tests/test_property.cpp
@@ -125,7 +125,7 @@ TEST_F(PropertyTest, SelectionValuesWithCustomClass)
     PropertyObjectPtr firstElement = selectionValuesList[0];
     ASSERT_EQ(firstElement.getClassName(), "TestClass");
 
-    auto serializer = JsonSerializer();
+    auto serializer = JsonSerializerWithVersion(1);
     ptr.serialize(serializer);
 
     std::string serialized = serializer.getOutput();

--- a/core/coreobjects/tests/test_property_object_class.cpp
+++ b/core/coreobjects/tests/test_property_object_class.cpp
@@ -92,7 +92,7 @@ TEST_F(PropertyObjectClassTest, SerializeJson)
 {
     std::string expectedJson =
         R"({"__type":"PropertyObjectClass","name":"PropertyObject","properties":{"Name":{"__type":"Property","name":"Name","valueType":3,"defaultValue":"","readOnly":false,"visible":true},"Index":{"__type":"Property","name":"Index","valueType":1,"defaultValue":0,"readOnly":false,"visible":true},"Unit":{"__type":"Property","name":"Unit","valueType":1,"defaultValue":0,"readOnly":false,"visible":true,"selectionValues":["a","b"]}}})";
-    auto serializer = JsonSerializer();
+    auto serializer = JsonSerializerWithVersion(1);
 
     propObjClass.serialize(serializer);
 

--- a/core/coretypes/include/coretypes/common.h
+++ b/core/coretypes/include/coretypes/common.h
@@ -245,7 +245,7 @@ extern "C"
 daq::ErrCode PUBLIC_EXPORT daqInterfaceIdToString(const daq::IntfID& iid, daq::CharPtr dest);
 
 extern "C"
-daq::ErrCode PUBLIC_EXPORT stringToDaqInterfaceId(const std::string& guidStr, daq::IntfID& iid);
+daq::ErrCode PUBLIC_EXPORT daqStringToInterfaceId(const std::string& guidStr, daq::IntfID& iid);
 
 #define OPENDAQ_TYPE_TOSTRING                                             \
     static daq::ErrCode OpenDaqType(daq::CharPtr* str)                    \

--- a/core/coretypes/include/coretypes/common.h
+++ b/core/coretypes/include/coretypes/common.h
@@ -244,6 +244,9 @@ daq::ErrCode PUBLIC_EXPORT daqDuplicateCharPtr(daq::ConstCharPtr source,
 extern "C"
 daq::ErrCode PUBLIC_EXPORT daqInterfaceIdToString(const daq::IntfID& iid, daq::CharPtr dest);
 
+extern "C"
+daq::ErrCode PUBLIC_EXPORT stringToDaqInterfaceId(const std::string& guidStr, daq::IntfID& iid);
+
 #define OPENDAQ_TYPE_TOSTRING                                             \
     static daq::ErrCode OpenDaqType(daq::CharPtr* str)                    \
     {                                                                     \

--- a/core/coretypes/include/coretypes/json_serializer.h
+++ b/core/coretypes/include/coretypes/json_serializer.h
@@ -31,4 +31,17 @@ inline ISerializer* JsonSerializer_Create(Bool pretty = False)
     throw std::bad_alloc();
 }
 
+extern "C"
+ErrCode PUBLIC_EXPORT createJsonSerializerWithVersion(ISerializer** obj, Int version, Bool pretty = False);
+
+inline ISerializer* JsonSerializer_Create(Int version, Bool pretty = False)
+{
+    ISerializer* obj;
+    ErrCode res = createJsonSerializerWithVersion(&obj, version, pretty);
+    if (OPENDAQ_SUCCEEDED(res))
+        return obj;
+
+    throw std::bad_alloc();
+}
+
 END_NAMESPACE_OPENDAQ

--- a/core/coretypes/include/coretypes/json_serializer_factory.h
+++ b/core/coretypes/include/coretypes/json_serializer_factory.h
@@ -27,4 +27,9 @@ inline SerializerPtr JsonSerializer(Bool pretty = False)
     return SerializerPtr(JsonSerializer_Create(pretty));
 }
 
+inline SerializerPtr JsonSerializerWithVersion(Int version, Bool pretty = False)
+{
+    return SerializerPtr(JsonSerializer_Create(version, pretty));
+}
+
 END_NAMESPACE_OPENDAQ

--- a/core/coretypes/include/coretypes/json_serializer_impl.h
+++ b/core/coretypes/include/coretypes/json_serializer_impl.h
@@ -29,6 +29,7 @@ class JsonSerializerImpl : public ImplementationOf<ISerializer>
 {
 public:
     JsonSerializerImpl();
+    JsonSerializerImpl(Int version);
 
     ErrCode INTERFACE_FUNC startList() override;
     ErrCode INTERFACE_FUNC endList() override;
@@ -60,10 +61,13 @@ public:
     ErrCode INTERFACE_FUNC getUser(IBaseObject** user) override;
     ErrCode INTERFACE_FUNC setUser(IBaseObject* user) override;
 
+    ErrCode INTERFACE_FUNC getVersion(Int* version) override;
+
 protected:
     rapidjson::StringBuffer buffer;
     TWriter writer;
     BaseObjectPtr userContext;
+    Int version;
 };
 
 template <typename TWriter>

--- a/core/coretypes/include/coretypes/serializer.h
+++ b/core/coretypes/include/coretypes/serializer.h
@@ -63,6 +63,8 @@ DECLARE_OPENDAQ_INTERFACE(ISerializer, IBaseObject)
 
     virtual ErrCode INTERFACE_FUNC getUser(IBaseObject** user) = 0;
     virtual ErrCode INTERFACE_FUNC setUser(IBaseObject* user) = 0;
+
+    virtual ErrCode INTERFACE_FUNC getVersion(Int * version) = 0;
 };
 
 /*!

--- a/core/coretypes/include/coretypes/serializer_ptr.h
+++ b/core/coretypes/include/coretypes/serializer_ptr.h
@@ -242,13 +242,25 @@ public:
         return userObject;
     }
 
-    void setUser(const BaseObjectPtr& user)
+    void setUser(const BaseObjectPtr& user) const
     {
         if (!object)
             DAQ_THROW_EXCEPTION(InvalidParameterException);
 
         ErrCode errCode = object->setUser(user);
         checkErrorInfo(errCode);
+    }
+
+    Int getVersion() const
+    {
+        if (!object)
+            DAQ_THROW_EXCEPTION(InvalidParameterException);
+
+        Int version;
+        ErrCode errCode = object->getVersion(&version);
+        checkErrorInfo(errCode);
+
+        return version;
     }
 };
 

--- a/core/coretypes/src/json_serializer_impl.cpp
+++ b/core/coretypes/src/json_serializer_impl.cpp
@@ -7,6 +7,14 @@ BEGIN_NAMESPACE_OPENDAQ
 template <typename TWriter>
 JsonSerializerImpl<TWriter>::JsonSerializerImpl()
     : writer(buffer)
+    , version(2)
+{
+}
+
+template <typename TWriter>
+JsonSerializerImpl<TWriter>::JsonSerializerImpl(Int version)
+    : writer(buffer)
+    , version(version)
 {
 }
 
@@ -214,6 +222,15 @@ ErrCode INTERFACE_FUNC JsonSerializerImpl<TWriter>::setUser(IBaseObject* user)
 }
 
 template <typename TWriter>
+ErrCode JsonSerializerImpl<TWriter>::getVersion(Int* version)
+{
+    OPENDAQ_PARAM_NOT_NULL(version);
+
+    *version = this->version;
+    return OPENDAQ_SUCCESS;
+}
+
+template <typename TWriter>
 ErrCode JsonSerializerImpl<TWriter>::getOutput(IString** output)
 {
     *output = String_Create(buffer.GetString());
@@ -247,5 +264,30 @@ ErrCode PUBLIC_EXPORT createJsonSerializer(ISerializer** jsonSerializer, Bool pr
     return OPENDAQ_SUCCESS;
 }
 
+// createJsonSerializer
+extern "C"
+ErrCode PUBLIC_EXPORT createJsonSerializerWithVersion(ISerializer** jsonSerializer, Int version, Bool pretty = False)
+{
+    OPENDAQ_PARAM_NOT_NULL(jsonSerializer);
+
+    ISerializer* object;
+    if (pretty)
+    {
+        object = new(std::nothrow) PrettyJsonSerializer(version);
+    }
+    else
+    {
+        object = new(std::nothrow) JsonSerializerImpl<>(version);
+    }
+
+    if (!object)
+    {
+        return OPENDAQ_ERR_NOMEMORY;
+    }
+
+    object->addRef();
+    *jsonSerializer = object;
+    return OPENDAQ_SUCCESS;
+}
 
 END_NAMESPACE_OPENDAQ

--- a/core/coretypes/src/json_serializer_impl.cpp
+++ b/core/coretypes/src/json_serializer_impl.cpp
@@ -50,7 +50,6 @@ template <typename TWriter>
 ErrCode JsonSerializerImpl<TWriter>::startList()
 {
     writer.StartArray();
-
     return OPENDAQ_SUCCESS;
 }
 
@@ -58,7 +57,6 @@ template <typename TWriter>
 ErrCode JsonSerializerImpl<TWriter>::endList()
 {
     writer.EndArray();
-
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/coretypes/src/util.cpp
+++ b/core/coretypes/src/util.cpp
@@ -2,6 +2,8 @@
 #include <coretypes/errors.h>
 #include <fmt/format.h>
 
+#include <regex>
+
 extern "C"
 daq::ErrCode PUBLIC_EXPORT daqInterfaceIdToString(const daq::IntfID& iid, daq::CharPtr dest)
 {
@@ -31,4 +33,41 @@ daq::ErrCode PUBLIC_EXPORT daqInterfaceIdToString(const daq::IntfID& iid, daq::C
     {
         return OPENDAQ_ERR_GENERALERROR;
     }
+}
+
+extern "C"
+daq::ErrCode PUBLIC_EXPORT stringToDaqInterfaceId(const std::string& guidStr, daq::IntfID& iid)
+{
+    std::regex guidRegex(
+        R"(\{([\dA-Fa-f]{8})-([\dA-Fa-f]{4})-([\dA-Fa-f]{4})-([\dA-Fa-f]{2})([\dA-Fa-f]{2})-((?:[\dA-Fa-f]{2}){6})\})");
+    
+    std::smatch match;
+    if (!std::regex_match(guidStr, match, guidRegex))
+    {
+        return OPENDAQ_ERR_GENERALERROR; // Invalid format
+    }
+
+    try
+    {
+        iid.Data1 = std::stoul(match[1].str(), nullptr, 16);
+        iid.Data2 = static_cast<uint16_t>(std::stoul(match[2].str(), nullptr, 16));
+        iid.Data3 = static_cast<uint16_t>(std::stoul(match[3].str(), nullptr, 16));
+
+        // First two bytes of Data4
+        iid.Data4[0] = static_cast<uint8_t>(std::stoul(match[4].str(), nullptr, 16));
+        iid.Data4[1] = static_cast<uint8_t>(std::stoul(match[5].str(), nullptr, 16));
+
+        // Last six bytes of Data4
+        std::string lastPart = match[6].str();
+        for (size_t i = 0; i < 6; ++i)
+        {
+            iid.Data4[2 + i] = static_cast<uint8_t>(std::stoul(lastPart.substr(i * 2, 2), nullptr, 16));
+        }
+    }
+    catch (...)
+    {
+        return OPENDAQ_ERR_GENERALERROR; // Conversion error
+    }
+
+    return OPENDAQ_SUCCESS;
 }

--- a/core/coretypes/src/util.cpp
+++ b/core/coretypes/src/util.cpp
@@ -1,7 +1,6 @@
 #include <coretypes/common.h>
 #include <coretypes/errors.h>
 #include <fmt/format.h>
-
 #include <regex>
 
 extern "C"
@@ -36,7 +35,7 @@ daq::ErrCode PUBLIC_EXPORT daqInterfaceIdToString(const daq::IntfID& iid, daq::C
 }
 
 extern "C"
-daq::ErrCode PUBLIC_EXPORT stringToDaqInterfaceId(const std::string& guidStr, daq::IntfID& iid)
+daq::ErrCode PUBLIC_EXPORT daqStringToInterfaceId(const std::string& guidStr, daq::IntfID& iid)
 {
     std::regex guidRegex(
         R"(\{([\dA-Fa-f]{8})-([\dA-Fa-f]{4})-([\dA-Fa-f]{4})-([\dA-Fa-f]{2})([\dA-Fa-f]{2})-((?:[\dA-Fa-f]{2}){6})\})");

--- a/core/coretypes/tests/test_intfid.cpp
+++ b/core/coretypes/tests/test_intfid.cpp
@@ -268,7 +268,7 @@ TEST_F(IntfIdTest, TestInterfaceToStringConversion)
         char iidString[39];
         IntfID iidOut;
         daqInterfaceIdToString(iidIn, iidString);
-        stringToDaqInterfaceId(iidString, iidOut);
+        daqStringToInterfaceId(iidString, iidOut);
         ASSERT_EQ(iidIn, iidOut);
     };
 

--- a/core/coretypes/tests/test_intfid.cpp
+++ b/core/coretypes/tests/test_intfid.cpp
@@ -260,3 +260,22 @@ TEST_F(IntfIdTest, VersionInfoString)
 {
     ASSERT_EQ(daqInterfaceIdString<IVersionInfo>(), "{5951D4D2-35EB-513C-B67D-89DABC6BE3BF}");
 }
+
+TEST_F(IntfIdTest, TestInterfaceToStringConversion)
+{
+    auto testInterfaceToStringConversion = [](const IntfID& iidIn)
+    {
+        char iidString[39];
+        IntfID iidOut;
+        daqInterfaceIdToString(iidIn, iidString);
+        stringToDaqInterfaceId(iidString, iidOut);
+        ASSERT_EQ(iidIn, iidOut);
+    };
+
+    testInterfaceToStringConversion(IString::Id);
+    testInterfaceToStringConversion(INumber::Id);
+    testInterfaceToStringConversion(IBaseObject::Id);
+    testInterfaceToStringConversion(IList::Id);
+    testInterfaceToStringConversion(IVersionInfo::Id);
+    testInterfaceToStringConversion(IInspectable::Id);
+}

--- a/core/coretypes/tests/test_json_serializer.cpp
+++ b/core/coretypes/tests/test_json_serializer.cpp
@@ -12,7 +12,7 @@ public:
 protected:
     void SetUp() override
     {
-        serializer = JsonSerializer();
+        serializer = JsonSerializerWithVersion(1);
     }
 
     void TearDown() override

--- a/core/coretypes/tests/test_listobject.cpp
+++ b/core/coretypes/tests/test_listobject.cpp
@@ -394,7 +394,7 @@ TEST_F(ListObjectTest, DoubleFreeze)
 TEST_F(ListObjectTest, SerializeId)
 {
     auto list = List<IBaseObject>();
-    ASSERT_THROW(list.getSerializeId(), NotImplementedException);
+    ASSERT_EQ(list.getSerializeId(), "List");
 }
 
 TEST_F(ListObjectTest, GetItemWithSubscriptionOperator)
@@ -414,6 +414,40 @@ TEST_F(ListObjectTest, ElementSmartPointerType)
     // element must be StringPtr
     ASSERT_EQ(el.getLength(), 2u);
 }
+
+TEST_F(ListObjectTest, SerializeDeserializeV1)
+{
+    auto ser = JsonSerializerWithVersion(1);
+    auto list = List<IString>("e1", "e2", "e3");
+    list.serialize(ser);
+    auto str = ser.getOutput();
+    ASSERT_EQ(str, "[\"e1\",\"e2\",\"e3\"]");
+
+    auto deser = JsonDeserializer();
+    auto obj = deser.deserialize(str);
+    ASSERT_EQ(obj, list);
+
+    IntfID id;
+    obj.asPtr<IListElementType>()->getElementInterfaceId(&id);
+    ASSERT_EQ(id, IUnknown::Id);
+}
+
+TEST_F(ListObjectTest, SerializeDeserializeV2)
+{
+    auto ser = JsonSerializerWithVersion(2);
+    auto list = List<IString>("e1", "e2", "e3");
+    list.serialize(ser);
+    auto str = ser.getOutput();
+
+    auto deser = JsonDeserializer();
+    auto obj = deser.deserialize(str);
+    ASSERT_EQ(obj, list);
+
+    IntfID id;
+    obj.asPtr<IListElementType>()->getElementInterfaceId(&id);
+    ASSERT_EQ(id, IString::Id);
+}
+
 
 TEST_F(ListObjectTest, FromVectorInt)
 {

--- a/core/coretypes/tests/test_listobject.cpp
+++ b/core/coretypes/tests/test_listobject.cpp
@@ -391,12 +391,6 @@ TEST_F(ListObjectTest, DoubleFreeze)
     ASSERT_EQ(list.asPtr<IFreezable>(true)->freeze(), OPENDAQ_IGNORED);
 }
 
-TEST_F(ListObjectTest, SerializeId)
-{
-    auto list = List<IBaseObject>();
-    ASSERT_EQ(list.getSerializeId(), "List");
-}
-
 TEST_F(ListObjectTest, GetItemWithSubscriptionOperator)
 {
     auto list = List<Int>(1, 2, 3);

--- a/core/coretypes/tests/test_listobject.cpp
+++ b/core/coretypes/tests/test_listobject.cpp
@@ -442,7 +442,6 @@ TEST_F(ListObjectTest, SerializeDeserializeV2)
     ASSERT_EQ(id, IString::Id);
 }
 
-
 TEST_F(ListObjectTest, FromVectorInt)
 {
     std::vector<int> vec = { 1, 2, 3, 4, 5, 6 };

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -136,7 +136,7 @@ TEST_F(NativeDeviceModulesTest, CheckProtocolVersion)
 
     auto info = client.getDevices()[0].getInfo();
     ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
-    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 9);
+    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 10);
 
     // because info holds a client device as owner, it have to be removed before module manager is destroyed
     // otherwise module of native client device would not be removed

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
@@ -177,14 +177,22 @@ public:
     ClientType connectionType = ClientType::Control;
 };
 
+inline std::set<uint16_t> createListOfSupportedVersions(uint16_t maxVersion)
+{
+    std::set<uint16_t> supportedVersions;
+    for (uint16_t i = 0; i <= maxVersion; ++i)
+        supportedVersions.insert(i);
+    return supportedVersions;
+}
+
 inline std::set<uint16_t> GetSupportedConfigProtocolVersions()
 {
-    return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    return createListOfSupportedVersions(10);
 }
 
 inline constexpr uint16_t GetLatestConfigProtocolVersion()
 {
-    return 9; // *GetSupportedConfigProtocolVersions().rbegin();
+    return 10; // *GetSupportedConfigProtocolVersions().rbegin();
 }
 
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -383,7 +383,12 @@ void ConfigProtocolClient<TRootDeviceImpl>::reconnect(Bool restoreClientConfigOn
 
     if (restoreClientConfigOnReconnect)
     {
-        const auto serializer = JsonSerializer();
+        SerializerPtr serializer;
+        if (getProtocolVersion() < 10)
+            serializer = JsonSerializerWithVersion(1);
+        else
+            serializer = JsonSerializerWithVersion(2);
+
         rootDevice.asPtr<IUpdatable>().serializeForUpdate(serializer);
         StringPtr serializedClientRootDevice = serializer.getOutput();
 

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -361,7 +361,13 @@ BaseObjectPtr ConfigProtocolClientComm::createRpcRequest(const StringPtr& name, 
 StringPtr ConfigProtocolClientComm::createRpcRequestJson(const StringPtr& name, const ParamsDictPtr& params)
 {
     const auto obj = createRpcRequest(name, params);
-    auto serializer = JsonSerializer();
+
+    SerializerPtr serializer;
+    if (getProtocolVersion() < 10)
+        serializer = JsonSerializerWithVersion(1);
+    else
+        serializer = JsonSerializerWithVersion(2);
+
     obj.serialize(serializer);
     return serializer.getOutput();
 }
@@ -542,7 +548,12 @@ std::tuple<uint32_t, StringPtr, StringPtr> ConfigProtocolClientComm::getExternal
     const SignalPtr& signal,
     const ConfigProtocolStreamingProducerPtr& streamingProducer)
 {
-    auto serializer = JsonSerializer();
+    SerializerPtr serializer;
+    if (getProtocolVersion() < 10)
+        serializer = JsonSerializerWithVersion(1);
+    else
+        serializer = JsonSerializerWithVersion(2);
+
     signal.serialize(serializer);
 
     return std::make_tuple(streamingProducer->registerOrUpdateSignal(signal),


### PR DESCRIPTION
# Brief

- Fixes list/dictionary deserialization not containing key/value/item interface IDs.
- Introduces serializer versioning; openDAQ list objects are now serialized as objects instead of JSON arrays.

# Description

List and Dictionary objects in openDAQ store a key/value/list interface ID internally that can be used to retrieve the expected interface of stored objects. This is set on object construction if specified as a constructor parameter.

However, the serialization/deserialization of objects did not store/restore said ID, resulting in deserialized objects losing said information. As the openDAQ Native Configuration protocol uses the serialization mechanisms, client list/dictionary objects did not retain the interface ID variables.

This PR addresses this issue by serializing said values. It, however, requires a server-side update of openDAQ for the server to start encoding the above information.

Fixes #677.

## Serializer versioning

Adds serializer versioning to openDAQ. The current version is 2. This is added to preserver backwards compatibility of the native protocol, where the server-side must be able to read received JSON serialized strings from newer clients. As such, if the native protocol version is <10, the version 1 serializer is used.

# API changes
```diff
+ ErrCode ISerializer::getVersion(Int * version)
+ SerializerPtr JsonSerializerWithVersion(Int version, Bool pretty = False)
```