### PR TITLE
Fix Incorrect SDK Version Display for Devices with SDK <3.10.3

### DIFF
--- a/shared/libraries/discovery/src/daq_discovery_client.cpp
+++ b/shared/libraries/discovery/src/daq_discovery_client.cpp
@@ -29,6 +29,8 @@ std::vector<MdnsDiscoveredDevice> DiscoveryClient::discoverMdnsDevices() const
         if (verifyDiscoveredDevice(device))
         {
             device.properties.erase("caps");
+            if (device.getPropertyOrDefault("sdkVersion").empty())
+                device.properties["sdkVersion"] = "<3.10.3";
             discovered.push_back(device);
         }
     }


### PR DESCRIPTION
# Brief

For devices using SDK versions older than 3.10.3, the displayed SDK version was incorrectly showing the client’s version. Since the actual version can’t be retrieved, we now indicate it as "<3.10.3".

# Description

Older SDK versions don’t include the SDK version in their mDNS TXT records. As a result, the client defaulted to its own SDK version when displaying device info. This has been fixed by explicitly setting sdkVersion to "<3.10.3" when the version is missing.