### PR TITLE
Fix examples CMake

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(OPENDAQ_EXAMPLES_VERSION ${OPENDAQ_PACKAGE_VERSION})
+if(NOT DEFINED OPENDAQ_PACKAGE_VERSION)
+  set(OPENDAQ_EXAMPLES_VERSION "0.0.0")
+elseif ()
+  set(OPENDAQ_EXAMPLES_VERSION ${OPENDAQ_PACKAGE_VERSION})
+endif()
+
 project(opendaq_examples VERSION ${OPENDAQ_EXAMPLES_VERSION})
+
+add_compile_definitions(MODULE_PATH="${OPENDAQ_MODULES_DIR}")
 
 option(OPENDAQ_CONSOLE_APP "Console application example." ON)
 option(OPENDAQ_DEVICE "Device example without a discovery server." ON)


### PR DESCRIPTION
# Brief

Fix examples CMake, which fixes examples when downloaded as solo archive via https://docs.opendaq.com/ or https://docs-dev.opendaq.com/ (when not part of whole openDAQ project)

# Description

* Set missing CMake variable `OPENDAQ_EXAMPLES_VERSION` that is amiss only if examples are downloaded solo via downloads webpage
* Set CMake variable `MODULE_PATH` in examples

(Individual high-level changes)

- Add Python GUI Demo functionality
- Rename a function
- ...

# Usage example

https://docs-dev.opendaq.com/manual/opendaq/dev/tutorials/quick_start_setting_up_cpp.html