### PR TITLE
Bulk create data packets

### DIFF
--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -1,6 +1,7 @@
 # Changes from 3.20 to 3.30
 
 ## Features
+- [#759](https://github.com/openDAQ/openDAQ/pull/759) Bulk create data packets 
 - [#837](https://github.com/openDAQ/openDAQ/pull/837) Add main thread event loop, SFML 3.0 migration, and renderer window control
 - [#838](https://github.com/openDAQ/openDAQ/pull/838) Set of multi reader improvements.
 - [#828](https://github.com/openDAQ/openDAQ/pull/828) Parallel device connection.

--- a/core/opendaq/signal/include/opendaq/bulk_data_packet.h
+++ b/core/opendaq/signal/include/opendaq/bulk_data_packet.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <opendaq/data_packet.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+/*!
+ * @brief Creates multiple data packets with associated domain packets using single heap allocation.
+ * @param[out] dataPackets The pointer to the array of data packets.
+ * @param valueDescriptors The array of value descriptors.
+ * @param domainDescriptors The array of domain descriptors.
+ * @param sampleCounts The array of sample counts for each value/domain packet.
+ * @param offsets Optional array of offsets for implicit domain packets.
+ * @param count The number of packets to create.
+ * @param dataAlign The alignment in bytes of underlying memory allocated on the heap for each packet.
+ *
+ * This factory function can be used to create (and allocate underlying data memory) multiple packets with a single heap allocation.
+ * The packets returned share the reference to the underlying memory. The memory for data and packets is freed when all the packets
+ * are released.
+ *
+ * The caller must provide arrays of valid value and domain descriptors. The array size must be of `count` size.
+ * The caller must also provide an array of `IDataPacket*` of `count` size, which is filled by the factory when it returns. The reference
+ * count of each packet returned is 1.
+ *
+ * `dataAlign` parameter specifies the alignment in bytes of packet data memory for each packet.
+ *
+ * `offsets` parameter should be `nullptr` if the packets created have explicit domain. If the domain is implicit, the parameter should point
+ * to array of 64 bit offsets, and it should be of size `count`. The function will fail if the domain is not of the same type for all packets,
+ * i.e. all domain descriptors must be either implicit or explicit.
+ */
+extern "C" PUBLIC_EXPORT ErrCode daqBulkCreateDataPackets(
+    IDataPacket** dataPackets,
+    IDataDescriptor** valueDescriptors,
+    IDataDescriptor** domainDescriptors,
+    size_t* sampleCounts,
+    int64_t* offsets,
+    size_t count,
+    size_t dataAlign);
+
+
+/*!
+ * @brief Creates value data packet and associated implicit domain packet using single heap allocation.
+ * @param[out] dataPacket The pointer to the data packet.
+ * @param valueDescriptor The value descriptor.
+ * @param domainDescriptor The domain descriptor.
+ * @param sampleCount The sample count for value/domain packet.
+ * @param offset The offset for the implicit domain packet.
+ * @param dataAlign The alignment in bytes of underlying memory allocated on the heap for the packet.
+ *
+ * This factory function can be used to create (and allocate underlying data memory) value packet and its associated domain packet with a single heap allocation.
+ * The value and domain packet returned share the reference to the underlying memory. The memory for data and packets is freed when both packets
+ * are released.
+ *
+ * `dataAlign` parameter specifies the alignment in bytes of packet data memory.
+ */
+extern "C" PUBLIC_EXPORT ErrCode daqCreateValuePacketWithImplicitDomainPacket(
+    IDataPacket** dataPacket,
+    IDataDescriptor* valueDescriptor,
+    IDataDescriptor* domainDescriptor,
+    size_t sampleCount,
+    int64_t offset,
+    size_t dataAlign);
+
+/*!
+ * @brief Creates value data packet and associated explicit domain packet using single heap allocation.
+ * @param[out] dataPacket The pointer to the data packet.
+ * @param valueDescriptor The value descriptor.
+ * @param domainDescriptor The domain descriptor.
+ * @param sampleCount The sample count for value/domain packet.
+ * @param dataAlign The alignment in bytes of underlying memory allocated on the heap for the packet.
+ *
+ * This factory function can be used to create (and allocate underlying data memory) value packet and its associated domain packet with a single
+ * heap allocation. The value and domain packet returned share the reference to the underlying memory. The memory for data and packets is freed when both
+ * packets are released.
+ *
+ * `dataAlign` parameter specifies the alignment in bytes of packet data memory.
+ */
+extern "C" PUBLIC_EXPORT ErrCode daqCreateValuePacketWithExplicitDomainPacket(
+    IDataPacket** dataPacket,
+    IDataDescriptor* valueDescriptor,
+    IDataDescriptor* domainDescriptor,
+    size_t sampleCount,
+    size_t dataAlign);
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/include/opendaq/bulk_data_packet_factory.h
+++ b/core/opendaq/signal/include/opendaq/bulk_data_packet_factory.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <opendaq/bulk_data_packet.h>
+#include <opendaq/data_packet_ptr.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+/*!
+ * @brief Creates value data packet and associated implicit domain packet using single heap allocation.
+ * @param valueDescriptor The value descriptor.
+ * @param domainDescriptor The domain descriptor.
+ * @param sampleCount The sample count for value/domain packet.
+ * @param offset The offset for the implicit domain packet.
+ * @param dataAlign The alignment in bytes of underlying memory allocated on the heap for the packet.
+ * @returns The data packet created.
+ *
+ * This factory function can be used to create (and allocate underlying data memory) value packet and its associated domain packet with a
+ * single heap allocation. The value and domain packet returned share the reference to the underlying memory. The memory for data and
+ * packets is freed when both packets are released.
+ *
+ * `dataAlign` parameter specifies the alignment in bytes of packet data memory.
+ */
+inline DataPacketPtr DataPacketWithImplicitDomainPacket(const DataDescriptorPtr& valueDescriptor,
+                                                        const DataDescriptorPtr& domainDescriptor,
+                                                        size_t sampleCount,
+                                                        int64_t offset,
+                                                        size_t dataAlign)
+{
+    DataPacketPtr dataPacket;
+    checkErrorInfo(daqCreateValuePacketWithImplicitDomainPacket(&dataPacket, valueDescriptor, domainDescriptor, sampleCount, offset, dataAlign));
+    return dataPacket;
+}
+
+/*!
+ * @brief Creates value data packet and associated explicit domain packet using single heap allocation.
+ * @param valueDescriptor The value descriptor.
+ * @param domainDescriptor The domain descriptor.
+ * @param sampleCount The sample count for value/domain packet.
+ * @param dataAlign The alignment in bytes of underlying memory allocated on the heap for the packet.
+ * @returns The data packet created.
+ *
+ * This factory function can be used to create (and allocate underlying data memory) value packet and its associated domain packet with a
+ * single heap allocation. The value and domain packet returned share the reference to the underlying memory. The memory for data and
+ * packets is freed when both packets are released.
+ *
+ * `dataAlign` parameter specifies the alignment in bytes of packet data memory.
+ */
+inline DataPacketPtr
+DataPacketWithExplicitDomainPacket(const DataDescriptorPtr& valueDescriptor,
+                                   const DataDescriptorPtr& domainDescriptor,
+                                   size_t sampleCount,
+                                   size_t dataAlign)
+{
+    DataPacketPtr dataPacket;
+    checkErrorInfo(daqCreateValuePacketWithExplicitDomainPacket(&dataPacket, valueDescriptor, domainDescriptor, sampleCount, dataAlign));
+    return dataPacket;
+}
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/include/opendaq/generic_data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/generic_data_packet_impl.h
@@ -32,6 +32,11 @@ public:
 protected:
     DataPacketPtr domainPacket;
     Int packetId;
+
+    void internalDispose([[maybe_unused]] bool disposing) override
+    {
+        domainPacket.release();
+    }
 };
 
 Int generatePacketId();

--- a/core/opendaq/signal/src/CMakeLists.txt
+++ b/core/opendaq/signal/src/CMakeLists.txt
@@ -207,6 +207,7 @@ function(create_component_source_groups_${BASE_NAME})
         ${SDK_SRC_DIR}/generic_data_packet_impl.cpp
         ${SDK_SRC_DIR}/event_packet_impl.cpp
         ${SDK_SRC_DIR}/binary_data_packet_impl.cpp
+        ${SDK_SRC_DIR}/bulk_data_packet_impl.cpp
     )
     
     source_group("signal//input_port" FILES 
@@ -333,6 +334,8 @@ set(SRC_PublicHeaders_Component
     packet_destruct_callback_factory.h
     signal_impl.h
     reference_domain_info_factory.h
+    bulk_data_packet.h
+    bulk_data_packet_factory.h
     ${SRC_Mimalloc_PublicHeaders}
     PARENT_SCOPE
 )
@@ -393,6 +396,7 @@ set(SRC_Cpp_Component
     signal.natvis
     reference_domain_info_impl.cpp
     reference_domain_info_builder_impl.cpp
+    bulk_data_packet.cpp
     ${SRC_Mimalloc_Cpp}
     PARENT_SCOPE
 )

--- a/core/opendaq/signal/src/bulk_data_packet.cpp
+++ b/core/opendaq/signal/src/bulk_data_packet.cpp
@@ -1,0 +1,248 @@
+#include <opendaq/data_packet_impl.h>
+#include <coretypes/integer_impl.h>
+#include <opendaq/deleter_factory.h>
+#include <opendaq/bulk_data_packet.h>
+#include <atomic>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+template <class Impl, class OnDestruct>
+class BulkImpl : public Impl
+{
+public:
+    using Impl::Impl;
+
+    int INTERFACE_FUNC releaseRef() override
+    {
+        const auto newRefCount = this->internalReleaseRef();
+        assert(newRefCount >= 0);
+        if (newRefCount == 0)
+        {
+            Impl::checkAndCallDispose();
+            // do not call delete
+            onDestruct();
+        }
+
+        return newRefCount;
+    }
+
+    template <class F>
+    void setDestruct(F&& f)
+    {
+        onDestruct = std::forward<F>(f);
+    }
+
+private:
+    OnDestruct onDestruct;
+};
+
+struct BulkDestruct;
+
+using BulkDataPacketImpl = BulkImpl<DataPacketImpl<>, BulkDestruct>;
+using BulkIntegerImpl = BulkImpl<IntegerImpl, BulkDestruct>;
+
+struct BulkDestruct
+{
+    void* memory;
+
+    void operator()() const
+    {
+        assert(memory != nullptr);
+
+        std::atomic<int>* refCount = static_cast<std::atomic<int>*>(memory);
+        const auto newRefCount = std::atomic_fetch_sub_explicit(refCount, 1, std::memory_order_acq_rel) - 1;
+        if (newRefCount == 0)
+            destruct();
+    }
+
+    void destruct() const
+    {
+        uint8_t* memPtr = static_cast<uint8_t*>(memory) + sizeof(std::atomic<int>);
+        const auto count = *reinterpret_cast<size_t*>(memPtr);
+        memPtr += sizeof(size_t);
+        const auto offsets = static_cast<bool>(*reinterpret_cast<size_t*>(memPtr));
+        memPtr += sizeof(size_t);
+        for (size_t i = 0; i < count; i++)
+        {
+            if (offsets)
+            {
+                reinterpret_cast<BulkIntegerImpl*>(memPtr)->~BulkIntegerImpl();
+                memPtr += sizeof(BulkIntegerImpl);
+            }
+            reinterpret_cast<BulkDataPacketImpl*>(memPtr)->~BulkDataPacketImpl();
+            memPtr += sizeof(BulkDataPacketImpl);
+            reinterpret_cast<BulkDataPacketImpl*>(memPtr)->~BulkDataPacketImpl();
+            memPtr += sizeof(BulkDataPacketImpl);
+        }
+
+        std::free(memory);
+    }
+};
+
+static size_t alignTo(size_t value, size_t align)
+{
+    return (value + align - 1) / align * align;
+}
+
+extern "C" PUBLIC_EXPORT ErrCode daqBulkCreateDataPackets(
+    IDataPacket** dataPackets,
+    IDataDescriptor** valueDescriptors,
+    IDataDescriptor** domainDescriptors,
+    size_t* sampleCounts,
+    int64_t* offsets,
+    size_t count,
+    size_t dataAlign)
+{
+    OPENDAQ_PARAM_NOT_NULL(dataPackets);
+    OPENDAQ_PARAM_NOT_NULL(valueDescriptors);
+    OPENDAQ_PARAM_NOT_NULL(sampleCounts);
+    OPENDAQ_PARAM_GE(count, 1);
+    OPENDAQ_PARAM_GE(dataAlign, 1);
+
+    const DataRuleType dataRuleType = DataDescriptorPtr::Borrow(domainDescriptors[0]).getRule().getType();
+
+#ifndef NDEBUG
+    for (size_t i = 0; i < count; i++)
+    {
+        auto domainDescriptorPtr = DataDescriptorPtr::Borrow(domainDescriptors[i]);
+        if (domainDescriptorPtr.getSampleType() != SampleType::Int64)
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDPARAMETER, "Domain descriptor sample type must be int64.", nullptr);
+        if (domainDescriptorPtr.getRule().getType() != dataRuleType)
+            return DAQ_MAKE_ERROR_INFO(
+                OPENDAQ_ERR_INVALIDPARAMETER, "Domain descriptor rule must be the same for all domain descriptors.", nullptr);
+    }
+
+    if (dataRuleType == DataRuleType::Linear)
+    {
+        if (offsets == nullptr)
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDPARAMETER, "Offsets parameter must not be null for linear data rule.", nullptr);
+    }
+#endif
+
+    const auto offsetSize = offsets != nullptr ? sizeof(BulkIntegerImpl) : 0;
+    size_t memSize = sizeof(std::atomic<int>) + sizeof(size_t) + sizeof(size_t) + (offsetSize + sizeof(BulkDataPacketImpl) * 2) * count;
+    // align to 128
+    memSize = alignTo(memSize, dataAlign);
+    const size_t dataOffset = memSize;
+
+    for (size_t i = 0; i < count; i++)
+    {
+        size_t rawSampleSize;
+        valueDescriptors[i]->getRawSampleSize(&rawSampleSize);
+        size_t dataSize = 0;
+        if (dataRuleType == DataRuleType::Explicit)
+        {
+            dataSize += sampleCounts[i] * sizeof(int64_t);
+            dataSize = alignTo(dataSize, dataAlign);
+        }
+        dataSize += sampleCounts[i] * rawSampleSize;
+        dataSize = alignTo(dataSize, dataAlign);
+        memSize += dataSize;
+    }
+
+    uint8_t* memory = static_cast<uint8_t*>(std::malloc(memSize));
+    BulkDestruct onDestruct{memory};
+
+    auto* memPtr = memory;
+    new (memPtr) std::atomic<int>(static_cast<int>(count * (offsets != nullptr ? 3 : 2)));
+    memPtr += sizeof(std::atomic<int>);
+    *reinterpret_cast<size_t*>(memPtr) = count;
+    memPtr += sizeof(size_t);
+    *reinterpret_cast<size_t*>(memPtr) = offsets != nullptr ? 1 : 0;
+    memPtr += sizeof(size_t);
+
+    auto* dataPtr = memory + dataOffset;
+
+    for (size_t i = 0; i < count; i++)
+    {
+        BulkDataPacketImpl* domainPacketImpl;
+
+        INumber* offset = nullptr;
+
+        if (offsets != nullptr)
+        {
+            const auto offsetImpl = new (memPtr) BulkIntegerImpl(offsets[i]);
+            offsetImpl->setDestruct(onDestruct);
+            offsetImpl->borrowInterface(INumber::Id, reinterpret_cast<void**>(&offset));
+            memPtr += sizeof(BulkIntegerImpl);
+        }
+
+        if (dataRuleType == DataRuleType::Explicit)
+        {
+            domainPacketImpl = new (memPtr)
+                BulkDataPacketImpl(
+                nullptr,
+                domainDescriptors[i],
+                sampleCounts[i],
+                offset,
+                reinterpret_cast<void*>(dataPtr),
+                nullptr);
+
+            const auto packetMemSize = sizeof(int64_t) * sampleCounts[i];
+            dataPtr += alignTo(packetMemSize, dataAlign);
+
+        }
+        else
+        {
+            domainPacketImpl = new (memPtr) BulkDataPacketImpl(
+                nullptr,
+                domainDescriptors[i],
+                sampleCounts[i],
+                offset,
+                nullptr,
+                nullptr);
+        }
+
+        domainPacketImpl->setDestruct(onDestruct);
+        IDataPacket* domainPacket;
+        domainPacketImpl->borrowInterface(IDataPacket::Id, reinterpret_cast<void**>(&domainPacket));
+        memPtr += sizeof(BulkDataPacketImpl);
+
+        size_t rawSampleSize;
+        valueDescriptors[i]->getRawSampleSize(&rawSampleSize);
+        const auto packetMemSize = rawSampleSize * sampleCounts[i];
+
+        BulkDataPacketImpl* packetImpl = new (memPtr) BulkDataPacketImpl(
+            domainPacket,
+            valueDescriptors[i],
+            sampleCounts[i],
+            nullptr,
+            reinterpret_cast<void*>(dataPtr),
+            nullptr,
+            packetMemSize);
+
+        packetImpl->setDestruct(onDestruct);
+        IDataPacket* dataPacket;
+        packetImpl->queryInterface(IDataPacket::Id, reinterpret_cast<void**>(&dataPacket));
+
+        dataPackets[i] = dataPacket;
+        memPtr += sizeof(BulkDataPacketImpl);
+        dataPtr += alignTo(packetMemSize, dataAlign);
+    }
+
+    return OPENDAQ_SUCCESS;
+}
+
+extern "C" PUBLIC_EXPORT ErrCode daqCreateValuePacketWithImplicitDomainPacket(
+    IDataPacket** dataPacket,
+    IDataDescriptor* valueDescriptor,
+    IDataDescriptor* domainDescriptor,
+    size_t sampleCount,
+    int64_t offset,
+    size_t dataAlign)
+{
+    return daqBulkCreateDataPackets(dataPacket, &valueDescriptor, &domainDescriptor, &sampleCount, &offset, 1, dataAlign);
+}
+
+extern "C" PUBLIC_EXPORT ErrCode daqCreateValuePacketWithExplicitDomainPacket(
+    IDataPacket** dataPacket,
+    IDataDescriptor* valueDescriptor,
+    IDataDescriptor* domainDescriptor,
+    size_t sampleCount,
+    size_t dataAlign)
+{
+    return daqBulkCreateDataPackets(dataPacket, &valueDescriptor, &domainDescriptor, &sampleCount, nullptr, 1, dataAlign);
+}
+
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/tests/CMakeLists.txt
+++ b/core/opendaq/signal/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_SOURCES
     test_data_path.cpp
     test_gap_checks.cpp
     test_reference_domain_info.cpp
+    test_bulk_data_packet.cpp
 )
 
 if (OPENDAQ_MIMALLOC_SUPPORT)

