### PR TITLE
lt2: tolerate signals without valid descriptors

### DIFF
--- a/modules/new_websocket_streaming_server_module/src/signal_writer_factory.cpp
+++ b/modules/new_websocket_streaming_server_module/src/signal_writer_factory.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -13,9 +14,18 @@
 daq::ws_streaming::signal_writer_factory daq::ws_streaming::create_signal_writer_factory(daq::SignalPtr& signal)
 {
     if (!signal.getDescriptor().assigned())
-        throw std::domain_error("can't determine appropriate signal_writer implementation: signal has no descriptor or no attached rule");
+    {
+        std::cerr << "[ws-streaming] can't determine appropriate signal_writer for '"
+            << signal.getGlobalId() << "': signal has no descriptor" << std::endl;
+        return {};
+    }
+
     if (!signal.getDescriptor().getRule().assigned())
-        throw std::domain_error("can't determine appropriate signal_writer implementation: signal descriptor has no attached rule");
+    {
+        std::cerr << "[ws-streaming] can't determine appropriate signal_writer for '"
+            << signal.getGlobalId() << "': signal descriptor has no attached rule" << std::endl;
+        return {};
+    }
 
     switch (signal.getDescriptor().getRule().getType())
     {
@@ -32,8 +42,9 @@ daq::ws_streaming::signal_writer_factory daq::ws_streaming::create_signal_writer
                 { return std::make_unique<explicit_signal_writer>(signo, client); };
 
         default:
-            throw std::domain_error(
-                "can't determine appropriate signal_writer implementation: unsupported rule: " +
-                std::to_string(static_cast<int>(signal.getDescriptor().getRule().getType())));
+            std::cerr << "[ws-streaming] can't determine appropriate signal_writer for '"
+                << signal.getGlobalId() << "': unsupported rule: "
+                << std::to_string(static_cast<int>(signal.getDescriptor().getRule().getType())) << std::endl;
+            return {};
     }
 }

--- a/modules/new_websocket_streaming_server_module/src/websocket_server.cpp
+++ b/modules/new_websocket_streaming_server_module/src/websocket_server.cpp
@@ -33,16 +33,38 @@ daq::ws_streaming::server::server(daq::DevicePtr device, std::uint16_t ws_port, 
     {
         if (listeners.find(signal.getGlobalId()) == listeners.end())
         {
+            try
+            {
+                daq::InputPortNotificationsPtr notifications = WebSocketSignalListener_Create(device, signal, signo++);
+                listeners.emplace(std::piecewise_construct, std::make_tuple(signal.getGlobalId()), std::make_tuple(std::move(notifications)));
+            }
+
+            catch (const std::exception& ex)
+            {
+                std::cerr << "[ws-streaming] ignoring signal '"
+                    << signal.getGlobalId()
+                    << "': " << ex.what() << std::endl;
+            }
+
             available.push_back(signal.getGlobalId());
-            daq::InputPortNotificationsPtr notifications = WebSocketSignalListener_Create(device, signal, signo++);
-            listeners.emplace(std::piecewise_construct, std::make_tuple(signal.getGlobalId()), std::make_tuple(std::move(notifications)));
         }
 
         if (auto domainSignal = signal.getDomainSignal(); domainSignal.assigned() && listeners.find(domainSignal.getGlobalId()) == listeners.end())
         {
+            try
+            {
+                daq::InputPortNotificationsPtr notifications = WebSocketSignalListener_Create(device, domainSignal, signo++);
+                listeners.emplace(std::piecewise_construct, std::make_tuple(domainSignal.getGlobalId()), std::make_tuple(std::move(notifications)));
+            }
+
+            catch (const std::exception& ex)
+            {
+                std::cerr << "[ws-streaming] ignoring signal '"
+                    << domainSignal.getGlobalId()
+                    << "': " << ex.what() << std::endl;
+            }
+
             available.push_back(domainSignal.getGlobalId());
-            daq::InputPortNotificationsPtr notifications = WebSocketSignalListener_Create(device, domainSignal, signo++);
-            listeners.emplace(std::piecewise_construct, std::make_tuple(domainSignal.getGlobalId()), std::make_tuple(std::move(notifications)));
         }
     }
 

--- a/modules/new_websocket_streaming_server_module/src/websocket_signal_listener_impl.cpp
+++ b/modules/new_websocket_streaming_server_module/src/websocket_signal_listener_impl.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <utility>
 
 #include <boost/asio.hpp>
@@ -29,6 +30,11 @@ daq::ws_streaming::WebSocketSignalListenerImpl::WebSocketSignalListenerImpl(
     , signo(signo)
     , writer_factory(create_signal_writer_factory(signal))
 {
+    // XXX TODO: We should lazy-initialize metadata and handle signals that
+    // change writer types (maybe even from unsupported to supported) at runtime.
+    if (!writer_factory)
+        throw std::runtime_error("Signal '" + signal.getGlobalId() + "' is of an unsupported type");
+
     internalAddRef();
 }
 


### PR DESCRIPTION
# Brief

The new ws-streaming (LT) server requires signals to have valid descriptors at the moment the server is created. This needs to be revisited and improved. As a short-term improvement, this PR changes it from a fatal error to a non-fatal one: signals without valid descriptors are simply ignored and will not be streamable.

In the future the code needs to be improved to "lazy-initialize" signals, so that the descriptors are only needed from the first data packet.