### PR TITLE
Allow IP connection with scheduler notification

### DIFF
--- a/core/opendaq/functionblock/tests/test_function_block.cpp
+++ b/core/opendaq/functionblock/tests/test_function_block.cpp
@@ -7,6 +7,8 @@
 #include <opendaq/input_port_config_ptr.h>
 #include <opendaq/tags_private_ptr.h>
 #include <coreobjects/property_object_class_factory.h>
+#include <opendaq/input_port_private.h>
+#include <opendaq/scheduler_factory.h>
 
 using FunctionBlockTest = testing::Test;
 
@@ -186,4 +188,50 @@ TEST_F(FunctionBlockTest, BeginUpdateEndUpdate)
 
     ASSERT_EQ(fb.getPropertyValue("FbProp"), "s");
     ASSERT_EQ(sig.getPropertyValue("SigProp"), "cs");
+}
+
+class MockFbImpl1 final : public daq::FunctionBlock
+{
+public:
+    MockFbImpl1(const daq::ContextPtr& context)
+        : daq::FunctionBlock(daq::FunctionBlockType("test_uid", "test_name", "test_description"), context, nullptr, "MockFb", "")
+    {
+        createAndAddInputPort("IP", daq::PacketReadyNotification::SameThread);
+        objPtr.addProperty(daq::IntProperty("ConnectIp", 100));
+    }
+    
+    void onPacketReceived(const daq::InputPortPtr& /*port*/) override
+    {
+        auto lock = getAcquisitionLock();
+    }
+};
+
+TEST_F(FunctionBlockTest, SetDomainDescriptorUnderLock)
+{
+    const auto logger = daq::Logger();
+    auto context = daq::Context(daq::Scheduler(logger), logger, daq::TypeManager(), nullptr, nullptr);
+    auto fb = daq::createWithImplementation<daq::IFunctionBlock, MockFbImpl1>(context);
+
+    auto desc1 = daq::DataDescriptorBuilder().build();
+    auto desc2 = daq::DataDescriptorBuilder().setSampleType(daq::SampleType::Int16).build();
+
+    const auto signal1 = Signal(context, nullptr, "sig");
+    const auto signal2 = Signal(context, nullptr, "domainSig");
+
+    signal1.setDescriptor(desc1);
+    signal2.setDescriptor(desc2);
+
+    fb.getOnPropertyValueWrite("ConnectIp") += [&fb, &signal1, &signal2](daq::PropertyObjectPtr&, const daq::PropertyValueEventArgsPtr& args)
+    {
+        daq::ErrCode err;
+        if (static_cast<int>(args.getValue()) % 2 == 0)
+            err = fb.getInputPorts()[0].asPtr<daq::IInputPortPrivate>()->connectSignalSchedulerNotification(signal1);
+        else
+            err = fb.getInputPorts()[0].asPtr<daq::IInputPortPrivate>()->connectSignalSchedulerNotification(signal2);
+
+        ASSERT_TRUE(OPENDAQ_SUCCEEDED(err));
+    };
+
+    for (int i = 0; i < 10; ++i)
+        fb.setPropertyValue("ConnectIp", i);
 }

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/input_port.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/input_port.h
@@ -40,6 +40,7 @@ struct MockInputPort : daq::MockGenericComponent<MockInputPort, daq::IInputPortC
     MOCK_METHOD(daq::ErrCode, setNotificationMethod, (daq::PacketReadyNotification method), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, notifyPacketEnqueued, (daq::Bool value), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, notifyPacketEnqueuedOnThisThread, (), (override MOCK_CALL));
+    MOCK_METHOD(daq::ErrCode, notifyPacketEnqueuedWithScheduler, (), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, setListener, (daq::IInputPortNotifications * port), (override MOCK_CALL));
 
     MOCK_METHOD(daq::ErrCode, getCustomData, (daq::IBaseObject** customData), (override MOCK_CALL));

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/signal.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/signal.h
@@ -59,6 +59,7 @@ struct MockSignal : daq::GenericPropertyObjectImpl<daq::ISignal, daq::ISignalEve
     MOCK_METHOD(daq::ErrCode, getDescription, (daq::IString** name), (override MOCK_CALL));
 
     MOCK_METHOD(daq::ErrCode, listenerConnected, (daq::IConnection* connection), (override MOCK_CALL));
