### PR TITLE
Gracefully handle operation mode getters when not supported on server

### DIFF
--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -17,7 +17,8 @@
 
 ## Bug fixes
 
-- [#827](https://github.com/openDAQ/openDAQ/pull/827) Fix setting irrelevant streaming source as active
+- [#848](https://github.com/openDAQ/openDAQ/pull/848) Do not throw an exception when getting operation modes on old devices. Return default state instead.
+- [#827](https://github.com/openDAQ/openDAQ/pull/827) Fix setting irrelevant streaming source as active.
 - [#808](https://github.com/openDAQ/openDAQ/pull/808) Fix examples CMake when downloaded as solo archive via https://docs.opendaq.com/ or https://docs-dev.opendaq.com/ (when not part of whole openDAQ project).
 - [#781](https://github.com/openDAQ/openDAQ/pull/781) Fix how Lists are interpreted for Function Property in Python.
 

--- a/core/coreobjects/include/coreobjects/eval_nodes.h
+++ b/core/coreobjects/include/coreobjects/eval_nodes.h
@@ -204,7 +204,7 @@ BaseObjectPtr ConstNode<T, CT>::getResult()
 }
 
 template <class T, CoreType CT>
-std::unique_ptr<BaseNode> ConstNode<T, CT>::clone(GetReferenceEvent refCall)
+std::unique_ptr<BaseNode> ConstNode<T, CT>::clone(GetReferenceEvent /*refCall*/)
 {
     return std::make_unique<ConstNode<T, CT>>(value);
 }

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -318,7 +318,8 @@ inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::getAvailableOperation
     OPENDAQ_PARAM_NOT_NULL(availableOpModes);
     return daqTry([this, availableOpModes] 
     {
-        if (this->clientComm->getProtocolVersion() < 12)
+        const auto protocolVersion = this->clientComm->getProtocolVersion();
+        if (protocolVersion >= 9 && protocolVersion < 12)
             *availableOpModes = this->clientComm->getAvailableOperationModes(this->remoteGlobalId).detach();
         else
             checkErrorInfo(Super::getAvailableOperationModes(availableOpModes));   
@@ -333,7 +334,6 @@ inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::setOperationMode(Oper
         this->clientComm->setOperationMode(this->remoteGlobalId, OperationModeTypeToString(modeType));
     });
 }
-
 
 template <class TDeviceBase>
 inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::setOperationModeRecursive(OperationModeType modeType)
@@ -350,7 +350,8 @@ inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::getOperationMode(Oper
     OPENDAQ_PARAM_NOT_NULL(modeType);
     return daqTry([this, modeType] 
     { 
-        if (this->clientComm->getProtocolVersion() < 12)
+        const auto protocolVersion = this->clientComm->getProtocolVersion();
+        if (protocolVersion >= 9 && protocolVersion < 12)
             *modeType = OperationModeTypeFromString(this->clientComm->getOperationMode(this->remoteGlobalId)); 
         else
             checkErrorInfo(Super::getOperationMode(modeType));   

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -319,7 +319,7 @@ inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::getAvailableOperation
     return daqTry([this, availableOpModes] 
     {
         const auto protocolVersion = this->clientComm->getProtocolVersion();
-        if (protocolVersion >= 9 && protocolVersion < 12)
+        if (protocolVersion > 8 && protocolVersion < 12)
             *availableOpModes = this->clientComm->getAvailableOperationModes(this->remoteGlobalId).detach();
         else
             checkErrorInfo(Super::getAvailableOperationModes(availableOpModes));   

--- a/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_device_impl.cpp
+++ b/shared/libraries/opcuatms/opcuatms_client/src/objects/tms_client_device_impl.cpp
@@ -138,7 +138,10 @@ ErrCode TmsClientDeviceImpl::getAvailableOperationModes(IList** availableOpModes
     OPENDAQ_PARAM_NOT_NULL(availableOpModes); 
     
     if (!this->hasReference("OperationModeOptions"))
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOT_SUPPORTED, "OperationModes are not supported by the server");
+    {
+        LOG_D("OperationModes are not supported by the server")
+        return Super::getAvailableOperationModes(availableOpModes);
+    }
 
     const auto nodeId = getNodeId("OperationModeOptions");
     auto opModesNodeStrList = VariantConverter<IString>::ToDaqList(client->readValue(nodeId));
@@ -184,7 +187,10 @@ ErrCode TmsClientDeviceImpl::getOperationMode(OperationModeType* modeType)
     OPENDAQ_PARAM_NOT_NULL(modeType);
 
     if (!this->hasReference("OperationMode"))
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOT_SUPPORTED, "OperationModes are not supported by the server");
+    {
+        LOG_D("OperationModes are not supported by the server")
+        return Super::getOperationMode(modeType);
+    }
     
     const auto nodeId = getNodeId("OperationMode");
     const auto variant = client->readValue(nodeId);


### PR DESCRIPTION
# Brief

Do not throw an exception when getting operation modes on old devices. Return default state instead.