### PR TITLE
Fix input port to signal notification

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -37,6 +37,7 @@
 
 ## Bug fixes
 
+- [#790](https://github.com/openDAQ/openDAQ/pull/790) Fix input port to signal notification
 - [#778](https://github.com/openDAQ/openDAQ/pull/778) Fixing calling remote function with enumeration inside
 - [#776](https://github.com/openDAQ/openDAQ/pull/776) Fixing restoring struct fields while loading configuration
 - [#757](https://github.com/openDAQ/openDAQ/pull/757) Device info obtained from device and discovery matching is changed from checking for connection string equality to SN + manufacturer equality.

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -69,12 +69,6 @@ namespace details
     }
 }
 
-namespace permissions
-{
-    static const auto DefaultPermissions =
-        PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
-}
-
 class PropertyImpl : public ImplementationOf<IProperty, ISerializable, IPropertyInternal, IOwnable>
 {
 protected:
@@ -314,7 +308,9 @@ public:
     {
 #ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
         defaultPermissionManager = PermissionManager();
-        defaultPermissionManager.setPermissions(permissions::DefaultPermissions);
+        const auto DefaultPermissions =
+            PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
+        defaultPermissionManager.setPermissions(DefaultPermissions);
 #else
         defaultPermissionManager = DisabledPermissionManager();
 #endif

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -69,6 +69,12 @@ namespace details
     }
 }
 
+namespace permissions
+{
+    static const auto DefaultPermissions =
+        PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
+}
+
 class PropertyImpl : public ImplementationOf<IProperty, ISerializable, IPropertyInternal, IOwnable>
 {
 protected:
@@ -308,9 +314,7 @@ public:
     {
 #ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
         defaultPermissionManager = PermissionManager();
-        const auto DefaultPermissions =
-            PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
-        defaultPermissionManager.setPermissions(DefaultPermissions);
+        defaultPermissionManager.setPermissions(permissions::DefaultPermissions);
 #else
         defaultPermissionManager = DisabledPermissionManager();
 #endif

--- a/core/opendaq/signal/tests/test_input_port.cpp
+++ b/core/opendaq/signal/tests/test_input_port.cpp
@@ -8,6 +8,8 @@
 #include <opendaq/deserialize_component_ptr.h>
 #include <opendaq/context_factory.h>
 #include <opendaq/component_deserialize_context_factory.h>
+#include <opendaq/scheduler_factory.h>
+#include <opendaq/signal_factory.h>
 
 using namespace daq;
 using namespace testing;
@@ -151,4 +153,23 @@ TEST_F(InputPortTest, SerializeAndDeserialize)
     const auto str2 = serializer2.getOutput();
 
     ASSERT_EQ(str1, str2);
+}
+
+TEST_F(InputPortTest, RemoveDisconnectedSignal)
+{
+    auto logger = Logger();
+    auto context = Context(Scheduler(logger, 1), logger, nullptr, nullptr, nullptr);
+    auto scheduler = context.getScheduler();
+
+    auto signal1 = Signal(context, nullptr, "sig1");
+    auto signal2 = Signal(context, nullptr, "sig2");
+
+    auto ip = InputPort(context, nullptr, "ip");
+
+    ip.connect(signal1);
+    ip.connect(signal2);
+
+    signal1.remove();
+
+    ASSERT_TRUE(ip.getSignal().assigned());
 }

--- a/shared/libraries/config_protocol/tests/test_c2d_streaming.cpp
+++ b/shared/libraries/config_protocol/tests/test_c2d_streaming.cpp
@@ -561,7 +561,7 @@ TEST_F_UNSTABLE_SKIPPED(ClientToDeviceStreamingTest, ReplaceConnectedSignalWithS
     EXPECT_EQ(serverExtSigFolder.getItems().getCount(), 1u);
     EXPECT_EQ(client1ExtSigFolder.getItems().getCount(), 1u);
     EXPECT_EQ(client2ExtSigFolder.getItems().getCount(), 0u);
-    // verify that signal disconnected
+    // verify that server signal connected
     EXPECT_TRUE(chIpClient1.getSignal().assigned());
     EXPECT_TRUE(chIpServer.getSignal().assigned());
     EXPECT_TRUE(chIpClient2.getSignal().assigned());
@@ -573,7 +573,7 @@ TEST_F_UNSTABLE_SKIPPED(ClientToDeviceStreamingTest, ReplaceConnectedSignalWithS
     EXPECT_EQ(serverExtSigFolder.getItems().getCount(), 0u);
     EXPECT_EQ(client1ExtSigFolder.getItems().getCount(), 0u);
     EXPECT_EQ(client2ExtSigFolder.getItems().getCount(), 0u);
-    // verify that signal disconnected
+    // verify that new signal connected
     EXPECT_TRUE(fbIpClient1.getSignal().assigned());
     EXPECT_TRUE(fbIpServer.getSignal().assigned());
     EXPECT_TRUE(fbIpClient2.getSignal().assigned());
@@ -599,7 +599,7 @@ TEST_F(ClientToDeviceStreamingTest, ReplaceConnectedSignalWithAnotherExternal)
     EXPECT_EQ(serverExtSigFolder.getItems().getCount(), 2u);
     EXPECT_EQ(client1ExtSigFolder.getItems().getCount(), 1u);
     EXPECT_EQ(client2ExtSigFolder.getItems().getCount(), 1u);
-    // verify that signal disconnected
+    // verify that new signal connected
     EXPECT_TRUE(chIpClient1.getSignal().assigned());
     EXPECT_TRUE(chIpServer.getSignal().assigned());
     EXPECT_TRUE(chIpClient2.getSignal().assigned());
@@ -611,7 +611,7 @@ TEST_F(ClientToDeviceStreamingTest, ReplaceConnectedSignalWithAnotherExternal)
     EXPECT_EQ(serverExtSigFolder.getItems().getCount(), 2u);
     EXPECT_EQ(client1ExtSigFolder.getItems().getCount(), 1u);
     EXPECT_EQ(client2ExtSigFolder.getItems().getCount(), 1u);
-    // verify that signal disconnected
+    // verify that new signal connected
     EXPECT_TRUE(fbIpClient1.getSignal().assigned());
     EXPECT_TRUE(fbIpServer.getSignal().assigned());
     EXPECT_TRUE(fbIpClient2.getSignal().assigned());
@@ -633,7 +633,7 @@ TEST_F(ClientToDeviceStreamingTest, SignalWithoutDomainPortRemove)
     EXPECT_EQ(serverExtSigFolder.getItems().getCount(), 0u);
     EXPECT_EQ(client1ExtSigFolder.getItems().getCount(), 0u);
     EXPECT_EQ(client2ExtSigFolder.getItems().getCount(), 0u);
-    // verify that signal disconnected
+    // verify that port removed
     EXPECT_TRUE(fbIpClient1.isRemoved());
     EXPECT_TRUE(fbIpServer.isRemoved());
     EXPECT_TRUE(fbIpClient2.isRemoved());


### PR DESCRIPTION
# Brief

Adds missing input port notification sent to previously connected signal when it is replaced by new connected signal.

# Description

- Stabilizes client-to-device streaming tests by fixing issues with input port to signal notifications and test environment