+    MOCK_METHOD(daq::ErrCode, listenerConnectedScheduled, (daq::IConnection* connection), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, listenerDisconnected, (daq::IConnection* connection), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, domainSignalReferenceSet, (daq::ISignal* signal), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, domainSignalReferenceRemoved, (daq::ISignal* signal), (override MOCK_CALL));

--- a/core/opendaq/signal/include/opendaq/connection.h
+++ b/core/opendaq/signal/include/opendaq/connection.h
@@ -176,6 +176,14 @@ DECLARE_OPENDAQ_INTERFACE(IConnection, IBaseObject)
      * @param[out] hasGapPacket True if the connection has a gap packet.
      */
     virtual ErrCode INTERFACE_FUNC hasGapPacket(Bool* hasGapPacket) = 0;
+
+    /*!
+     * @brief Places a packet at the back of the queue.
+     * @param packet The packet to be enqueued.
+     *
+     * The connection schedules the `onPacketReceived` notification.
+     */
+    virtual ErrCode INTERFACE_FUNC enqueueWithScheduler(IPacket* packet) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/signal/include/opendaq/connection_impl.h
+++ b/core/opendaq/signal/include/opendaq/connection_impl.h
@@ -47,6 +47,7 @@ public:
     ErrCode INTERFACE_FUNC enqueueMultipleAndStealRef(IList* packets) override;
 
     ErrCode INTERFACE_FUNC enqueueOnThisThread(IPacket* packet) override;
+    ErrCode INTERFACE_FUNC enqueueWithScheduler(IPacket* packet) override;
     ErrCode INTERFACE_FUNC dequeue(IPacket** packet) override;
     ErrCode INTERFACE_FUNC dequeueAll(IList** packets) override;
     ErrCode INTERFACE_FUNC peek(IPacket** packet) override;

--- a/core/opendaq/signal/include/opendaq/input_port_config.h
+++ b/core/opendaq/signal/include/opendaq/input_port_config.h
@@ -99,6 +99,13 @@ DECLARE_OPENDAQ_INTERFACE(IInputPortConfig, IInputPort)
      * @param gapCheckingEnabled true if gap checking is requested by the input port.
      */
     virtual ErrCode INTERFACE_FUNC getGapCheckingEnabled(Bool* gapCheckingEnabled) = 0;
+
+    /*!
+     * @brief Gets called when a packet was enqueued in a connection.
+     *
+     * The notification is scheduled.
+     */
+    virtual ErrCode INTERFACE_FUNC notifyPacketEnqueuedWithScheduler()  = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/signal/include/opendaq/input_port_impl.h
+++ b/core/opendaq/signal/include/opendaq/input_port_impl.h
@@ -59,6 +59,7 @@ public:
     ErrCode INTERFACE_FUNC setNotificationMethod(PacketReadyNotification method) override;
     ErrCode INTERFACE_FUNC notifyPacketEnqueued(Bool queueWasEmpty) override;
     ErrCode INTERFACE_FUNC notifyPacketEnqueuedOnThisThread() override;
+    ErrCode INTERFACE_FUNC notifyPacketEnqueuedWithScheduler() override;
     ErrCode INTERFACE_FUNC setListener(IInputPortNotifications* port) override;
 
     ErrCode INTERFACE_FUNC getCustomData(IBaseObject** data) override;
@@ -69,6 +70,7 @@ public:
 
     // IInputPortPrivate
     ErrCode INTERFACE_FUNC disconnectWithoutSignalNotification() override;
+    ErrCode INTERFACE_FUNC connectSignalSchedulerNotification(ISignal* signal) override;
 
     // IOwnable
     ErrCode INTERFACE_FUNC setOwner(IPropertyObject* owner) override;
@@ -87,6 +89,7 @@ public:
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 
 protected:
+    ErrCode connectInternal(ISignal* signal, bool scheduled);
     void serializeCustomObjectValues(const SerializerPtr& serializer, bool forUpdate) override;
 
     void updateObject(const SerializedObjectPtr& obj, const BaseObjectPtr& context) override;
@@ -99,7 +102,6 @@ protected:
                                        const FunctionPtr& factoryCallback) override;
 
     virtual ConnectionPtr createConnection(const SignalPtr& signal);
-
     ConnectionPtr getConnectionNoLock();
     void removed() override;
     
@@ -179,86 +181,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::canConnectSignal(ISignal* signal) c
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::connect(ISignal* signal)
 {
-    OPENDAQ_PARAM_NOT_NULL(signal);
-
-    try
-    {
-        auto err = canConnectSignal(signal);
-        OPENDAQ_RETURN_IF_FAILED(err);
-
-        auto signalPtr = SignalPtr::Borrow(signal);
-
-        const auto connection = createConnection(signalPtr);
-
-        InputPortNotificationsPtr inputPortListener;
-        {
-            auto lock = this->getRecursiveConfigLock();
-            if (this->isComponentRemoved)
-                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Cannot connect signal to removed input port");
-
-            {
-                ConnectionPtr oldConnection = connectionRef.assigned() ? connectionRef.getRef() : nullptr;
-                connectionRef.release();
-                disconnectSignalInternal(std::move(oldConnection), false, true, false);
-            }
-            connectionRef = connection;
-
-            if (listenerRef.assigned())
-                inputPortListener = listenerRef.getRef();
-        }
-
-        if (inputPortListener.assigned())
-        {
-            err = inputPortListener->connected(Super::template borrowInterface<IInputPort>());
-            if (OPENDAQ_FAILED(err))
-            {
-                connectionRef.release();
-                return DAQ_MAKE_ERROR_INFO(err);
-            }
-        }
-
-        const auto events = signalPtr.asPtrOrNull<ISignalEvents>(true);
-        if (events.assigned())
-        {
-            // NORRIS/TODO: what's the correct behavior if this fails? what about when the error is OPENDAQ_ERR_NOTIMPLEMENTED?
-            // - behavior before my change is to propagate the error up to the caller even in the latter case, which seems wrong
-            // - behavior now is that OPENDAQ_ERR_NOTIMPLEMENTED is ignored but other errors are propagated
-            // - do we have (and if not, do we want) helper methods for exception handling like this? something like:
-            //       ignoreErrors([]() { events.listenerConnected(connection); }, OPENDAQ_ERR_HARMLESS1, OPENDAQ_ERR_HARMLESS2);
-
-            try
-            {
-                events.listenerConnected(connection);
-            }
-            catch (const DaqException& e)
-            {
-                if (e.getErrCode() != OPENDAQ_ERR_NOTIMPLEMENTED)
-                    throw;
-            }
-        }
-    }
-    catch (const DaqException& e)
-    {
-        return errorFromException(e, this->getThisAsBaseObject());
-    }
-    catch (const std::exception& e)
-    {
-        return DAQ_ERROR_FROM_STD_EXCEPTION(e, this->getThisAsBaseObject(), OPENDAQ_ERR_GENERALERROR);
-    }
-    catch (...)
-    {
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_GENERALERROR);
-    }
-
-    if (!this->coreEventMuted && this->coreEvent.assigned())
-    {
-        const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(CoreEventId::SignalConnected,
-                                                                                      Dict<IString, IBaseObject>({{"Signal", signal}}));
-
-        this->triggerCoreEvent(args);
-    }
-
-    return OPENDAQ_SUCCESS;
+    return connectInternal(signal, false);
 }
 
 template <class... Interfaces>
@@ -444,6 +367,24 @@ ErrCode GenericInputPortImpl<Interfaces...>::notifyPacketEnqueuedOnThisThread()
         });
 }
 