--- a/core/opendaq/signal/tests/test_bulk_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_bulk_data_packet.cpp
@@ -1,0 +1,197 @@
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <opendaq/data_rule_factory.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/sample_type_traits.h>
+#include <opendaq/deleter_factory.h>
+#include <opendaq/data_descriptor_factory.h>
+#include <opendaq/bulk_data_packet_factory.h>
+
+using namespace daq;
+
+class BulkDataPacketTest: public ::testing::TestWithParam<size_t>
+{
+protected:
+    static size_t alignTo(size_t value, size_t align)
+    {
+        return (value + align - 1) / align * align;
+    }
+};
+
+TEST_P(BulkDataPacketTest, Implicit)
+{
+    const size_t align = GetParam();
+    constexpr SampleType sampleType[] = {SampleType::Float32, SampleType::Float64, SampleType::Int32};
+
+    const auto domainDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Int64).setRule(LinearDataRule(1, 0)).setUnit(Unit("s", -1, "seconds", "time")).setTickResolution(Ratio(1, 1000)).build();
+    const auto valueDescriptor0 = DataDescriptorBuilder().setSampleType(sampleType[0]).build();
+    const auto valueDescriptor1 = DataDescriptorBuilder().setSampleType(sampleType[1]).build();
+    const auto valueDescriptor2 = DataDescriptorBuilder().setSampleType(sampleType[2]).build();
+
+    IDataDescriptor* valueDescriptors[] = {valueDescriptor0, valueDescriptor1, valueDescriptor2};
+    IDataDescriptor* domainDescriptors[] = {domainDescriptor, domainDescriptor, domainDescriptor};
+    size_t sampleCount[] = {1, 2, 4};
+    Int offsets[] = {0, 0, 200};
+
+    IDataPacket* dataPackets[3];
+
+    daqBulkCreateDataPackets(dataPackets, valueDescriptors, domainDescriptors, sampleCount, offsets, 3, align);
+
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[0]).getDataDescriptor(), DataDescriptorPtr::Borrow(valueDescriptors[0]));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[0]).getDomainPacket().getDataDescriptor(), DataDescriptorPtr::Borrow(domainDescriptor));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[1]).getDataDescriptor(), DataDescriptorPtr::Borrow(valueDescriptors[1]));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[1]).getDomainPacket().getDataDescriptor(), DataDescriptorPtr::Borrow(domainDescriptor));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[2]).getDataDescriptor(), DataDescriptorPtr::Borrow(valueDescriptors[2]));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[2]).getDomainPacket().getDataDescriptor(), DataDescriptorPtr::Borrow(domainDescriptor));
+
+    const auto rawData0 = static_cast<float*>(DataPacketPtr::Borrow(dataPackets[0]).getRawData());
+    const auto rawData1 = static_cast<double*>(DataPacketPtr::Borrow(dataPackets[1]).getRawData());
+    const auto rawData2 = static_cast<int32_t*>(DataPacketPtr::Borrow(dataPackets[2]).getRawData());
+
+    ASSERT_EQ(reinterpret_cast<uint8_t*>(rawData0) + alignTo(sampleCount[0] * getSampleSize(sampleType[0]), align),
+              reinterpret_cast<uint8_t*>(rawData1));
+    ASSERT_EQ(reinterpret_cast<uint8_t*>(rawData1) + alignTo(sampleCount[1] * getSampleSize(sampleType[1]), align),
+              reinterpret_cast<uint8_t*>(rawData2));
+
+    for (size_t i = 0; i < sampleCount[0]; i++)
+        rawData0[i] = 1.0f;
+    for (size_t i = 0; i < sampleCount[1]; i++)
+        rawData1[i] = 2.0;
+    for (size_t i = 0; i < sampleCount[2]; i++)
+        rawData2[i] = 4;
+
+    for (size_t i = 0; i < sampleCount[0]; i++)
+        ASSERT_EQ(rawData0[i], 1.0f);
+    for (size_t i = 0; i < sampleCount[1]; i++)
+        ASSERT_EQ(rawData1[i],  2.0);
+    for (size_t i = 0; i < sampleCount[2]; i++)
+        ASSERT_EQ(rawData2[i], 4);
+
+    for (size_t i = 0; i < 3; i++)
+    {
+        ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[i]).getDomainPacket().getOffset(), offsets[i]);
+        dataPackets[i]->releaseRef();
+    }
+}
+
+TEST_P(BulkDataPacketTest, Explicit)
+{
+    const size_t align = GetParam();
+    constexpr SampleType sampleType[] = {SampleType::Float32, SampleType::Float64, SampleType::Int32};
+
+    const auto domainDescriptor = DataDescriptorBuilder()
+                                      .setSampleType(SampleType::Int64)
+                                      .setUnit(Unit("s", -1, "seconds", "time"))
+                                      .setTickResolution(Ratio(1, 1000))
+                                      .build();
+    const auto valueDescriptor0 = DataDescriptorBuilder().setSampleType(sampleType[0]).build();
+    const auto valueDescriptor1 = DataDescriptorBuilder().setSampleType(sampleType[1]).build();
+    const auto valueDescriptor2 = DataDescriptorBuilder().setSampleType(sampleType[2]).build();
+
+    IDataDescriptor* valueDescriptors[] = {valueDescriptor0, valueDescriptor1, valueDescriptor2};
+    IDataDescriptor* domainDescriptors[] = {domainDescriptor, domainDescriptor, domainDescriptor};
+    size_t sampleCount[] = {1, 2, 4};
+
+    IDataPacket* dataPackets[3];
+
+    daqBulkCreateDataPackets(dataPackets, valueDescriptors, domainDescriptors, sampleCount, nullptr, 3, align);
+
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[0]).getDataDescriptor(), DataDescriptorPtr::Borrow(valueDescriptors[0]));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[0]).getDomainPacket().getDataDescriptor(), DataDescriptorPtr::Borrow(domainDescriptor));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[1]).getDataDescriptor(), DataDescriptorPtr::Borrow(valueDescriptors[1]));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[1]).getDomainPacket().getDataDescriptor(), DataDescriptorPtr::Borrow(domainDescriptor));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[2]).getDataDescriptor(), DataDescriptorPtr::Borrow(valueDescriptors[2]));
+    ASSERT_EQ(DataPacketPtr::Borrow(dataPackets[2]).getDomainPacket().getDataDescriptor(), DataDescriptorPtr::Borrow(domainDescriptor));
+
+    const auto rawData0 = static_cast<float*>(DataPacketPtr::Borrow(dataPackets[0]).getRawData());
+    const auto rawData1 = static_cast<double*>(DataPacketPtr::Borrow(dataPackets[1]).getRawData());
+    const auto rawData2 = static_cast<int32_t*>(DataPacketPtr::Borrow(dataPackets[2]).getRawData());
+
+    const auto rawDomainData0 = static_cast<int64_t*>(DataPacketPtr::Borrow(dataPackets[0]).getDomainPacket().getRawData());
+    const auto rawDomainData1 = static_cast<int64_t*>(DataPacketPtr::Borrow(dataPackets[1]).getDomainPacket().getRawData());
+    const auto rawDomainData2 = static_cast<int64_t*>(DataPacketPtr::Borrow(dataPackets[2]).getDomainPacket().getRawData());
+
+    ASSERT_EQ(reinterpret_cast<uint8_t*>(rawData0) + alignTo(sampleCount[0] * getSampleSize(sampleType[0]), align) + alignTo(sampleCount[1] * sizeof(int64_t), align), reinterpret_cast<uint8_t*>(rawData1));
+    ASSERT_EQ(reinterpret_cast<uint8_t*>(rawData1) + alignTo(sampleCount[1] * getSampleSize(sampleType[1]), align) + alignTo(sampleCount[2] * sizeof(int64_t), align), reinterpret_cast<uint8_t*>(rawData2));
+
+    ASSERT_EQ(reinterpret_cast<uint8_t*>(rawDomainData0) + alignTo(sampleCount[0] * getSampleSize(sampleType[0]), align) + alignTo(sampleCount[0] * sizeof(int64_t), align), reinterpret_cast<uint8_t*>(rawDomainData1));
+    ASSERT_EQ(reinterpret_cast<uint8_t*>(rawDomainData1) + alignTo(sampleCount[1] * getSampleSize(sampleType[1]), align) + alignTo(sampleCount[1] * sizeof(int64_t), align), reinterpret_cast<uint8_t*>(rawDomainData2));
+
+    for (size_t i = 0; i < sampleCount[0]; i++)
+    {
+        rawData0[i] = 1.0f;
+        rawDomainData0[i] = 1;
+    }
+    for (size_t i = 0; i < sampleCount[1]; i++)
+    {
+        rawData1[i] = 2.0;
+        rawDomainData1[i] = 2.0;
+    }
+    for (size_t i = 0; i < sampleCount[2]; i++)
+    {
+        rawData2[i] = 4;
+        rawDomainData2[i] = 4;
+    }
+
+    for (size_t i = 0; i < sampleCount[0]; i++)
+    {
+        ASSERT_EQ(rawData0[i], 1.0f);
+        ASSERT_EQ(rawDomainData0[i], 1);
+    }
+    for (size_t i = 0; i < sampleCount[1]; i++)
+    {
+        ASSERT_EQ(rawData1[i], 2.0);
+        ASSERT_EQ(rawDomainData1[i], 2.0);
+    }
+    for (size_t i = 0; i < sampleCount[2]; i++)
+    {
+        ASSERT_EQ(rawData2[i], 4);
+        ASSERT_EQ(rawDomainData2[i], 4);
+    }
+
+    for (size_t i = 0; i < 3; i++)
+    {
+        ASSERT_FALSE(DataPacketPtr::Borrow(dataPackets[i]).getDomainPacket().getOffset().assigned());
+        dataPackets[i]->releaseRef();
+    }
+}
+
+TEST_P(BulkDataPacketTest, ValuePacketWithImplicitDomain)
+{
+    const size_t align = GetParam();
+
+    const auto domainDescriptor = DataDescriptorBuilder()
+                                      .setSampleType(SampleType::Int64)
+                                      .setRule(LinearDataRule(1, 0))
+                                      .setUnit(Unit("s", -1, "seconds", "time"))
+                                      .setTickResolution(Ratio(1, 1000))
+                                      .build();
+    const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
+
+    const auto valuePacket = daq::DataPacketWithImplicitDomainPacket(valueDescriptor, domainDescriptor, 4, 10, align);
+    ASSERT_EQ(valuePacket.getDataDescriptor(), valueDescriptor);
+    ASSERT_EQ(valuePacket.getDomainPacket().getDataDescriptor(), domainDescriptor);
+    ASSERT_EQ(valuePacket.getDomainPacket().getOffset(), 10);
+}
+
+TEST_P(BulkDataPacketTest, ValuePacketWithExplicit)
+{
+    const size_t align = GetParam();
+
+    const auto domainDescriptor = DataDescriptorBuilder()
+                                      .setSampleType(SampleType::Int64)
+                                      .setUnit(Unit("s", -1, "seconds", "time"))
+                                      .setTickResolution(Ratio(1, 1000))
+                                      .build();
+    const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Float32).build();
+
+    const auto valuePacket = daq::DataPacketWithExplicitDomainPacket(valueDescriptor, domainDescriptor, 4, align);
+    ASSERT_EQ(valuePacket.getDataDescriptor(), valueDescriptor);
+    ASSERT_EQ(valuePacket.getDomainPacket().getDataDescriptor(), domainDescriptor);
+}
+
+INSTANTIATE_TEST_CASE_P(BulkDataPacketTests,
+                        BulkDataPacketTest,
+                        ::testing::Values(1, 4, 16, 64, 128),
+                        [](testing::TestParamInfo<size_t> paramInfo) { return fmt::format("align{}", paramInfo.param); });
+


