### PR TITLE
`hasProperty` extension for nested property object paths

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- [#773](https://github.com/openDAQ/openDAQ/pull/773) Extend IPropertyObject::hasProperty() to accept nested property lookup via "dot" notation.
 - [#733](https://github.com/openDAQ/openDAQ/pull/733) Introduces serializer versioning; openDAQ list objects are now serialized as objects instead of JSON arrays.
 - [#730](https://github.com/openDAQ/openDAQ/pull/730) Provide list of connected clients info via DeviceInfo.
 - [#718](https://github.com/openDAQ/openDAQ/pull/718) Adds new Native Configuration Protocol RPCs for handling sub-function blocks (function blocks that are children of other FBs.

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -412,8 +412,9 @@ protected:
                                            PropertyObjectPtr& propObjPtr);
 
     // Child property handling - Used when a property is queried in the "parent.child" format
-    bool isChildProperty(const StringPtr& name, StringPtr& childName, StringPtr& subName) const;
-    std::pair<std::string, std::string> splitByLastDot(const std::string& input) const;
+    bool isChildProperty(const StringPtr& name) const;
+    void splitOnFirstDot(const StringPtr& input, StringPtr& head, StringPtr& tail) const;
+    void splitOnLastDot(const StringPtr& input, StringPtr& head, StringPtr& tail) const;
 
     // Update
 
@@ -656,34 +657,42 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getClassName
 #endif
 
 template <class PropObjInterface, class... Interfaces>
-bool GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::isChildProperty(const StringPtr& name,
-                                                                                 StringPtr& childName,
-                                                                                 StringPtr& subName) const
+bool GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::isChildProperty(const StringPtr& name) const
 {
-    auto strName = name.getCharPtr();
-    auto propName = strchr(strName, '.');
-    if (propName != nullptr)
-    {
-        childName = String(strName, propName - strName);
-        subName = String(propName + 1);
-        return true;
-    }
-
-    return false;
+    auto chr = strchr(name.getCharPtr(), '.');
+    return chr != nullptr;
 }
 
 template <typename PropObjInterface, typename... Interfaces>
-std::pair<std::string, std::string> GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::splitByLastDot(const std::string& input) const
+void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::splitOnFirstDot(const StringPtr& input,
+                                                                                 StringPtr& head,
+                                                                                 StringPtr& tail) const
 {
-    size_t pos = input.rfind('.');
+    const std::string inputStr = input;
+    head = input;
+
+    size_t pos = inputStr.find('.');
     if (pos == std::string::npos)
-    {
-        // No dot found, return whole input as head, empty tail
-        return {input, ""};
-    }
-    std::string head = input.substr(0, pos);
-    std::string tail = input.substr(pos + 1);
-    return {head, tail};
+        return;
+    
+    head = inputStr.substr(0, pos);
+    tail = inputStr.substr(pos + 1);
+}
+
+template <typename PropObjInterface, typename... Interfaces>
+void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::splitOnLastDot(const StringPtr& input,
+                                                                                StringPtr& head,
+                                                                                StringPtr& tail) const
+{
+    const std::string inputStr = input;
+    head = input;
+
+    size_t pos = inputStr.rfind('.');
+    if (pos == std::string::npos)
+        return;
+
+    head = inputStr.substr(0, pos);
+    tail = inputStr.substr(pos + 1);
 }
 
 template <typename PropObjInterface, typename... Interfaces>
@@ -1114,12 +1123,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             return OPENDAQ_SUCCESS;
         }
 
-        StringPtr childName;
         StringPtr subName;
-        const auto isChildProp = isChildProperty(propName, childName, subName);
+        const auto isChildProp = isChildProperty(propName);
         if (isChildProp)
         {
-            propName = childName;
+            splitOnFirstDot(propName, propName, subName);
         }
 
         PropertyPtr prop = getUnboundProperty(propName);
@@ -1858,12 +1866,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
             return OPENDAQ_SUCCESS;
         }
 
-        StringPtr childName;
         StringPtr subName;
-        const auto isChildProp = isChildProperty(propName, childName, subName);
+        const auto isChildProp = isChildProperty(propName);
         if (isChildProp)
         {
-            propName = childName;
+            splitOnFirstDot(propName, propName, subName);
         }
 
         PropertyPtr prop = getUnboundPropertyOrNull(propName);
@@ -1977,12 +1984,12 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyV
         BaseObjectPtr valuePtr;
         ErrCode err;
 
-        StringPtr childName;
-        StringPtr subName;
 
-        if (isChildProperty(propName, childName, subName))
+        if (isChildProperty(propName))
         {
-            err = getChildPropertyValue(childName, subName, valuePtr);
+            StringPtr subName;
+            splitOnFirstDot(propName, propName, subName);
+            err = getChildPropertyValue(propName, subName, valuePtr);
         }
         else
         {
@@ -2015,10 +2022,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
         BaseObjectPtr valuePtr;
         PropertyPtr prop;
 
-        StringPtr childName;
-        StringPtr subName;
-
-        if (isChildProperty(propName, childName, subName))
+        if (isChildProperty(propName))
         {
             getProperty(propName, &prop);
             if (!prop.assigned())
@@ -2082,19 +2086,18 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getProperty(
     OPENDAQ_PARAM_NOT_NULL(propertyName);
     OPENDAQ_PARAM_NOT_NULL(property);
 
-    return daqTry([&]() -> auto {
-        StringPtr childName;
-        StringPtr subName;
+    return daqTry([&]() -> auto
+    {
+
         StringPtr propName = propertyName;
-
-        const auto isChildProp = isChildProperty(propName, childName, subName);
-
         PropertyPtr prop;
 
-        if (isChildProp)
+        if (isChildProperty(propName))
         {
-            propName = childName;
+            StringPtr subName;
             BaseObjectPtr childProp;
+
+            splitOnFirstDot(propName, propName, subName);
             const ErrCode err = getPropertyValueInternal(propName, &childProp);
             if (OPENDAQ_FAILED(err))
             {
@@ -3223,21 +3226,23 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::hasProperty(
     OPENDAQ_PARAM_NOT_NULL(propertyName);
     OPENDAQ_PARAM_NOT_NULL(hasProperty);
 
-    const auto propName = StringPtr::Borrow(propertyName);
+    auto propName = StringPtr::Borrow(propertyName);
 
-    auto splitStr = splitByLastDot(propName);
-    if (!(splitStr.first == propName))
+    if (isChildProperty(propName))
     {
         BaseObjectPtr val;
-        ErrCode err = getPropertyValue(String(splitStr.first), &val);
+        StringPtr childStr;
+        splitOnLastDot(propName, propName, childStr);
+
+        ErrCode err = getPropertyValue(propName, &val);
         if (OPENDAQ_FAILED(err))
-            return DAQ_MAKE_ERROR_INFO(err, fmt::format(R"(Failed to retrieve child object with name {})", splitStr.first));
+            return DAQ_MAKE_ERROR_INFO(err, fmt::format(R"(Failed to retrieve child object with name {})", propName));
 
         PropertyObjectPtr obj = val.asPtrOrNull<IPropertyObject>(true);
         if (!obj.assigned())
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, fmt::format(R"(Child with name {} is not a Object-type property)", splitStr.first));
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, fmt::format(R"(Child with name {} is not a Object-type property)", propName));
 
-        return obj->hasProperty(String(splitStr.second), hasProperty);
+        return obj->hasProperty(childStr, hasProperty);
     }
     
 

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -750,6 +750,36 @@ TEST_F(PropertyObjectTest, NestedChildPropSet)
     ASSERT_EQ(childObj3.getPropertyValue("IntProperty"), 3);
 }
 
+TEST_F(PropertyObjectTest, NestedChildPropHasProperty)
+{
+    auto propObj = PropertyObject(objManager, "Test");
+    auto defaultObj1 = PropertyObject(objManager, "Test");
+    auto defaultObj2 = PropertyObject(objManager, "Test");
+    auto defaultObj3 = PropertyObject(objManager, "Test");
+
+    const auto childProp3 = ObjectProperty("Child", defaultObj3);
+    defaultObj2.addProperty(childProp3);
+    
+    const auto childProp2 = ObjectProperty("Child", defaultObj2);
+    defaultObj1.addProperty(childProp2);
+
+    const auto childProp1 = ObjectProperty("Child", defaultObj1);
+    propObj.addProperty(childProp1);
+
+    const PropertyObjectPtr childObj1 = propObj.getPropertyValue("Child");
+    const PropertyObjectPtr childObj2 = childObj1.getPropertyValue("Child");
+
+    ASSERT_THROW(propObj.hasProperty("Child.IntProperty.Foo"), InvalidTypeException);
+    ASSERT_THROW(propObj.hasProperty("Child.WrongChild.IntProperty"), NotFoundException);
+
+    ASSERT_TRUE(propObj.hasProperty("Child.IntProperty"));
+    ASSERT_TRUE(propObj.hasProperty("Child.Child.IntProperty"));
+    ASSERT_TRUE(propObj.hasProperty("Child.Child.Child.IntProperty"));
+
+    ASSERT_TRUE(childObj2.hasProperty("IntProperty"));
+    ASSERT_TRUE(childObj2.hasProperty("Child.IntProperty"));
+}
+
 TEST_F(PropertyObjectTest, ChildPropGet)
 {
     auto propObj = PropertyObject(objManager, "Test");

--- a/core/opendaq/functionblock/src/function_block_wrapper_impl.cpp
+++ b/core/opendaq/functionblock/src/function_block_wrapper_impl.cpp
@@ -302,10 +302,11 @@ ErrCode FunctionBlockWrapperImpl::setPropertyValue(IString* propertyName, IBaseO
         {
             auto valuePtr = BaseObjectPtr::Borrow(value);
 
-            StringPtr childName;
-            StringPtr subName;
-            if (isChildProperty(propertyNameStr, childName, subName))
+            if (isChildProperty(propertyNameStr))
             {
+                StringPtr childName;
+                StringPtr subName;
+                splitOnFirstDot(propertyNameStr, childName, subName);
                 if (!isPropertyVisible(childName))
                     DAQ_THROW_EXCEPTION(NotFoundException);
             }

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -36,9 +36,7 @@ ErrCode TmsClientPropertyObjectBaseImpl<Impl>::setOPCUAPropertyValueInternal(ISt
     }
     auto propertyNamePtr = StringPtr::Borrow(propertyName);
 
-    StringPtr childName;
-    StringPtr subName;
-    if (this->isChildProperty(propertyNamePtr, childName, subName))
+    if (this->isChildProperty(propertyNamePtr))
     {
         PropertyPtr prop;
         ErrCode err = getProperty(propertyNamePtr, &prop);
@@ -138,9 +136,7 @@ ErrCode INTERFACE_FUNC TmsClientPropertyObjectBaseImpl<Impl>::getPropertyValue(I
     }
     auto propertyNamePtr = StringPtr::Borrow(propertyName);
 
-    StringPtr childName;
-    StringPtr subName;
-    if (this->isChildProperty(propertyNamePtr, childName, subName))
+    if (this->isChildProperty(propertyNamePtr))
     {
         PropertyPtr prop;
         ErrCode err = getProperty(propertyNamePtr, &prop);


### PR DESCRIPTION
# Brief
Extend `IPropertyObject::hasProperty()` to accept nested property lookup via "dot" notation.

# Usage example

```cpp
auto propObj = PropertyObject();
auto childObj = PropertyObject();
childObj.addProperty(StringProperty("foo", "bar"));

const auto childProp = ObjectProperty("child", childObj );
propObj.addProperty(childProp);

// returns `true`
bool hasProp = propObj.hasProperty("child.foo");
```