### PR TITLE
Fix native config protocol versioning

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -18,7 +18,7 @@
 - [#606](https://github.com/openDAQ/openDAQ/pull/606) Mechanism for retrieving and monitoring the device's connection statuses, enabling tracking of streaming connections.
 - [#605](https://github.com/openDAQ/openDAQ/pull/605) Add support for View Only client to the openDAQ Native configuration protocol.
 - [#704](https://github.com/openDAQ/openDAQ/pull/704) Support setting operation mode for the device which notifies all sub components
-- [#697](https://github.com/openDAQ/openDAQ/pull/697) Added `IRecorder` interface and the `basic_csv_recorder_module`.
+- [#697](https://github.com/openDAQ/openDAQ/pull/697) [#783](https://github.com/openDAQ/openDAQ/pull/783) Added `IRecorder` interface and the `basic_csv_recorder_module`.
 
 ## Python
 

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -137,7 +137,7 @@ TEST_F(NativeDeviceModulesTest, CheckProtocolVersion)
 
     auto info = client.getDevices()[0].getInfo();
     ASSERT_TRUE(info.hasProperty("NativeConfigProtocolVersion"));
-    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 13);
+    ASSERT_EQ(static_cast<uint16_t>(info.getPropertyValue("NativeConfigProtocolVersion")), 14);
 
     // because info holds a client device as owner, it have to be removed before module manager is destroyed
     // otherwise module of native client device would not be removed

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
@@ -187,12 +187,12 @@ inline std::set<uint16_t> createListOfSupportedVersions(uint16_t maxVersion)
 
 inline std::set<uint16_t> GetSupportedConfigProtocolVersions()
 {
-    return createListOfSupportedVersions(13);
+    return createListOfSupportedVersions(14);
 }
 
 inline constexpr uint16_t GetLatestConfigProtocolVersion()
 {
-    return 13;
+    return 14;
 }
 
 }

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -326,17 +326,17 @@ PropertyObjectPtr ConfigProtocolClientComm::getComponentConfig(const std::string
 
 void ConfigProtocolClientComm::startRecording(const std::string& globalId)
 {
-    sendComponentCommand(globalId, ClientCommand("StartRecording", 12));
+    sendComponentCommand(globalId, ClientCommand("StartRecording", 14));
 }
 
 void ConfigProtocolClientComm::stopRecording(const std::string& globalId)
 {
-    sendComponentCommand(globalId, ClientCommand("StopRecording", 12));
+    sendComponentCommand(globalId, ClientCommand("StopRecording", 14));
 }
 
 BooleanPtr ConfigProtocolClientComm::getIsRecording(const std::string& globalId)
 {
-    return sendComponentCommand(globalId, ClientCommand("GetIsRecording", 12));
+    return sendComponentCommand(globalId, ClientCommand("GetIsRecording", 14));
 }
 
 BaseObjectPtr ConfigProtocolClientComm::getLastValue(const std::string& globalId)


### PR DESCRIPTION
# Brief

Increases config protocol version number to 14 and fixes wrong version number for Recorder RPCs
