### PR TITLE
Fix: Assign Correct Type Manager to Deserialized Property Object Classes on Native client

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object_class.h
+++ b/core/coreobjects/include/coreobjects/property_object_class.h
@@ -18,6 +18,7 @@
 #include <coretypes/listobject.h>
 #include <coreobjects/property.h>
 #include <coretypes/type_ptr.h>
+#include <coretypes/type_manager.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -29,6 +30,9 @@ struct IPropertyObjectClassBuilder;
  * @{
  */
 
+/*#
+ * [interfaceSmartPtr(ITypeManager, TypeManagerPtr, "<coretypes/type_manager_ptr.h>")]
+ */
 /*!
  * @brief Container of properties that can be used as a base class when instantiating a Property object.
  *
@@ -86,6 +90,13 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObjectClass, IType)
      * not listed in the custom sorting order are listed at the end of the properties list, sorted in insertion order.
      */
     virtual ErrCode INTERFACE_FUNC getProperties(Bool includeInherited, IList** properties) = 0;
+
+    /*!
+     * @brief Clones the property object class.
+     * @param[out] cloned The cloned property object class.
+     * @param typeManager The type manager to use for the cloned property object class. if type manager is not provided, cloned class will store a type manager from the original class.
+     */
+    virtual ErrCode INTERFACE_FUNC clone(IPropertyObjectClass** cloned, ITypeManager* typeManager = nullptr) = 0;
 };
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/property_object_class_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_class_impl.h
@@ -43,6 +43,7 @@ public:
     ErrCode INTERFACE_FUNC getProperty(IString* propertyName, IProperty** property) override;
     ErrCode INTERFACE_FUNC hasProperty(IString* propertyName, Bool* hasProperty) override;
     ErrCode INTERFACE_FUNC getProperties(Bool includeInherited, IList** properties) override;
+    ErrCode INTERFACE_FUNC clone(IPropertyObjectClass** cloned, ITypeManager* typeManager = nullptr) override;
 
     ErrCode INTERFACE_FUNC serialize(ISerializer* serializer) override;
     ErrCode INTERFACE_FUNC getSerializeId(ConstCharPtr* id) const override;

--- a/core/coreobjects/src/property_object_class_impl.cpp
+++ b/core/coreobjects/src/property_object_class_impl.cpp
@@ -4,8 +4,10 @@
 #include <coreobjects/errors.h>
 #include <coreobjects/property_internal_ptr.h>
 
-#include "property_object_class_ptr.h"
-#include "coreobjects/property_object_class_factory.h"
+#include <coreobjects/property_object_class_builder.h>
+#include <coreobjects/property_object_internal.h>
+#include <property_object_class_ptr.h>
+#include <coreobjects/property_object_class_factory.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 PropertyObjectClassImpl::PropertyObjectClassImpl(IPropertyObjectClassBuilder* builder)
@@ -19,11 +21,8 @@ PropertyObjectClassImpl::PropertyObjectClassImpl(IPropertyObjectClassBuilder* bu
     for (const auto& [name, prop] : props)
         this->props.emplace(name, prop);
 
-    const ListPtr<IString> customOrder = builderPtr.getPropertyOrder();
-    for (const auto& name : customOrder)
-        this->customOrder.push_back(name);
+    this->customOrder = builderPtr.getPropertyOrder().toVector();
 }
-
 
 ErrCode PropertyObjectClassImpl::getName(IString** typeName)
 {
@@ -378,15 +377,35 @@ ErrCode PropertyObjectClassImpl::getSerializeId(ConstCharPtr* id) const
 
 ErrCode PropertyObjectClassImpl::toString(CharPtr* str)
 {
-    if (str == nullptr)
-    {
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ARGUMENT_NULL, "Parameter must not be null");
-    }
+    OPENDAQ_PARAM_NOT_NULL(str);
 
     std::ostringstream stream;
     stream << "PropertyObjectClass {" << name << "}";
 
     return daqDuplicateCharPtr(stream.str().c_str(), str);
+}
+
+ErrCode PropertyObjectClassImpl::clone(IPropertyObjectClass** cloned, ITypeManager* typeManager)
+{
+    OPENDAQ_PARAM_NOT_NULL(cloned);
+
+    return daqTry([&]
+    {
+        TypeManagerPtr managerPtr(typeManager);
+        if (!managerPtr.assigned())
+            managerPtr = this->manager.getRef();
+
+        auto builder = PropertyObjectClassBuilder(this->name, managerPtr);
+        builder.setParentName(this->parent);
+
+        for (const auto& [_, prop] : this->props)
+            builder.addProperty(prop.asPtr<IPropertyInternal>(true).clone());
+
+        builder.setPropertyOrder(ListPtr<IString>::FromVector(this->customOrder));
+
+        PropertyObjectClassPtr clonedObj = builder.build();
+        *cloned = clonedObj.detach();
+    });
 }
 
 OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(


### PR DESCRIPTION
#Brief

Resolved an issue where deserialized property object classes held weak references to a temporary type manager, causing exceptions during access.

#Description

During the deserialization process on the native client, a temporary type manager is created to reconstruct the type tree. Once deserialization is complete, the client’s main type manager is populated with types from this temporary instance. However, property object classes deserialized during this process retained weak references to the temporary type manager. This led to runtime exceptions when these classes were accessed after the temporary manager was discarded. To fix this, we now explicitly clone the property object classes and reassign them to use the correct, persistent client type manager, ensuring stability and correctness post-deserialization. 
