### PR TITLE
openDAQ and python bindings updates for python module

### DIFF
--- a/bindings/python/core_objects/include/py_core_objects/py_variant_extractor.h
+++ b/bindings/python/core_objects/include/py_core_objects/py_variant_extractor.h
@@ -179,7 +179,16 @@ daq::ObjectPtr<std::remove_pointer_t<DaqType>> getVariantValue(Variant& v)
     }
     if constexpr (std::is_same_v<DaqType, daq::INumber*> && is_variant_member_v<double, Variant> && is_variant_member_v<int64_t, Variant>)
     {
+        if constexpr (is_variant_member_v<daq::INumber*, Variant>)
+        {
+            if (auto number = std::get_if<daq::INumber*>(&v))
+            {
+                return daq::NumberPtr(*number);
+            }
+        }
+
         variant_full_t variant;
+
         if (auto doublePtr = std::get_if<double>(&v))
         {
             variant = *doublePtr;
@@ -188,6 +197,7 @@ daq::ObjectPtr<std::remove_pointer_t<DaqType>> getVariantValue(Variant& v)
         {
             variant = *intPtr;
         }
+
         return getVariantValueInternal(variant);
     }
     if (auto daq = std::get_if<DaqType>(&v))

--- a/bindings/python/core_types/include/py_core_types/py_opendaq_daq.h
+++ b/bindings/python/core_types/include/py_core_types/py_opendaq_daq.h
@@ -168,5 +168,15 @@ auto wrapInterface(pybind11::module_ m, const char* name, const Extra&... extra)
     cls.def_static("cast_from", [](daq::IBaseObject* obj) { return castFrom<Interface>(obj); });
     cls.def_static("convert_from", [](daq::IBaseObject* obj) { return convertFrom<Interface>(obj); });
     cls.def_static("can_cast_from", [](daq::IBaseObject* obj) { return canCastFrom<Interface>(obj); });
+    cls.def_static("from_raw_interface",
+                   [](const py::capsule& rawInterface)
+                   {
+                       if (std::strcmp(rawInterface.name(), "opendaq.raw_interface") != 0)
+                           throw std::invalid_argument("Invalid capsule");
+
+                       daq::IBaseObject* obj = rawInterface.get_pointer<daq::IBaseObject>();
+                       return castFrom<Interface>(obj);
+                   });
+
     return cls;
 }

--- a/bindings/python/core_types/src/py_base_object.cpp
+++ b/bindings/python/core_types/src/py_base_object.cpp
@@ -104,4 +104,10 @@ void declareAndDefineIBaseObject(pybind11::module_ m)
             InterfaceWrapper<daq::IBaseObject> wrappedInterface(obj);
             return py::cast(wrappedInterface);
         });
+    cls.def("to_native_object",
+        [](daq::IBaseObject* obj)
+        {
+            const auto objPtr = daq::BaseObjectPtr::Borrow(obj);
+            return baseObjectToPyObject(obj, daq::IBaseObject::Id, false);
+        });
 }

--- a/bindings/python/opendaq/include/py_opendaq/py_packet_buffer.h
+++ b/bindings/python/opendaq/include/py_opendaq/py_packet_buffer.h
@@ -59,16 +59,12 @@ public:
     static void wrap(pybind11::module_ m)
     {
         py::class_<Buffer> cls(m, Buffer::getName().c_str(), py::buffer_protocol());
-        cls.def(py::init([](daq::IBaseObject* owner, void* mem, size_t size)
-            {
-                return std::make_unique<Buffer>(owner, mem, size);
-            }));
 
         cls.def_buffer([](Buffer& buffer)
             {
                 return py::buffer_info(buffer.getMem(), 1, py::format_descriptor<uint8_t>::format(), buffer.getSize());
             });
-    }
+    } 
 
 private:
     daq::BaseObjectPtr owner;

--- a/bindings/python/opendaq/py_opendaq.cpp
+++ b/bindings/python/opendaq/py_opendaq.cpp
@@ -20,7 +20,8 @@ void wrapDaqComponentOpenDaq(pybind11::module_ m)
         .value("ComplexFloat64", daq::SampleType::ComplexFloat64)
         .value("Binary", daq::SampleType::Binary)
         .value("String", daq::SampleType::String)
-        .value("Struct", daq::SampleType::Struct);
+        .value("Struct", daq::SampleType::Struct)
+        .value("Null", daq::SampleType::Null);
 
     py::enum_<daq::ScaledSampleType>(m, "ScaledSampleType")
         .value("Invalid", daq::ScaledSampleType::Invalid)

--- a/bindings/python/tests/test_core_types.py
+++ b/bindings/python/tests/test_core_types.py
@@ -134,6 +134,12 @@ class TestInteger(TestNumObjectWrapper.TestNumObject):
 
     def test_can_cast_from(self):
         self.assertTrue(daq.IBaseObject.can_cast_from(daq.Integer(2)))
+        
+    def test_to_py_object(self):
+        obj = daq.Integer(2)
+        py_obj = obj.to_native_object()
+        self.assertFalse(isinstance(obj, int))
+        self.assertTrue(isinstance(py_obj, int))
 
 class TestFloat(TestNumObjectWrapper.TestNumObject):
     def createObject(self, num):

--- a/bindings/python/tests/test_core_types.py
+++ b/bindings/python/tests/test_core_types.py
@@ -41,6 +41,12 @@ class TestBaseObject(opendaq_test.TestCase):
         obj2 = daq.BaseObject()
         self.assertTrue(obj1 == obj1)
         self.assertTrue(obj1 != obj2)
+        
+    def test_raw_interface(self):
+        obj1 = daq.BaseObject()        
+        raw_interface = obj1.get_raw_interface()
+        obj2 = daq.IBaseObject.from_raw_interface(raw_interface)
+        self.assertTrue(obj1 == obj1)
 
 class TestBoolean(opendaq_test.TestCase):
     def test_create(self):
@@ -75,6 +81,12 @@ class TestBoolean(opendaq_test.TestCase):
 
     def test_can_cast_from(self):
         self.assertTrue(daq.IBaseObject.can_cast_from(daq.Boolean(True)))
+
+    def test_raw_interface(self):
+        obj1 = daq.Boolean(True)        
+        raw_interface = obj1.get_raw_interface()
+        obj2 = daq.IBoolean.from_raw_interface(raw_interface)
+        self.assertTrue(obj1 == obj1)
 
 class TestNumObjectWrapper:
     class TestNumObject(opendaq_test.TestCase):


### PR DESCRIPTION
# Brief

Internal changes required for the Python device & function block module


# Description

These changes are necessary for implementing the Python module. 

Requires an additional fix for the stream reader not overwriting the notification method on the input port, which will be addressed in the multi-reader PR.