### PR TITLE
Change daqStringToInterfaceId signature to C compatible, rewrite it without regex for optimization

### DIFF
--- a/core/corecontainers/src/dictobject_impl.cpp
+++ b/core/corecontainers/src/dictobject_impl.cpp
@@ -486,7 +486,7 @@ ErrCode INTERFACE_FUNC deserializeDict(ISerializedObject* ser, IBaseObject* cont
     {
         StringPtr str;
         ser->readString(String("keyIntfID"), &str);
-        daqStringToInterfaceId(str, keyId);
+        daqStringToInterfaceId(str.getCharPtr(), keyId);
     }
     
     hasKey = false;
@@ -496,7 +496,7 @@ ErrCode INTERFACE_FUNC deserializeDict(ISerializedObject* ser, IBaseObject* cont
     {
         StringPtr str;
         ser->readString(String("valueIntfID"), &str);
-        daqStringToInterfaceId(str, valueId);
+        daqStringToInterfaceId(str.getCharPtr(), valueId);
     }
 
     SerializedListPtr list = nullptr;

--- a/core/corecontainers/src/listobject_impl.cpp
+++ b/core/corecontainers/src/listobject_impl.cpp
@@ -507,7 +507,7 @@ ErrCode INTERFACE_FUNC deserializeList(ISerializedObject* ser, IBaseObject* cont
     {
         StringPtr str;
         ser->readString(String("itemIntfID"), &str);
-        daqStringToInterfaceId(str, id);
+        daqStringToInterfaceId(str.getCharPtr(), id);
     }
 
     SerializedListPtr list = nullptr;

--- a/core/coretypes/include/coretypes/common.h
+++ b/core/coretypes/include/coretypes/common.h
@@ -245,7 +245,7 @@ extern "C"
 daq::ErrCode PUBLIC_EXPORT daqInterfaceIdToString(const daq::IntfID& iid, daq::CharPtr dest);
 
 extern "C"
-daq::ErrCode PUBLIC_EXPORT daqStringToInterfaceId(const std::string& guidStr, daq::IntfID& iid);
+daq::ErrCode PUBLIC_EXPORT daqStringToInterfaceId(daq::ConstCharPtr guidStr, daq::IntfID& iid);
 
 #define OPENDAQ_TYPE_TOSTRING                                             \
     static daq::ErrCode OpenDaqType(daq::CharPtr* str)                    \

--- a/core/coretypes/tests/test_intfid.cpp
+++ b/core/coretypes/tests/test_intfid.cpp
@@ -261,6 +261,12 @@ TEST_F(IntfIdTest, VersionInfoString)
     ASSERT_EQ(daqInterfaceIdString<IVersionInfo>(), "{5951D4D2-35EB-513C-B67D-89DABC6BE3BF}");
 }
 
+TEST_F(IntfIdTest, TestInterfaceToStringConversionFail)
+{
+    IntfID id;
+    ASSERT_EQ(daqStringToInterfaceId("{5951D4D2-35EB-X13C-B67D-89DABC6BE3BF}", id), OPENDAQ_ERR_INVALIDPARAMETER);
+}
+
 TEST_F(IntfIdTest, TestInterfaceToStringConversion)
 {
     auto testInterfaceToStringConversion = [](const IntfID& iidIn)


### PR DESCRIPTION
Change the signature of `daqStringToInterfaceId` to be C-compatible. Optimize it by rewriting it without using regex.

# Brief

The current implementation uses std::string as a parameter, which is not C-compliant. The updated signature uses a standard C-style string.

Reimplements the conversion without regex, which is slower than the new implementation.

# API changes

```diff
- ErrCode daqStringToInterfaceId(std::string& guidStr, daq::IntfID& iid);
+ErrCode daqStringToInterfaceId(daq::ConstCharPtr guidStr, daq::IntfID& iid);

```
# Required application changes

(Changes required in openDAQ applications/executables)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
std::string guidStr = "....";
daq::IntfID id;
daqStringToInterfaceId(guidStr, id);
```

Do:

```cpp
std::string guidStr = "....";
daq::IntfID id;
daqStringToInterfaceId(guidStr.c_str(), id);
```