### PR TITLE
Change default Python load paths

### DIFF
--- a/bindings/python/package/opendaq/__init__.py
+++ b/bindings/python/package/opendaq/__init__.py
@@ -4,14 +4,18 @@ import os
 OPENDAQ_MODULES_DIR = os.path.dirname(os.path.abspath(__file__))
 OPENDAQ_CWD = os.getcwd()
 
-
 # BUG: in mac os creating the project with `-> IInstance:` is failing`. 
 # To build successfully, we need to remove the `-> IInstance:` from the code.
+
 def Instance(*args) -> IInstance:
     if len(args) == 0:
         builder = opendaq.InstanceBuilder()
-        builder.add_module_path(OPENDAQ_MODULES_DIR)
-        builder.scheduler_worker_num = 0
+        builder.module_path = OPENDAQ_MODULES_DIR
         return opendaq.InstanceFromBuilder(builder)
     else:
         return opendaq.Instance(*args)
+
+def InstanceBuilder() -> IInstanceBuilder:
+    builder = opendaq.InstanceBuilder()
+    builder.module_path = OPENDAQ_MODULES_DIR
+    return builder


### PR DESCRIPTION
# Brief

Set default module load paths in Python to OPENDAQ_MODULES_DIR.