### PR TITLE
Fixing restoring struct fields while loading configuration

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- [#776)](https://github.com/openDAQ/openDAQ/pull/776) Fixing restoring struct fields while loading configuration
 - [#773](https://github.com/openDAQ/openDAQ/pull/773) Extend IPropertyObject::hasProperty() to accept nested property lookup via "dot" notation.
 - [#733](https://github.com/openDAQ/openDAQ/pull/733) Introduces serializer versioning; openDAQ list objects are now serialized as objects instead of JSON arrays.
 - [#730](https://github.com/openDAQ/openDAQ/pull/730) Provide list of connected clients info via DeviceInfo.

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -3303,14 +3303,16 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyF
         case ctStruct:
         case ctObject:
         {
+            const auto strongManager = manager.assigned() ? manager.getRef() : nullptr;
+
             const auto obj = propObj.getPropertyValue(propName);
-            if (const auto updatable = obj.asPtrOrNull<IUpdatable>(); updatable.assigned())
+            if (const auto updatable = obj.asPtrOrNull<IUpdatable>(true); updatable.assigned())
             {
                 const auto serializedNestedObj = serialized.readSerializedObject(propName);
-                return updatable->update(serializedNestedObj, manager.assigned() ? manager.getRef() : nullptr);
+                return updatable->update(serializedNestedObj, strongManager);
             }
 
-            propValue = serialized.readObject(propName);
+            propValue = serialized.readObject(propName, strongManager);
             break;
         }
         case ctProc:
@@ -3362,7 +3364,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::updateObject
 
     if (serialized.hasKey("propValues"))
         serializedProps = serialized.readSerializedObject("propValues");
-
+ 
     beginUpdate();
     Finally finally([this]() { endUpdate(); });
 

--- a/core/opendaq/opendaq/mocks/mock_physical_device.cpp
+++ b/core/opendaq/opendaq/mocks/mock_physical_device.cpp
@@ -65,8 +65,15 @@ inline MockPhysicalDeviceImpl::MockPhysicalDeviceImpl(const ContextPtr& ctx,
     registerProperties();
     registerNetworkConfigProperties();
 
-    const PropertyObjectPtr thisPtr = this->borrowPtr<PropertyObjectPtr>();
-    thisPtr.addProperty(StringProperty("TestProperty", "Test").detach());
+    this->addProperty(StringProperty("TestProperty", "Test"));
+
+    auto structFields = daq::Dict<daq::IString, daq::IBaseObject>(
+    {
+        {"value1", 0.0},
+        {"value2", 0.0}
+    });
+    this->addProperty(daq::StructProperty("DeviceStructure", daq::Struct("TestMockStructure", structFields, ctx.getTypeManager())));
+
     this->tags.add("phys_device");
 
     this->setDeviceDomain(DeviceDomain(Ratio(123, 456), "Origin", Unit("UnitSymbol", 987, "UnitName", "UnitQuantity")));

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -968,6 +968,7 @@ TEST_F(InstanceTest, SaveLoadDeviceStruct)
     auto device = instance.getDevices()[0];
     StructPtr deviceStruct = device.getPropertyValue("DeviceStructure");
     ASSERT_EQ(deviceStruct.get("value1"), 5e-7);
+    ASSERT_EQ(deviceStruct.get("value2"), 0.0);
 }
 
 TEST_F(InstanceTest, TestRemoved1)

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -957,13 +957,13 @@ TEST_F(InstanceTest, SaveLoadDeviceStruct)
 
         auto device = instance.getDevices()[0];
         StructPtr deviceStruct = device.getPropertyValue("DeviceStructure");
-        deviceStruct = StructBuilder(deviceStruct).set("value1", 5e-7);
+        deviceStruct = StructBuilder(deviceStruct).set("value1", 5e-7).build();
         device.setPropertyValue("DeviceStructure", deviceStruct);
 
         config = instance.saveConfiguration();
     }
 
-    auto instance = Instance();
+    auto instance = test_helpers::setupInstance();
     instance.loadConfiguration(config);
     auto device = instance.getDevices()[0];
     StructPtr deviceStruct = device.getPropertyValue("DeviceStructure");

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -947,6 +947,29 @@ TEST_F(InstanceTest, DISABLED_SaveLoadServers)
     ASSERT_EQ(servers[0].getId(), serverId);
 }
 
+TEST_F(InstanceTest, SaveLoadDeviceStruct)
+{
+    StringPtr config;
+    StringPtr serverId;
+    {
+        auto instance = test_helpers::setupInstance();
+        instance.addDevice("daqmock://phys_device");
+
+        auto device = instance.getDevices()[0];
+        StructPtr deviceStruct = device.getPropertyValue("DeviceStructure");
+        deviceStruct = StructBuilder(deviceStruct).set("value1", 5e-7);
+        device.setPropertyValue("DeviceStructure", deviceStruct);
+
+        config = instance.saveConfiguration();
+    }
+
+    auto instance = Instance();
+    instance.loadConfiguration(config);
+    auto device = instance.getDevices()[0];
+    StructPtr deviceStruct = device.getPropertyValue("DeviceStructure");
+    ASSERT_EQ(deviceStruct.get("value1"), 5e-7);
+}
+
 TEST_F(InstanceTest, TestRemoved1)
 {
     auto instance = test_helpers::setupInstance();


### PR DESCRIPTION
# Brief

Fixing restoring struct fields while loading configuration

# Description

type manager was missed in reading object in `setPropertyFromSerialized`

# API changes

None

# Required application changes

None

# Required module changes

None