### PR TITLE
Fix hidden components deserialization

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -38,6 +38,7 @@
 
 ## Bug fixes
 
+- [#805](https://github.com/openDAQ/openDAQ/pull/805) Fix hidden components deserialization
 - [#794](https://github.com/openDAQ/openDAQ/pull/794) Small refactor/fixing of child object cloning logic. Ensure thread safety on core event enabling.
 - [#790](https://github.com/openDAQ/openDAQ/pull/790) Fix input port to signal notification
 - [#778](https://github.com/openDAQ/openDAQ/pull/778) Fixing calling remote function with enumeration inside

--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -38,7 +38,7 @@
 
 ## Bug fixes
 
-- [#805](https://github.com/openDAQ/openDAQ/pull/805) Fix hidden components deserialization
+- [#806](https://github.com/openDAQ/openDAQ/pull/806) Fix hidden components deserialization
 - [#794](https://github.com/openDAQ/openDAQ/pull/794) Small refactor/fixing of child object cloning logic. Ensure thread safety on core event enabling.
 - [#790](https://github.com/openDAQ/openDAQ/pull/790) Fix input port to signal notification
 - [#778](https://github.com/openDAQ/openDAQ/pull/778) Fixing calling remote function with enumeration inside

--- a/core/opendaq/opendaq/mocks/advanced_components_setup_utils.cpp
+++ b/core/opendaq/opendaq/mocks/advanced_components_setup_utils.cpp
@@ -181,6 +181,12 @@ MockFb1Impl::MockFb1Impl(const ContextPtr& ctx, const ComponentPtr& parent, cons
     sig2.setDomainSignal(sigDomain);
 
     createAndAddInputPort("ip", PacketReadyNotification::None);
+
+    auto hiddenInputPort = createAndAddInputPort("ip_hidden", PacketReadyNotification::None);
+    auto addedComponentPrivate = hiddenInputPort.asPtr<IComponentPrivate>(true);
+    addedComponentPrivate.unlockAttributes(List<IString>("Visible"));
+    hiddenInputPort.setVisible(false);
+    addedComponentPrivate.lockAttributes(List<IString>("Visible"));
 }
 
 DictPtr<IString, IFunctionBlockType> MockFb1Impl::onGetAvailableFunctionBlockTypes()
@@ -233,9 +239,15 @@ MockChannel1Impl::MockChannel1Impl(const ContextPtr& ctx, const ComponentPtr& pa
     objPtr.addProperty(BoolPropertyBuilder("TestStringPropWritten", false).setReadOnly(true).build());
     objPtr.getOnPropertyValueWrite("TestStringProp") +=
         [&](PropertyObjectPtr&, PropertyValueEventArgsPtr&) { objPtr.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue("TestStringPropWritten", true); };
+
     const auto valueSig = createAndAddSignal("sig_ch");
     const auto domainSig = createAndAddSignal("sig_ch_time");
     valueSig.setDomainSignal(domainSig);
+
+    const auto hiddenValueSig = createAndAddSignal("sig_ch_hidden", nullptr, false);
+    const auto hiddenDomainSig = createAndAddSignal("sig_ch_time_hidden", nullptr, false);
+    hiddenValueSig.setDomainSignal(hiddenDomainSig);
+
     const auto childFb = createWithImplementation<IFunctionBlock, MockFb1Impl>(ctx, this->functionBlocks, "childFb");
     addNestedFunctionBlock(childFb);
 }
@@ -264,6 +276,7 @@ MockDevice1Impl::MockDevice1Impl(const ContextPtr& ctx, const ComponentPtr& pare
     addNestedFunctionBlock(fb);
 
     fb.getInputPorts()[0].connect(sig);
+    fb.getInputPorts(search::Not(search::Visible()))[0].connect(sig);
 
     setDeviceDomain(DeviceDomain(Ratio(1, 100), "N/A" , Unit("s", -1, "second", "time")));
 }

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -9,6 +9,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <opendaq/search_filter_factory.h>
 #include <opendaq/mirrored_device_config.h>
 #include <opendaq/custom_log.h>
 #include <opendaq/device_private.h>
@@ -828,7 +829,7 @@ void InstanceImpl::forEachComponent(const ComponentPtr& component, F&& callback)
         const auto folder = component.asPtrOrNull<IFolder>(true);
         if (folder.assigned())
         {
-            for (const auto item : folder.getItems())
+            for (const auto item : folder.getItems(search::Any()))
                 forEachComponent(item, std::forward<F>(callback));
         }
     }

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -881,7 +881,7 @@ void ConfigProtocolClientComm::forEachComponent(const ComponentPtr& component, c
     const auto folder = component.asPtrOrNull<IFolder>(true);
     if (folder.assigned())
     {
-        for (const auto item : folder.getItems())
+        for (const auto item : folder.getItems(search::Any()))
             forEachComponent<Interface>(item, f);
     }
 }

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -97,10 +97,18 @@ TEST_F(ConfigProtocolIntegrationTest, Connect)
 
 TEST_F(ConfigProtocolIntegrationTest, InputPortConnected)
 {
+    // visible input ports
     ASSERT_EQ(serverDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts()[0].getSignal(),
               serverDevice.getDevices()[0].getSignals()[0]);
 
     ASSERT_EQ(clientDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts()[0].getSignal(),
+              clientDevice.getDevices()[0].getSignals()[0]);
+
+    // hidden input ports
+    ASSERT_EQ(serverDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts(search::Not(search::Visible()))[0].getSignal(),
+              serverDevice.getDevices()[0].getSignals()[0]);
+
+    ASSERT_EQ(clientDevice.getDevices()[0].getFunctionBlocks()[0].getInputPorts(search::Not(search::Visible()))[0].getSignal(),
               clientDevice.getDevices()[0].getSignals()[0]);
 }
 
@@ -442,11 +450,19 @@ TEST_F(ConfigProtocolIntegrationTest, SetStructPropertyValue)
 
 TEST_F(ConfigProtocolIntegrationTest, DomainSignals)
 {
+    // visible signals
     ASSERT_EQ(serverDevice.getDevices()[0].getChannels()[0].getSignals()[0].getDomainSignal(),
               serverDevice.getDevices()[0].getChannels()[0].getSignals()[1]);
 
     ASSERT_EQ(clientDevice.getDevices()[0].getChannels()[0].getSignals()[0].getDomainSignal(),
               clientDevice.getDevices()[0].getChannels()[0].getSignals()[1]);
+
+    // hidden signals
+    ASSERT_EQ(serverDevice.getDevices()[0].getChannels()[0].getSignals(search::Not(search::Visible()))[0].getDomainSignal(),
+              serverDevice.getDevices()[0].getChannels()[0].getSignals(search::Not(search::Visible()))[1]);
+
+    ASSERT_EQ(clientDevice.getDevices()[0].getChannels()[0].getSignals(search::Not(search::Visible()))[0].getDomainSignal(),
+              clientDevice.getDevices()[0].getChannels()[0].getSignals(search::Not(search::Visible()))[1]);
 }
 
 TEST_F(ConfigProtocolIntegrationTest, BeginEndUpdate)


### PR DESCRIPTION
# Brief

Fix issue with domain signals missing for hidden signals of device connected via native configuration protocol

# Description

Previously, domain signals were not assigned for hidden signals when connected via the native configuration protocol. 
The configuration client handled domain assignment (for signals) and connected signal resolution (for input ports) only for visible components, now it does so also for hidden ones.