### PR TITLE
Fixing remote calling function with enumeration

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -2,7 +2,6 @@
 
 ## Features
 
-- [#776)](https://github.com/openDAQ/openDAQ/pull/776) Fixing restoring struct fields while loading configuration
 - [#773](https://github.com/openDAQ/openDAQ/pull/773) Extend IPropertyObject::hasProperty() to accept nested property lookup via "dot" notation.
 - [#733](https://github.com/openDAQ/openDAQ/pull/733) Introduces serializer versioning; openDAQ list objects are now serialized as objects instead of JSON arrays.
 - [#730](https://github.com/openDAQ/openDAQ/pull/730) Provide list of connected clients info via DeviceInfo.
@@ -33,6 +32,8 @@
 
 ## Bug fixes
 
+- [#778](https://github.com/openDAQ/openDAQ/pull/778) Fixing calling remote function with enumeration inside
+- [#776)](https://github.com/openDAQ/openDAQ/pull/776) Fixing restoring struct fields while loading configuration
 - [#757](https://github.com/openDAQ/openDAQ/pull/757) Device info obtained from device and discovery matching is changed from checking for connection string equality to SN + manufacturer equality.
 - [#753](https://github.com/openDAQ/openDAQ/pull/753) Fixes crash when deserializing struct types that have a type name that's present in the list of protected type names.
 - [#756](https://github.com/openDAQ/openDAQ/pull/756) With CMake 4.0.0 the Windows builds would no longer find the test executables somehow.

--- a/core/coretypes/include/coretypes/struct_impl.h
+++ b/core/coretypes/include/coretypes/struct_impl.h
@@ -407,7 +407,7 @@ ErrCode GenericStructImpl<StructInterface, Interfaces...>::Deserialize(
 {
     TypeManagerPtr typeManager;
     if (context == nullptr || OPENDAQ_FAILED(context->queryInterface(ITypeManager::Id, reinterpret_cast<void**>(&typeManager))))
-        return OPENDAQ_ERR_NO_TYPE_MANAGER;
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NO_TYPE_MANAGER, "Type manager is required for deserialization of Struct");
 
     StringPtr typeName;
     ErrCode errCode = ser->readString("typeName"_daq, &typeName);

--- a/core/coretypes/src/enumeration_impl.cpp
+++ b/core/coretypes/src/enumeration_impl.cpp
@@ -202,7 +202,7 @@ ErrCode EnumerationImpl::Deserialize(ISerializedObject* ser, IBaseObject* contex
 {
     TypeManagerPtr typeManager;
     if (context == nullptr || OPENDAQ_FAILED(context->queryInterface(ITypeManager::Id, reinterpret_cast<void**>(&typeManager))))
-        return OPENDAQ_ERR_NO_TYPE_MANAGER;
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NO_TYPE_MANAGER, "Type manager is required for deserialization of Enumeration");
 
     StringPtr typeName;
     ErrCode errCode = ser->readString("typeName"_daq, &typeName);

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -148,10 +148,10 @@ private:
     void requireMinServerVersion(const ClientCommand& command);
     ComponentDeserializeContextPtr createDeserializeContext(const std::string& remoteGlobalId,
                                                             const ContextPtr& context,
-                                                            const ComponentPtr& root,
-                                                            const ComponentPtr& parent,
-                                                            const StringPtr& localId,
-                                                            IntfID* intfID);
+                                                            const ComponentPtr& root = nullptr,
+                                                            const ComponentPtr& parent = nullptr,
+                                                            const StringPtr& localId = nullptr,
+                                                            IntfID* intfID = nullptr);
     BaseObjectPtr createRpcRequest(const StringPtr& name, const ParamsDictPtr& params) const;
     StringPtr createRpcRequestJson(const StringPtr& name, const ParamsDictPtr& params);
     PacketBuffer createRpcRequestPacketBuffer(uint64_t id, const StringPtr& name, const ParamsDictPtr& params);

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -101,8 +101,7 @@ BaseObjectPtr ConfigProtocolClientComm::getPropertyValue(const std::string& glob
     auto getPropertyValueRpcRequestPacketBuffer = createRpcRequestPacketBuffer(generateId(), "GetPropertyValue", dict);
     const auto getPropertyValueRpcReplyPacketBuffer = sendRequestCallback(getPropertyValueRpcRequestPacketBuffer);
 
-    const auto deserializeContext = createDeserializeContext(std::string{}, daqContext, nullptr, nullptr, nullptr, nullptr);
-
+    const auto deserializeContext = createDeserializeContext(std::string{}, daqContext);
     return parseRpcOrRejectReply(getPropertyValueRpcReplyPacketBuffer.parseRpcRequestOrReply(), deserializeContext);
 }
 
@@ -159,7 +158,8 @@ BaseObjectPtr ConfigProtocolClientComm::callProperty(const std::string& globalId
     auto callPropertyRpcRequestPacketBuffer = createRpcRequestPacketBuffer(generateId(), "CallProperty", dict);
     const auto callPropertyRpcReplyPacketBuffer = sendRequestCallback(callPropertyRpcRequestPacketBuffer);
 
-    const auto result = parseRpcOrRejectReply(callPropertyRpcReplyPacketBuffer.parseRpcRequestOrReply());
+    const auto deserializeContext = createDeserializeContext(std::string{}, daqContext);
+    const auto result = parseRpcOrRejectReply(callPropertyRpcReplyPacketBuffer.parseRpcRequestOrReply(), deserializeContext);
     return result;
 }
 
@@ -326,7 +326,7 @@ BaseObjectPtr ConfigProtocolClientComm::getLastValue(const std::string& globalId
     auto getPropertyValueRpcRequestPacketBuffer = createRpcRequestPacketBuffer(generateId(), "GetLastValue", dict);
     const auto getPropertyValueRpcReplyPacketBuffer = sendRequestCallback(getPropertyValueRpcRequestPacketBuffer);
 
-    const auto deserializeContext = createDeserializeContext(std::string{}, daqContext, nullptr, nullptr, nullptr, nullptr);
+    const auto deserializeContext = createDeserializeContext(std::string{}, daqContext);
     return parseRpcOrRejectReply(getPropertyValueRpcReplyPacketBuffer.parseRpcRequestOrReply(), deserializeContext);
 }
 
@@ -831,8 +831,7 @@ BaseObjectPtr ConfigProtocolClientComm::sendComponentCommandInternal(const Clien
         remoteGlobalId = temp.toStdString();
     }
 
-    const auto deserializeContext = createDeserializeContext(remoteGlobalId, daqContext, nullptr, parentComponent, nullptr, nullptr);
-
+    const auto deserializeContext = createDeserializeContext(remoteGlobalId, daqContext, nullptr, parentComponent);
     return parseRpcOrRejectReply(sendCommandRpcReplyPacketBuffer.parseRpcRequestOrReply(), deserializeContext, isGetRootDeviceCommand);
 }
 


### PR DESCRIPTION
# Brief

Fixing calling remote function with enumeration inside


# Description

While remote calling of function, the context was not provided which causes the problem for returning result, which uses type manager

# API changes

None

# Required application changes

None

# Required module changes

None