+template <class ... Interfaces>
+ErrCode GenericInputPortImpl<Interfaces...>::notifyPacketEnqueuedWithScheduler()
+{
+    return wrapHandler(
+        [this]
+        {
+            switch (notifyMethod)
+            {
+                case PacketReadyNotification::SameThread:
+                case PacketReadyNotification::Scheduler:
+                case PacketReadyNotification::SchedulerQueueWasEmpty:
+                    notifyPacketEnqueuedScheduler();
+                case PacketReadyNotification::None:
+                    break;
+            }
+        });
+}
+
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setListener(IInputPortNotifications* port)
 {
@@ -519,6 +460,12 @@ ErrCode GenericInputPortImpl<Interfaces...>::disconnectWithoutSignalNotification
             disconnectSignalInternal(std::move(connection), true, false, true);
             return OPENDAQ_SUCCESS;
         });
+}
+
+template <class ... Interfaces>
+ErrCode GenericInputPortImpl<Interfaces...>::connectSignalSchedulerNotification(ISignal* signal)
+{
+    return connectInternal(signal, true);
 }
 
 template <class... Interfaces>
@@ -639,6 +586,94 @@ ErrCode GenericInputPortImpl<Interfaces...>::Deserialize(ISerializedObject* seri
                        })
                        .detach();
         });
+}
+
+template <class ... Interfaces>
+ErrCode GenericInputPortImpl<Interfaces...>::connectInternal(ISignal* signal, bool scheduled)
+{
+    OPENDAQ_PARAM_NOT_NULL(signal);
+
+    try
+    {
+        auto err = canConnectSignal(signal);
+        OPENDAQ_RETURN_IF_FAILED(err);
+
+        auto signalPtr = SignalPtr::Borrow(signal);
+
+        const auto connection = createConnection(signalPtr);
+
+        InputPortNotificationsPtr inputPortListener;
+        {
+            auto lock = this->getRecursiveConfigLock();
+            if (this->isComponentRemoved)
+                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Cannot connect signal to removed input port");
+
+            {
+                ConnectionPtr oldConnection = connectionRef.assigned() ? connectionRef.getRef() : nullptr;
+                connectionRef.release();
+                disconnectSignalInternal(std::move(oldConnection), false, true, false);
+            }
+            connectionRef = connection;
+
+            if (listenerRef.assigned())
+                inputPortListener = listenerRef.getRef();
+        }
+
+        if (inputPortListener.assigned())
+        {
+            err = inputPortListener->connected(Super::template borrowInterface<IInputPort>());
+            if (OPENDAQ_FAILED(err))
+            {
+                connectionRef.release();
+                return DAQ_MAKE_ERROR_INFO(err);
+            }
+        }
+
+        const auto events = signalPtr.asPtrOrNull<ISignalEvents>(true);
+        if (events.assigned())
+        {
+            // NORRIS/TODO: what's the correct behavior if this fails? what about when the error is OPENDAQ_ERR_NOTIMPLEMENTED?
+            // - behavior before my change is to propagate the error up to the caller even in the latter case, which seems wrong
+            // - behavior now is that OPENDAQ_ERR_NOTIMPLEMENTED is ignored but other errors are propagated
+            // - do we have (and if not, do we want) helper methods for exception handling like this? something like:
+            //       ignoreErrors([]() { events.listenerConnected(connection); }, OPENDAQ_ERR_HARMLESS1, OPENDAQ_ERR_HARMLESS2);
+
+            try
+            {
+                if (!scheduled)
+                    events.listenerConnected(connection);
+                else
+                    events.listenerConnectedScheduled(connection);
+            }
+            catch (const DaqException& e)
+            {
+                if (e.getErrCode() != OPENDAQ_ERR_NOTIMPLEMENTED)
+                    throw;
+            }
+        }
+    }
+    catch (const DaqException& e)
+    {
+        return errorFromException(e, this->getThisAsBaseObject());
+    }
+    catch (const std::exception& e)
+    {
+        return DAQ_ERROR_FROM_STD_EXCEPTION(e, this->getThisAsBaseObject(), OPENDAQ_ERR_GENERALERROR);
+    }
+    catch (...)
+    {
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_GENERALERROR);
+    }
+
+    if (!this->coreEventMuted && this->coreEvent.assigned())
+    {
+        const auto args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(CoreEventId::SignalConnected,
+                                                                                      Dict<IString, IBaseObject>({{"Signal", signal}}));
+
+        this->triggerCoreEvent(args);
+    }
+
+    return OPENDAQ_SUCCESS;
 }
 
 template <class... Interfaces>

