### PR TITLE
Set thread names

### DIFF
--- a/core/opendaq/logger/src/logger_thread_pool_impl.cpp
+++ b/core/opendaq/logger/src/logger_thread_pool_impl.cpp
@@ -1,11 +1,10 @@
 #include <opendaq/logger_thread_pool_impl.h>
-
+#include <opendaq/thread_name.h>
 #include <coretypes/impl.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
-LoggerThreadPoolImpl::LoggerThreadPoolImpl() :
-    spdlogThreadPool(std::make_shared<ThreadPool>(8192, 1, []{}))
+LoggerThreadPoolImpl::LoggerThreadPoolImpl() : spdlogThreadPool(std::make_shared<ThreadPool>(8192, 1, [] { LoggerThreadPoolImpl::threadStart(); }))
 {
 }
 
@@ -17,6 +16,11 @@ ErrCode LoggerThreadPoolImpl::getThreadPoolImpl(ThreadPoolPtr *impl)
     }
     *impl = spdlogThreadPool;
     return OPENDAQ_SUCCESS;
+}
+
+void LoggerThreadPoolImpl::threadStart()
+{
+    daqNameThread("Logger");
 }
 
 OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, LoggerThreadPool)

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -33,6 +33,8 @@
 #include <opendaq/client_type.h>
 #include <opendaq/network_interface_factory.h>
 
+#include "opendaq/thread_name.h"
+
 BEGIN_NAMESPACE_OPENDAQ
 
 using namespace std::chrono_literals;
@@ -70,6 +72,7 @@ ModuleManagerImpl::ModuleManagerImpl(const BaseObjectPtr& path)
     {
         pool.emplace_back([this]
         {
+            daqNameThread("ModuleManager");
             ioContext.run();
         });
     }

--- a/core/opendaq/utility/include/opendaq/thread_name.h
+++ b/core/opendaq/utility/include/opendaq/thread_name.h
@@ -15,26 +15,7 @@
  */
 
 #pragma once
-#include <opendaq/logger_thread_pool.h>
-#include <opendaq/logger_thread_pool_private.h>
-#include <coretypes/intfs.h>
 
-#include <memory>
+#include <coretypes/common.h>
 
-BEGIN_NAMESPACE_OPENDAQ
-
-class LoggerThreadPoolImpl final : public ImplementationOf<ILoggerThreadPool, ILoggerThreadPoolPrivate>
-{
-public:
-    LoggerThreadPoolImpl();
-
-    // ILoggerThreadPoolPrivate
-    ErrCode INTERFACE_FUNC getThreadPoolImpl(ThreadPoolPtr *impl) override;
-
-private:
-    ThreadPoolPtr spdlogThreadPool;
-
-    static void threadStart();
-};
-
-END_NAMESPACE_OPENDAQ
+extern "C" PUBLIC_EXPORT void daqNameThread(const char* name);

--- a/core/opendaq/utility/src/CMakeLists.txt
+++ b/core/opendaq/utility/src/CMakeLists.txt
@@ -8,16 +8,14 @@ function(create_component_source_groups_${BASE_NAME})
     set(SDK_HEADERS_DIR "utility/include/opendaq")
     set(SDK_SRC_DIR "utility/src")
     
