### PR TITLE
Ensure property order is preserved from server to client via the native protocol.

### DIFF
--- a/core/corecontainers/include/coretypes/listptr.h
+++ b/core/corecontainers/include/coretypes/listptr.h
@@ -288,7 +288,7 @@ public:
     /*!
      * @brief Returns a copy of list as std::vector.
      */
-    std::vector<TValuePtr> toVector()
+    std::vector<TValuePtr> toVector() const
     {
         return std::vector<TValuePtr>(begin(), end());
     }

--- a/core/coreobjects/include/coreobjects/core_event_args.h
+++ b/core/coreobjects/include/coreobjects/core_event_args.h
@@ -392,6 +392,21 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY, CoreEventArgsTypeRemoved, ICoreEventArgs,
     IString*, typeName
 )
+
+/*!
+ * @brief Creates Core event args that property order of a component is changed.
+ * @param propOwner The property object that owns the properties whose order was changed.
+ * @param propertyOrder The list of property names in the new order.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ *
+ * The ID of the event is 190, and the event name is "PropertyOrderChanged".
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY, CoreEventArgsPropertyOrderChanged, ICoreEventArgs,
+    IPropertyObject*, propOwner,
+    IList*, propertyOrder,
+    IString*, path
+)
 /*!@}*/
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/core_event_args_factory.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_factory.h
@@ -119,6 +119,20 @@ inline CoreEventArgsPtr CoreEventArgsTypeRemoved(const StringPtr& typeName)
     return obj;
 }
 
+/*!
+ * @brief Creates Core event args that are passed as argument when the property order of a component is changed.
+ * @param propOwner The property object that owns the properties whose order was changed.
+ * @param propertyOrder The list of property names in the new order.
+ * @param path The relative path to the property owner from the sender component. Used for object-type properties. Eg. "child1.child2".
+ *
+ * The ID of the event is 190, and the event name is "PropertyOrderChanged".
+ */
+inline CoreEventArgsPtr CoreEventArgsPropertyOrderChanged(const PropertyObjectPtr& propOwner, const ListPtr<IString>& propertyOrder, const StringPtr& path)
+{
+    CoreEventArgsPtr obj(CoreEventArgsPropertyOrderChanged_Create(propOwner, propertyOrder, path));
+    return obj;
+}
+
 /*!@}*/
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/core_event_args_ids.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_ids.h
@@ -46,6 +46,7 @@ enum class CoreEventId : EnumType
     DeviceLockStateChanged = 160,
     ConnectionStatusChanged = 170,
     DeviceOperationModeChanged = 180,
+    PropertyOrderChanged = 190,
 };
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/core_event_args_impl.h
+++ b/core/coreobjects/include/coreobjects/core_event_args_impl.h
@@ -67,6 +67,8 @@ namespace core_event_args_impl
                 return "ConnectionStatusChanged";
             case CoreEventId::DeviceOperationModeChanged:
                 return "DeviceOperationModeChanged";
+            case CoreEventId::PropertyOrderChanged:
+                return "PropertyOrderChanged";
             default:
                 break;
         }
@@ -241,6 +243,8 @@ inline bool CoreEventArgsImpl::validateParameters() const
                    && parameters.hasKey("Message");
         case CoreEventId::DeviceOperationModeChanged:
             return parameters.hasKey("OperationMode");
+        case CoreEventId::PropertyOrderChanged:
+            return parameters.hasKey("PropertyOrder") && parameters.hasKey("Path");
         default:
             break;
     }

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -394,6 +394,7 @@ protected:
     ErrCode getPropertyValueInternal(IString* propertyName, IBaseObject** value, Bool retrieveUpdatingValue = false);
     ErrCode getPropertySelectionValueInternal(IString* propertyName, IBaseObject** value, Bool retrieveUpdatingValue = false);
     ErrCode checkForReferencesInternal(IProperty* property, Bool* isReferenced);
+    ErrCode setPropertyOrderInternal(IList* orderedPropertyNames, bool isUpdating = false);
 
     // Serialization
 
@@ -413,6 +414,11 @@ protected:
                                            const BaseObjectPtr& context,
                                            const FunctionPtr& factoryCallback,
                                            PropertyObjectPtr& propObjPtr);
