### PR TITLE
Fix: Assign Correct Type Manager to Deserialized Property Object Classes on Native client

### DIFF
--- a/core/coreobjects/src/property_object_class_builder_impl.cpp
+++ b/core/coreobjects/src/property_object_class_builder_impl.cpp
@@ -81,8 +81,7 @@ ErrCode PropertyObjectClassBuilderImpl::addProperty(IProperty* property)
         auto defaultValue = p.asPtr<IPropertyInternal>().getDefaultValueUnresolved();
         if (auto freezable = defaultValue.asPtrOrNull<IFreezable>(); freezable.assigned())
         {
-            if (!freezable.isFrozen())
-                freezable.freeze();
+            freezable.freeze();
         }
 
         return OPENDAQ_SUCCESS;

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -30,6 +30,7 @@
 #include <opendaq/custom_log.h>
 #include <config_protocol/config_protocol_streaming_producer.h>
 #include <coreobjects/property_object_class_factory.h>
+#include <coreobjects/property_internal_ptr.h>
 
 namespace daq::config_protocol
 {


### PR DESCRIPTION
# Brief

Resolved an issue where deserialized property object classes held weak references to a temporary type manager, causing exceptions during access.

# Description

During the deserialization process on the native client, a temporary type manager is created to reconstruct the type tree. Once deserialization is complete, the client’s main type manager is populated with types from this temporary instance. However, property object classes deserialized during this process retained weak references to the temporary type manager. This led to runtime exceptions when these classes were accessed after the temporary manager was discarded.
To fix this, we now explicitly clone the property object classes and reassign them to use the correct, persistent client type manager, ensuring stability and correctness post-deserialization.