### PR TITLE
Partial High-Performance WebSocket Streaming Server Module fixes

### DIFF
--- a/modules/new_websocket_streaming_server_module/include/httpparser/httprequestparser.h
+++ b/modules/new_websocket_streaming_server_module/include/httpparser/httprequestparser.h
@@ -13,6 +13,10 @@
 
 #include "request.h"
 
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#endif
+
 namespace httpparser
 {
 

--- a/modules/new_websocket_streaming_server_module/src/CMakeLists.txt
+++ b/modules/new_websocket_streaming_server_module/src/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(${LIB_NAME}
         daq::opendaq
     PRIVATE
         Boost::headers
+        Boost::asio
         cryptopp::cryptopp
         nlohmann_json::nlohmann_json
 )


### PR DESCRIPTION
# Brief

Partially addresses problems encountered while building the new High-Performance WebSocket Streaming Server Module.

# Description

* Fix `Boost::asio` in CMake
* Fix `strcasecmp`
