### PR TITLE
Device operation mode switching in Python GUI Demo Application

### DIFF
--- a/bindings/python/opendaq/generated/device/py_device.cpp
+++ b/bindings/python/opendaq/generated/device/py_device.cpp
@@ -386,14 +386,19 @@ void defineIDevice(pybind11::module_ m, PyDaqIntf<daq::IDevice, daq::IFolder> cl
         py::return_value_policy::take_ownership,
         "Gets a list of available operation modes for the device.");
     cls.def_property("operation_mode",
-        nullptr,
+        [](daq::IDevice *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::DevicePtr::Borrow(object);
+            return objectPtr.getOperationMode();
+        },
         [](daq::IDevice *object, daq::OperationModeType modeType)
         {
             py::gil_scoped_release release;
             const auto objectPtr = daq::DevicePtr::Borrow(object);
             objectPtr.setOperationMode(modeType);
         },
-        "Sets the operation mode of the device subtree excluding the sub-devices.");
+        "Gets the operation mode of the device subtree excluding the sub-devices. / Sets the operation mode of the device subtree excluding the sub-devices.");
     cls.def_property("operation_mode_recursive",
         nullptr,
         [](daq::IDevice *object, daq::OperationModeType modeType)

--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -6,7 +6,7 @@
 
 ## Python
 
-
+- [#807](https://github.com/openDAQ/openDAQ/pull/807) Enable Device operation mode switching in Python GUI Demo Application.
 
 ## Bug fixes
 

--- a/examples/cpp/quick_start/quick_start_empty.cpp
+++ b/examples/cpp/quick_start/quick_start_empty.cpp
@@ -3,10 +3,10 @@
  * example can be found in app_quick_start_full.cpp
  */
 
-#include <opendaq/opendaq.h>
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <opendaq/opendaq.h>
 
 int main(int /*argc*/, const char* /*argv*/[])
 {
@@ -16,4 +16,4 @@ int main(int /*argc*/, const char* /*argv*/[])
     std::cout << "Press \"enter\" to exit the application..." << std::endl;
     std::cin.get();
     return 0;
-}
+} 

--- a/examples/cpp/quick_start/quick_start_empty.cpp
+++ b/examples/cpp/quick_start/quick_start_empty.cpp
@@ -13,7 +13,20 @@ int main(int /*argc*/, const char* /*argv*/[])
     // Create an Instance, loading modules at MODULE_PATH
     const daq::InstancePtr instance = daq::Instance(MODULE_PATH);
 
-    std::cout << "Press \"enter\" to exit the application..." << std::endl;
+    auto device = instance.addDevice("daqref://device0");
+
+    auto modes = device.getAvailableOperationModes();
+    std::cout << "Available operation modes:\n";
+    for (const auto& mode : modes) {
+        std::cout << "  " << mode << "\n";
+    }
+
+    auto oldMode = device.getOperationMode();
+    device.setOperationMode(daq::OperationModeType::Idle);
+    auto newMode = device.getOperationMode();
+
+
+    std::cout << "Press \"enter\" to exit the application...\n";
     std::cin.get();
     return 0;
 } 

--- a/examples/cpp/quick_start/quick_start_empty.cpp
+++ b/examples/cpp/quick_start/quick_start_empty.cpp
@@ -3,30 +3,17 @@
  * example can be found in app_quick_start_full.cpp
  */
 
+#include <opendaq/opendaq.h>
 #include <chrono>
 #include <iostream>
 #include <thread>
-#include <opendaq/opendaq.h>
 
 int main(int /*argc*/, const char* /*argv*/[])
 {
     // Create an Instance, loading modules at MODULE_PATH
     const daq::InstancePtr instance = daq::Instance(MODULE_PATH);
 
-    auto device = instance.addDevice("daqref://device0");
-
-    auto modes = device.getAvailableOperationModes();
-    std::cout << "Available operation modes:\n";
-    for (const auto& mode : modes) {
-        std::cout << "  " << mode << "\n";
-    }
-
-    auto oldMode = device.getOperationMode();
-    device.setOperationMode(daq::OperationModeType::Idle);
-    auto newMode = device.getOperationMode();
-
-
-    std::cout << "Press \"enter\" to exit the application...\n";
+    std::cout << "Press \"enter\" to exit the application..." << std::endl;
     std::cin.get();
     return 0;
-} 
+}

