### PR TITLE
Wrapped data packet

### DIFF
--- a/core/opendaq/signal/include/opendaq/wrapped_data_packet.h
+++ b/core/opendaq/signal/include/opendaq/wrapped_data_packet.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <opendaq/data_descriptor.h>
+#include <opendaq/data_packet.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+/*#
+ * [interfaceSmartPtr(IDataPacket, GenericDataPacketPtr)]
+ */
+
+/*!
+ * @ingroup opendaq_packets
+ * @addtogroup opendaq_data_packet Wrapped data packet
+ * @{
+ */
+
+/*!
+ * @brief Data packet that wraps the source packet.
+ *
+ * Wrapped data packets share the same raw data with source packet but have their own data descriptor.
+ * This typically means that their raw sample type and sample count should be the same.
+ */
+DECLARE_OPENDAQ_INTERFACE(IWrappedDataPacket, IBaseObject)
+{
+    // [templateType(packet, IDataPacket)]
+    /*!
+     * @brief Gets the wrapped source data packet.
+     * @param[out] sourcePacket The wrapped source data packet.
+     */
+    virtual ErrCode INTERFACE_FUNC getSourcePacket(IDataPacket** sourcePacket) = 0;
+};
+
+/*!@}*/
+
+/*!
+ * @brief Creates a wrapped data packet.
+ * @param sourcePacket The source packet being wrapped.
+ * @param descriptor The descriptor of the packet.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(LIBRARY_FACTORY,
+                                                            WrappedDataPacket,
+                                                            IDataPacket,
+                                                            createWrappedDataPacket,
+                                                            IDataPacket*,
+                                                            sourcePacket,
+                                                            IDataDescriptor*,
+                                                            descriptor)
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/include/opendaq/wrapped_data_packet_factory.h
+++ b/core/opendaq/signal/include/opendaq/wrapped_data_packet_factory.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <opendaq/data_packet_ptr.h>
+#include <opendaq/wrapped_data_packet.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+/*!
+ * @ingroup opendaq_packets
+ * @addtogroup opendaq_packet_factories Factories
+ * @{
+ */
+
+/*!
+ * @brief Creates a wrapped data packet.
+ * @param sourcePacket The source packet being wrapped.
+ * @param descriptor The descriptor of the packet.
+ */
+inline DataPacketPtr WrappedDataPacket(const DataPacketPtr& sourcePacket,
+                                       const DataDescriptorPtr& descriptor)
+{
+    DataPacketPtr obj(WrappedDataPacket_Create(sourcePacket, descriptor));
+    return obj;
+}
+
+/*!@}*/
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/include/opendaq/wrapped_data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/wrapped_data_packet_impl.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <opendaq/data_packet_ptr.h>
+#include <opendaq/data_packet_impl.h>
+#include <opendaq/wrapped_data_packet.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+class WrappedDataPacketImpl : public DataPacketImpl<IDataPacket, IWrappedDataPacket>
+{
+public:
+    using Super = DataPacketImpl<IDataPacket, IWrappedDataPacket>;
+
+    explicit WrappedDataPacketImpl(IDataPacket* sourcePacket,
+                                   IDataDescriptor* descriptor);
+
+    ErrCode INTERFACE_FUNC getDomainPacket(IDataPacket** packet) override;
+    ErrCode INTERFACE_FUNC getOffset(INumber** offset) override;
+
+    ErrCode INTERFACE_FUNC getSourcePacket(IDataPacket** sourcePacket) override;
+
+protected:
+    void internalDispose([[maybe_unused]] bool disposing) override;
+
+private:
+    DataPacketPtr sourcePacket;
+};
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/src/CMakeLists.txt
+++ b/core/opendaq/signal/src/CMakeLists.txt
@@ -31,6 +31,7 @@ function(rtgen_component_${BASE_NAME})
     rtgen(SRC_Allocator allocator.h)
     rtgen(SRC_ReferenceDomainInfo reference_domain_info.h)
     rtgen(SRC_ReferenceDomainInfoBuilder reference_domain_info_builder.h)
