### PR TITLE
[TBBAS-2157] Function blocks with dynamic input ports don't get correctly loaded if input port names don't match name

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -29,7 +29,7 @@
 - [#596](https://github.com/openDAQ/openDAQ/pull/596) Adds a device info popup the the Python GUI application "Add device" dialog.
 
 ## Bug fixes
-
+- [#740](https://github.com/openDAQ/openDAQ/pull/740) Fixes restoring connection signals to dynamic input ports of a function block while loading the configuration when the name of the new input does not match the old one.
 - [#733](https://github.com/openDAQ/openDAQ/pull/733) Fixes list/dictionary deserialization not containing key/value/item interface IDs. Requires server-side update.
 - [#731](https://github.com/openDAQ/openDAQ/pull/731) Fixes nested object access over OPC UA. Object properties original PropertyObject is now stored in PropertyObjectImpl; PropertyImpl now contains the clone.
 - [#719](https://github.com/openDAQ/openDAQ/pull/719) Fixes error when accessing selection property values using "dot" notation (eg. `getPropertySelectionValue("child.val")`).


### PR DESCRIPTION
# Brief

Fixed an issue with restoring connection signals to dynamic input ports of a function block while loading the configuration when the name of the new input does not match the old one.


# Description

The issue was in the logic of the method `FunctionBlockImpl<TInterface, Interfaces...>::onUpdatableUpdateEnd`. If a signal did not find the expected input port, it searched for an unconnected input port. However, for some reason, the connection to another input port was not registered in `ComponentUpdateContext`, causing the input port to be unaware of which signal to connect to.

This PR resolves the issue by ensuring that the connection to the correct input port is properly registered in `ComponentUpdateContext`, allowing signals to be restored correctly when loading the configuration.