-    source_group("utility//sample_type" FILES 
-        ${SDK_HEADERS_DIR}/sample_type.h
-    )
-    
     source_group("utility//ids_parser" FILES 
         ${SDK_HEADERS_DIR}/ids_parser.h
         ${SDK_SRC_DIR}/ids_parser.cpp
     )
     
     source_group("utility" FILES 
+        ${SDK_HEADERS_DIR}/thread_name.h
+        ${SDK_SRC_DIR}/thread_name.cpp
         ${SDK_HEADERS_DIR}/utility_errors.h
         ${SDK_HEADERS_DIR}/utility_exceptions.h
         ${SDK_SRC_DIR}/utility.natvis
@@ -26,6 +24,7 @@ endfunction()
 
 set(SRC_Cpp_Component 
     ids_parser.cpp
+    thread_name.cpp
     utility.natvis
     PARENT_SCOPE
 )
@@ -35,6 +34,7 @@ set(SRC_PublicHeaders_Component
     utility_exceptions.h
     ids_parser.h
     mem_pool_allocator.h
+    thread_name.h
     PARENT_SCOPE
 )
 

--- a/core/opendaq/utility/src/thread_name.cpp
+++ b/core/opendaq/utility/src/thread_name.cpp
@@ -1,0 +1,80 @@
+#include <opendaq/thread_name.h>
+
+#if defined(_WIN32) && !defined(__WINPTHREADS_VERSION)
+#include <Windows.h>
+#endif
+
+#define DELPHI_WORKAROUND  // delphi recognises only naming defined from exception
+
+#if !defined DELPHI_WORKAROUND
+#if defined _WIN32 || defined __CYGWIN__
+extern "C" typedef HRESULT(WINAPI* t_SetThreadDescription)(HANDLE, PCWSTR);
+extern "C" typedef HRESULT(WINAPI* t_GetThreadDescription)(HANDLE, PWSTR*);
+#endif
+#endif
+
+#if defined _GNU_SOURCE && !defined __EMSCRIPTEN__ && !defined __CYGWIN__
+#include <pthread.h>
+#endif
+
+extern "C" PUBLIC_EXPORT void daqNameThread(const char* name)
+{
+#if defined _WIN32 || defined __CYGWIN__
+#if !defined DELPHI_WORKAROUND
+    static auto _SetThreadDescription = (t_SetThreadDescription) GetProcAddress(GetModuleHandleA("kernel32.dll"), "SetThreadDescription");
+    if (_SetThreadDescription)
+    {
+        wchar_t buf[256];
+        mbstowcs(buf, name, 256);
+        _SetThreadDescription(GetCurrentThread(), buf);
+    }
+    else
+    {
+#endif
+#if defined _MSC_VER
+        const DWORD MS_VC_EXCEPTION = 0x406D1388;
+#pragma pack(push, 8)
+        struct THREADNAME_INFO
+        {
+            DWORD dwType;
+            LPCSTR szName;
+            DWORD dwThreadID;
+            DWORD dwFlags;
+        };
+#pragma pack(pop)
+
+        DWORD ThreadId = GetCurrentThreadId();
+        THREADNAME_INFO info;
+        info.dwType = 0x1000;
+        info.szName = name;
+        info.dwThreadID = ThreadId;
+        info.dwFlags = 0;
+
+        __try
+        {
+            RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*) &info);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+        }
+#endif
+#if !defined DELPHI_WORKAROUND
+    }
+#endif
+#elif defined _GNU_SOURCE && !defined __EMSCRIPTEN__ && !defined __CYGWIN__
+    {
+        const auto sz = ::strlen(name);
+        if (sz <= 15)
+        {
+            pthread_setname_np(pthread_self(), name);
+        }
+        else
+        {
+            char buf[16];
+            memcpy(buf, name, 15);
+            buf[15] = '\0';
+            pthread_setname_np(pthread_self(), buf);
+        }
+    }
+#endif
+}

--- a/modules/native_streaming_client_module/src/CMakeLists.txt
+++ b/modules/native_streaming_client_module/src/CMakeLists.txt
@@ -62,7 +62,6 @@ target_link_libraries(${LIB_NAME} PUBLIC  daq::opendaq
                                   PRIVATE daq::discovery
                                           daq::native_streaming_protocol
                                           daq::config_protocol
-                                          daq::opendaq_dev
                                           ${BCRYPT_LIB}
                                           $<BUILD_INTERFACE:Boost::uuid>
 )

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -15,6 +15,7 @@
 #include <config_protocol/config_protocol_client.h>
 #include <opendaq/address_info_factory.h>
 #include <opendaq/client_type.h>