--- a/core/opendaq/signal/include/opendaq/input_port_private.h
+++ b/core/opendaq/signal/include/opendaq/input_port_private.h
@@ -36,6 +36,15 @@ DECLARE_OPENDAQ_INTERFACE(IInputPortPrivate, IBaseObject)
      * @brief Disconnects the signal without notification to the signal.
      */
     virtual ErrCode INTERFACE_FUNC disconnectWithoutSignalNotification() = 0;
+
+    /*!
+     * @brief Connects the signal to the input port, forming a Connection.
+     * @param signal The signal to be connected to the input port.
+     *
+     * On connect, an event packet is enqueued in the connection. This method schedules the
+     * `onPacketReceived` notification instead of invoking it on the same thread.
+     */
+    virtual ErrCode INTERFACE_FUNC connectSignalSchedulerNotification(ISignal* signal) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/signal/include/opendaq/signal_events.h
+++ b/core/opendaq/signal/include/opendaq/signal_events.h
@@ -35,6 +35,9 @@ DECLARE_OPENDAQ_INTERFACE(ISignalEvents, IBaseObject)
     /*!
      * @brief Notifies the signal that it has been connected to an input port forming a new connection.
      * @param connection The formed connection.
+     *
+     * The data descriptor of the signal is enqueued on the connection, triggering the `onPacketReceived` 
+     * callback on the same thread.
      */
     virtual ErrCode INTERFACE_FUNC listenerConnected(IConnection* connection) = 0;
 
@@ -57,6 +60,15 @@ DECLARE_OPENDAQ_INTERFACE(ISignalEvents, IBaseObject)
      * @param signal The callee signal on which the domain signal reference has been removed.
      */
     virtual ErrCode INTERFACE_FUNC domainSignalReferenceRemoved(ISignal* signal) = 0;
+
+    /*!
+     * @brief Notifies the signal that it has been connected to an input port forming a new connection.
+     * @param connection The formed connection.
+     *
+     * The data descriptor of the signal is enqueued on the connection, scheduling the `onPacketReceived` 
+     * callback.
+     */
+    virtual ErrCode INTERFACE_FUNC listenerConnectedScheduled(IConnection* connection) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/signal/src/connection_impl.cpp
+++ b/core/opendaq/signal/src/connection_impl.cpp
@@ -84,6 +84,15 @@ ErrCode INTERFACE_FUNC ConnectionImpl::enqueueOnThisThread(IPacket* packet)
     return enqueueInternal(packetPtr, [this](bool) { port.notifyPacketEnqueuedOnThisThread(); });
 }
 
+ErrCode ConnectionImpl::enqueueWithScheduler(IPacket* packet)
+{
+    OPENDAQ_PARAM_NOT_NULL(packet);
+
+    const auto packetPtr = PacketPtr::Borrow(packet);
+
+    return enqueueInternal(packetPtr, [this](bool) { port.notifyPacketEnqueuedWithScheduler(); });
+}
+
 #if _MSC_VER < 1920
 
 ErrCode ConnectionImpl::enqueueMultipleInternal(const ListPtr<IPacket>& packets)

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -139,6 +139,11 @@ public:
         *remote = False;
         return OPENDAQ_SUCCESS;
     }
+
+    ErrCode INTERFACE_FUNC enqueueWithScheduler(IPacket* packet) override
+    {
+        return OPENDAQ_SUCCESS;
+    }
 };
 
 class PacketMockImpl : public ImplementationOf<IPacket>

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_connection_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_connection_impl.h
@@ -33,6 +33,7 @@ public:
     ErrCode INTERFACE_FUNC enqueueAndStealRef(IPacket* packet) override;
     ErrCode INTERFACE_FUNC enqueueMultipleAndStealRef(IList* packet) override;
     ErrCode INTERFACE_FUNC enqueueOnThisThread(IPacket* packet) override;