--- a/examples/python/gui_demo/components/block_view.py
+++ b/examples/python/gui_demo/components/block_view.py
@@ -1,7 +1,9 @@
+import tkinter
 import tkinter as tk
 from tkinter import ttk
 
 import opendaq as daq
+from opendaq import OperationModeType
 
 from ..event_port import EventPort
 from .input_ports_view import InputPortsView
@@ -9,9 +11,7 @@ from .output_signals_view import OutputSignalsView
 from .properties_view import PropertiesView
 from .attributes_dialog import AttributesDialog
 
-
 class BlockView(ttk.Frame):
-
     def __init__(self, parent, node, context=None, expanded=False, **kwargs):
         ttk.Frame.__init__(self, parent, **kwargs)
         self.parent = parent
@@ -95,6 +95,42 @@ class BlockView(ttk.Frame):
                 self.label_icon.config(image=self.device_img)
                 self.cols = [0, 1]
                 self.rows = [0]
+
+                opts = ["Unknown", "Idle", "Operation", "SafeOperation"]
+                op_mode = self.node.operation_mode
+                mode_string = ""
+                if op_mode == OperationModeType.Unknown:
+                    mode_string = "Unknown"
+                elif op_mode == OperationModeType.Idle:
+                    mode_string = "Idle"
+                elif op_mode == OperationModeType.Operation:
+                    mode_string = "Operation"
+                elif op_mode == OperationModeType.SafeOperation:
+                    mode_string = "SafeOperation"
+
+                opt = tkinter.StringVar(value=mode_string)
+                def on_option_change(*args):
+                    var = opt.get()
+                    if var == "Unknown":
+                        self.node.operation_mode = OperationModeType.Unknown
+                    elif var == "Idle":
+                        self.node.operation_mode = OperationModeType.Idle
+                    elif var == "Operation":
+                        self.node.operation_mode = OperationModeType.Operation
+                    elif var == "SafeOperation":
+                        self.node.operation_mode = OperationModeType.SafeOperation
+
+                opt.trace_add("write", on_option_change)
+
+                combined = tk.Frame(self.expanded_frame)
+                combined.grid(row=1, column=0, padx=5, pady=5)
+
+                label = tk.Label(combined, text="Operation mode: ")
+                label.pack(side="left")
+                options = tkinter.OptionMenu(combined, opt, *opts)
+                options.pack(side="left")
+
+
             elif daq.IFunctionBlock.can_cast_from(self.node):
                 self.node = daq.IFunctionBlock.cast_from(self.node)
                 self.properties = PropertiesView(

--- a/examples/python/gui_demo/components/block_view.py
+++ b/examples/python/gui_demo/components/block_view.py
@@ -1,4 +1,3 @@
-import tkinter
 import tkinter as tk
 from tkinter import ttk
 
@@ -117,7 +116,7 @@ class BlockView(ttk.Frame):
                 elif op_mode == daq.OperationModeType.SafeOperation:
                     mode_string = "SafeOperation"
 
-                opt = tkinter.StringVar(value=mode_string)
+                opt = tk.StringVar(value=mode_string)
                 def on_option_change(*args):
                     var = opt.get()
                     if var == "Unknown":
@@ -136,7 +135,7 @@ class BlockView(ttk.Frame):
 
                 label = tk.Label(combined, text="Operation mode: ")
                 label.pack(side="left")
-                options = tkinter.OptionMenu(combined, opt, *available_op_modes)
+                options = tk.OptionMenu(combined, opt, *available_op_modes)
                 options.pack(side="left")
 
 

--- a/examples/python/gui_demo/components/block_view.py
+++ b/examples/python/gui_demo/components/block_view.py
@@ -96,7 +96,17 @@ class BlockView(ttk.Frame):
                 self.cols = [0, 1]
                 self.rows = [0]
 
-                opts = ["Unknown", "Idle", "Operation", "SafeOperation"]
+                available_op_modes = []
+                op_modes_nums = list(self.node.available_operation_modes)
+                if 0 in op_modes_nums:
+                    available_op_modes.append("Unknown")
+                if 1 in op_modes_nums:
+                    available_op_modes.append("Idle")
+                if 2 in op_modes_nums:
+                    available_op_modes.append("Operation")
+                if 3 in op_modes_nums:
+                    available_op_modes.append("SafeOperation")
+
                 op_mode = self.node.operation_mode
                 mode_string = ""
                 if op_mode == OperationModeType.Unknown:
@@ -127,7 +137,7 @@ class BlockView(ttk.Frame):
 
                 label = tk.Label(combined, text="Operation mode: ")
                 label.pack(side="left")
-                options = tkinter.OptionMenu(combined, opt, *opts)
+                options = tkinter.OptionMenu(combined, opt, *available_op_modes)
                 options.pack(side="left")
 
 

--- a/examples/python/gui_demo/components/block_view.py
+++ b/examples/python/gui_demo/components/block_view.py
@@ -3,7 +3,6 @@ import tkinter as tk
 from tkinter import ttk
 
 import opendaq as daq
-from opendaq import OperationModeType
 
 from ..event_port import EventPort
 from .input_ports_view import InputPortsView
@@ -109,26 +108,26 @@ class BlockView(ttk.Frame):
 
                 op_mode = self.node.operation_mode
                 mode_string = ""
-                if op_mode == OperationModeType.Unknown:
+                if op_mode == daq.OperationModeType.Unknown:
                     mode_string = "Unknown"
-                elif op_mode == OperationModeType.Idle:
+                elif op_mode == daq.OperationModeType.Idle:
                     mode_string = "Idle"
-                elif op_mode == OperationModeType.Operation:
+                elif op_mode == daq.OperationModeType.Operation:
                     mode_string = "Operation"
-                elif op_mode == OperationModeType.SafeOperation:
+                elif op_mode == daq.OperationModeType.SafeOperation:
                     mode_string = "SafeOperation"
 
                 opt = tkinter.StringVar(value=mode_string)
                 def on_option_change(*args):
                     var = opt.get()
                     if var == "Unknown":
-                        self.node.operation_mode = OperationModeType.Unknown
+                        self.node.operation_mode = daq.OperationModeType.Unknown
                     elif var == "Idle":
-                        self.node.operation_mode = OperationModeType.Idle
+                        self.node.operation_mode = daq.OperationModeType.Idle
                     elif var == "Operation":
-                        self.node.operation_mode = OperationModeType.Operation
+                        self.node.operation_mode = daq.OperationModeType.Operation
                     elif var == "SafeOperation":
-                        self.node.operation_mode = OperationModeType.SafeOperation
+                        self.node.operation_mode = daq.OperationModeType.SafeOperation
 
                 opt.trace_add("write", on_option_change)
 

--- a/examples/python/gui_demo/components/block_view.py
+++ b/examples/python/gui_demo/components/block_view.py
@@ -9,7 +9,9 @@ from .output_signals_view import OutputSignalsView
 from .properties_view import PropertiesView
 from .attributes_dialog import AttributesDialog
 
+
 class BlockView(ttk.Frame):
+
     def __init__(self, parent, node, context=None, expanded=False, **kwargs):
         ttk.Frame.__init__(self, parent, **kwargs)
         self.parent = parent


### PR DESCRIPTION
# Brief

Enable Device operation mode switching in Python GUI Demo Application.

# Description

- Add `operation_mode` getter to Python bindings
- Add logic to handle operation mode switching though Python GUI Demo App

# Usage example

In Python GUI Demo App use:
![image](https://github.com/user-attachments/assets/d809cca7-ad98-4c53-ab69-f59d6b231dc2)
