### PR TITLE
Logging improvement

### DIFF
--- a/core/coretypes/include/coretypes/bb_exception.h
+++ b/core/coretypes/include/coretypes/bb_exception.h
@@ -53,6 +53,14 @@ public:
         return fileLine;
     }
 
+    [[nodiscard]]
+    std::string getErrorMessage() const
+    {
+        if (fileName != nullptr)
+            return fmt::format("{} [ File {}:{} ]", what(), fileName, fileLine);
+        return what();
+    }
+
 protected:
     template <typename... Params>
     explicit DaqException(bool defaultMsg, ErrCode errCode, const std::string& msg, ConstCharPtr fileName = nullptr, Int fileLine = -1)

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1877,6 +1877,10 @@ void GenericDevice<TInterface, Interfaces...>::updateDevice(const std::string& d
         const auto updatableDevice = device.template asPtr<IUpdatable>(true);
         updatableDevice.updateInternal(serializedDevice, context);
     }
+    catch (const DaqException& e)
+    {
+        LOG_W("Failed to update device: {}", e.getErrorMessage());
+    }
     catch (const std::exception& e)
     {
         LOG_W("Failed to update device: {}", e.what());

--- a/core/opendaq/modulemanager/include/opendaq/module_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_impl.h
@@ -471,7 +471,7 @@ private:
         }
         catch (const DaqException& e)
         {
-            LOG_W("Failed to merge configuration: {}", e.what())
+            LOG_W("Failed to merge configuration: {}", e.getErrorMessage())
             return configIn;
         }
         catch (const std::exception& e)

--- a/core/opendaq/signal/include/opendaq/input_port_impl.h
+++ b/core/opendaq/signal/include/opendaq/input_port_impl.h
@@ -372,6 +372,10 @@ void GenericInputPortImpl<Interfaces...>::notifyPacketEnqueuedSameThread()
             {
                 listener.packetReceived(this->template thisInterface<IInputPort>());
             }
+            catch (const DaqException& e)
+            {
+                LOG_E("Input port notification failed: {}", e.getErrorMessage());
+            }
             catch (const std::exception& e)
             {
                 LOG_E("Input port notification failed: {}", e.what());
@@ -462,6 +466,10 @@ ErrCode GenericInputPortImpl<Interfaces...>::setListener(IInputPortNotifications
                 try
                 {
                     notify.packetReceived(port);
+                }
+                catch (const DaqException& e)
+                {
+                    LOG_E("Input port notification failed: {}", e.getErrorMessage());
                 }
                 catch (const std::exception& e)
                 {


### PR DESCRIPTION
# Brief

When catching an exception and logging it, use method `DaqException::getErrorMessage`, which will generate a message including the source where it occurred



# Usage example

In C++ use:

```cpp
try
{
    DAQ_THROW_EXCEPTION(InvalidParameterException);
}
catch (const DaqException& e)
{
    LOG_E("caught the exception: {}", e.getErrorMessage());
}
```