+    ErrCode INTERFACE_FUNC enqueueWithScheduler(IPacket* packet) override;
     ErrCode INTERFACE_FUNC dequeue(IPacket** packet) override;
     ErrCode INTERFACE_FUNC dequeueAll(IList** packet) override;
     ErrCode INTERFACE_FUNC peek(IPacket** packet) override;
@@ -92,6 +93,11 @@ inline ErrCode INTERFACE_FUNC ConfigClientConnectionImpl::enqueueMultipleAndStea
 }
 
 inline ErrCode ConfigClientConnectionImpl::enqueueOnThisThread(IPacket* packet)
+{
+    return OPENDAQ_IGNORED;
+}
+
+inline ErrCode ConfigClientConnectionImpl::enqueueWithScheduler(IPacket* packet)
 {
     return OPENDAQ_IGNORED;
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
@@ -37,6 +37,7 @@ public:
                               const StringPtr& className = nullptr);
 
     ErrCode INTERFACE_FUNC connect(ISignal* signal) override;
+    ErrCode INTERFACE_FUNC connectSignalSchedulerNotification(ISignal* signal) override;
     ErrCode INTERFACE_FUNC disconnect() override;
 
     ErrCode INTERFACE_FUNC assignSignal(ISignal* signal) override;
@@ -109,6 +110,11 @@ inline ErrCode ConfigClientInputPortImpl::connect(ISignal* signal)
 
             return Super::connect(signal);
         });
+}
+
+inline ErrCode ConfigClientInputPortImpl::connectSignalSchedulerNotification(ISignal* signal)
+{
+    return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NATIVE_CLIENT_CALL_NOT_AVAILABLE);
 }
 
 inline ErrCode ConfigClientInputPortImpl::disconnect()

--- a/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_input_port_impl.h
+++ b/shared/libraries/opcuatms/opcuatms_client/include/opcuatms_client/objects/tms_client_input_port_impl.h
@@ -31,6 +31,7 @@ public:
 
     ErrCode INTERFACE_FUNC acceptsSignal(ISignal* signal, Bool* accepts) override;
     ErrCode INTERFACE_FUNC connect(ISignal* signal) override;
+    ErrCode INTERFACE_FUNC connectSignalSchedulerNotification(ISignal* signal) override;
     ErrCode INTERFACE_FUNC disconnect() override;
     ErrCode INTERFACE_FUNC getSignal(ISignal** signal) override;
     ErrCode INTERFACE_FUNC getConnection(IConnection** connection) override;

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_input_port_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_input_port_impl.cpp
@@ -87,6 +87,11 @@ ErrCode TmsClientInputPortImpl::connect(ISignal* signal)
     });
 }
 
+ErrCode TmsClientInputPortImpl::connectSignalSchedulerNotification(ISignal* signal)
+{
+    return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_OPCUA_CLIENT_CALL_NOT_AVAILABLE);
+}
+
 ErrCode TmsClientInputPortImpl::disconnect()
 {
     return daqTry([&]()


### PR DESCRIPTION
# Brief

Added method to allow IP connection with scheduler notification.

# Description

This feature aims to resolve deadlock occurrence when a component is trying to connect a signal into its own input port while holding a lock. The new `IInputPortConfig::connectSignalSchedulerNotification` method does not trigger the `onPacketReceived` notification on the same thread, but instead schedules it. This allows for the pattern of locking the the internal component mutex in `onPacketReceived` to continue being used.

# Usage example


# API changes

```diff
+ IConnection::enqueueWithScheduler(IPacket* packet)
+ IInputPortConfig::notifyPacketEnqueuedWithScheduler()
+ IInputPortPrivate::connectSignalSchedulerNotification(ISignal* signal)
+ ISignalEvents::listenerConnectedScheduled(IConnection* connection)
```
