### PR TITLE
Refactor child object cloning + thread safety

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -37,6 +37,7 @@
 
 ## Bug fixes
 
+- [#790](https://github.com/openDAQ/openDAQ/pull/794) Small refactor/fixing of child object cloning logic. Ensure thread safety on core event enabling.
 - [#790](https://github.com/openDAQ/openDAQ/pull/790) Fix input port to signal notification
 - [#778](https://github.com/openDAQ/openDAQ/pull/778) Fixing calling remote function with enumeration inside
 - [#776](https://github.com/openDAQ/openDAQ/pull/776) Fixing restoring struct fields while loading configuration

--- a/core/coreobjects/include/coreobjects/property_builder_impl.h
+++ b/core/coreobjects/include/coreobjects/property_builder_impl.h
@@ -275,7 +275,7 @@ public:
         if (value != nullptr)
         {
             const auto valuePtr = BaseObjectPtr::Borrow(value);
-            if (valuePtr.assigned())
+            if (valuePtr.assigned() && !valuePtr.supportsInterface(IPropertyObject::Id))
                 if (const auto freezable = valuePtr.asPtrOrNull<IFreezable>(); freezable.assigned())
                 {
                     const auto err = freezable->freeze();

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -69,12 +69,6 @@ namespace details
     }
 }
 
-namespace permissions
-{
-    static const auto DefaultPermissions =
-        PermissionsBuilder().inherit(false).assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
-}
-
 class PropertyImpl : public ImplementationOf<IProperty, ISerializable, IPropertyInternal, IOwnable>
 {
 protected:
@@ -118,8 +112,6 @@ public:
         propPtr = this->borrowPtr<PropertyPtr>();
         owner = nullptr;
 
-        if (this->defaultValue.supportsInterface<IPropertyObject>())
-            initDefaultPermissionManager();
         checkErrorInfo(validateDuringConstruction());
     }
 
@@ -219,13 +211,6 @@ public:
         const auto err = validateDuringConstruction();
         if (err != OPENDAQ_SUCCESS)
             throwExceptionFromErrorCode(err);
-
-        if (this->defaultValue.assigned())
-        {
-            initDefaultPermissionManager();
-            auto defaultValueObj = this->defaultValue.asPtr<IPropertyObject>();
-            defaultValueObj.getPermissionManager().asPtr<IPermissionManagerInternal>().setParent(this->defaultPermissionManager);
-        }
     }
 
     // FunctionProperty()
@@ -308,16 +293,6 @@ public:
         const auto err = validateDuringConstruction();
         if (err != OPENDAQ_SUCCESS)
             throwExceptionFromErrorCode(err);
-    }
-
-    void initDefaultPermissionManager()
-    {
-#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
-        defaultPermissionManager = PermissionManager();
-        defaultPermissionManager.setPermissions(permissions::DefaultPermissions);
-#else
-        defaultPermissionManager = DisabledPermissionManager();
-#endif
     }
 
     ErrCode INTERFACE_FUNC getValueType(CoreType* type) override
@@ -1228,7 +1203,7 @@ public:
 
             if (defaultValueObj.assigned())
             {
-                auto cloneableDefaultValue = defaultValue.asPtrOrNull<IPropertyObjectInternal>();
+                auto cloneableDefaultValue = defaultValue.asPtrOrNull<IPropertyObjectInternal>(true);
                 if (cloneableDefaultValue.assigned())
                     defaultValueObj = cloneableDefaultValue.clone();
             }
@@ -1428,14 +1403,14 @@ public:
 
         if (this->defaultValue.assigned())
         {
-            PermissionManagerPtr parentManager;
-            ErrCode err = owner->getPermissionManager(&parentManager);
-            OPENDAQ_RETURN_IF_FAILED(err);
+            if (const auto defaultValueObj = this->defaultValue.asPtrOrNull<IPropertyObject>(true); defaultValueObj.assigned())
+            {
+                PermissionManagerPtr parentManager;
+                ErrCode err = owner->getPermissionManager(&parentManager);
+                OPENDAQ_RETURN_IF_FAILED(err);
 
-            const auto defaultValueObj = this->defaultValue.asPtrOrNull<IPropertyObject>();
-
-            if (defaultValueObj.assigned())
-                defaultValueObj.getPermissionManager().asPtr<IPermissionManagerInternal>().setParent(parentManager);
+                defaultValueObj.getPermissionManager().asPtr<IPermissionManagerInternal>(true).setParent(parentManager);
+            }
         }
 
         return OPENDAQ_SUCCESS;
@@ -1461,7 +1436,6 @@ protected:
     CallableInfoPtr callableInfo;
     EventEmitter<PropertyObjectPtr, PropertyValueEventArgsPtr> onValueWrite;
     EventEmitter<PropertyObjectPtr, PropertyValueEventArgsPtr> onValueRead;
-    PermissionManagerPtr defaultPermissionManager;
 
 private:
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -44,6 +44,7 @@
 #include <coretypes/updatable.h>
 #include <coretypes/validation.h>
 #include <tsl/ordered_map.h>
+#include <atomic>
 #include <map>
 #include <thread>
 #include <utility>
@@ -379,7 +380,7 @@ protected:
     PropertyObjectPtr objPtr;
     int updateCount;
     UpdatingActions updatingPropsAndValues;
-    bool coreEventMuted;
+    std::atomic<bool> coreEventMuted;
     WeakRefPtr<ITypeManager> manager;
     PropertyOrderedMap localProperties;
     StringPtr path;
@@ -2720,7 +2721,8 @@ template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getCoreEventTrigger(IProcedure** trigger)
 {
     OPENDAQ_PARAM_NOT_NULL(trigger);
-
+    
+    auto lock = getRecursiveConfigLock();
     *trigger = this->triggerCoreEvent.addRefAndReturn();
     return OPENDAQ_SUCCESS;
 }
@@ -2728,6 +2730,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getCoreEvent
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setCoreEventTrigger(IProcedure* trigger)
 {
+    auto lock = getRecursiveConfigLock();
     this->triggerCoreEvent = trigger;
     return OPENDAQ_SUCCESS;
 }
@@ -2762,6 +2765,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPath(IStr
 {
     OPENDAQ_PARAM_NOT_NULL(path);
 
+    auto lock = getRecursiveConfigLock();
     if (this->path.getLength())
         return OPENDAQ_IGNORED;
 


### PR DESCRIPTION
# Brief
Small refactor/fixing of child object cloning logic. Ensure thread safety on core event enabling.

# Description

- When adding object-type properties, the default value of the property is first stored, then cloned and overridden in the property.
- `setPath` and `setCoreEventTrigger` are now under a lock.
- Removed default permission manager from property implementations.
