### PR TITLE
Move return macros to cutils.h

### DIFF
--- a/core/coretypes/include/coretypes/ctutils.h
+++ b/core/coretypes/include/coretypes/ctutils.h
@@ -348,6 +348,20 @@ ErrCode makeErrorInfo(ErrCode errCode, IBaseObject* source, const std::string& m
         daq::makeErrorInfo(__FILE__, __LINE__, errCode, nullptr, ##__VA_ARGS__)
 #endif
 
+#define OPENDAQ_RETURN_IF_FAILED_EXCEPT(errCode, expectedErrCode)                       \
+    do {                                                                                \
+        if ((errCode) == (expectedErrCode))                                             \
+            daqClearErrorInfo();                                                        \
+        else if (OPENDAQ_FAILED(errCode))                                               \
+            return DAQ_MAKE_ERROR_INFO(errCode, "Error propagated from lower level");   \
+    } while (0)
+
+#define OPENDAQ_RETURN_IF_FAILED(errCode) \
+    do { if (OPENDAQ_FAILED(errCode)) return DAQ_MAKE_ERROR_INFO(errCode, "Error propagated from lower level"); } while (0)
+
+#define OPENDAQ_PARAM_REQUIRE(cond) \
+    do { if (!(cond)) return OPENDAQ_ERR_INVALIDPARAMETER; } while (0)
+
 inline ErrCode errorFromException(const DaqException& e, IBaseObject* source = nullptr)
 {
 #ifdef NDEBUG

--- a/core/coretypes/include/coretypes/validation.h
+++ b/core/coretypes/include/coretypes/validation.h
@@ -26,20 +26,6 @@
 
 #ifdef OPENDAQ_ENABLE_PARAMETER_VALIDATION
 
-#define OPENDAQ_RETURN_IF_FAILED_EXCEPT(errCode, expectedErrCode)                       \
-    do {                                                                                \
-        if ((errCode) == (expectedErrCode))                                             \
-            daqClearErrorInfo();                                                        \
-        else if (OPENDAQ_FAILED(errCode))                                               \
-            return DAQ_MAKE_ERROR_INFO(errCode, "Error propagated from lower level");   \
-    } while (0)
-
-#define OPENDAQ_RETURN_IF_FAILED(errCode) \
-    do { if (OPENDAQ_FAILED(errCode)) return DAQ_MAKE_ERROR_INFO(errCode, "Error propagated from lower level"); } while (0)
-
-#define OPENDAQ_PARAM_REQUIRE(cond) \
-    do { if (!(cond)) return OPENDAQ_ERR_INVALIDPARAMETER; } while (0)
-
 #ifdef NDEBUG
     #define OPENDAQ_PARAM_NOT_NULL(param) \
         do { if (nullptr == (param)) return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ARGUMENT_NULL, "Parameter %s must not be null in the function \"%s\"", #param, __func__); } while (0)


### PR DESCRIPTION
# Brief

Moves the new return macros from validation.h to cutils.h to prevent build issues when `OPENDAQ_ENABLE_PARAMETER_VALIDATION` is off. 