### PR TITLE
Optimize validateTypeName

### DIFF
--- a/core/coretypes/include/coretypes/ctutils.h
+++ b/core/coretypes/include/coretypes/ctutils.h
@@ -624,8 +624,17 @@ TPtr callNotNull(TPtr ptr, TFunc func)
 
 inline bool validateTypeName(ConstCharPtr typeName)
 {
-    const std::regex validatorRegex("^[a-zA-Z_]+[a-zA-Z0-9_]*$");
-    return std::regex_match(typeName, validatorRegex);
+    if (typeName == nullptr || typeName[0] == '\0')
+        return false;
+
+    if (!(std::islower(typeName[0]) || std::isupper(typeName[0]) || typeName[0] == '_'))
+        return false;
+
+    for (size_t i = 1; typeName[i] != '\0'; ++i)
+        if (!(std::islower(typeName[i]) || std::isupper(typeName[i]) || std::isdigit(typeName[i]) || typeName[i] == '_'))
+            return false;
+
+    return true;
 }
 
 template <typename T>

--- a/core/coretypes/tests/test_type_name.cpp
+++ b/core/coretypes/tests/test_type_name.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <coretypes/common.h>
 
+#include "coretypes/ctutils.h"
+
 using TypeNameTest = testing::Test;
 
 using namespace daq;
@@ -163,4 +165,16 @@ TEST_F(TypeNameTest, UInt16)
 {
     constexpr auto uint16Type = typeName<uint16_t>();
     ASSERT_EQ(uint16Type, "uint16");
+}
+
+TEST_F(TypeNameTest, ValidateTypeName)
+{
+    ASSERT_TRUE(validateTypeName("aB0_"));
+    ASSERT_TRUE(validateTypeName("_B0"));
+    ASSERT_TRUE(validateTypeName("gB0_"));
+
+    ASSERT_FALSE(validateTypeName("0BA_"));
+    ASSERT_FALSE(validateTypeName("A*B"));
+    ASSERT_FALSE(validateTypeName(""));
+    ASSERT_FALSE(validateTypeName(nullptr));
 }


### PR DESCRIPTION
# Brief

Optimize `validateTypeName` function.

# Description

The function constructs the regular expression pattern within itself. It is rewritten without regex.