+    rtgen(SRC_WrappedDataPacket wrapped_data_packet.h)
     
     set(SRC_PublicHeaders_Component_Generated 
         ${SRC_Connection_PublicHeaders}
@@ -62,6 +63,7 @@ function(rtgen_component_${BASE_NAME})
         ${SRC_SignalPrivate_PublicHeaders}
         ${SRC_ReferenceDomainInfo_PublicHeaders}
         ${SRC_ReferenceDomainInfoBuilder_PublicHeaders}
+        ${SRC_WrappedDataPacket_PublicHeaders}
         PARENT_SCOPE
     )
     
@@ -97,6 +99,7 @@ function(rtgen_component_${BASE_NAME})
         ${SRC_Allocator_PrivateHeaders}
         ${SRC_ReferenceDomainInfo_PrivateHeaders}
         ${SRC_ReferenceDomainInfoBuilder_PrivateHeaders}
+        ${SRC_WrappedDataPacket_PrivateHeaders}
         PARENT_SCOPE
     )
     
@@ -125,6 +128,7 @@ function(rtgen_component_${BASE_NAME})
         ${SRC_Allocator_Cpp}
         ${SRC_ReferenceDomainInfo_Cpp}
         ${SRC_ReferenceDomainInfoBuilder_Cpp}
+        ${SRC_WrappedDataPacket_Cpp}
         PARENT_SCOPE
     )
 endfunction()
@@ -188,6 +192,7 @@ function(create_component_source_groups_${BASE_NAME})
         ${SDK_HEADERS_DIR}/reusable_data_packet.h
         ${SDK_HEADERS_DIR}/generic_data_packet_impl.h
         ${SDK_HEADERS_DIR}/data_packet_impl.h
+        ${SDK_HEADERS_DIR}/wrapped_data_packet_impl.h
         ${SDK_HEADERS_DIR}/event_packet.h
         ${SDK_HEADERS_DIR}/event_packet_impl.h
         ${SDK_HEADERS_DIR}/event_packet_ids.h
@@ -203,11 +208,18 @@ function(create_component_source_groups_${BASE_NAME})
         ${SDK_HEADERS_DIR}/packet_destruct_callback_factory.h
         ${SDK_HEADERS_DIR}/packet_destruct_callback_impl.h
         ${SDK_HEADERS_DIR}/reference_domain_offset_adder.h
+        ${SDK_HEADERS_DIR}/bulk_data_packet.h
+        ${SDK_HEADERS_DIR}/bulk_data_packet_ptr.h
+        ${SDK_HEADERS_DIR}/wrapped_packet_factory.h
+        ${SDK_HEADERS_DIR}/wrapped_packet.h
+        ${SDK_HEADERS_DIR}/wrapped_data_packet.h
+        ${SDK_HEADERS_DIR}/wrapped_data_packet_factory.h
         ${SDK_SRC_DIR}/data_packet_impl.cpp
         ${SDK_SRC_DIR}/generic_data_packet_impl.cpp
         ${SDK_SRC_DIR}/event_packet_impl.cpp
         ${SDK_SRC_DIR}/binary_data_packet_impl.cpp
         ${SDK_SRC_DIR}/bulk_data_packet_impl.cpp