+
+    static void DeserializePropertyOrder(const SerializedObjectPtr& serialized,
+                                         const BaseObjectPtr& context,
+                                         const FunctionPtr& factoryCallback,
+                                         PropertyObjectPtr& propObjPtr);
 
     // Child property handling - Used when a property is queried in the "parent.child" format
     bool isChildProperty(const StringPtr& name) const;
@@ -2195,21 +2201,26 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getAllProper
 }
 
 template <class PropObjInterface, typename... Interfaces>
-ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyOrder(IList* orderedPropertyNames)
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyOrderInternal(IList* orderedPropertyNames, bool isUpdating)
 {
     if (frozen)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
-
-    customOrder.clear();
+    
     if (orderedPropertyNames != nullptr)
-    {
-        for (auto&& propName : ListPtr<IString>::Borrow(orderedPropertyNames))
-        {
-            customOrder.emplace_back(propName);
-        }
-    }
+        customOrder = ListPtr<IString>::Borrow(orderedPropertyNames).toVector();
+    else
+        customOrder.clear();
+
+    if (!isUpdating)
+        triggerCoreEventInternal(CoreEventArgsPropertyOrderChanged(objPtr, orderedPropertyNames, path));
 
     return OPENDAQ_SUCCESS;
+}
+
+template <class PropObjInterface, typename... Interfaces>
+ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyOrder(IList* orderedPropertyNames)
+{
+    return setPropertyOrderInternal(orderedPropertyNames);
 }
 
 template <class PropObjInterface, class... Interfaces>
@@ -2901,7 +2912,6 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::serializePro
         property.serialize(serializer);
         return OPENDAQ_SUCCESS;
     });
-
 }
 
 template <class PropObjInterface, class... Interfaces>
@@ -2963,8 +2973,17 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::serializeLoc
 
         auto serializerPtr = SerializerPtr::Borrow(serializer);
 
-        checkErrorInfo(serializer->key("properties"));
-        checkErrorInfo(serializer->startList());
+        if (!customOrder.empty())
+        {
+            serializerPtr.key("propertyOrder");
+            serializerPtr.startList();
+            for (const auto& group : customOrder)
+                group.serialize(serializer);
+            serializerPtr.endList();
+        }
+
+        serializerPtr.key("properties");
+        serializerPtr.startList();
         for (const auto& prop : localProperties)
         {
             if (!hasUserReadAccess(serializerPtr.getUser(), prop.second.getDefaultValue()))
@@ -2972,7 +2991,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::serializeLoc
 
             checkErrorInfo(serializeProperty(prop.second, serializer));
         }
-        checkErrorInfo(serializer->endList());
+        serializerPtr.endList();
 
         return OPENDAQ_SUCCESS;
     });
@@ -3027,6 +3046,8 @@ PropertyObjectPtr GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::De
 
     PropertyObjectPtr propObjPtr = f(serialized, context, className);
 
+    DeserializePropertyOrder(serialized, context, factoryCallback, propObjPtr);
+
     DeserializeLocalProperties(serialized, context, factoryCallback, propObjPtr);
 
     DeserializePropertyValues(serialized, context, factoryCallback, propObjPtr);
@@ -3051,17 +3072,18 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::Deserialize(
     OPENDAQ_PARAM_NOT_NULL(serialized);
     OPENDAQ_PARAM_NOT_NULL(obj);
 
-    return daqTry([&serialized, &context, &factoryCallback, &obj]() {
+    return daqTry([&serialized, &context, &factoryCallback, &obj]
+    {
         *obj = DeserializePropertyObject(serialized,
                                          context,
                                          factoryCallback,
-                                         [](const SerializedObjectPtr&, const BaseObjectPtr& context, const StringPtr& className) {
+                                         [](const SerializedObjectPtr&, const BaseObjectPtr& context, const StringPtr& className)
+                                          {
                                              const TypeManagerPtr objManager = context.asOrNull<ITypeManager>();
                                              if (objManager.assigned())
                                                  return PropertyObject(objManager, className);
                                              return PropertyObject();
-                                         })
-                   .detach();
+                                        }).detach();
     });
 }
 
@@ -3087,6 +3109,25 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::DeserializeProp
         const auto propValue = propValues.readObject(key, context, factoryCallback);
         protectedPropObjPtr.setProtectedPropertyValue(key, propValue);
     }
