### PR TITLE
Bump LT version to 1.2.6

### DIFF
--- a/external/streaming_protocol/CMakeLists.txt
+++ b/external/streaming_protocol/CMakeLists.txt
@@ -6,8 +6,8 @@ endif()
 
 opendaq_dependency(
     NAME                streaming_protocol
-    REQUIRED_VERSION    1.2.5
+    REQUIRED_VERSION    1.2.6
     GIT_REPOSITORY      https://github.com/openDAQ/streaming-protocol-lt.git
-    GIT_REF             v1.2.5
+    GIT_REF             v1.2.6
     EXPECT_TARGET       daq::streaming_protocol
 )


### PR DESCRIPTION
# Brief

Bumps LT version to 1.2.6 to fix MacOS build issues.