### PR TITLE
Initial set of Antora docs improvements

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object.h
+++ b/core/coreobjects/include/coreobjects/property_object.h
@@ -127,7 +127,7 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObject, IBaseObject)
      * @retval OPENDAQ_ERR_INVALIDPARAMETER if attempting to get a value at an index of a non-list Property.
      * @retval OPENDAQ_ERR_OUTOFRANGE if attempting to get a value of a list Property at an out-of-bounds index.
      *
-     * The value is retrieved from a local dictionary of Property values where they are stored when set. If a a value is not
+     * The value is retrieved from a local dictionary of Property values where they are stored when set. If a value is not
      * present under the `propertyName` key, the default value of the corresponding Property is returned. If said property
      * is not part of the Property object, an error occurs.
      *

--- a/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
@@ -2,6 +2,18 @@
 :page-toclevels: 4
 :toclevels: 4
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this tutorial, learners will be able to:
+
+- 🖥️ Set up and simulate Devices — Create and configure a simulated openDAQ(TM) device.
+- 🔍 Discover and connect to Devices — Identify available devices and establish remote connections.
+- 📦 Read and process data —retrieve Device data, handle Packets, and interpret timestamps.
+- ⚙️ Configure and use Function Blocks — Modify properties and manage data flow using function blocks.
+- 🛠️ Develop an openDAQ(TM) client application — Build a complete application with example code.
+====
+
 The openDAQ(TM) SDK allows users to quickly and easily set up an application that can connect to an openDAQ(TM)-compatible device, configure it and read its data. It allows for easy signal processing and routing of signals through blocks that process and manipulate signal data.
 
 This guide illustrates the process of configuring and connecting to Devices, using simulated

--- a/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
@@ -17,25 +17,12 @@ making use of the provided openDAQ(TM) binaries and examples.
 
 For this guide, we will be using a xref:glossary:glossary.adoc#device[Device] simulator that outputs synthetic sine xref:glossary:glossary.adoc#signal[Signal]s at a chosen sample rate, with a chosen amplitude and frequency. It hosts an xref:glossary:glossary.adoc#opc_ua[OPC UA] server and a Native streaming server, allowing clients to inspect and configure the Device, and read its data.
 
