### PR TITLE
Optimize find component

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1158,16 +1158,21 @@ ComponentPtr ComponentImpl<Intf, Intfs...>::findComponentInternal(const Componen
     if (!folder.assigned())
         return nullptr;
 
-    if (folder.hasItem(startStr))
+    ComponentPtr subComponent;
+    const auto errCode = folder->getItem(String(startStr), &subComponent);
+    if (OPENDAQ_SUCCEEDED(errCode))
     {
-        const auto subComponent = folder.getItem(startStr);
         if (hasSubComponentStr)
             return findComponentInternal(subComponent, restStr);
-
-        return subComponent;
     }
+    else if (errCode == OPENDAQ_ERR_NOTFOUND)
+    {
+        daqClearErrorInfo();
+    }
+    else
+        checkErrorInfo(errCode);
 
-    return nullptr;
+    return subComponent;
 }
 
 template <class Intf, class ... Intfs>

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -31,16 +31,21 @@ ComponentPtr ComponentFinderRootDevice::findComponentInternal(const ComponentPtr
     if (!folder.assigned())
         return nullptr;
 
-    if (folder.hasItem(startStr))
+    ComponentPtr subComponent;
+    const auto errCode = folder->getItem(String(startStr), &subComponent);
+    if (OPENDAQ_SUCCEEDED(errCode))
     {
-        auto subComponent = folder.getItem(startStr);
         if (hasSubComponentStr)
             return findComponentInternal(subComponent, restStr);
-
-        return subComponent;
     }
+    else if (errCode == OPENDAQ_ERR_NOTFOUND)
+    {
+        daqClearErrorInfo();
+    }
+    else
+        checkErrorInfo(errCode);
 
-    return nullptr;
+    return subComponent;
 }
 
 ComponentPtr ComponentFinderRootDevice::findComponent(const std::string& globalId)


### PR DESCRIPTION
# Brief

Optimize `IComponent.findComponent`

# Description

`findComponent` uses  `getItem` and `hasItem` methods of `IComponent`. The former already returns an error if the item is not found, so there is no need to call `hasItem`. Note that both methods employ a recursive lock, which means that the optimization reduces the number of recursive locks by 50%.