### PR TITLE
OPC-UA client: warn and ignore duplicate properties

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -29,6 +29,8 @@
 - [#596](https://github.com/openDAQ/openDAQ/pull/596) Adds a device info popup the the Python GUI application "Add device" dialog.
 
 ## Bug fixes
+
+- [#754](https://github.com/openDAQ/openDAQ/pull/754) Treat duplicate OPC-UA properties, with names that differ only in case, as warnings instead of fatal errors.
 - [#740](https://github.com/openDAQ/openDAQ/pull/740) Fixes restoring connection signals to dynamic input ports of a function block while loading the configuration when the name of the new input does not match the old one.
 - [#733](https://github.com/openDAQ/openDAQ/pull/733) Fixes list/dictionary deserialization not containing key/value/item interface IDs. Requires server-side update.
 - [#731](https://github.com/openDAQ/openDAQ/pull/731) Fixes nested object access over OPC UA. Object properties original PropertyObject is now stored in PropertyObjectImpl; PropertyImpl now contains the clone.

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -533,10 +533,20 @@ void TmsClientPropertyObjectBaseImpl<Impl>::browseRawProperties()
         addMethodProperties(nodeId, orderedProperties, unorderedProperties, functionPropValues);
     }
 
+    auto addPropertyIgnoreDuplicates = [this](const daq::PropertyPtr& prop)
+    {
+        auto ec = Impl::addProperty(prop);
+        if (ec != OPENDAQ_ERR_ALREADYEXISTS)
+            return ec;
+        LOG_W("TMS server exposes two properties with the same name \"{}\" differing only in case. The duplicate property will be ignored.",
+            prop.getName());
+        return OPENDAQ_SUCCESS;
+    };
+
     for (const auto& val : orderedProperties)
-        daq::checkErrorInfo(Impl::addProperty(val.second));
+        daq::checkErrorInfo(addPropertyIgnoreDuplicates(val.second));
     for (const auto& val : unorderedProperties)
-        daq::checkErrorInfo(Impl::addProperty(val));
+        daq::checkErrorInfo(addPropertyIgnoreDuplicates(val));
     for (const auto& val : functionPropValues)
         daq::checkErrorInfo(Impl::setProtectedPropertyValue(String(val.first), val.second));
 

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -538,8 +538,7 @@ void TmsClientPropertyObjectBaseImpl<Impl>::browseRawProperties()
         auto ec = Impl::addProperty(prop);
         if (ec != OPENDAQ_ERR_ALREADYEXISTS)
             return ec;
-        LOG_W("TMS server exposes two properties with the same name \"{}\" differing only in case. The duplicate property will be ignored.",
-            prop.getName());
+        LOG_W("OPC UA exposes two properties with the same name \"{}\". The duplicate property will be ignored.", prop.getName())
         return OPENDAQ_SUCCESS;
     };
 

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_device.cpp
@@ -234,13 +234,13 @@ void TmsServerDevice::populateDeviceInfo()
         });
     }
 
-    std::map<std::string, std::string> theBestProportiesEver = 
+    std::map<std::string, std::string> deviceInfoFieldsMap = 
     {
         {"userName", "UserName"},
         {"location", "Location"}
     };
 
-    for (const auto& [propName, browseName] : theBestProportiesEver)
+    for (const auto& [propName, browseName] : deviceInfoFieldsMap)
     {
         const auto& prop = deviceInfo.getProperty(propName);
         const auto nodeId = getChildNodeId(browseName);


### PR DESCRIPTION
# Brief

Treat duplicate OPC-UA properties, with names that differ only in case, as warnings instead of fatal errors.

# Description

During the in-person workshop in Darmstadt, debugging revealed that devices using older openDAQ SDK versions may publish the "Location" and "UserName" twice, with the published nodes differing only in case. Those two properties are explicitly handled in openDAQ  to map to the lowercase "location" and "userName" property of a Device/DeviceInfo. This results in an "AlreadyExistsException" being thrown on connect.

This PR changes the TMS client to treat this condition as a warning instead of a fatal error. A message like this is logged to the logger:

    "OPC UA property "location" already exists. The duplicate property will be ignored."

This allows the current SDK to connect to OPC-UA servers using openDAQ 3.2.