-The simulator can be downloaded in the form of a VirtualBox image, or built from source.
-
-=== Using a virtual machine
-
-The simulator can be used in the form of a VirtualBox `.ova` image. The image (opendaq-version_device_simulator.ova) can be found at https://docs.opendaq.com, and should be run with https://www.virtualbox.org/wiki/Downloads/[VirtualBox 7.0.6 or newer].
-
-Once your see the log in prompt, the simulator is already started as a service in the background and there is no need to log in.
-
-Detailed instructions on setting up the simulator can be found xref:howto_guides:howto_vbox_simulator.adoc[here].
-
-[#own_simulator]
-=== Building a simulator from source
-
 [tabs]
 ====
 Cpp::
 +
 --
-To create an application that simulates an openDAQ(TM) Device, we build and run the `cpp/quick_start/quick_start_simulator.cpp` code example.  To do so, navigate to the `cpp/quick_start` examples folder and run the following commands:
+To create an application that simulates an openDAQ(TM) Device, we build and run the `cpp/quick_start/quick_start_simulator.cpp` code example. To do so, navigate to the `cpp/quick_start` examples folder and run the following commands:
 
 [source,bash]
 ----
@@ -86,7 +73,7 @@ You will be greeted by a prompt to press a key (which will end the simulation). 
 
 == openDAQ(TM) client application
 
-Having set up a simulator Device that is running openDAQ(TM) servers, we now move on to implement the client application that connects to the simulated Device. The client-side application uses a Client module to connect to an openDAQ(TM) Server. When connected, the application is used to read the Device's Signal data, read / modify its Properties, and perform structural changes such as adding / removing / re-routing Function Blocks or Devices - all of which will be explained throughout this guide.
+Having set up a simulator Device that is running openDAQ(TM) servers, we now move on to implement the client application that connects to the simulated Device. The client-side application uses a Client module to connect to an openDAQ(TM) Server. When connected, the application is used to read the Device's Signal data, read/modify its Properties, and perform structural changes such as adding/removing/re-routing Function Blocks or Devices - all of which will be explained throughout this guide.
 
 NOTE: There are several server/client modules available in the SDK. Throughout this guide will will be using the default "native" openDAQ protocol to connect to our devices.
 
@@ -241,7 +228,7 @@ Device name: Device 1, Connection string: daqref://device1
 Connection strings in openDAQ(TM) are used to connect to a device. They always appear in the format of "_prefix_://_address_". The prefix is used to differentiate between different modules that will be used for connection to the device:
 
 * "Simulator device" has a connection string that starts with `daq://`. Devices running an openDAQ(TM) server have a connection string of the format `daq://Manufacturer_SerialNumber`. We might discover multiple servers of the same device. They will be grouped under the same connection string, and their information made available in the "Server capabilities" field as shown in the previous code snippet. When connecting via a connection string with the `daq://` prefix, openDAQ(TM) will automatically choose the most optimal connection protocol.
-* "Reference device" has a connection string that starts with `daqref://`. Said prefix corresponds to the openDAQ(TM) simulator devices that can be created locally. They are used by our simulator virtual image/application.
+* "Reference device" has a connection string that starts with `daqref://`. Said prefix corresponds to the openDAQ(TM) simulator devices that can be created locally. They are used by our simulator application.
 
 NOTE: Any device with an undefined manufacturer, serial number, or without an openDAQ(TM) server (with no "server capabilities") will not use the  `daq://Manufacturer_SerialNumber` connection string format, but will use the one provided by an individual device/client implementation (Eg. `daqref://`)
 

--- a/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
@@ -644,7 +644,7 @@ for (int i = 0; i < 40; i++)
 
 Running the example, we can see very high numbers for the domain values. This is due to them being relative to the domain signal's origin. Above, we read and output the domain signal origin, noting that it equates to the UNIX epoch of `"1970-01-01T00:00:00Z"`. The domain values read are thus relative to the UNIX epoch.
 
-===== Using a Time Reader
+==== Using a Time Reader
 :iso-8601-url: https://www.iso.org/iso-8601-date-and-time-format.html
 
 To read time-domain signal data, a Time Reader can be used to perform the conversion from `ticks` to system wall-clock time.

--- a/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_application.adoc
@@ -7,7 +7,7 @@ The openDAQ(TM) SDK allows users to quickly and easily set up an application tha
 This guide illustrates the process of configuring and connecting to Devices, using simulated
 xref:glossary:glossary.adoc#device[Device]s and xref:glossary:glossary.adoc#signal[Signal]s, requiring no prior knowledge of the openDAQ(TM) framework.
 
-Full final source files of the examples featured in this guide are available at the bottom of the page, as well as within the binary packages available at {docs-website}[the openDAQ(TM) documentation and releases webpage].
+Full final source files of the examples featured in this guide are available at the bottom of the page, as well as within the binary packages available at https://docs.opendaq.com.
 
 This guide continues from the openDAQ(TM) project state at the end of the Setting up guide
 (xref:quick_start_setting_up_cpp.adoc[{cpp}]/xref:quick_start_setting_up_python.adoc[Python]/xref:quick_start_setting_up_csharp.adoc[C#]),
@@ -21,7 +21,7 @@ The simulator can be downloaded in the form of a VirtualBox image, or built from
 
 === Using a virtual machine
 
-The simulator can be used in the form of a VirtualBox `.ova` image. The image (opendaq-version_device_simulator.ova) can be found at {docs-website}[the openDAQ(TM) documentation and releases webpage], and should be run with https://www.virtualbox.org/wiki/Downloads/[VirtualBox 7.0.6 or newer].
+The simulator can be used in the form of a VirtualBox `.ova` image. The image (opendaq-version_device_simulator.ova) can be found at https://docs.opendaq.com, and should be run with https://www.virtualbox.org/wiki/Downloads/[VirtualBox 7.0.6 or newer].
 
 Once your see the log in prompt, the simulator is already started as a service in the background and there is no need to log in.
 

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
@@ -1,6 +1,6 @@
 = Setting up ({cpp})
 
-To start working with openDAQ(TM), the requisite binaries are required. They can be obtained at {docs-website}[the openDAQ(TM) documentation and releases webpage]. The binaries are currently available for Windows and Ubuntu (20.04 or newer).
+To start working with openDAQ(TM), the requisite binaries are required. They can be obtained from https://docs.opendaq.com and from https://docs-dev.opendaq.com for the latest development version. The binaries are currently available for Windows and Ubuntu (20.04 or newer).
 
 [tabs]
 ====
@@ -26,7 +26,7 @@ sudo apt install ./opendaq-{version}-ubuntu20.04-x86_64.deb
 
 == Creating an openDAQ(TM) project
 
-We start our project from the `"quick_start_app"` example that can be found at the {docs-website}[openDAQ(TM) documentation and releases webpage]. Download the `examples.zip` archive and extract it to a folder of choice.
+We start our project from the `"quick_start_app"` example that can be found at https://docs.opendaq.com. Download the `examples.zip` archive and extract it to a folder of choice.
 
 === Requirements
 

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_cpp.adoc
@@ -7,7 +7,7 @@ To start working with openDAQ(TM), the requisite binaries are required. They can
 Windows::
 +
 --
-To install openDAQ(TM), download the `opendaq-{version}-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
+To install openDAQ(TM), download the `opendaq-<version>-win64.exe` installer, run it, and follow its instructions. Make sure to add openDAQ(TM) to the system path to be able to run openDAQ(TM) application examples.
 
 We recommend using the default installation path to avoid issues requiring additional environment variable modifications and troubleshooting.
 --
@@ -15,18 +15,18 @@ We recommend using the default installation path to avoid issues requiring addit
 Linux::
 +
 --
-To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-{version}-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
+To install openDAQ(TM) on Ubuntu 20.04 or newer, download the `opendaq-<version>-ubuntu20.04-x86_64.deb` Debian package. Install it using the following command:
 
 [source,shell]
 ----
-sudo apt install ./opendaq-{version}-ubuntu20.04-x86_64.deb
+sudo apt install ./opendaq-<version>-ubuntu20.04-x86_64.deb
 ----
 --
 ====
 
 == Creating an openDAQ(TM) project
 
-We start our project from the `"quick_start_app"` example that can be found at https://docs.opendaq.com. Download the `examples.zip` archive and extract it to a folder of choice.
+We start our project from the `"quick_start_app"` example that can be found at https://docs.opendaq.com. Download the `opendaq-<version>-examples.zip` archive and extract it to a folder of choice.
 
 === Requirements
 

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_csharp.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_csharp.adoc
@@ -1,6 +1,6 @@
 = Setting up (C#)
 
-To start working with openDAQ(TM), the requisite binaries are required. They can be obtained as a NuGet package at {docs-website}[the openDAQ(TM) documentation and releases webpage] or from http://nuget.org (recommended way).  
+To start working with openDAQ(TM), the requisite binaries are required. They can be obtained from http://nuget.org (the recommended way) or from https://docs.opendaq.com (https://docs-dev.opendaq.com for the development version).
 
 NOTE: The .NET binaries are available from the Windows(TM) SDK packages, but they only contain the Windows(TM) libraries. +
       For both, Windows(TM) and Linux(TM) all binaries are available in the NuGet package, which is the recommended consumption method for .NET developers.  
@@ -9,7 +9,7 @@ All commands in this guide use the .NET command-line interface (dotnet CLI) whic
 
 == Creating an openDAQ(TM) project
 
-Below, we start a Console Project in Visual Studio(TM) from scratch but there are also example files which can be found in the examples archive from the {docs-website}[openDAQ(TM) documentation and releases webpage].
+Below, we start a Console Project in Visual Studio(TM) from scratch but there are also example files which can be found in the examples archive from https://docs.opendaq.com.
 
 === Requirements
 

--- a/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
+++ b/docs/Antora/modules/getting_started/pages/quick_start_setting_up_python.adoc
@@ -15,7 +15,7 @@ pip install opendaq
 
 The latest versions of the Python bindings are available at https://docs-dev.opendaq.com. There you can download the Python Wheels for your OS/Python version. 
 
-The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-{version}_ad68082-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
+The python version the wheel is intended for can be discerned from the name of the file. Eg. opendaq-<version>_<short-sha>-cp310-cp310-win_amd64.whl is to be used with Python 3.10, as indicated by the "cp310" part of the filename.
 
 To install the wheel, use:
 [source,bash]

--- a/docs/Antora/modules/glossary/pages/glossary.adoc
+++ b/docs/Antora/modules/glossary/pages/glossary.adoc
@@ -328,7 +328,7 @@ For example, openDAQ(TM) provides:
 
 When enumerating available <<device>>s, each <<module>> is queried for what <<device>>s it can connect to / create.
 This is done with the <<module>>'s provided discovery mechanism.
-The openDAQ(TM) xref:glossary.adoc#opendaq_opcua_client_module[OPC-UA Client Module], xref:glossary.adoc#opendaq_native_client_module[Native Streaming Module] and
+The openDAQ(TM) xref:glossary.adoc#opendaq_opcua_client_module[OPC UA Client Module], xref:glossary.adoc#opendaq_native_client_module[Native Streaming Module] and
 xref:glossary.adoc#opendaq_streaming_lt_client_module[Streaming LT Client Module] use a {mdns-wiki}[mDNS] query to discover all supported devices on the network.
 Those <<device>>s are assumed to be running a {mdns-wiki}[mDNS] discovery service, 
 advertising the `_opcua-tcp._tcp.local.` service, with a `TXT` record entry of `caps=TMS` if device is openDAQ(TM) OPC UA-supported,
@@ -342,7 +342,7 @@ and a {mdns-wiki}[mDNS] discovery service, advertising the `_streaming-lt._tcp.l
 The {opc-foundation-website}[OPC Foundation] (Open Platform Communications) is an industry consortium that creates and maintains standards for open connectivity of industrial automation devices and systems, such as industrial control systems and process control generally.
 
 [#opc_ua]
-== OPC-UA
+== OPC UA
 :opcua-website: https://opcfoundation.org/about/opc-technologies/opc-ua/
 :iec-opcua: https://webstore.iec.ch/publication/61114
 
@@ -354,10 +354,10 @@ The {opc-foundation-website}[OPC Foundation] (Open Platform Communications) is a
 // suppress inspection "GrazieInspection"
 A test-and-measurement standard that describes openDAQ devices based on the OPC UA for devices standard.
 It is a protocol that describes the structure of a <<device>>.
-The openDAQ(TM) xref:glossary.adoc#opendaq_opcua_client_module[OPC-UA Client Module] can connect to <<device>>s that adhere to this protocol.
+The openDAQ(TM) xref:glossary.adoc#opendaq_opcua_client_module[OPC UA Client Module] can connect to <<device>>s that adhere to this protocol.
 
 [#opendaq_opcua_server_module]
-== OPC-UA Server Module
+== OPC UA Server Module
 
 Allows for the creation of an OPC UA server on an openDAQ(TM) <<instance>>.
 It publishes the structure of the <<root_device>> and all its descendants (other <<device>>s and <<function_block>>s), and allows for changing the <<property_value>>s of all the structures from a remote client.
@@ -366,13 +366,13 @@ The structure is as of this moment locked to the state it is when the Server is 
 If a new <<function_block>>, <<device>>, <<channel>>, or other <<component>> is added, the Server doesn't yet react to that change.
 
 [#opendaq_opcua_client_module]
-== OPC-UA Client Module
+== OPC UA Client Module
 
 Allows for connecting to xref:glossary.adoc#opendaq_opcua[openDAQ(TM) OPC UA]-enabled devices running an OPC UA server.
 It reads the structure of the remote <<device>> and mirrors it as a sub-device.
 Settings changed on the <<device>> mirror are also changed on the actual <<device>> itself.
 
-The openDAQ(TM) OPC-UA Client <<module>> also can use xref:glossary.adoc#opendaq_native_client_module[openDAQ(TM) Native Client Module]
+The openDAQ(TM) OPC UA Client <<module>> also can use xref:glossary.adoc#opendaq_native_client_module[openDAQ(TM) Native Client Module]
 and xref:glossary.adoc#opendaq_streaming_lt_client_module[openDAQ(TM) Streaming LT Client Module]
 to connect to the server component created by the corresponding Streaming Server Module.
 Doing so enables transferring <<data_packet>>s from server <<signal>>s into client xref:glossary.adoc#device[Signals].

--- a/docs/Antora/modules/howto_guides/nav-howto-guides.adoc
+++ b/docs/Antora/modules/howto_guides/nav-howto-guides.adoc
@@ -8,6 +8,7 @@
 ** xref:howto_configure_instance_providers.adoc[Configure Instance Provider]
 ** xref:howto_configure_streaming.adoc[]
 ** xref:howto_measure_single_value.adoc[]
+** xref:howto_save_load_configuration.adoc[]
 // ** xref:howto_configure_a_device.adoc[Configure a Device]
 // ** Configure a Signal
 // *** xref:howto_create_a_signal.adoc[]
@@ -20,7 +21,6 @@
 *** xref:howto_read_with_timestamps.adoc[Absolute time-stamps]
 *** xref:howto_read_with_timeouts.adoc[Time-outs]
 *** xref:howto_read_aligned_signals.adoc[Align multiple Signals]
-** xref:howto_save_load_configuration.adoc[]
 ** Access control
 *** xref:howto_access_control_introduction.adoc[Introduction]
 *** xref:howto_access_control_connect.adoc[]

--- a/docs/Antora/modules/howto_guides/pages/howto.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto.adoc
@@ -8,6 +8,7 @@
 * xref:howto_configure_instance_providers.adoc[]
 * xref:howto_configure_streaming.adoc[]
 * xref:howto_measure_single_value.adoc[]
+* xref:howto_save_load_configuration.adoc[]
 
 == Read data with Readers
 
@@ -16,10 +17,6 @@
 * xref:howto_read_with_timestamps.adoc[]
 * xref:howto_read_with_timeouts.adoc[]
 * xref:howto_read_aligned_signals.adoc[]
-
-== Configuration
-
-* xref:howto_save_load_configuration.adoc[]
 
 == Access control
 

--- a/docs/Antora/modules/howto_guides/pages/howto_access_control_connect.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_access_control_connect.adoc
@@ -1,5 +1,14 @@
-
 = Connect with username and password
+
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🔑️ Provide credentials via configuration.
+- 🧩 Handle anonymous access scenarios.
+- 🖥️ Apply code examples.
+====
 
 To connect to a device, you can provide the username and password using the `config` parameter of the `addDevice` method.
 If you don't provide these credentials, the device will attempt to connect as an anonymous user. Whether anonymous authentication

--- a/docs/Antora/modules/howto_guides/pages/howto_access_control_introduction.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_access_control_introduction.adoc
@@ -1,5 +1,15 @@
-
 = Access control
+
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🗝️ Understand basics of access control.
+- 🧑‍🤝‍🧑 Describe user roles and permissions.
+- 🌍 Recognize transport layer authentication.
+- 🛡 Understand native protocol access control.
+====
 
 In many cases, we have a data acquisition system that can be accessed by multiple users. Typically, we want each user to have specific permissions based on their role.
 For instance, an admin user should be able to configure the device and modify all its settings. A guest user might only need read-only access, while a calibrator user

--- a/docs/Antora/modules/howto_guides/pages/howto_access_control_protected_object.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_access_control_protected_object.adoc
@@ -1,5 +1,15 @@
-
 = Adding a protected object
+
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🧩 Add protected property objects.
+- 🧑‍🤝‍🧑 Customize user group permissions.
+- 🧱 Prevent permission inheritance for control.
+- 🧑‍💻 Apply permission builder patterns.
+====
 
 OpenDAQ devices, channels, signals, and other components are property objects. Each property object includes a permission manager
 that can be used to grant or restrict access to that object based on user group membership. In this section, we will demonstrate how to add

--- a/docs/Antora/modules/howto_guides/pages/howto_access_control_user_list.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_access_control_user_list.adoc
@@ -1,5 +1,15 @@
-
 = Defining a list of users
+
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🏛️ Create an authentication provider.
+- 🧑‍💼 Define users and groups.
+- 🚫 Enable or disable anonymous access.
+- 🧑‍💻 Apply setup code examples.
+====
 
 An openDAQ server instance can accept an `AuthenticationProvider` object, which is responsible for providing a list of all users who can connect to the device.
 For each user, we need to provide a username, password, and the list of groups that the user belongs to. By default, every user is a member of the group `everyone`.

--- a/docs/Antora/modules/howto_guides/pages/howto_add_function_block.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_add_function_block.adoc
@@ -1,5 +1,17 @@
 = Add Function Block
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🧱 Understand Function Blocks and their role.
+- 🗒️ List all available Fnction Blocks using the SDK.
+- ➗ Add a Function Block using its ID.
+- 🧷 Access metadata of Function Block instances.
+- 💡 Implement full code examples.
+====
+
 openDAQ(TM) provides processing features through xref:knowledge_base:function_blocks.adoc[Function Blocks].
 They can process Signals either on a xref:knowledge_base:device.adoc[Device] or on a host PC where the SDK
 is running.

--- a/docs/Antora/modules/howto_guides/pages/howto_configure_function_block.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_configure_function_block.adoc
@@ -1,5 +1,15 @@
 = Configure Function Block
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- ⚙ List Properties of a Function Block.
+- 📝 Read and modify Property values.
+- 📊 Work with Statistics Function Block as a hands-on example.
+====
+
 openDAQ(TM) provides processing features through xref:knowledge_base:function_blocks.adoc[Function Blocks].
 They can process Signals either on a xref:knowledge_base:device.adoc[Device] or on a host PC where the SDK
 is running.

--- a/docs/Antora/modules/howto_guides/pages/howto_configure_instance.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_configure_instance.adoc
@@ -1,5 +1,16 @@
 = Instance Configuration
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🧩 Create default and custom-configured Instances.
+- 🧾 Configure using JSON, environment variables, or CLI.
+- 🧮 Set global and component-specific logging levels.
+- 🛠️ Apply configuration snippets.
+====
+
 :tip-caption: Assumptions
 [TIP]
 ====

--- a/docs/Antora/modules/howto_guides/pages/howto_configure_instance_providers.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_configure_instance_providers.adoc
@@ -1,5 +1,15 @@
 = Instance Configuration with Providers
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 📦 Understand config providers in openDAQ(TM).
+- 🧊 Recognize formatting and data handling rules.
+- 📃 Apply code examples.
+====
+
 :tip-caption: Assumptions
 [TIP]
 ====

--- a/docs/Antora/modules/howto_guides/pages/howto_configure_streaming.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_configure_streaming.adoc
@@ -1,5 +1,16 @@
 = Configure Streaming
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🌐 Understand streaming protocols and server setup.
+- 🧩 Add streaming servers properly.
+- 🪄 Compose streaming connection strings.
+- ⚙️ Apply streaming configuration in code.
+====
+
 [#server_config]
 == Server side Configuration
 

--- a/docs/Antora/modules/howto_guides/pages/howto_connect_to_device.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_connect_to_device.adoc
@@ -1,5 +1,16 @@
 = Connect to a Device
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🔌 Understand openDAQ(TM) Device discovery and connectivity.
+- 🗂 List and retrieve connection metadata.
+- 🔗 Establish Device connection using the client.
+- 🏷 Understand automatic Device handling by the Instance and root Device.
+====
+
 openDAQ(TM) provides Device connectivity features through Modules. Said Modules contain mechanisms for discovering and connecting to Devices.
 By listing available Devices, Modules are asked to return meta-information about Devices they can connect to.
 This metadata contains an address (connection string) at which the Device is accessible.

--- a/docs/Antora/modules/howto_guides/pages/howto_connect_to_device.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_connect_to_device.adoc
@@ -24,18 +24,19 @@ The procedure of querying Modules for available Devices, as well as selecting th
 openDAQ(TM) provides three client and three server modules. They make possible to connect to openDAQ(TM) devices, as well as transfer their signal data. 
 To discover available devices, we can use the `getAvailableDevices` method of the openDAQ(TM) instance which returns the list of devices info of all available devices.
 Device info contains information about device such as name, serial number, connection string, server capabilities, etc.
-Connection string is used to connect to the device. Prefix of connection string indentifies the protocol used to connect to the device or a type of device.
+Connection string is used to connect to the device. Prefix of connection string identifies the protocol used to connect to the device or a type of device.
 
 * `daqref://` indentifies the reference Device Module that simulates sine wave signals;
 * `daq.opcua://` is a prefix of OPC UA device;
-* `daq.ns://` indentifies the devices which supports native streaming protocol;
+* `daq.nd://` is used for devices that support the native configuration protocol;
+* `daq.ns://` indentifies devices which support the native streaming protocol;
 * `daq.lt://` is a prefix of device that supports streaming Lt protocol;
-* `daq://` is a prefix of the device that supports multiple protocols and alows to connect with optimal protocol. The host will represent the device manufacturer and serial number and will have a list of server capabilities which represent the protocols that device supports and connection strings for each protocol.
+* `daq://` is a prefix of the device that supports multiple protocols and allows to connect with optimal protocol. The host will represent the device manufacturer and serial number and will have a list of server capabilities which represent the protocols that device supports and connection strings for each protocol.
 
 == Connecting to Devices
-To connect to device developer can use either connection string from the device Info or if there is a need to connect with required protocol, use conenction string from server capability. Some server capabilities may contain multiple connection strings for the same protocol. The primary connection string can be view with the method `getConnectionString` and all possible addresses with the method `getConnectionStrings`.
+To connect to device developer can use either connection string from the device Info or if there is a need to connect with required protocol, use connection string from server capability. Some server capabilities may contain multiple connection strings for the same protocol. The primary connection string can be view with the method `getConnectionString` and all possible addresses with the method `getConnectionStrings`.
 
-NOTE: Device info may contatin server capability only for OpcUa, Native and streaming Lt protocol. Devices like reference device and audio does not have server capabilities.
+NOTE: Device info may contain server capability only for OpcUa, Native and streaming Lt protocol. Devices like reference device and audio does not have server capabilities.
 
 == Connecting to openDAQ(TM) OPC UA devices
 

--- a/docs/Antora/modules/howto_guides/pages/howto_measure_single_value.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_measure_single_value.adoc
@@ -1,5 +1,15 @@
 = Measure a single value
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🎯 Retrieve latest signal values.
+- 🧬 Work with complex types like structs and lists.
+- 📄 Use code examples.
+====
+
 openDAQ(TM) offers a variety of solutions for reading Signal values, including Readers. 
 
 However, for developers requiring access to only the most recent value, the Signal interface provides a method for doing just that.

--- a/docs/Antora/modules/howto_guides/pages/howto_read_aligned_signals.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_read_aligned_signals.adoc
@@ -1,5 +1,15 @@
 = Read multiple Signals aligned
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🧩 Use Multi Reader for synchronized reading.
+- 🧰 Create and configure Multi Readers.
+- 🖱 Apply code examples.
+====
+
 :tip-caption: Assumptions
 [TIP]
 ====

--- a/docs/Antora/modules/howto_guides/pages/howto_read_last_n_samples.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_read_last_n_samples.adoc
@@ -1,5 +1,16 @@
 = Read last N samples
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- ⏲️ Use Tail Reader for latest N samples.
+- 🔧 Configure history size.
+- ⚠️ Handle limited sample availability.
+- 🧑‍💻 Apply code examples.
+====
+
 :tip-caption: Assumptions
 [TIP]
 ====

--- a/docs/Antora/modules/howto_guides/pages/howto_read_with_domain.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_read_with_domain.adoc
@@ -1,5 +1,16 @@
 = Read basic value and Domain data
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 📖 Create Stream Reader for Signal values and Domain data.
+- 🧩 Specify sample types.
+- 🔄 Handle automatic type conversion.
+- 🧑‍💻 Use code examples.
+====
+
 :tip-caption: Assumptions
 [TIP]
 ====

--- a/docs/Antora/modules/howto_guides/pages/howto_read_with_timeouts.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_read_with_timeouts.adoc
@@ -1,5 +1,15 @@
 = Read with time-outs
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- ⌛ Understand non-blocking reads.
+- 🕹 Configure timeouts for read operations.
+- 👨‍💻 Use code examples.
+====
+
 :tip-caption: Assumptions
 [TIP]
 ====

--- a/docs/Antora/modules/howto_guides/pages/howto_read_with_timestamps.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_read_with_timestamps.adoc
@@ -1,5 +1,15 @@
 = Read with absolute time-stamps
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 🧭 Understand time Domains.
+- 🧾 Ensure preconditions for time-based reading.
+- 💻 Use code examples.
+====
+
 :tip-caption: Assumptions
 [TIP]
 ====

--- a/docs/Antora/modules/howto_guides/pages/howto_save_load_configuration.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_save_load_configuration.adoc
@@ -1,5 +1,16 @@
 = Save and load Configuration
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 📚 Understand openDAQ(TM) configuration components.
+- 💾 Save configuration to JSON.
+- 📥 Load configurations from JSON.
+- 🖥️ Apply code examples.
+====
+
 openDAQ(TM) provides features to save the current Configuration to JSON format. The Configuration is defined as the current state of
 the complete openDAQ tree. It consists of:
 

--- a/docs/Antora/modules/howto_guides/pages/howto_vbox_simulator.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_vbox_simulator.adoc
@@ -1,11 +1,9 @@
 = Set up an openDAQ(TM) VirtualBox Device simulator
 
-:sdk-docs-website: https://docs.opendaq.com
-
 The openDAQ(TM) VirtualBox image provides a simulated xref:glossary:glossary.adoc#device[Device] that is discoverable by openDAQ(TM), and can be connected to using the openDAQ(TM) client.
 The Device itself outputs two sine wave xref:knowledge_base:signals.adoc[Signal]s, with configurable parameters such as the signal amplitude and frequency.
 
-To start, head over to {sdk-docs-website}[The openDAQ(TM) downloads page] and download the simulator image. Within this guide we will be using https://www.virtualbox.org/wiki/Downloads[VirtualBox] to run the simulator.
+To start, head over to https://docs.opendaq.com and download the simulator image. Within this guide we will be using https://www.virtualbox.org/wiki/Downloads[VirtualBox] to run the simulator.
 
 [#running_the_simulator]
 == Running the simulator

--- a/docs/Antora/modules/howto_guides/pages/howto_vbox_simulator.adoc
+++ b/docs/Antora/modules/howto_guides/pages/howto_vbox_simulator.adoc
@@ -1,5 +1,14 @@
 = Set up an openDAQ(TM) VirtualBox Device simulator
 
+:note-caption: Learning Outcomes
+[NOTE]
+====
+By the end of this guide, learners will be able to:
+
+- 📥 Download and import the openDAQ(TM) VirtualBox simulator.
+- 🧮 Run one or multiple simulators in VirtualBox.
+====
+
 The openDAQ(TM) VirtualBox image provides a simulated xref:glossary:glossary.adoc#device[Device] that is discoverable by openDAQ(TM), and can be connected to using the openDAQ(TM) client.
 The Device itself outputs two sine wave xref:knowledge_base:signals.adoc[Signal]s, with configurable parameters such as the signal amplitude and frequency.
 

--- a/docs/Antora/modules/knowledge_base/nav-knowledge_base.adoc
+++ b/docs/Antora/modules/knowledge_base/nav-knowledge_base.adoc
@@ -12,7 +12,5 @@
 *** xref:multireader_spec.adoc[Multi Reader]
 *** xref:streaming.adoc[Streaming]
 *** xref:modules.adoc[Modules]
-** *Server/Client protocols*
-*** xref:protocol_features_characteristics.adoc[Protocol features and characteristics]
-** *Internals*
-*** xref:interfaces_objects_wrappers.adoc[Interfaces, Objects and Wrappers]
+** xref:protocol_features_characteristics.adoc[*Protocol features and characteristics*]
+** xref:interfaces_objects_wrappers.adoc[*Interfaces, Objects and Wrappers*]

--- a/docs/Antora/modules/knowledge_base/pages/modules.adoc
+++ b/docs/Antora/modules/knowledge_base/pages/modules.adoc
@@ -15,8 +15,7 @@ allowing to view its structure and modify its configuration.
 The Streaming Client Modules are used to connect to devices with corresponding Streaming Server running,
 allowing to read device signals data.
 
-Those modules are present in the binary files available at the
-{docs-website}[openDAQ(TM) documentation and releases webpage] in the `modules`
+Those modules are present in the binary files available at https://docs.opendaq.com in the `modules`
 directory, as files with the `.module.dll` / `.module.so` / `.module.dylib` extension, depending on your operating
 system.
 


### PR DESCRIPTION
# Brief

Introduces the first set of Antora docs improvements

# Description

- Clean up links in Antora docs
- Move "Save and load Configuration" how-to guide up
- Fix "OPC-UA" to "OPC UA"
- Move some articles to a higher level in navigation
- Version fix:
    - Use placeholder `<version>` (`dev` is erroneously shown in development mode)
    -  Use placeholder `<short-sha>`
- Fix DoxyGen comment (unrelated)
- Shorten `quick_start_application.adoc` somewhat, minor fixes
- Fix indentation
- Add learning outcomes to Antora docs
- Add `daq.nd://` explainer and fix some typos