### PR TITLE
Fix Python GUI app crash for Python versions below 3.11 on startup

### DIFF
--- a/examples/python/gui_demo/utils.py
+++ b/examples/python/gui_demo/utils.py
@@ -16,12 +16,13 @@ yes_no_inv = {
     'yes': True
 }
 
-class StatusColor(enum.StrEnum):
+class StatusColor(enum.Enum):
     OK = 'olive drab'
     WARNING = 'orange'
     ERROR = 'red'
     NOT_SET = 'light blue'
-
+    def __str__(self):
+        return self.value
 
 def find_component(id, parent=None, convert_id=True):
     if convert_id:


### PR DESCRIPTION
# Brief

Fix Python GUI app crash for Python versions below 3.11 by mimicking `enum.StrEnum` functionality via `enum.Enum`.
