### PR TITLE
Exclude ComponentConfig from OPC UA Component Properties

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -39,6 +39,7 @@
 
 ## Bug fixes
 
+- [#842](https://github.com/openDAQ/openDAQ/pull/842) Exclude ComponentConfig from OPC UA Component Properties
 - [#833](https://github.com/openDAQ/openDAQ/pull/833) Fix Invalid MultiReader in PowerReaderFb on Sample Rate Change
 - [#831](https://github.com/openDAQ/openDAQ/pull/831) Uses newly added sendPacketRecursiveLock method to send descriptor changed events on value signals that use the signal of which descriptor was changed as their domain signal.
 - [#827](https://github.com/openDAQ/openDAQ/pull/827) Fix setting irrelevant streaming source as active

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_component_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_component_impl.cpp
@@ -210,13 +210,13 @@ bool TmsClientComponentBaseImpl<Impl>::isChildComponent(const ComponentPtr& comp
 template <class Impl>
 PropertyObjectPtr TmsClientComponentBaseImpl<Impl>::findAndCreateComponentConfig()
 {
-    PropertyObjectPtr componentConfig;
-    if (const auto& objIt = this->objectTypeIdMap.find("ComponentConfig"); objIt != this->objectTypeIdMap.cend())
-    {
-        componentConfig = TmsClientPropertyObject(this->daqContext, this->clientContext, objIt->second);
-        this->objectTypeIdMap.erase(objIt);
-    }
-    return componentConfig;
+
+    std::string referenceName = "ComponentConfig";
+    if (!this->hasReference(referenceName))
+        return nullptr;
+
+    auto refNodeId = this->getNodeId(referenceName);
+    return TmsClientPropertyObject(this->daqContext, this->clientContext, refNodeId);
 }
 
 template class TmsClientComponentBaseImpl<ComponentImpl<IComponent, ITmsClientComponent>>;

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_property_object_impl.cpp
@@ -23,7 +23,10 @@ using namespace opcua;
 
 namespace detail
 {
-    std::unordered_set<std::string> ignoredPropertyNames{"ServerCapabilities", "OperationMode", "OperationModeOptions"};
+    std::unordered_set<std::string> ignoredPropertyNames{"ServerCapabilities",
+                                                         "OperationMode",
+                                                         "OperationModeOptions",
+                                                         "ComponentConfig"};
 }
 
 template <class Impl>

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
@@ -235,8 +235,6 @@ void TmsServerComponent<Ptr>::addChildNodes()
     
     this->server->addVariableNode(params);
 
-    // this property will be added manually
-    tmsPropertyObject->ignoredProps.emplace("ComponentConfig");
     tmsPropertyObject->registerToExistingOpcUaNode(this->nodeId);
     if (tmsComponentConfig)
         tmsComponentConfig->registerOpcUaNode(this->nodeId);


### PR DESCRIPTION
# Brief

Ensure that `ComponentConfig` is not exposed as a property of components in OPC UA.

# Description

`ComponentConfig` is an internal property of the `Component` object, represented by a `PropertyObject` type, which stores the configuration used during the component's creation. Due to an oversight, this internal property was inadvertently exposed to OPC UA clients as a regular component property.

This PR corrects that behavior by excluding `componentConfig` from the set of properties exposed via OPC UA, keeping it internal as originally intended.


# API changes

None

# Required application changes

None

# Required module changes

None
