### PR TITLE
Fixing freezing the gui demo on calling function property with args. gui demo improvements

### DIFF
--- a/examples/python/gui_demo/components/dialog.py
+++ b/examples/python/gui_demo/components/dialog.py
@@ -15,6 +15,9 @@ class Dialog(tk.Toplevel):
         self.configure(padx=10, pady=5)
         self.attributes('-topmost', True)
         self.transient(parent)
+        
+        # Bind Escape key to close the dialog
+        self.bind("<Escape>", lambda event: self.close())
 
     def center_window(self):
         main_window = self.parent.winfo_toplevel()
@@ -29,5 +32,9 @@ class Dialog(tk.Toplevel):
         self.center_window()
         if self.initial_update_func is not None:
             self.initial_update_func()
-        self.grab_set()
+        self.grab_set()         # Prevent interaction with other windows
+        self.focus_set()        # Ensure focus is on this dialog
         self.wait_window(self)
+        
+    def close(self):
+        self.destroy()

--- a/examples/python/gui_demo/components/edit_container_property.py
+++ b/examples/python/gui_demo/components/edit_container_property.py
@@ -195,6 +195,3 @@ class EditContainerPropertyDialog(Dialog):
         if self.property.value != self.data:
             self.property.value = self.data
             self.event_port.emit()
-
-    def close(self):
-        self.destroy()

--- a/examples/python/gui_demo/components/function_dialog.py
+++ b/examples/python/gui_demo/components/function_dialog.py
@@ -100,13 +100,13 @@ class FunctionDialog(Dialog):
     def exec_clicked(self):
         ret = None
         try:
-            args = []
+            list = daq.List()
             if self.node.callable_info.arguments:
                 for argument in self.node.callable_info.arguments:
-                    args.append(self.create_argument(argument.Type,
+                    list.push_back(self.create_argument(argument.Type,
                                 self.arguments[argument.Name].get()))
 
-            ret = self.function(*args)
+            ret = self.function(list)
         except (Exception, ValueError) as e:
             ret = e
         self.return_value.set(str(ret))


### PR DESCRIPTION
…window in focus. add closing the windows on escape

# Brief

(Concise one-line description of what changed and what was added/removed, maybe even why)



# Description

(Individual high-level changes)

- Add Python GUI Demo functionality
- Rename a function
- ...

# Usage example

In C++ use:

```cpp
auto variable = "foo";
```

In terminal use:

```shell
cd folder
```

# API changes

> [!NOTE]
> Modifying, removing, or adding a function to an interface inherited by another, breaks binary compatibility of module shared libraries

(An overview of changes on the interface level (abstract structs with pure virtual functions), if any, one function per line)

```diff
+ this
- that
```

# Required application changes

(Changes required in openDAQ applications/executables)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```

# Required module changes

(Changes required in openDAQ shared libraries/modules)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```
