### PR TITLE
Set default value as args newValue on clear instead of empty ptr

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -51,6 +51,7 @@
 
 ## Misc
 
+- [#738](https://github.com/openDAQ/openDAQ/pull/738) When clearing a property value, the PropertyValueArgs object obtained in the onWrite callback now contains the default value instead of an empty ptr.
 - [#728](https://github.com/openDAQ/openDAQ/pull/728) Add timeout on to re-scan after for available devices after 5s in the module manager call `createDevice`.
 - [#714](https://github.com/openDAQ/openDAQ/pull/714) Set of permission manager optimizations that reduce the number of Dictionary object creations on Property/PropertyObject construction.
 - [#706](https://github.com/openDAQ/openDAQ/pull/706) Limit reference device channel count to min/max values.

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -1002,6 +1002,33 @@ TEST_F(PropertyObjectTest, OnValueChangeClear)
     ASSERT_EQ(numCallbacks, 2);
 }
 
+TEST_F(PropertyObjectTest, OnValueChangeClearDefaultValue)
+{
+    auto propObj = PropertyObject(objManager, "Test");
+    Int numCallbacks = 0;
+
+    propObj.getOnPropertyValueWrite("FloatProperty") +=
+        [&numCallbacks](PropertyObjectPtr& /*sender*/, PropertyValueEventArgsPtr& args)
+        {
+            if (args.getPropertyEventType() == PropertyEventType::Clear)
+            {
+                if (numCallbacks == 0)
+                {
+                    ASSERT_EQ(args.getValue(), args.getProperty().getDefaultValue());
+                    args.setValue(50.0);
+                }
+                numCallbacks++;
+            }
+        };
+
+    propObj.setPropertyValue("FloatProperty", 2.0);
+    propObj.clearPropertyValue("FloatProperty");
+    ASSERT_DOUBLE_EQ(propObj.getPropertyValue("FloatProperty"), 50.0);
+    propObj.clearPropertyValue("FloatProperty");
+    ASSERT_DOUBLE_EQ(propObj.getPropertyValue("FloatProperty"), 1.0);
+    ASSERT_EQ(numCallbacks, 2);
+}
+
 TEST_F(PropertyObjectTest, OnValueChangePropertyEvent)
 {
     auto propObj = PropertyObject(objManager, "Test");


### PR DESCRIPTION
# Brief
When clearing a property value, the `PropertyValueArgs` object obtained in the `onWrite` callback now contains the default value instead of an empty ptr.

# Description
When a `onWrite` event was previously triggered by a `clearPropertyValue` call, the `args.getValue()` method would return an empty ptr. Users needed to always check for `args.getPropertyEventType()` being `Clear` to know whether or not the args contain a newly written value.

With this change, the same code can be used whether the event is `Clear` or `Write`, as the args value on `Clear` will contain the default property value.

# Usage example

```cpp
propObj.getOnPropertyValueWrite("FloatProperty") +=
	[](PropertyObjectPtr& /*sender*/, PropertyValueEventArgsPtr& args)
	{
              // Works regardless of PropertyEventType
              valueChanged(args.getValue());
	};
```