### PR TITLE
Fix race condition in native streaming caused by signal removal

### DIFF
--- a/changelog/changelog_3.10-3.20.md
+++ b/changelog/changelog_3.10-3.20.md
@@ -39,7 +39,8 @@
 
 ## Bug fixes
 
-- [#842](https://github.com/openDAQ/openDAQ/pull/846) Do not bind properties on serialize. Prevents crashes when serializing property object classes.
+- [#856](https://github.com/openDAQ/openDAQ/pull/856) Fix race condition in native streaming caused by signal removal.
+- [#846](https://github.com/openDAQ/openDAQ/pull/846) Do not bind properties on serialize. Prevents crashes when serializing property object classes.
 - [#842](https://github.com/openDAQ/openDAQ/pull/842) Exclude ComponentConfig from OPC UA Component Properties
 - [#833](https://github.com/openDAQ/openDAQ/pull/833) Fix Invalid MultiReader in PowerReaderFb on Sample Rate Change
 - [#831](https://github.com/openDAQ/openDAQ/pull/831) Uses newly added sendPacketRecursiveLock method to send descriptor changed events on value signals that use the signal of which descriptor was changed as their domain signal.

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
@@ -87,9 +87,14 @@ public:
 
     /// Removes a registered signal, usually when the signal is being removed from a device.
     /// @param signal The openDAQ signal to unregister.
-    /// @return true if the removed signal was subscribed, false otherwise.
     /// @throw NativeStreamingProtocolException if the signal is not registered
-    bool removeSignal(const SignalPtr& signal);
+    void removeSignal(const SignalPtr& signal);
+
+    /// Check if a registered signal is subscribed.
+    /// @param signal The openDAQ signal to check.
+    /// @return true if the signal is subscribed, false otherwise.
+    /// @throw NativeStreamingProtocolException if the signal is not registered
+    bool isSignalSubscribed(const SignalPtr& signal);
 
     /// Registers a connected client as a streaming client.
     /// @param clientId The unique string ID provided by the client or automatically assigned by the server.

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
@@ -127,8 +127,12 @@ void NativeStreamingServerHandler::removeComponentSignals(const StringPtr& compo
         // removed component is a signal, or signal is a descendant of removed component
         if (signalStringId == removedComponentId || IdsParser::isNestedComponentId(removedComponentId, signalStringId))
         {
-            if (streamingManager.removeSignal(signalPtr))
+            // unsubscribe signal
+            if (streamingManager.isSignalSubscribed(signalPtr))
                 signalUnsubscribedHandler(signalPtr);
+
+            // unregister signal
+            streamingManager.removeSignal(signalPtr);
 
             auto streamingClientsIds = streamingManager.getRegisteredClientsIds();
             for (const auto& clientId : streamingClientsIds)

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -56,7 +56,7 @@ void StreamingManager::sendPacketToSubscribers(const std::string& signalStringId
     }
     else
     {
-        throw NativeStreamingProtocolException(fmt::format("Signal {} is not registered in streaming", signalStringId));
+        throw NativeStreamingProtocolException(fmt::format("Can't send packet - signal {} is not registered in streaming", signalStringId));
     }
 }
 
@@ -104,7 +104,7 @@ void StreamingManager::processPackets(const tsl::ordered_map<std::string, Packet
         }
         else
         {
-            throw NativeStreamingProtocolException(fmt::format("Signal {} is not registered in streaming", signalStringId));
+            throw NativeStreamingProtocolException(fmt::format("Can't process packet - signal {} is not registered in streaming", signalStringId));
         }
     }
 }
@@ -237,25 +237,38 @@ SignalNumericIdType StreamingManager::registerSignal(const SignalPtr& signal)
     }
 }
 
-bool StreamingManager::removeSignal(const SignalPtr& signal)
+void StreamingManager::removeSignal(const SignalPtr& signal)
 {
-    bool doSignalUnsubscribe = false;
     auto signalStringId = signal.getGlobalId().toStdString();
 
     std::scoped_lock lock(sync);
-
     if (auto signalIter = registeredSignals.find(signalStringId); signalIter != registeredSignals.end())
     {
-        const auto& subscribers = signalIter->second.subscribedClientsIds;
-        if (!subscribers.empty())
-            doSignalUnsubscribe = true;
         registeredSignals.erase(signalIter);
     }
     else
     {
-        throw NativeStreamingProtocolException(fmt::format("Signal {} is not registered in streaming", signalStringId));
+        throw NativeStreamingProtocolException(fmt::format("Can't remove - signal {} is not registered in streaming", signalStringId));
     }
-    return doSignalUnsubscribe;
+}
+
+bool StreamingManager::isSignalSubscribed(const SignalPtr& signal)
+{
+    auto signalStringId = signal.getGlobalId().toStdString();
+
+    std::scoped_lock lock(sync);
+    if (auto signalIter = registeredSignals.find(signalStringId); signalIter != registeredSignals.end())
+    {
+        const auto& subscribers = signalIter->second.subscribedClientsIds;
+        if (!subscribers.empty())
+            return true;
+        else
+            return false;
+    }
+    else
+    {
+        throw NativeStreamingProtocolException(fmt::format("Can't check subscriptions - signal {} is not registered in streaming", signalStringId));
+    }
 }
 
 void StreamingManager::registerClient(const std::string& clientId,
@@ -374,7 +387,7 @@ bool StreamingManager::registerSignalSubscriber(const std::string& signalStringI
     }
     else
     {
-        throw NativeStreamingProtocolException(fmt::format("Signal {} is not registered in streaming", signalStringId));
+        throw NativeStreamingProtocolException(fmt::format("Can't register subscriber - signal {} is not registered in streaming", signalStringId));
     }
 
     return doSignalSubscribe;
@@ -407,7 +420,7 @@ bool StreamingManager::removeSignalSubscriberNoLock(const std::string& signalStr
     }
     else
     {
-        throw NativeStreamingProtocolException(fmt::format("Signal {} is not registered in streaming", signalStringId));
+        throw NativeStreamingProtocolException(fmt::format("Can't remove subscriber - signal {} is not registered in streaming", signalStringId));
     }
 
     return doSignalUnsubscribe;
@@ -422,7 +435,7 @@ SignalNumericIdType StreamingManager::findSignalNumericId(const SignalPtr& signa
     if (auto iter = registeredSignals.find(signalStringId); iter != registeredSignals.end())
         return iter->second.numericId;
     else
-        throw NativeStreamingProtocolException(fmt::format("Signal {} is not registered in streaming", signalStringId));
+        throw NativeStreamingProtocolException(fmt::format("Can't find numeric ID - signal {} is not registered in streaming", signalStringId));
 }
 
 SignalPtr StreamingManager::findRegisteredSignal(const std::string& signalStringId)
@@ -432,7 +445,7 @@ SignalPtr StreamingManager::findRegisteredSignal(const std::string& signalString
     if (auto iter = registeredSignals.find(signalStringId); iter != registeredSignals.end())
         return iter->second.daqSignal;
     else
-        throw NativeStreamingProtocolException(fmt::format("Signal {} is not registered in streaming", signalStringId));
+        throw NativeStreamingProtocolException(fmt::format("Can't find openDAQ signal - signal {} is not registered in streaming", signalStringId));
 }
 
 std::map<SignalNumericIdType, SignalPtr> StreamingManager::getRegisteredSignals()


### PR DESCRIPTION
# Brief

Fixes race conditions during signal removal that caused exceptions on the server and client side of the native streaming protocol implementation.

# Description

A race condition was occurring during the signal removal processing sequence due to issues in parallel handling, leading to exceptions on either the server or client side. 

The sequence that led to issues was as follows:

* A parent component is removed.
* A core event is triggered to reflect the removal.
* The config server catches the core event and propagates it to the client.
* The streaming server catches the same core event and:
   - Unregisters the signal within the streaming manager.
   - Removes the reader if the signal was subscribed - this action is synchronized with the signals' data accumulation phase in the streaming read thread.
   - Notifies clients that the signal is no longer available.

Meanwhile, processing in the streaming read thread:

* Iterates over all active readers to accumulate signals' data - synchronized with reader removal; however, if the signal has already been unregistered in the manager, a server-side exception is thrown.
* Then schedules sending the accumulated data (this part of processing is outside the synchronization scope for performance). If the data is sent after the signal has already been reported as unavailable, the client then receives the data and throws an exception on the client side.

### With the fix:

* The reader is now being removed before the signal is unregistered in the streaming manager.  
  → This eliminates the risk of server-side exceptions during the data accumulation phase.

* The client now gracefully ignores data received for a signal that is no longer available on its side.  
  → This avoids client-side exceptions due to late-arriving data.

---

> **Additional Notes:**
>
> - Since the server schedules data sending outside the synchronization lock scope (for optimization), it is possible for the “signal unavailable” message to arrive before the final data packet(s) on the client.
> - Some related race conditions may still occur — for example, the client trying to subscribe or unsubscribe to a signal that has just been removed by the server — no exceptions thrown in such cases and but logged as warnings instead.
> These race conditions may arise because the configuration protocol (which communicates core events) and the streaming protocol (which communicates signal availability) operate over independent communication channels, leading to occasional out-of-sync behavior.