### PR TITLE
Bugfix: Initialize IProcedure objects to nullptr

### DIFF
--- a/core/coretypes/include/coretypes/procedure_impl.h
+++ b/core/coretypes/include/coretypes/procedure_impl.h
@@ -311,7 +311,7 @@ ErrCode createProcedureWrapper(IProcedure** obj, TFunctor* proc)
 template <typename TFunctor>
 IProcedure* ProcedureWrapper_Create(TFunctor proc)
 {
-    IProcedure* obj;
+    IProcedure* obj = nullptr;
     const ErrCode res = createProcedureWrapper<TFunctor>(&obj, std::move(proc));
     checkErrorInfo(res);
 
@@ -323,7 +323,7 @@ IProcedure* ProcedureWrapper_Create(TFunctor proc)
 template <typename TFunctor>
 IProcedure* ProcedureWrapper_Create(TFunctor* proc)
 {
-    IProcedure* obj;
+    IProcedure* obj = nullptr;
     const ErrCode res = createProcedureWrapper<TFunctor>(&obj, proc);
     checkErrorInfo(res);
 


### PR DESCRIPTION
# Brief

Initialized IProcedure objects to default value: `nullptr`.
Uninitialized objects cause potential use-before-init errors for certain compilers.

