### PR TITLE
[TBBAS-1957] .NET bindings usage guide on Linux

### DIFF
--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/OpenDaqGettingStartedGuidesTests.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/OpenDaqGettingStartedGuidesTests.cs
@@ -4,12 +4,9 @@
 // Ignore Spelling: Opc Ua nullable daqref
 
 
-using System.Collections;
-using System.Diagnostics;
-
+using Daq.Core.Types;
 using Daq.Core.Objects;
 using Daq.Core.OpenDAQ;
-using Daq.Core.Types;
 
 
 namespace openDaq.Net.Test;
@@ -17,70 +14,121 @@ namespace openDaq.Net.Test;
 
 public class OpenDaqGettingStartedGuidesTests : OpenDAQTestsBase
 {
-    // Corresponding document: Antora/modules/getting_started/pages/quick_start_application.adoc
+    [SetUp]
+    public void Setup()
+    {
+        base.DontWarn();
+        base.DontCollectAndFinalize();
+        base.DontCheckAliveObjectCount();
+    }
+
+    //[TearDown]
+    //public void TearDown()
+    //{
+    //}
+
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 
+    // Corresponding document: Antora/modules/getting_started/pages/quick_start_application.adoc
     [Test]
     public void FullExampleCodeTest()
     {
         // Create a fresh openDAQ(TM) instance that we will use for all the interactions with the openDAQ(TM) SDK
         var instance = OpenDAQFactory.Instance();
 
-        // Find and connect to a simulator device
-        Device device = null;
-        foreach (var deviceInfo in instance.AvailableDevices)
-        {
-            if (deviceInfo.ConnectionString.StartsWith("daq://openDAQ_"))
-            {
-                device = instance.AddDevice(deviceInfo.ConnectionString);
-                break;
-            }
-        }
-
-        if (device == null)
+        // Find the simulator device
+        var deviceInfo = instance.AvailableDevices.FirstOrDefault(devInfo => devInfo.Name == "Reference device simulator");
+        if (deviceInfo == null)
         {
             Console.WriteLine("No relevant device found!");
+            return;
+        }
+
+        // Connect to the simulator device
+        var device = instance.AddDevice(deviceInfo.ConnectionString);
+        if (device == null)
+        {
+            Console.WriteLine("Device connection failed!");
             return;
         }
 
         // Output the name of the added device
         Console.WriteLine(device.Info.Name);
 
-        // Get the first channel and its signal
+        // Get the first signal of the first device's channel
         var channel = device.GetChannels()[0];
-        var signal = channel.GetSignals()[0];
+        var signal  = channel.GetSignals()[0];
+
+        // Print out the last value of the signal
+        Console.WriteLine($"Using signal: '{signal.Name}'");
+        Console.WriteLine($"Last value of the signal: {signal.LastValue}");
 
         var reader = OpenDAQFactory.CreateStreamReader(signal); //defaults to CreateStreamReader<double, long>
+
+        // Allocate buffer for reading double samples
+        double[] samples = new double[100];
+
+        for (int i = 0; i < 40; ++i)
+        {
+            Thread.Sleep(25);
+
+            // Read up to 100 samples, storing the amount read into `count`
+            nuint count = 100;
+            reader.Read(samples, ref count);
+
+            // The call to Read() might return count==0 (explained in the how-to guides)
+            if (count > 0)
+                Console.WriteLine($"Last value of read block {i+1,2}: {samples[count - 1]}");
+        }
 
         // Get the resolution and origin
         var descriptor = signal.DomainSignal.Descriptor;
         var resolution = descriptor.TickResolution;
-        var origin = descriptor.Origin;
+        var origin     = descriptor.Origin;
         var unitSymbol = descriptor.Unit.Symbol;
 
-        Console.WriteLine($"Reading signal: {signal.Name}");
-        Console.WriteLine($"Origin: {origin}");
+        Console.WriteLine($"Domain origin: {origin}");
 
-        // Allocate buffer for reading double samples
-        double[] samples = new double[100];
+        // Allocate buffer for reading domain samples
         long[] domainSamples = new long[100];
-        int cnt = 0;
-        while (cnt < 40)
+
+        for (int i = 0; i < 40; i++)
         {
             Thread.Sleep(100);
 
             // Read up to 100 samples every 100ms, storing the amount read into `count`
             nuint count = 100;
             reader.ReadWithDomain(samples, domainSamples, ref count);
+
+            // The call to ReadWithDomain() might return count==0 (explained in the how-to guides)
             if (count > 0)
             {
+                // Scale the domain value to the Signal unit (seconds)
                 double domainValue = (double)domainSamples[count - 1] * ((double)resolution.Numerator / resolution.Denominator);
-                Console.WriteLine($"Value: {samples[count - 1]}, Domain: {domainValue}{unitSymbol}");
-                cnt++;
+                Console.WriteLine($"Last value of read block {i + 1,2}: {samples[count - 1]}, Domain: {domainValue}{unitSymbol}");
             }
         }
 
-        //TimeReader currently not available in .NET Bindings
+        // In contrast to C++, the time reader in .NET does not change the domain signal type of the stream reader
+
+        // Create a time reader which uses the previously created stream reader
+        var timeReader = OpenDAQFactory.CreateTimeReader(reader, signal);
+
+        // Allocate buffer for reading timestamps
+        DateTime[] timeStamps = new DateTime[100];
+
+        for (int i = 0; i < 40; i++)
+        {
+            Thread.Sleep(25);
+
+            // Read up to 100 samples, storing the amount read into `count`
+            nuint count = 100;
+            timeReader.ReadWithDomain(samples, timeStamps, ref count);
+
+            // The call to ReadWithDomain() might return count==0 (explained in the how-to guides)
+            if (count > 0)
+                Console.WriteLine($"Last value of read block {i + 1,2}: {samples[count - 1]}, Time: {timeStamps[count - 1]:yyyy-MM-dd HH:mm:ss.fffffff}");
+        }
 
         // Create an instance of the renderer function block
         var renderer = instance.AddFunctionBlock("RefFBModuleRenderer");
@@ -106,29 +154,16 @@ public class OpenDaqGettingStartedGuidesTests : OpenDAQTestsBase
         // Set the noise amplitude to 0.75
         channel.SetPropertyValue("NoiseAmplitude", 0.75d);
 
-#if !documentation
-        Stopwatch sw = Stopwatch.StartNew();
-#endif
-
         // Modulate the signal amplitude by a step of 0.1 every 25ms.
         double amplStep = 0.1d;
-        while (true)
+        for (int i = 0; i < 200; ++i)
         {
             Thread.Sleep(25);
             double ampl = channel.GetPropertyValue("Amplitude");
-            if (9.95d < ampl || ampl < 1.05d)
+            if ((9.95d < ampl) || (ampl < 1.05d))
                 amplStep *= -1d;
             channel.SetPropertyValue("Amplitude", ampl + amplStep);
-
-#if !documentation
-            if (sw.Elapsed.TotalSeconds >= 3)
-                break;
-#endif
         }
-
-#if !documentation
-        sw.Stop();
-#endif
     }
 
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/openDAQ.Net.Test.csproj
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/openDAQ.Net.Test.csproj
@@ -16,6 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- without this no class would be expanded in Solution Explorer somehow -->
+    <Compile Include=".\*.cs" />
+    <!-- Include local unit tests if available (no error if there is none) -->
+    <Compile Include="..\..\..\..\build\bindings\CSharp\local-tests\*.cs" Link="%(FileName).cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/coreobjects/CoreObjectsFactory.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/coreobjects/CoreObjectsFactory.cs
@@ -15,12 +15,25 @@
  */
 
 
+using Daq.Core.OpenDAQ;
+using Daq.Core.Types;
+
 namespace Daq.Core.Objects;
 
 
 /// <summary>Factory functions of the &apos;CoreObjects&apos; library.</summary>
 public static partial class CoreObjectsFactory
 {
+    /// <summary>
+    /// Initializes the openDAQ SDK.
+    /// </summary>
+    static CoreObjectsFactory()
+    {
+        // initialize the SDK (load all depending SDK libraries)
+        _ = CoreTypesFactory.SdkVersion;
+        _ = CoreObjectsFactory.SdkVersion;
+    }
+
     //void daqCoreObjectsGetVersion(unsigned int* major, unsigned int* minor, unsigned int* revision); cdecl;
     [DllImport(CoreObjectsDllInfo.FileName, CallingConvention = CallingConvention.Cdecl)]
     private static extern void daqCoreObjectsGetVersion(out int major, out int minor, out int revision);

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/coretypes/CoreTypesFactory.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/coretypes/CoreTypesFactory.cs
@@ -15,12 +15,23 @@
  */
 
 
+using Daq.Core.Objects;
+
 namespace Daq.Core.Types;
 
 
 /// <summary>Factory functions of the &apos;CoreTypes&apos; library.</summary>
 public static partial class CoreTypesFactory
 {
+    /// <summary>
+    /// Initializes the openDAQ SDK.
+    /// </summary>
+    static CoreTypesFactory()
+    {
+        // initialize the SDK (load all depending SDK libraries)
+        _ = CoreTypesFactory.SdkVersion;
+    }
+
     //void daqCoreTypesGetVersion(unsigned int* major, unsigned int* minor, unsigned int* revision); cdecl;
     [DllImport(CoreTypesDllInfo.FileName, CallingConvention = CallingConvention.Cdecl)]
     private static extern void daqCoreTypesGetVersion(out int major, out int minor, out int revision);

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/opendaq/OpenDAQFactory.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/core/opendaq/OpenDAQFactory.cs
@@ -33,7 +33,7 @@ public static partial class OpenDAQFactory
     /// </summary>
     static OpenDAQFactory()
     {
-        // initialize the SDK (load all SDK libraries)
+        // initialize the SDK (load all depending SDK libraries)
         _ = CoreTypesFactory.SdkVersion;
         _ = CoreObjectsFactory.SdkVersion;
         _ = OpenDAQFactory.SdkVersion;

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/openDAQ.Net.csproj
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/openDAQ.Net.csproj
@@ -94,8 +94,8 @@
 
   <!-- $(BaseOutputPath) -->
   <ItemGroup>
-    <!-- include the RTGen build output; exclude files which are managed manually -->
-    <Compile Include="$(_RTGenOutputPath)\**\*.cs" Exclude="$(_RTGenOutputPath)\**\*Private.cs;$(_RTGenOutputPath)\**\DeserializeComponent.cs;$(_RTGenOutputPath)\shared\**" />
+    <!-- include the RTGen build output (core); exclude files which are meant to be SDK private -->
+    <Compile Include="$(_RTGenOutputPath)\core*\**\*.cs" Exclude="$(_RTGenOutputPath)\**\*Private.cs;$(_RTGenOutputPath)\**\DeserializeComponent.cs" />
     <!-- include the documentation path into the SolutionExplorer -->
     <None Include="$(_DocsPath)\**\*.adoc">
       <Link>docs\%(RecursiveDir)\%(FileName)%(Extension)</Link>

--- a/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
@@ -10,7 +10,7 @@ xref:glossary:glossary.adoc#device[Device]s and xref:glossary:glossary.adoc#sign
 Full final source files of the examples featured in this guide are available at the bottom of the page, as well as within the binary packages available at {docs-website}[the openDAQ(TM) documentation and releases webpage].
 
 This guide continues from the openDAQ(TM) project state at the end of the Setting up guide
-(xref:quick_start_setting_up_cpp.adoc[{cpp}]/xref:quick_start_setting_up_python.adoc[Python]),
+(xref:quick_start_setting_up_cpp.adoc[{cpp}]/xref:quick_start_setting_up_python.adoc[Python]/xref:quick_start_setting_up_csharp.adoc[C#]),
 making use of the provided openDAQ(TM) binaries and examples.
 
 == Simulating an openDAQ(TM) Device
@@ -73,41 +73,14 @@ py simulator.py
 C#::
 +
 --
-The following code example creates a C# application that simulates an openDAQ(TM) Device:
+To create an application that simulates an openDAQ(TM) Device, we build and run the code example in `examples/csharp/quick_start/quick_start_simulator.cs`. Just replace the code of the file `Program.cs` in the xref:quick_start_setting_up_csharp.adoc[quick-start setting up C#] example and run it.
 
-[source,csharp]
+[source,bash]
 ----
-using Daq.Core.OpenDAQ;
-
-var config = CoreObjectsFactory.CreatePropertyObject();
-config.AddProperty(CoreObjectsFactory.CreateStringProperty("Name", "Reference device simulator", true));
-config.AddProperty(CoreObjectsFactory.CreateStringProperty("LocalId", "RefDevSimulator", true));
-config.AddProperty(CoreObjectsFactory.CreateStringProperty("SerialNumber", "sim01", true));
-
-// Create an openDAQ(TM) instance builder to configure the instance
-
-var instanceBuilder = OpenDAQFactory.InstanceBuilder();
-
-// Add mDNS discovery service available for servers
-instanceBuilder.AddDiscoveryService("mdns");
-
-// Set reference device as a root
-instanceBuilder.SetRootDevice("daqref://device1", config);
-
-// Creating a new instance from builder
-var instance = instanceBuilder.Build();
-
-// Start the openDAQ OPC UA and native streaming servers
-var servers = instance.AddStandardServers();
-
-for (int i = 0; i < servers.Count; i++)
-{
-    servers[i].EnableDiscovery();
-}
-
-Console.Write("Press a key to exit the application ...");
-Console.ReadKey(intercept: true);
+dotnet run --no-restore
 ----
+
+You will be greeted by a prompt to press a key (which will end the simulation). While the simulation is running, you can discover it (name "Reference device simulator") in another application, e.g. the `openDAQDemo.Net.exe`. This works even across WSL and Windows(TM).
 --
 ====
 
@@ -353,21 +326,20 @@ using Daq.Core.OpenDAQ;
 // Create a fresh openDAQ(TM) instance that we will use for all the interactions with the openDAQ(TM) SDK
 var instance = OpenDAQFactory.Instance();
 
-// Find and connect to a simulator device
-Device device = null;
-foreach (var deviceInfo in instance.AvailableDevices)
+// Find the simulator device
+var deviceInfo = instance.AvailableDevices.FirstOrDefault(devInfo => devInfo.Name == "Reference device simulator");
+if (deviceInfo == null)
 {
-    if (deviceInfo.Name.Equals("Reference device simulator"))
-    {
-        device = instance.AddDevice(deviceInfo.ConnectionString);
-        break; 
-    }
+    Console.WriteLine("No relevant device found!");
+    return;
 }
 
+// Connect to the simulator device
+var device = instance.AddDevice(deviceInfo.ConnectionString);
 if (device == null)
 {
-    // Exit if no device is found
-    return 0;
+    Console.WriteLine("Device connection failed!");
+    return;
 }
 
 // Output the name of the added device
@@ -552,6 +524,7 @@ var reader = OpenDAQFactory.CreateStreamReader(signal); //defaults to CreateStre
 
 // Allocate buffer for reading double samples
 double[] samples = new double[100];
+
 for (int i = 0; i < 40; i++) 
 {
     Thread.Sleep(25);
@@ -559,8 +532,10 @@ for (int i = 0; i < 40; i++)
     // Read up to 100 samples, storing the amount read into `count`
     nuint count = 100;
     reader.Read(samples, ref count);
+
+    // The call to Read() might return count==0 (explained in the how-to guides)
     if (count > 0)
-        Console.WriteLine(samples[count - 1]);
+        Console.WriteLine($"Last value of read block {i+1,2}: {samples[count - 1]}");
 }
 ----
 --
@@ -652,26 +627,28 @@ C#::
 // Get the resolution, origin, and unit
 var descriptor = signal.DomainSignal.Descriptor;
 var resolution = descriptor.TickResolution;
-var origin = descriptor.Origin;
+var origin     = descriptor.Origin;
 var unitSymbol = descriptor.Unit.Symbol;
 
 Console.WriteLine($"Origin: {origin}");
 
 // Allocate buffer for reading domain samples
-
 long[] domainSamples = new long[100];
+
 for (int i = 0; i < 40; i++) 
 {
-    Thread.Sleep(100);
+    Thread.Sleep(25);
 
     // Read up to 100 samples, storing the amount read into `count`
     nuint count = 100;
     reader.ReadWithDomain(samples, domainSamples, ref count);
+
+    // The call to ReadWithDomain() might return count==0 (explained in the how-to guides)
     if (count > 0)
     {
         // Scale the domain value to the Signal unit (seconds)
         double domainValue = (double)domainSamples[count - 1] * ((double)resolution.Numerator / resolution.Denominator);
-        Console.WriteLine($"Value: {samples[count - 1]}, Domain: {domainValue}{unitSymbol}");
+        Console.WriteLine($"Last value of read block {i + 1,2}: {samples[count - 1]}, Domain: {domainValue}{unitSymbol}");
     }
 }
 ----
@@ -744,7 +721,28 @@ C#::
 --
 [source,csharp]
 ----
-//TimeReader currently not available in .NET Bindings
+// ...
+
+// In contrast to C++, the time reader in .NET does not change the domain signal type of the stream reader
+
+// Create a time reader which uses the previously created stream reader
+var timeReader = OpenDAQFactory.CreateTimeReader(reader, signal);
+
+// Allocate buffer for reading timestamps
+DateTime[] timeStamps = new DateTime[100];
+
+for (int i = 0; i < 40; i++) 
+{
+    Thread.Sleep(25);
+
+    // Read up to 100 samples, storing the amount read into `count`
+    nuint count = 100;
+    timeReader.ReadWithDomain(samples, timeStamps, ref count);
+
+    // The call to ReadWithDomain() might return count==0 (explained in the how-to guides)
+    if (count > 0)
+        Console.WriteLine($"Value: {samples[count - 1]}, Time: {timeStamps[count - 1]:yyyy-MM-dd HH:mm:ss.fffffff}");
+}
 ----
 --
 ====
@@ -1257,21 +1255,20 @@ using Daq.Core.OpenDAQ;
 // Create a fresh openDAQ(TM) instance that we will use for all the interactions with the openDAQ(TM) SDK
 var instance = OpenDAQFactory.Instance();
 
-// Find and connect to a simulator device
-Device device = null;
-foreach (var deviceInfo in instance.AvailableDevices)
+// Find the simulator device
+var deviceInfo = instance.AvailableDevices.FirstOrDefault(devInfo => devInfo.Name == "Reference device simulator");
+if (deviceInfo == null)
 {
-    if (deviceInfo.Name.Equals("Reference device simulator"))
-    {
-        device = instance.AddDevice(deviceInfo.ConnectionString);
-        break; 
-    }
+    Console.WriteLine("No relevant device found!");
+    return;
 }
 
+// Connect to the simulator device
+var device = instance.AddDevice(deviceInfo.ConnectionString);
 if (device == null)
 {
-    // Exit if no device is found
-    return 0;
+    Console.WriteLine("Device connection failed!");
+    return;
 }
 
 // Output the name of the added device
@@ -1279,51 +1276,77 @@ Console.WriteLine(device.Info.Name);
 
 // Get the first signal of the first device's channel
 var channel = device.GetChannels()[0];
-var signal = channel.GetSignals()[0];
+var signal  = channel.GetSignals()[0];
 
 // Print out the last value of the signal
-Console.WriteLine(signal.LastValue);
+Console.WriteLine($"Using signal: '{signal.Name}'");
+Console.WriteLine($"Last value of the signal: {signal.LastValue}");
 
-// Output 40 samples using reader
 var reader = OpenDAQFactory.CreateStreamReader(signal); //defaults to CreateStreamReader<double, long>
 
 // Allocate buffer for reading double samples
 double[] samples = new double[100];
-for (int i = 0; i < 40; i++) 
+
+for (int i = 0; i < 40; ++i)
 {
     Thread.Sleep(25);
 
     // Read up to 100 samples, storing the amount read into `count`
     nuint count = 100;
     reader.Read(samples, ref count);
+
+    // The call to Read() might return count==0 (explained in the how-to guides)
     if (count > 0)
-        Console.WriteLine(samples[count - 1]);
+        Console.WriteLine($"Last value of read block {i+1,2}: {samples[count - 1]}");
 }
 
-// Get the resolution, origin, and unit
+// Get the resolution and origin
 var descriptor = signal.DomainSignal.Descriptor;
 var resolution = descriptor.TickResolution;
-var origin = descriptor.Origin;
+var origin     = descriptor.Origin;
 var unitSymbol = descriptor.Unit.Symbol;
 
-Console.WriteLine($"Origin: {origin}");
+Console.WriteLine($"Domain origin: {origin}");
 
 // Allocate buffer for reading domain samples
-
 long[] domainSamples = new long[100];
-for (int i = 0; i < 40; i++) 
+
+for (int i = 0; i < 40; i++)
 {
     Thread.Sleep(100);
 
-    // Read up to 100 samples, storing the amount read into `count`
+    // Read up to 100 samples every 100ms, storing the amount read into `count`
     nuint count = 100;
     reader.ReadWithDomain(samples, domainSamples, ref count);
+
+    // The call to ReadWithDomain() might return count==0 (explained in the how-to guides)
     if (count > 0)
     {
         // Scale the domain value to the Signal unit (seconds)
         double domainValue = (double)domainSamples[count - 1] * ((double)resolution.Numerator / resolution.Denominator);
-        Console.WriteLine($"Value: {samples[count - 1]}, Domain: {domainValue}{unitSymbol}");
+        Console.WriteLine($"Last value of read block {i + 1,2}: {samples[count - 1]}, Domain: {domainValue}{unitSymbol}");
     }
+}
+
+// In contrast to C++, the time reader in .NET does not change the domain signal type of the stream reader
+
+// Create a time reader which uses the previously created stream reader
+var timeReader = OpenDAQFactory.CreateTimeReader(reader, signal);
+
+// Allocate buffer for reading timestamps
+DateTime[] timeStamps = new DateTime[100];
+
+for (int i = 0; i < 40; i++)
+{
+    Thread.Sleep(25);
+
+    // Read up to 100 samples, storing the amount read into `count`
+    nuint count = 100;
+    timeReader.ReadWithDomain(samples, timeStamps, ref count);
+
+    // The call to ReadWithDomain() might return count==0 (explained in the how-to guides)
+    if (count > 0)
+        Console.WriteLine($"Last value of read block {i + 1,2}: {samples[count - 1]}, Time: {timeStamps[count - 1]:yyyy-MM-dd HH:mm:ss.fffffff}");
 }
 
 // Create an instance of the renderer function block
@@ -1350,13 +1373,69 @@ channel.SetPropertyValue("Frequency", 5);
 // Set the noise amplitude to 0.75
 channel.SetPropertyValue("NoiseAmplitude", 0.75d);
 
-// Modulate the signal amplitude by a step of 0.1 every 25 ms.
+// Modulate the signal amplitude by a step of 0.1 every 25ms.
 double amplStep = 0.1d;
-for (int i = 0; i < 200; i++)
+for (int i = 0; i < 200; ++i)
 {
     Thread.Sleep(25);
     double ampl = channel.GetPropertyValue("Amplitude");
-    if (9.95d < ampl || ampl < 1.05d)
+    if ((9.95d < ampl) || (ampl < 1.05d))
+        amplStep *= -1d;
+    channel.SetPropertyValue("Amplitude", ampl + amplStep);
+}
+
+// In contrast to C++, the time reader in .NET does not change the domain signal type of the stream reader
+
+// Create a time reader which uses the previously created stream reader
+var timeReader = OpenDAQFactory.CreateTimeReader(reader, signal);
+
+// Allocate buffer for reading domain samples
+DateTime[] timeStamps = new DateTime[100];
+
+for (int i = 0; i < 40; i++)
+{
+    Thread.Sleep(25);
+
+    // Read up to 100 samples, storing the amount read into `count`
+    nuint count = 100;
+    timeReader.ReadWithDomain(samples, timeStamps, ref count);
+
+    // The first call to ReadWithDomain() might return count==0 (explained in the how-to guides)
+    if (count > 0)
+        Console.WriteLine($"Last value of read block {i + 1,2}: {samples[count - 1]}, Time: {timeStamps[count - 1]:yyyy-MM-dd HH:mm:ss.fffffff}");
+}
+
+// Create an instance of the renderer function block
+var renderer = instance.AddFunctionBlock("RefFBModuleRenderer");
+
+// Connect the first output signal of the device to the renderer
+renderer.GetInputPorts()[0].Connect(signal);
+
+// Create an instance of the statistics function block
+var statistics = instance.AddFunctionBlock("RefFBModuleStatistics");
+
+// Connect the first output signal of the device to the statistics
+statistics.GetInputPorts()[0].Connect(signal);
+
+// Connect the first output signal of the statistics to the renderer
+renderer.GetInputPorts()[1].Connect(statistics.GetSignals()[0]);
+
+// List the names of all properties
+foreach (var prop in channel.VisibleProperties)
+    Console.WriteLine(prop.Name);
+
+// Set the frequency to 5 Hz
+channel.SetPropertyValue("Frequency", 5);
+// Set the noise amplitude to 0.75
+channel.SetPropertyValue("NoiseAmplitude", 0.75d);
+
+// Modulate the signal amplitude by a step of 0.1 every 25ms.
+double amplStep = 0.1d;
+for (int i = 0; i < 200; ++i)
+{
+    Thread.Sleep(25);
+    double ampl = channel.GetPropertyValue("Amplitude");
+    if ((9.95d < ampl) || (ampl < 1.05d))
         amplStep *= -1d;
     channel.SetPropertyValue("Amplitude", ampl + amplStep);
 }

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_csharp.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_csharp.adoc
@@ -1,10 +1,11 @@
 = Setting up (C#)
 
-To start working with openDAQ(TM), the requisite binaries are required. They can be obtained at {docs-website}[the openDAQ(TM) documentation and releases webpage] or from http://nuget.org (recommended way). 
+To start working with openDAQ(TM), the requisite binaries are required. They can be obtained as a NuGet package at {docs-website}[the openDAQ(TM) documentation and releases webpage] or from http://nuget.org (recommended way).  
 
-NOTE: The .NET binaries are currently only available in the Windows(TM) SDK packages. For Linux(TM) they are included in the NuGet package, although here the .NET Bindings are not tested.  
+NOTE: The .NET binaries are available from the Windows(TM) SDK packages, but they only contain the Windows(TM) libraries. +
+      For both, Windows(TM) and Linux(TM) all binaries are available in the NuGet package, which is the recommended consumption method for .NET developers.  
 
-All commands in this guide use the .NET command-line interface (dotnet CLI) which is a cross-platform toolchain for developing, building, running, and publishing .NET applications.
+All commands in this guide use the .NET command-line interface (dotnet CLI) which is a cross-platform toolchain for developing, building, running, and publishing .NET applications.  
 
 == Creating an openDAQ(TM) project
 
@@ -21,47 +22,47 @@ Windows::
    - https://learn.microsoft.com/en-us/dotnet/core/sdk[.NET SDK] (used in this guide).
    - Visual Studio 2022(TM).
    - Visual Studio Code with extension "C# Dev Kit".
-
-NOTE: On Windows there is the https://learn.microsoft.com/en-us/windows/wsl/install[Windows Subsystem for Linux (WSL)] (use an Ubuntu 22.04 distribution)
-      where the cross-compiled executable can be tested. +
-      See also points 2 and 3 on the _Linux_ tab.
 --
 
 Linux::
 +
 --
  * Ubuntu 22.04 (see also the note below).
- * On Windows(TM) users can just cross-compile the project for Linux(TM) using the Windows(TM)-requirements (used in this guide).
- * For development (not tested) and running on Linux(TM): +
+ * For development and running on Linux(TM): +
    https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet8&pivots=os-linux-ubuntu-2204[Install .NET SDK or .NET Runtime on Ubuntu].
  * Alternatively (cross-) compiled projects can be run on https://learn.microsoft.com/en-us/windows/wsl/install[Windows Subsystem for Linux (WSL)] (use an Ubuntu 22.04 distribution).
+
+NOTE: On Windows there is the https://learn.microsoft.com/en-us/windows/wsl/install[Windows Subsystem for Linux (WSL)], +
+      where .NET projects can also be created (use an Ubuntu 22.04 distribution).
 --
 ====
 
 In general everything around .NET can be found here: +
 https://dotnet.microsoft.com/en-us/download/dotnet/8.0
 
+In this guide we use a `Developer PowerShell for VS2022` prompt on Windows(TM) for creating and building projects. +
+To use Linux(TM) as a Windows(TM) user, the `Windows Subsystem for Linux (WSL)` can be used.
+
 === Creating and building the project
 
-In this guide we use a `Developer PowerShell for VS2022` prompt on Windows(TM) for creating and (cross-) building the project. +
-To run the result of the cross-compilation we use a `bash` prompt on Linux(TM) (or WSL on Windows(TM)).
+With the following commands in PowerShell(TM) or WSL/Linux(TM) Bash:
 
-To start, create a `csharp/quick_start` directory and navigate to it.
-
-With  the following commands:
-
-- we first create an empty (.NET8.0) console application project
-- and then we add the _openDAQ.Net_ Bindings NuGet package reference (from nuget.org) to the project, which contains all the needed binaries.
+- We create a `csharp/quick_start` directory and navigate to it.
+- Then we create an empty (.NET8.0) console application project (named by its folder).
+- Then we add the _openDAQ.Net_ Bindings NuGet package reference (from nuget.org) to the project, which contains all the needed binaries for Windows(TM ) and Linux(TM).
 
 [source,shell]
 ----
+mkdir ./csharp/quick_start
+cd ./csharp/quick_start
 dotnet new console
 dotnet add package openDAQ.Net
+# dotnet add package openDAQ.Net --source path/to/folder --prerelease
 ----
 
 NOTE: Alternatively, the latest version of the .NET Bindings is available at https://docs-dev.opendaq.com/ and can be used via: +
-`dotnet add package openDAQ.Net --source path/to/folder` +
-See also https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package[Learn NET - dotnet add package]
+      `dotnet add package openDAQ.Net --source path/to/folder --prerelease` +
+      See also https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package[Learn NET - dotnet add package]
 
 With this, we are ready to start developing: +
 We fill in our `Program.cs` executable code as follows (replacing the default content):
@@ -86,38 +87,26 @@ Console.ReadKey(intercept: true);
 
 NOTE: When creating the openDAQ(TM) `instance`, we don't need to specify the root directory of our openDAQ(TM) Modules as they are conveniently being deployed by the NuGet package and found where they are.
 
-Now we can compile and run our program in our PowerShell(TM) instance from above.
+Now we can compile and run our program in our PowerShell(TM) or WSL instance from above.
 
-[tabs]
-====
-Windows::
-+
---
 [source,shell]
 ----
-dotnet run
-----
---
-
-Linux::
-+
---
-Cross-compiling on Windows(TM) and running the result on Linux(TM) using WSL:
-[source,shell]
-----
-dotnet build --runtime linux-x64
-wsl
-cd ./bin/Debug/net8.0/linux-x64/
-./quick_start
-exit
+dotnet run --no-restore
 ----
 
-NOTE: `dotnet build --runtime linux-x64` builds the console application for Linux(TM) and uses the associated binaries from the NuGet package. The result (`./bin/Debug/net8.0/linux-x64/quick_start`) can then be run in WSL under Ubuntu 22.04 (see Requirements above).
---
-====
+NOTE: `--no-restore` tells the compiler not to restore (NuGet) packages. They have been restored/installed already by the `dotnet add package` command above. +
+      This is particularly useful if you are using a local package, as it cannot be found without specifying its location.
 
-With the `run` command the project is being built (when there was a change after the last run) and the resulting `quick_start.exe` executed. +
+With the `run` command the project is being built (when there was a change after the last run) and the resulting `quick_start.exe` is executed. +
 All binaries from the Nuget package will be copied to the target directory (which defaults to `./bin/Debug/net8.0`). These dependencies are also entered in the file `quick_start.deps.json` so that the executable can find the openDAQ(TM) SDK binaries during execution.  
 
-Congratulations, if you managed to reach this point, you have successfully created your first openDAQ(TM) project! +
-To find out more about using openDAQ(TM) applications to connect to, configure, and read data of Devices, continue with the xref:quick_start_application.adoc[openDAQ(TM) application quick start guide].
+In case a new version of the openDAQ(TM) NuGet package is available, you need to update the version in your project file by calling the add-package command again (one of the two, depending on the package source):
+
+[source,shell]
+----
+dotnet add package openDAQ.Net
+# dotnet add package openDAQ.Net --source path/to/folder --prerelease
+----
+
+Congratulations, if you have managed to reach this point, you have successfully created your first openDAQ(TM) project! +
+To find out more about using openDAQ(TM) in applications to connect to, configure, and read data of Devices, continue with the xref:quick_start_application.adoc[openDAQ(TM) application quick start guide].

--- a/examples/dotnet/quick_start/quick_start_simulator.cs
+++ b/examples/dotnet/quick_start/quick_start_simulator.cs
@@ -7,17 +7,25 @@ using Daq.Core.Types;
 using Daq.Core.Objects;
 using Daq.Core.OpenDAQ;
 
+// Create a simulation-device configuration object
 PropertyObject config = CoreObjectsFactory.CreatePropertyObject();
 config.AddProperty(CoreObjectsFactory.CreateStringProperty("Name", "Reference device simulator", visible: true));
 config.AddProperty(CoreObjectsFactory.CreateStringProperty("LocalId", "RefDevSimulator", visible: true));
 config.AddProperty(CoreObjectsFactory.CreateStringProperty("SerialNumber", "sim01", visible: true));
 
+// Create an openDAQ(TM) instance builder to configure the instance
 var instanceBuilder = OpenDAQFactory.InstanceBuilder();
-instanceBuilder.AddModulePath(".");
+
+// Add mDNS discovery service available for servers
 instanceBuilder.AddDiscoveryServer("mdns");
-instanceBuilder.SetRootDevice("daqref://device1", config);
+
+// Set reference device as a root
+instanceBuilder.SetRootDevice("daqref://device0", config);
+
+// Creating a new instance from builder
 var instance = instanceBuilder.Build();
 
+// Start the openDAQ OPC UA and native streaming servers
 var servers = instance.AddStandardServers();
 
 foreach (var server in servers)
@@ -26,3 +34,4 @@ foreach (var server in servers)
 Console.WriteLine();
 Console.Write("Press a key to exit the application ...");
 Console.ReadKey(intercept: true);
+Console.WriteLine();


### PR DESCRIPTION
# Brief

General update of the quick-start documentation for usage of .NET on Windows and Linux.

# Description

General alignment of the .NET examples to the C++ and Python examples.
Now the .NET examples and commands can be run from both, Windows and Linux console (tested with WSL/Windows Subsystem for Linux).
There is also a small fix regarding the preloading of openDAQ libraries under Linux (in the static constructor of the factories) so that the dependencies can be found.

Also contains fix for `WORKING_DIRECTORY` of CMake `add_test(...)` applied to RC 3.20.

# Usage example

n/a

# API changes

n/a

# Required application changes

n/a

# Required module changes

n/a