+#include <opendaq/thread_name.h>
 #include <opendaq/device_info_internal_ptr.h>
 
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_CLIENT_MODULE
@@ -162,6 +163,7 @@ DevicePtr NativeStreamingClientModule::createNativeDevice(const ContextPtr& cont
     auto processingThread = std::thread(
         [this, processingIOContextPtr]()
         {
+            daqNameThread("NatCliDevCfgProc");
             using namespace boost::asio;
             auto workGuard = make_work_guard(*processingIOContextPtr);
             processingIOContextPtr->run();
@@ -173,6 +175,7 @@ DevicePtr NativeStreamingClientModule::createNativeDevice(const ContextPtr& cont
     auto reconnectionProcessingThread = std::thread(
         [this, reconnectionProcessingIOContextPtr]()
         {
+            daqNameThread("NatCliDevReconnProc");
             using namespace boost::asio;
             auto workGuard = make_work_guard(*reconnectionProcessingIOContextPtr);
             reconnectionProcessingIOContextPtr->run();
@@ -505,6 +508,7 @@ std::shared_ptr<boost::asio::io_context> NativeStreamingClientModule::addStreami
     auto processingThread = std::thread(
         [this, processingIOContextPtr, connectionString]()
         {
+            daqNameThread("NatCliStreamProc");
             using namespace boost::asio;
             auto workGuard = make_work_guard(*processingIOContextPtr);
             processingIOContextPtr->run();

--- a/modules/native_streaming_server_module/src/CMakeLists.txt
+++ b/modules/native_streaming_server_module/src/CMakeLists.txt
@@ -45,6 +45,10 @@ target_include_directories(${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_
                                               $<INSTALL_INTERFACE:include>
 )
 
+if (MSVC)
+    target_compile_options(${LIB_NAME} PRIVATE /bigobj)
+endif()
+
 opendaq_set_module_properties(${LIB_NAME} ${PROJECT_VERSION_MAJOR})
 create_version_header(${LIB_NAME})
 

--- a/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
+++ b/modules/native_streaming_server_module/src/native_streaming_server_impl.cpp
@@ -15,9 +15,9 @@
 
 #include <boost/asio/dispatch.hpp>
 #include <opendaq/input_port_factory.h>
+#include <opendaq/thread_name.h>
 
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_SERVER_MODULE
-
 using namespace daq;
 using namespace opendaq_native_streaming_protocol;
 using namespace config_protocol;
@@ -158,6 +158,7 @@ void NativeStreamingServerImpl::startTransportOperations()
     transportThread = std::thread(
         [this]()
         {
+            daqNameThread("NatSrvStreamTrans");
             using namespace boost::asio;
             auto workGuard = make_work_guard(*transportIOContextPtr);
             transportIOContextPtr->run();
@@ -191,6 +192,8 @@ void NativeStreamingServerImpl::startProcessingOperations()
     processingThread = std::thread(
         [this]()
         {
+            daqNameThread("NatSrvProc");
+
             using namespace boost::asio;
             auto workGuard = make_work_guard(processingIOContext);
             processingIOContext.run();
@@ -409,6 +412,7 @@ void NativeStreamingServerImpl::startReading()
     readThreadActive = true;
     this->readThread = std::thread([this]()
     {
+        daqNameThread("NatSrvStreamRead");
         this->startReadThread();
         LOG_I("Reading thread finished");
     });

--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -18,6 +18,7 @@
 #include <iomanip>
 #include <sstream>
 #include <utility>
+#include <opendaq/thread_name.h>
 
 #ifdef DAQMODULES_REF_DEVICE_MODULE_SIMULATOR_ENABLED
 #ifdef __linux__
@@ -27,7 +28,6 @@
 #endif
 
 BEGIN_NAMESPACE_REF_DEVICE_MODULE
-
 StringPtr ToIso8601(const std::chrono::system_clock::time_point& timePoint);
 
 RefDeviceImpl::RefDeviceImpl(size_t id,
@@ -214,6 +214,8 @@ void RefDeviceImpl::initSyncComponent()
 
 void RefDeviceImpl::acqLoop()
 {
+    daqNameThread("RefDevice");
+
     using namespace std::chrono_literals;
     using milli = std::chrono::milliseconds;
 

--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -9,8 +9,10 @@
 #include <opendaq/custom_log.h>
 #include <ref_fb_module/dispatch.h>
 #include <coreobjects/eval_value_factory.h>
+#include <opendaq/thread_name.h>
 #include <date/date.h>
 #include <iomanip>
+
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
@@ -737,6 +739,8 @@ void RendererFbImpl::updateSingleXAxis() {
 
 void RendererFbImpl::renderLoop()
 {
+    daqNameThread("Renderer");
+
     unsigned int width;
     unsigned int height;
     getWidthAndHeight(width, height);

--- a/shared/libraries/config_protocol/src/config_protocol_streaming_producer.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_streaming_producer.cpp
@@ -1,5 +1,6 @@
 #include <config_protocol/config_protocol_streaming_producer.h>
 #include <opendaq/custom_log.h>
+#include <opendaq/thread_name.h>
 
 namespace daq::config_protocol
 {
@@ -142,7 +143,8 @@ void ConfigProtocolStreamingProducer::stopReadSignal(StreamedSignal& streamedSig
 
 void ConfigProtocolStreamingProducer::readerThreadFunc()
 {
-    LOG_D("Streaming producer thread started");
+    daqNameThread("CfgProtoStreamProd");
+    LOG_D("Streaming producer thread started")
     while (readThreadRunning)
     {
         {

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
@@ -7,9 +7,9 @@
 
 #include <coreobjects/property_factory.h>
 #include <coreobjects/property_object_factory.h>
+#include <opendaq/thread_name.h>
 
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL
-
 using namespace daq::native_streaming;
 
 NativeStreamingClientImpl::NativeStreamingClientImpl(const ContextPtr& context,
@@ -579,6 +579,8 @@ void NativeStreamingClientHandler::startTransportOperations()
     ioThread =
         std::thread([this]()
                     {
+                        daqNameThread("NatCliTransIO");
+
                         using namespace boost::asio;
                         executor_work_guard<io_context::executor_type> workGuard(ioContextPtr->get_executor());
                         ioContextPtr->run();

--- a/shared/libraries/opcua/opcuaclient/src/opcuaclient.cpp
+++ b/shared/libraries/opcua/opcuaclient/src/opcuaclient.cpp
@@ -49,6 +49,7 @@ ClientLockGuard::operator UA_Client*()
 OpcUaClient::OpcUaClient(const OpcUaEndpoint& endpoint)
     : endpoint(endpoint)
     , timerTasks()
+    , iterateThread("OpcUaClient")
 {
     iterateThread.setCallback(std::bind(&OpcUaClient::executeIterateCallback, this));
     initialize();

--- a/shared/libraries/utils/include/opendaq/utils/timer_thread.h
+++ b/shared/libraries/utils/include/opendaq/utils/timer_thread.h
@@ -32,6 +32,7 @@
 #include <functional>
 #include <condition_variable>
 #include <optional>
+#include <string>
 
 BEGIN_NAMESPACE_UTILS
 
@@ -51,24 +52,28 @@ public:
 
     /**
      * @brief Initializes a new instance of the TimerThread class with default 1000 milliseconds period.
+     * @param name a thread name.
      * @param intervalMs a interval in milliseconds.
      * @param callback a callback function you want the TimerThread to execute.
      * @param delayMs start delay (amount of time before first execution) in milliseconds. If negative, then the interval time is used for start delay.
      * @param timerMode a timer mode.
      */
-    explicit TimerThread(int intervalMs = 1000,
+    explicit TimerThread(const std::string& name,
+                         int intervalMs = 1000,
                          CallbackFunction callback = nullptr,
                          int delayMs = -1,
                          TimerMode timerMode = TimerMode::FixedDelay);
 
     /**
      * @brief Initializes a new instance of the TimerThread class.
+     * @param name a thread name.
      * @param interval a interval in microseconds.
      * @param callback a callback function you want the TimerThread to execute.
      * @param delay start delay (amount of time before first execution) in microseconds. If empty, then the interval time is used for start delay.
      * @param timerMode a timer mode.
      */
-    explicit TimerThread(std::chrono::microseconds interval,
+    explicit TimerThread(const std::string& name,
+                         std::chrono::microseconds interval,
                          CallbackFunction callback = nullptr,
                          std::optional<std::chrono::microseconds> delay = std::nullopt,
                          TimerMode timerMode = TimerMode::FixedDelay);
@@ -144,6 +149,7 @@ protected:
     virtual void executeTimerCallback();
 
 private:
+    std::string name;
     std::mutex terminateMutex;
     std::condition_variable doTerminate;
     std::atomic<int64_t> noOfCallbacks{0};

--- a/shared/libraries/utils/src/timer_thread.cpp
+++ b/shared/libraries/utils/src/timer_thread.cpp
@@ -12,8 +12,8 @@
 
 BEGIN_NAMESPACE_UTILS
 
-TimerThread::TimerThread(int intervalMs, CallbackFunction callback, int delayMs, TimerMode timerMode)
-    : TimerThread(std::chrono::milliseconds(static_cast<int64_t>(intervalMs)),
+TimerThread::TimerThread(const std::string& name, int intervalMs, CallbackFunction callback, int delayMs, TimerMode timerMode)
+    : TimerThread(name, std::chrono::milliseconds(static_cast<int64_t>(intervalMs)),
                   std::move(callback),
                   delayMs == -1 ? std::chrono::milliseconds(static_cast<int64_t>(intervalMs))
                                 : std::chrono::milliseconds(static_cast<int64_t>(delayMs)),
@@ -21,11 +21,13 @@ TimerThread::TimerThread(int intervalMs, CallbackFunction callback, int delayMs,
 {
 }
 
-TimerThread::TimerThread(std::chrono::microseconds interval,
+TimerThread::TimerThread(const std::string& name,
+                         std::chrono::microseconds interval,
                          CallbackFunction callback,
                          std::optional<std::chrono::microseconds> delay,
                          TimerMode timerMode)
-    : intervalMcs{interval}
+    : name(name)
+    ,intervalMcs{interval}
     , delayMcs(delay.has_value() ? delay.value() : interval)
     , timerMode(timerMode)
     , callback{std::move(callback)}

--- a/shared/libraries/utils/tests/test_timer_thread.cpp
+++ b/shared/libraries/utils/tests/test_timer_thread.cpp
@@ -26,27 +26,27 @@ public:
 TEST_F(TimerThreadTest, CreateTimer)
 {
     TestCallbackClass callbackFunciton;
-    TimerThread timerThread{1000, [&callbackFunciton] { callbackFunciton.callback(); }};
+    TimerThread timerThread{"test", 1000, [&callbackFunciton] { callbackFunciton.callback(); }};
 }
 
 TEST_F(TimerThreadTest, CreateAndStart)
 {
     TestCallbackClass callbackFunciton;
-    TimerThread timerThread{1000, [&callbackFunciton] { callbackFunciton.callback(); }};
+    TimerThread timerThread{"test", 1000, [&callbackFunciton] { callbackFunciton.callback(); }};
     timerThread.start();
 }
 
 TEST_F(TimerThreadTest, ExecuteTimer)
 {
     TestCallbackClass callbackFunciton;
-    TimerThread timerThread{1, [&callbackFunciton] { callbackFunciton.callback(); }};
+    TimerThread timerThread{"test", 1, [&callbackFunciton] { callbackFunciton.callback(); }};
     ASSERT_EQ(timerThread.getNoOfCallbacks(), callbackFunciton.callbackCalls);
     ASSERT_EQ(callbackFunciton.callbackCalls, 0);
 }
 
 TEST_F(TimerThreadTest, TerminateTimerTest)
 {
-    TimerThread timerThread{1000, nullptr};
+    TimerThread timerThread{"test", 1000, nullptr};
     timerThread.start();
     timerThread.stop();
 }
@@ -54,7 +54,7 @@ TEST_F(TimerThreadTest, TerminateTimerTest)
 TEST_F(TimerThreadTest, ExecuteDelay)
 {
     TestCallbackClass callbackFunciton;
-    TimerThread timerThread{10000, [&callbackFunciton] { callbackFunciton.callback(); }};
+    TimerThread timerThread{"test", 10000, [&callbackFunciton] { callbackFunciton.callback(); }};
     timerThread.start();
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     timerThread.stop();


### PR DESCRIPTION
# Brief

Adds `daqNameThread`, which sets a thread's name. This is helpful during debugging and resource monitoring. It also sets the name of some threads.


# Description

Debuggers usually have a "threads" view that displays a list of threads. However, it can be challenging to identify them. Most debuggers and resource monitoring tools can also print the thread's name. `daqNameThread` must be called within the context of the target thread.

# Usage example

In C++ use:

```cpp

#include <opendaq/thread_name>

std::thread([] {
    // ...
    daqNameThread("CustomThread");
    // ...
}
```
# API Changes

```diff
+ daqNameThread(const char* name)
```