+}
+
+template <class PropObjInterface, class... Interfaces>
+void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::DeserializePropertyOrder(const SerializedObjectPtr& serialized,
+                                                                                          const BaseObjectPtr& context,
+                                                                                          const FunctionPtr& /*factoryCallback*/,
+                                                                                          PropertyObjectPtr& propObjPtr)
+{
+    const auto keyStr = String("propertyOrder");
+    const auto hasKey = serialized.hasKey(keyStr);
+
+    if (!IsTrue(hasKey))
+        return;
+
+    const auto propertyOrder = serialized.readList<IString>(keyStr, context);
+    if (!propertyOrder.assigned())
+        return;
+
+    propObjPtr.setPropertyOrder(propertyOrder.toVector());
 }
 
 template <class PropObjInterface, class... Interfaces>

--- a/core/coreobjects/src/core_event_args_impl.cpp
+++ b/core/coreobjects/src/core_event_args_impl.cpp
@@ -49,6 +49,13 @@ ErrCode PUBLIC_EXPORT createCoreEventArgsTypeRemoved(ICoreEventArgs** objTmp, IS
     return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, CoreEventId, IDict*>(objTmp, CoreEventId::TypeRemoved, dict);
 }
 
+extern "C"
+ErrCode PUBLIC_EXPORT createCoreEventArgsPropertyOrderChanged(ICoreEventArgs** objTmp, IPropertyObject* propOwner, IList* propertyOrder, IString* path)
+{
+    const auto dict = Dict<IString, IBaseObject>({{"Owner", propOwner}, {"PropertyOrder", propertyOrder}, {"Path", path}});
+    return daq::createObject<ICoreEventArgs, CoreEventArgsImpl, CoreEventId, IDict*>(objTmp, CoreEventId::PropertyOrderChanged, dict);
+}
+
 #endif
 
 END_NAMESPACE_OPENDAQ

--- a/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/modules/tests/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -3472,3 +3472,71 @@ TEST_F(NativeDeviceModulesTest, TestEnumerationPropertyRemote)
     ASSERT_EQ(result.getValue(), "Successful");
 }
 
+TEST_F(NativeDeviceModulesTest, TestPropertyOrderOnClient)
+{
+    const InstancePtr server = Instance();
+    server.addServer("OpenDAQNativeStreaming", nullptr);
+
+    server.addProperty(StringProperty("Property1", ""));
+    server.addProperty(StringProperty("Property2", ""));
+
+    auto propertyOrder = List<IString>("Property2", "Property1");
+    server.setPropertyOrder(propertyOrder);
+
+    // check that on server side the order is correct
+    {
+        const auto props = server.getVisibleProperties();
+        for (SizeT i = 0; i < propertyOrder.getCount(); ++i)
+            ASSERT_EQ(propertyOrder[i], props[i].getName());
+    }
+
+    const InstancePtr client = Instance();
+    auto clientDevice = client.addDevice("daq.nd://127.0.0.1");
+
+    // Check that the property order is preserved on the client side as well
+    {
+        const auto props = clientDevice.getVisibleProperties();
+        for (SizeT i = 0; i < propertyOrder.getCount(); ++i)
+            ASSERT_EQ(propertyOrder[i], props[i].getName());
+    }
+
+    std::promise<void> propertyOrderChangedPromise;
+    std::future<void> propertyOrderChangedFuture = propertyOrderChangedPromise.get_future();
+    clientDevice.getOnComponentCoreEvent() += [&propertyOrderChangedPromise](ComponentPtr& /*comp*/, CoreEventArgsPtr& args)    
+    {
+        if (static_cast<CoreEventId>(args.getEventId()) == CoreEventId::PropertyOrderChanged)
+            propertyOrderChangedPromise.set_value();
+    };
+
+    // change the property order on the server side
+    propertyOrder = List<IString>("Property1", "Property2");
+    server.setPropertyOrder(propertyOrder);
+    ASSERT_EQ(propertyOrderChangedFuture.wait_for(std::chrono::seconds(3)), std::future_status::ready);
+
+    {
+        const auto props = server.getVisibleProperties();
+        for (SizeT i = 0; i < propertyOrder.getCount(); ++i)
+            ASSERT_EQ(propertyOrder[i], props[i].getName());
+    }
+
+    {
+        const auto props = clientDevice.getVisibleProperties();
+        for (SizeT i = 0; i < propertyOrder.getCount(); ++i)
+            ASSERT_EQ(propertyOrder[i], props[i].getName());
+    }
+
+    // changing the property order on the client side is forbidden
+    ASSERT_THROW(clientDevice.setPropertyOrder(List<IString>("Property2", "Property1")), InvalidOperationException);
+
+    {
+        const auto props = server.getVisibleProperties();
+        for (SizeT i = 0; i < propertyOrder.getCount(); ++i)
+            ASSERT_EQ(propertyOrder[i], props[i].getName());
+    }
+
+    {
+        const auto props = clientDevice.getVisibleProperties();
+        for (SizeT i = 0; i < propertyOrder.getCount(); ++i)
+            ASSERT_EQ(propertyOrder[i], props[i].getName());
+    }
+}

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -98,6 +98,7 @@ private:
     void propertyObjectUpdateEnd(const CoreEventArgsPtr& args);
     void propertyAdded(const CoreEventArgsPtr& args);
     void propertyRemoved(const CoreEventArgsPtr& args);