+        ${SDK_SRC_DIR}/wrapped_data_packet_impl.cpp
     )
     
     source_group("signal//input_port" FILES 
@@ -336,6 +348,7 @@ set(SRC_PublicHeaders_Component
     reference_domain_info_factory.h
     bulk_data_packet.h
     bulk_data_packet_factory.h
+    wrapped_data_packet_factory.h
     ${SRC_Mimalloc_PublicHeaders}
     PARENT_SCOPE
 )
@@ -351,6 +364,7 @@ set(SRC_PrivateHeaders_Component
     packet_impl.h
     generic_data_packet_impl.h
     data_packet_impl.h
+    wrapped_data_packet_impl.h
     event_packet_impl.h
     scaling_impl.h
     scaling_builder_impl.h
@@ -379,6 +393,7 @@ set(SRC_Cpp_Component
     range_impl.cpp
     signal_impl.cpp
     data_packet_impl.cpp
+    wrapped_data_packet_impl.cpp
     generic_data_packet_impl.cpp
     event_packet_impl.cpp
     dimension_rule_impl.cpp

--- a/core/opendaq/signal/src/wrapped_data_packet_impl.cpp
+++ b/core/opendaq/signal/src/wrapped_data_packet_impl.cpp
@@ -1,0 +1,62 @@
+#include <opendaq/wrapped_data_packet_impl.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+WrappedDataPacketImpl::WrappedDataPacketImpl(IDataPacket* sourcePacket, IDataDescriptor* descriptor)
+    : Super(PacketDetails::CreatePacketNoMemoryTag{},
+            nullptr,
+            descriptor,
+            DataPacketPtr::Borrow(sourcePacket).getSampleCount(),
+            nullptr)
+    , sourcePacket(sourcePacket)
+{
+#ifdef OPENDAQ_ENABLE_PARAMETER_VALIDATION
+    if (sourcePacket == nullptr)
+        DAQ_THROW_EXCEPTION(ArgumentNullException, "Source packet is null.");
+
+    const DataDescriptorPtr sourceDataDescriptor = this->sourcePacket.getDataDescriptor();
+
+    if (sourceDataDescriptor.getRawSampleSize() != this->rawSampleSize)
+        DAQ_THROW_EXCEPTION(ArgumentNullException, "Raw data does not match.");
+#endif
+
+    checkErrorInfo(sourcePacket->getRawData(&data));
+}
+
+ErrCode WrappedDataPacketImpl::getDomainPacket(IDataPacket** packet)
+{
+    assert(sourcePacket.assigned());
+    return sourcePacket->getDomainPacket(packet);
+}
+
+ErrCode WrappedDataPacketImpl::getOffset(INumber** offset)
+{
+    assert(sourcePacket.assigned());
+    return sourcePacket->getOffset(offset);
+}
+
+ErrCode WrappedDataPacketImpl::getSourcePacket(IDataPacket** sourcePacket)
+{
+    OPENDAQ_PARAM_NOT_NULL(sourcePacket);
+
+    *sourcePacket = this->sourcePacket.addRefAndReturn();
+    return OPENDAQ_SUCCESS;
+}
+
+void WrappedDataPacketImpl::internalDispose(bool disposing)
+{
+    Super::internalDispose(disposing);
+
+    sourcePacket.release();
+}
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(LIBRARY_FACTORY,
+                                                               WrappedDataPacketImpl,
+                                                               IDataPacket,
+                                                               createWrappedDataPacket,
+                                                               IDataPacket*,
+                                                               sourcePacket,
+                                                               IDataDescriptor*,
+                                                               descriptor)
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/tests/CMakeLists.txt
+++ b/core/opendaq/signal/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TEST_SOURCES
     test_gap_checks.cpp
     test_reference_domain_info.cpp
     test_bulk_data_packet.cpp
+    test_wrapped_data_packet.cpp
 )
 
 if (OPENDAQ_MIMALLOC_SUPPORT)

--- a/core/opendaq/signal/tests/test_wrapped_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_wrapped_data_packet.cpp
@@ -1,0 +1,47 @@
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <opendaq/data_rule_factory.h>
+#include <opendaq/wrapped_data_packet_factory.h>
+#include <opendaq/data_descriptor_factory.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/scaling_factory.h>
+
+using namespace daq;
+
+using WrappedDataPacketTest = ::testing::Test;
+
+TEST_F(WrappedDataPacketTest, Packet)
+{
+    const auto domainDescriptor = DataDescriptorBuilder()
+        .setSampleType(SampleType::Int32)
+        .setRule(LinearDataRule(1, 0))
+        .setTickResolution(Ratio(1, 1000))
+        .build();
+
+    const auto sourceValueDescriptor = DataDescriptorBuilder()
+        .setSampleType(SampleType::Float32)
+        .setPostScaling(LinearScaling(1.0, 0.0, SampleType::Int32, ScaledSampleType::Float32))
+        .build();
+
+    constexpr size_t sampleCount = 4;
+
+    auto sourcePacket = DataPacket(sourceValueDescriptor, sampleCount);
+    auto sourceRawData = static_cast<int32_t*>(sourcePacket.getRawData());
+    for (size_t i = 0; i < sampleCount; i++)
+        *sourceRawData++ = static_cast<int32_t>(i);
+
+    auto sourceData = static_cast<float*>(sourcePacket.getData());
+    for (size_t i = 0; i < sampleCount; i++)
+        ASSERT_FLOAT_EQ(*sourceData++, static_cast<float>(i));
+
+    const auto wrappedValueDescriptor = DataDescriptorBuilder()
+        .setSampleType(SampleType::Float32)
+        .setPostScaling(LinearScaling(2.0, 1.0, SampleType::Int32, ScaledSampleType::Float32))
+        .build();
+
+    auto wrappedPacket = WrappedDataPacket(sourcePacket, wrappedValueDescriptor);
+
+    auto wrappedData = static_cast<float*>(wrappedPacket.getData());
+    for (size_t i = 0; i < sampleCount; i++)
+        ASSERT_FLOAT_EQ(*wrappedData++, 2.0f * static_cast<float>(i) + 1.0f);
+}


### PR DESCRIPTION
# Brief

Wrapped data packets

# Description

Wrapped data packets are packets that wrap another data packet as a source and use their data buffers. A wrapped data packet can set a different data descriptor from the source. This is useful if a function block processes source packets in a way that leaves raw data untouched, and it only changes post-scaling factors. This avoids unnecessary memory copies of raw data.

Note that the current implementation of native and LT streaming does not recognize wrapped data packets and treats them as standard data packets. This means that if both source and wrapped data packets are transmitted, the underlying shared buffer will be transmitted twice. This represents a potential area for future optimization.

# Usage example

In C++ use:

```cpp
    const auto domainDescriptor = DataDescriptorBuilder()
        .setSampleType(SampleType::Int32)
        .setRule(LinearDataRule(1, 0))
        .setTickResolution(Ratio(1, 1000))
        .build();

    const auto sourceValueDescriptor = DataDescriptorBuilder()
        .setSampleType(SampleType::Float32)
        .setPostScaling(LinearScaling(1.0, 0.0, SampleType::Int32, ScaledSampleType::Float32))
        .build();

    constexpr size_t sampleCount = 4;

    auto sourcePacket = DataPacket(sourceValueDescriptor, sampleCount);
    auto sourceRawData = static_cast<int32_t*>(sourcePacket.getRawData());
    for (size_t i = 0; i < sampleCount; i++)
        *sourceRawData++ = static_cast<int32_t>(i);

    auto sourceData = static_cast<float*>(sourcePacket.getData());
    for (size_t i = 0; i < sampleCount; i++)
        assert(*sourceData++ == static_cast<float>(i));

    const auto wrappedValueDescriptor = DataDescriptorBuilder()
        .setSampleType(SampleType::Float32)
        .setPostScaling(LinearScaling(2.0, 1.0, SampleType::Int32, ScaledSampleType::Float32))
        .build();

    auto wrappedPacket = WrappedDataPacket(sourcePacket, wrappedValueDescriptor);

    auto wrappedData = static_cast<float*>(wrappedPacket.getData());
    for (size_t i = 0; i < sampleCount; i++)
        assert(*wrappedData++ == 2.0f * static_cast<float>(i) + 1.0f);
```

# API changes

```diff
+ [factory] DataPacketPtr WrappedDataPacket(const DataPacketPtr& sourcePacket, const DataDescriptorPtr& descriptor)
```