### PR DESCRIPTION
# Brief

Adds functions to create multiple packets with one heap allocation

# Description

The typical value signal and the domain signal require four heap allocations per packet pair. `daqBulkCreateDataPackets` creates multiple packets for multiple signals with one heap allocation. The heap memory deallocation occurs when all of the packets' reference counts drop to zero.

The `daqBulkCreateDataPackets` does not include a smart pointer wrapper because we usually want to avoid list and vector allocations. However, two helper wrappers exist when creating a value/domain packet pair for one signal.

# Usage example

In terminal use:

```cpp
size_t sampleCount = 4;
Int offset = 100;
size_t align = 1;
const auto valuePacket = daq::DataPacketWithImplicitDomainPacket(valueDescriptor, domainDescriptor, sampleCount, offset, align);
const auto domainPacket = valuePacket.getDomainPacket();
```

# API changes

```diff
+ [factory] DataPacketPtr DataPacketWithImplicitDomainPacket(const DataDescriptorPtr& valueDescriptor, const DataDescriptorPtr& domainDescriptor, size_t sampleCount, int64_t offset, size_t dataAlign)
+ [factory] DataPacketPtr DataPacketWithExplicitDomainPacket(const DataDescriptorPtr& valueDescriptor, const DataDescriptorPtr& domainDescriptor, size_t sampleCount, size_t dataAlign)
+ [factory] ErrCode daqBulkCreateDataPackets(IDataPacket** dataPackets, IDataDescriptor** valueDescriptors, IDataDescriptor** domainDescriptors, size_t* sampleCounts, int64_t* offsets, size_t count, size_t dataAlign)
```