+    void propertyOrderChanged(const CoreEventArgsPtr& args);
     PropertyObjectPtr getObjectAtPath(const CoreEventArgsPtr& args);
     BaseObjectPtr getFullPropName(const std::string& propName) const;
 
@@ -338,6 +339,8 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::getAllProperties(IList** prope
 template <class Impl>
 ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::setPropertyOrder(IList* orderedPropertyNames)
 {
+    if (!deserializationComplete)
+        return Impl::setPropertyOrderInternal(orderedPropertyNames, true);
     return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALID_OPERATION);
 }
 
@@ -603,6 +606,9 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::handleRemoteCoreObjectInternal(co
         case CoreEventId::PropertyRemoved:
             propertyRemoved(args);
             break;
+        case CoreEventId::PropertyOrderChanged:
+            propertyOrderChanged(args);
+            break;
         default:
             break;
     }
@@ -828,6 +834,25 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::propertyRemoved(const CoreEventAr
 }
 
 template <class Impl>
+void ConfigClientPropertyObjectBaseImpl<Impl>::propertyOrderChanged(const CoreEventArgsPtr& args)
+{
+    const auto params = args.getParameters();
+    const PropertyObjectPtr obj = getObjectAtPath(args);
+    
+    const ListPtr<IString> orderedPropertyNames = params.get("PropertyOrder");
+
+    if (params.get("Path") != "")
+    {
+        ScopedRemoteUpdate update(obj);
+        obj.setPropertyOrder(orderedPropertyNames);
+    }
+    else
+    {
+        DAQ_CHECK_ERROR_INFO(Impl::setPropertyOrder(orderedPropertyNames));
+    }
+}
+
+template <class Impl>
 PropertyObjectPtr ConfigClientPropertyObjectBaseImpl<Impl>::getObjectAtPath(const CoreEventArgsPtr& args)
 {
     const auto params = args.getParameters();
@@ -898,7 +923,7 @@ inline ErrCode ConfigClientPropertyObjectImpl::setProtectedPropertyValue(IString
 {
     if (remoteUpdating)
         return Impl::setProtectedPropertyValue(propertyName, value);
-    return Super::setProtectedPropertyValue(propertyName,value);
+    return Super::setProtectedPropertyValue(propertyName, value);
 }
 
 inline ErrCode ConfigClientPropertyObjectImpl::clearPropertyValue(IString* propertyName)

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -473,6 +473,7 @@ ListPtr<IBaseObject> ConfigProtocolServer::packCoreEvent(const ComponentPtr& com
         case CoreEventId::SignalConnected:
         case CoreEventId::ComponentAdded:
         case CoreEventId::AttributeChanged:
+        case CoreEventId::PropertyOrderChanged:
             packedEvent.pushBack(processCoreEventArgs(args));
             break;
         case CoreEventId::ComponentUpdateEnd:


### PR DESCRIPTION
# Brief

(Concise one-line description of what changed and what was added/removed, maybe even why)



# Description

(Individual high-level changes)

- Add Python GUI Demo functionality
- Rename a function
- ...

# Usage example

In C++ use:

```cpp
auto variable = "foo";
```

In terminal use:

```shell
cd folder
```

# API changes

> [!NOTE]
> Modifying, removing, or adding a function to an interface inherited by another, breaks binary compatibility of module shared libraries

(An overview of changes on the interface level (abstract structs with pure virtual functions), if any, one function per line)

```diff
+ this
- that
```

# Required application changes

(Changes required in openDAQ applications/executables)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```

# Required module changes

(Changes required in openDAQ shared libraries/modules)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```
