### PR TITLE
Fixed unknown std::chrono namespace issue introduced in VS2022 17.13.…

### DIFF
--- a/core/opendaq/logger/tests/test_logger_component.cpp
+++ b/core/opendaq/logger/tests/test_logger_component.cpp
@@ -17,6 +17,7 @@
 #include <coretypes/impl.h>
 #include <opendaq/logger_sink_ptr.h>
 
+#include <chrono>
 #include <thread>
 
 using namespace daq;

--- a/core/opendaq/modulemanager/src/icmp_ping.cpp
+++ b/core/opendaq/modulemanager/src/icmp_ping.cpp
@@ -3,6 +3,7 @@
 #include <opendaq/ipv4_header.h>
 #include <opendaq/format.h>
 #include <opendaq/custom_log.h>
+#include <chrono>
 #include <thread>
 
 using namespace boost;

--- a/core/opendaq/modulemanager/tests/module_manager_test.cpp
+++ b/core/opendaq/modulemanager/tests/module_manager_test.cpp
@@ -5,6 +5,7 @@
 
 #include "mock/mock_module.h"
 
+#include <chrono>
 #include <thread>
 
 using namespace daq;

--- a/core/opendaq/modulemanager/tests/test_module_manager_internals.cpp
+++ b/core/opendaq/modulemanager/tests/test_module_manager_internals.cpp
@@ -7,6 +7,7 @@
 #include <opendaq/logger_component_ptr.h>
 #include <opendaq/logger_factory.h>
 
+#include <chrono>
 #include <thread>
 
 using namespace daq;

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -12,6 +12,7 @@
 
 #include <fmt/ostream.h>
 #include <set>
+#include <chrono>
 #include <thread>
 
 using namespace std::chrono;

--- a/core/opendaq/reader/tests/reader_common.h
+++ b/core/opendaq/reader/tests/reader_common.h
@@ -27,6 +27,7 @@
 #include <opendaq/signal_factory.h>
 #include <testutils/testutils.h>
 
+#include <chrono>
 #include <thread>
 
 using namespace daq;

--- a/core/opendaq/scheduler/tests/test_scheduler.cpp
+++ b/core/opendaq/scheduler/tests/test_scheduler.cpp
@@ -1,8 +1,8 @@
 #include "test_scheduler.h"
 #include <gtest/gtest.h>
 
-#include <thread>
 #include <chrono>
+#include <thread>
 
 #include <opendaq/logger_factory.h>
 

--- a/core/opendaq/scheduler/tests/test_scheduler.h
+++ b/core/opendaq/scheduler/tests/test_scheduler.h
@@ -24,6 +24,7 @@
 
 #include <mutex>
 #include <random>
+#include <chrono>
 #include <thread>
 #include <opendaq/logger_factory.h>
 

--- a/core/opendaq/scheduler/tests/test_scheduler_internals.cpp
+++ b/core/opendaq/scheduler/tests/test_scheduler_internals.cpp
@@ -2,8 +2,8 @@
 #include <opendaq/scheduler_impl.h>
 #include <gtest/gtest.h>
 
-#include <thread>
 #include <chrono>
+#include <thread>
 #include <opendaq/logger_factory.h>
 
 class SchedulerInternalsTest : public testing::Test

--- a/examples/cpp/reader_timeouts_example/reader_timeouts_example.cpp
+++ b/examples/cpp/reader_timeouts_example/reader_timeouts_example.cpp
@@ -6,6 +6,7 @@
 #include <opendaq/signal_factory.h>
 
 #include <cassert>
+#include <chrono>
 #include <thread>
 
 using namespace daq;

--- a/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
+++ b/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
@@ -20,6 +20,7 @@
 #include <opendaq/device_impl.h>
 #include <opendaq/logger_ptr.h>
 #include <opendaq/logger_component_ptr.h>
+#include <chrono>
 #include <thread>
 #include <condition_variable>
 #include <opendaq/log_file_info_ptr.h>

--- a/modules/ref_device_module/src/ref_can_channel_impl.cpp
+++ b/modules/ref_device_module/src/ref_can_channel_impl.cpp
@@ -13,6 +13,7 @@
 #include <opendaq/custom_log.h>
 #include <coreobjects/property_object_protected_ptr.h>
 #include <opendaq/dimension_factory.h>
+#include <chrono>
 
 
 #define PI 3.141592653589793

--- a/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
+++ b/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
@@ -35,6 +35,7 @@
     #pragma warning(pop)
 #endif
 
+#include <chrono>
 #include <thread>
 #include <condition_variable>
 #include <queue>

--- a/modules/ref_fb_module/tests/test_ref_fb_module.cpp
+++ b/modules/ref_fb_module/tests/test_ref_fb_module.cpp
@@ -10,6 +10,7 @@
 #include <ref_fb_module/module_dll.h>
 #include <ref_fb_module/version.h>
 #include <testutils/testutils.h>
