### PR TITLE
[TBBAS-2183/SHS-152] .NET Bindings - Fixed AccessViolation on Garbage Collection

### DIFF
--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.CI.Test/OpenDAQ_CITests.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.CI.Test/OpenDAQ_CITests.cs
@@ -461,62 +461,62 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
     }
 
     [Test]
-    public void Test_0101_InstanceManualDispose()
+    public void Test_0101_ObjectManualDispose()
     {
         //instruct TearDown function not to collect and finalize managed objects explicitly
         base.DontCollectAndFinalize();
 
-        Instance daqInstance = OpenDAQFactory.Instance(".");
-        Assert.That(daqInstance.IsDisposed, Is.False);
+        var openDaqObject = OpenDAQFactory.CreateLinearScaling(1.1, 0.2, SampleType.Float64, ScaledSampleType.Float64);
+        Assert.That(openDaqObject.IsDisposed, Is.False);
 
         //can do something with 'daqInstance' here
-        using var info = daqInstance.Info;
+        using var parameters = openDaqObject.Parameters;
 
-        var name = info.Name;
-        Console.WriteLine($"daqInstance name = '{name}'");
+        var count = parameters.Count;
+        Console.WriteLine($"openDaqObject.Parameters.Count = '{count}'");
 
-        //finally free managed resources (release reference)
-        daqInstance.Dispose();
-        Assert.That(daqInstance.IsDisposed, Is.True);
+        //finally free resources (release reference)
+        openDaqObject.Dispose();
+        Assert.That(openDaqObject.IsDisposed, Is.True);
     }
 
     [Test]
-    public void Test_0102_InstanceAutoDispose1()
+    public void Test_0102_ObjectAutoDispose1()
     {
         //instruct TearDown function not to collect and finalize managed objects explicitly
         base.DontCollectAndFinalize();
 
-        Instance daqInstance;
+        Scaling openDaqObject;
 
-        using (daqInstance = OpenDAQFactory.Instance("."))
+        using (openDaqObject = OpenDAQFactory.CreateLinearScaling(1.1, 0.2, SampleType.Float64, ScaledSampleType.Float64))
         {
-            Assert.That(daqInstance.IsDisposed, Is.False);
+            Assert.That(openDaqObject.IsDisposed, Is.False);
 
             //can do something with 'daqInstance' here
-            using var info = daqInstance.Info;
+            using var parameters = openDaqObject.Parameters;
 
-            var name = info.Name;
-            Console.WriteLine($"daqInstance name = '{name}'");
+            var count = parameters.Count;
+            Console.WriteLine($"openDaqObject.Parameters.Count = '{count}'");
         } //losing scope here, automatically calling Dispose() and thus freeing managed resources (release reference)
 
-        Assert.That(daqInstance.IsDisposed, Is.True);
+        Assert.That(openDaqObject.IsDisposed, Is.True);
     }
 
     [Test]
-    public void Test_0103_InstanceAutoDispose2()
+    public void Test_0103_ObjectAutoDispose2()
     {
         //instruct TearDown function not to collect and finalize managed objects explicitly
         base.DontCollectAndFinalize();
 
-        using var daqInstance = OpenDAQFactory.Instance(".");
+        using var openDaqObject = OpenDAQFactory.CreateLinearScaling(1.1, 0.2, SampleType.Float64, ScaledSampleType.Float64);
 
-        Assert.That(daqInstance.IsDisposed, Is.False);
+        Assert.That(openDaqObject.IsDisposed, Is.False);
 
         //can do something with 'daqInstance' here
-        using var info = daqInstance.Info;
+        using var parameters = openDaqObject.Parameters;
 
-        var name = info.Name;
-        Console.WriteLine($"daqInstance name = '{name}'");
+        var count = parameters.Count;
+        Console.WriteLine($"openDaqObject.Parameters.Count = '{count}'");
 
         //losing scope at the end of this method, automatically calling Dispose() and thus freeing managed resources (release reference)
     }


### PR DESCRIPTION
# Brief

Fixed AccessViolation on Garbage Collection.

# Description

When Garbage Collector destroys managed instance object before managed child objects (OPC UA connection), destruction of the child objects leads to a native AccesViolationException that cannot be caught in .NET.
With the instance the `ModuleManager` will also be destroyed, unloading the module libraries, rendering those child objects invalid.

This fix (lines 657+) uses `GC.ReRegisterForFinalize(this)` when the managed instance object is about to be released (`ReleaseReference()`) in the common `Dispose()` method. That way, the finalization of the instance is put at the end of the queue so that references to child objects are kept alive for finalization.

Edit: The CI tests had to be adapted, since the instance disposal is now delayed, so using a Scaling object instead of the Instance object now (this was no real use-case anyway).

There are also some improvements around the native pointer (thread-safety, zero-check).

# Usage example

n/a

# API changes

n/a

# Required application changes

n/a

# Required module changes

n/a
