### PR TITLE
Remove Boost::endian dep

### DIFF
--- a/modules/new_websocket_streaming_server_module/src/CMakeLists.txt
+++ b/modules/new_websocket_streaming_server_module/src/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(${LIB_NAME}
         daq::opendaq
     PRIVATE
         Boost::asio
-        Boost::endian
         Boost::headers
         Boost::uuid
         nlohmann_json::nlohmann_json

--- a/modules/new_websocket_streaming_server_module/src/CMakeLists.txt
+++ b/modules/new_websocket_streaming_server_module/src/CMakeLists.txt
@@ -24,6 +24,10 @@ target_link_libraries(${LIB_NAME}
         nlohmann_json::nlohmann_json
 )
 
+if (TARGET Boost::endian)
+    target_link_libraries(${LIB_NAME} PRIVATE Boost::endian)
+endif ()
+
 target_include_directories(${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
                                               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/base64>
                                               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/streaming>


### PR DESCRIPTION
# Brief

There is no boost::endian library when boost libraries are installed via package manager on ubuntu



# Description

Remove implicit library dependency on boost endian. boost::headers should be enough.