+#include <chrono>
 #include <thread>
 #include "testutils/memcheck_listener.h"
 

--- a/modules/tests/test_opendaq_device_modules/test_helpers/test_helpers.h
+++ b/modules/tests/test_opendaq_device_modules/test_helpers/test_helpers.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <thread>
 #include <future>
 #include <fstream>

--- a/modules/tests/test_ref_modules/test_ref_modules.cpp
+++ b/modules/tests/test_ref_modules/test_ref_modules.cpp
@@ -9,6 +9,7 @@
 #include <opendaq/config_provider_factory.h>
 #include <coreobjects/property_object_factory.h>
 #include <coreobjects/property_factory.h>
+#include <chrono>
 #include <thread>
 #include <fstream>
 #include "classifier_test_helper.h"

--- a/modules/tests/test_ws_siggen_integration/test_websocket_siggen.cpp
+++ b/modules/tests/test_ws_siggen_integration/test_websocket_siggen.cpp
@@ -1,6 +1,7 @@
 #include <testutils/testutils.h>
 #include <opendaq/opendaq.h>
 #include "testutils/memcheck_listener.h"
+#include <chrono>
 #include <thread>
 
 using SiggenTest = testing::TestWithParam<std::string>;

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_streaming_producer.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_streaming_producer.h
@@ -20,6 +20,7 @@
 #include <opendaq/packet_ptr.h>
 #include <opendaq/reader_factory.h>
 #include <opendaq/input_port_ptr.h>
+#include <chrono>
 #include <thread>
 
 namespace daq::config_protocol

--- a/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
+++ b/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
@@ -28,6 +28,7 @@
 #include <cstdio>
 #include <csignal>
 #include <mutex>
+#include <chrono>
 #include <thread>
 #include <vector>
 #include <unordered_set>

--- a/shared/libraries/opcua/opcuaclient/include/opcuaclient/opcuaclient.h
+++ b/shared/libraries/opcua/opcuaclient/include/opcuaclient/opcuaclient.h
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <mutex>
 #include <set>
+#include <chrono>
 #include <thread>
 
 #include <opcuaclient/opcuacallmethodrequest.h>

--- a/shared/libraries/opcua/opcuaclient/tests/include/opcuaservertesthelper.h
+++ b/shared/libraries/opcua/opcuaclient/tests/include/opcuaservertesthelper.h
@@ -22,6 +22,7 @@
 #include "opcuashared/opcua.h"
 #include "opcuashared/opcuacommon.h"
 #include <open62541/server_config_default.h>
+#include <chrono>
 #include <thread>
 
 BEGIN_NAMESPACE_OPENDAQ_OPCUA

--- a/shared/libraries/signal_generator/include/signal_generator/signal_generator.h
+++ b/shared/libraries/signal_generator/include/signal_generator/signal_generator.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <coretypes/common.h>
 #include <opendaq/signal_factory.h>
+#include <chrono>
 
 BEGIN_NAMESPACE_OPENDAQ
 

--- a/shared/libraries/utils/tests/test_thread_ex.cpp
+++ b/shared/libraries/utils/tests/test_thread_ex.cpp
@@ -1,5 +1,6 @@
 #include <testutils/testutils.h>
 #include <functional>
+#include <chrono>
 #include <thread>
 #include <opendaq/utils/thread_ex.h>
 

--- a/shared/libraries/utils/tests/test_timer_thread.cpp
+++ b/shared/libraries/utils/tests/test_timer_thread.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <math.h>
 #include <functional>
+#include <chrono>
 #include <thread>
 #include <iostream>
 #include <opendaq/utils/timer_thread.h>

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/async_packet_reader.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/async_packet_reader.h
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <chrono>
 #include <thread>
 #include "websocket_streaming/websocket_streaming.h"
 #include <opendaq/device_ptr.h>

--- a/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
+++ b/shared/libraries/websocket_streaming/include/websocket_streaming/streaming_client.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <opendaq/device_ptr.h>
 #include <string>
+#include <chrono>
 #include <thread>
 #include "websocket_streaming/websocket_streaming.h"
 #include "websocket_streaming/input_signal.h"


### PR DESCRIPTION
Cherry-pick fix for chrono library issues in windows builds. Original PR comment:


# Brief

Fixed "unknown std::chrono namespace" issue introduced in VS2022 17.13.0


# Description

Microsoft changed an internal header, so the `chrono` header has to be included directly when `std::chrono` is in use (no longer included in `thread` header). 
Added `#include <chrono>` wherever there was `#include <thread>` and use of `std::chrono`. 
Affected directories: `./core/`, `./examples/`, `./modules/`, `./shared/libraries/`. 
Not all files containing `#include <thread>` are affected. 

# Usage example

Instead of:

`#include <thread>`

Do:

`#include <chrono>`
`#include <thread>`

# Required module changes

n/a