### PR TITLE
Fix setting irrelevant streaming source as active

### DIFF
--- a/core/opendaq/streaming/include/opendaq/streaming.h
+++ b/core/opendaq/streaming/include/opendaq/streaming.h
@@ -76,7 +76,8 @@ DECLARE_OPENDAQ_INTERFACE(IStreaming, IBaseObject)
      * @retval OPENDAQ_ERR_NOINTERFACE if a signal on the list is not a mirrored signal.
      *
      * After a signal is added to the Streaming, the Streaming automatically appears in the list of
-     * available streaming sources of a signal.
+     * available streaming sources of a signal. Some signals, however, may be silently ignored
+     * without triggering an error - for example, private signals are excluded by default.
      */
     virtual ErrCode INTERFACE_FUNC addSignals(IList* signals) = 0;
 

--- a/core/opendaq/streaming/include/opendaq/streaming_source_manager.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_source_manager.h
@@ -186,7 +186,7 @@ inline void StreamingSourceManager::enableStreamingForAddedComponent(const Compo
     if (!ownerDevice.assigned())
         return;
 
-    auto isAncestorComponent = Function(
+    auto isAncestorOrAddedComponent = Function(
         [addedComponentId = addedComponent.getGlobalId()](const ComponentPtr& comp)
         {
             return IdsParser::isNestedComponentId(comp.getGlobalId(), addedComponentId) || comp.getGlobalId() == addedComponentId;
@@ -194,26 +194,27 @@ inline void StreamingSourceManager::enableStreamingForAddedComponent(const Compo
     );
     auto ancestorDevices = List<IDevice>();
     if (minHopsStreamingHeuristicEnabled) // skip nested devices' streamings if MinHops disabled
-        ancestorDevices = ownerDevice.getDevices(search::Recursive(search::Custom(isAncestorComponent)));
+        ancestorDevices = ownerDevice.getDevices(search::Recursive(search::Custom(isAncestorOrAddedComponent)));
     ancestorDevices.pushFront(ownerDevice);
 
-    // collect all relevant streaming sources for the component by retrieving sources from itself and all its ancestor devices
-    // from top to the bottom
-    auto allStreamingSources = List<IStreaming>();
+    // collect all relevant streaming sources for the added component by retrieving sources from itself (if it is device)
+    // and all its ancestor devices, saving by priority in order from bottom to the top;
+    // i.e. the sources of added component (or its closest ancestor device) will be the first ones in the saved vector
+    std::vector<StreamingPtr> allStreamingSources;
     for (const auto& ancestorDevice : ancestorDevices)
     {
         if (auto mirroredDevice = ancestorDevice.asPtrOrNull<IMirroredDevice>(); mirroredDevice.assigned())
         {
-            auto streamingSources = mirroredDevice.getStreamingSources();
-            for (const auto& streaming : streamingSources)
-                allStreamingSources.pushBack(streaming);
+            auto streamingSources = mirroredDevice.getStreamingSources().toVector();
+            // prepend to the result vector
+            allStreamingSources.insert(allStreamingSources.begin(), streamingSources.begin(), streamingSources.end());
         }
     }
 
     if (allStreamingSources.empty())
         return;
 
-    auto setupStreamingForSignal = [this, allStreamingSources](const SignalPtr& signal)
+    auto setupStreamingForSignal = [this, &allStreamingSources](const SignalPtr& signal)
     {
         if (!signal.getPublic())
             return;
@@ -221,6 +222,8 @@ inline void StreamingSourceManager::enableStreamingForAddedComponent(const Compo
         {
             ErrCode errCode = daqTry([&]()
                                      {
+                                         // does not guarantee that signal will be added, as some signals,
+                                         // e.g. private ones (by default), may be silently ignored
                                          streaming.addSignals({signal});
                                      });
             if (OPENDAQ_SUCCEEDED(errCode))
@@ -239,21 +242,20 @@ inline void StreamingSourceManager::enableStreamingForAddedComponent(const Compo
         auto mirroredSignalConfigPtr = signal.template asPtr<IMirroredSignalConfig>();
         if (!mirroredSignalConfigPtr.getActiveStreamingSource().assigned())
         {
-            // streaming sources were created and ordered by priority on the device connection, cache the highest-priority
-            // source from the deepest in-tree ancestor or top device if no MinHops enabled to be active for signals of new component
+            // streaming sources were created (by completeStreamingConnections) and ordered by priority above,
+            // set the highest-priority source as active for signal, if relevant
             auto signalStreamingSources = mirroredSignalConfigPtr.getStreamingSources();
             for (const auto& streaming : allStreamingSources)
             {
                 auto connectionString = streaming.getConnectionString();
-
                 auto it = std::find(signalStreamingSources.begin(), signalStreamingSources.end(), connectionString);
                 if (it != signalStreamingSources.end())
                 {
                     mirroredSignalConfigPtr.setActiveStreamingSource(connectionString);
+                    LOG_D("Set active streaming source \"{}\" for signal \"{}\"", connectionString, signal.getGlobalId());
                     break;
                 }
             }
-
         }
     };
 


### PR DESCRIPTION
# Brief

Fixes an issue where automatic streaming setup attempted to set an irrelevant streaming source as active.


# Description

Some streaming protocols may support only a subset of device signals. This needs to be considered during automatic streaming source setup for signal. This PR reintroduces integration patch (originally added by https://github.com/openDAQ/openDAQ/pull/492 and discarded by refactoring done in https://github.com/openDAQ/openDAQ/pull/734) to perform the necessary validation (fixes TBBAS-2355).

