### PR TITLE
Fix and stabilize native device removal and disposal flow 3.10

### DIFF
--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -76,6 +76,8 @@ private:
     void setSignalActiveStreamingSource(const SignalPtr& signal, const StreamingPtr& streaming);
     void updateConnectionStatus(opendaq_native_streaming_protocol::ClientConnectionStatus status);
     void tryConfigProtocolReconnect();
+    void startAcceptNotificationPackets();
+    void stopAcceptNotificationPackets();
 
     std::shared_ptr<boost::asio::io_context> processingIOContextPtr;
     std::shared_ptr<boost::asio::io_context> reconnectionProcessingIOContextPtr;
@@ -88,10 +90,12 @@ private:
     WeakRefPtr<IDevice> deviceRef;
     opendaq_native_streaming_protocol::ClientConnectionStatus connectionStatus;
     bool acceptNotificationPackets;
+    bool subscribedToCoreEvent;
     std::chrono::milliseconds configProtocolRequestTimeout;
     Bool restoreClientConfigOnReconnect;
     const StringPtr connectionString;
-    std::mutex sync;
+    std::mutex requestReplySync;
+    std::mutex flagsSync;
 
     std::shared_ptr<boost::asio::steady_timer> configProtocolReconnectionRetryTimer;
     std::chrono::milliseconds reconnectionPeriod;
@@ -131,6 +135,7 @@ protected:
 private:
     void initStatuses();
     void attachDeviceHelper(std::shared_ptr<NativeDeviceHelper> deviceHelper);
+    void disconnectAndCleanUp();
 
     std::shared_ptr<NativeDeviceHelper> deviceHelper;
 };

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -298,16 +298,16 @@ void NativeDeviceHelper::tryConfigProtocolReconnect()
 
         configProtocolReconnectionRetryTimer->expires_from_now(reconnectionPeriod);
         configProtocolReconnectionRetryTimer->async_wait(
-            [weak_self = weak_from_this()](const boost::system::error_code& ec)
+            [deviceHelperWeak = weak_from_this()](const boost::system::error_code& ec)
             {
                 if (ec)
                     return;
-                if (auto shared_self = weak_self.lock())
+                if (auto deviceHelperSelf = deviceHelperWeak.lock())
                 {
-                    auto device = shared_self->deviceRef.assigned() ? shared_self->deviceRef.getRef() : nullptr;
+                    auto device = deviceHelperSelf->deviceRef.assigned() ? deviceHelperSelf->deviceRef.getRef() : nullptr;
                     // retry if device is still alive
                     if (device.assigned())
-                        shared_self->tryConfigProtocolReconnect();
+                        deviceHelperSelf->tryConfigProtocolReconnect();
                 }
             }
         );
@@ -374,15 +374,15 @@ void NativeDeviceHelper::setupProtocolClients(const ContextPtr& context)
         auto packetBufferPtr = std::make_shared<PacketBuffer>(std::move(packetBuffer));
         boost::asio::dispatch(
             *processingIOContextPtr,
-            [packetBufferPtr, weak_self = weak_from_this()]()
+            [packetBufferPtr, deviceHelperWeak = weak_from_this()]()
             {
-                if (auto shared_self = weak_self.lock())
+                if (auto deviceHelperSelf = deviceHelperWeak.lock())
                 {
-                    auto device = shared_self->deviceRef.assigned() ? shared_self->deviceRef.getRef() : nullptr;
+                    auto device = deviceHelperSelf->deviceRef.assigned() ? deviceHelperSelf->deviceRef.getRef() : nullptr;
                     // process incoming config protocol packets if the device connection is not completed yet
                     // or completed and device is still alive
-                    if (!shared_self->deviceRef.assigned() || device.assigned())
-                        shared_self->processConfigPacket(std::move(*packetBufferPtr));
+                    if (!deviceHelperSelf->deviceRef.assigned() || device.assigned())
+                        deviceHelperSelf->processConfigPacket(std::move(*packetBufferPtr));
                 }
             }
         );
@@ -393,13 +393,13 @@ void NativeDeviceHelper::setupProtocolClients(const ContextPtr& context)
     {
         boost::asio::dispatch(
             *reconnectionProcessingIOContextPtr,
-            [status, weak_self = weak_from_this()]()
+            [status, deviceHelperWeak = weak_from_this()]()
             {
-                if (auto shared_self = weak_self.lock())
+                if (auto deviceHelperSelf = deviceHelperWeak.lock())
                 {
-                    auto device = shared_self->deviceRef.assigned() ? shared_self->deviceRef.getRef() : nullptr;
+                    auto device = deviceHelperSelf->deviceRef.assigned() ? deviceHelperSelf->deviceRef.getRef() : nullptr;
                     if (device.assigned())
-                        shared_self->connectionStatusChangedHandler(status);
+                        deviceHelperSelf->connectionStatusChangedHandler(status);
                 }
             }
         );

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -30,7 +30,7 @@ NativeDeviceHelper::NativeDeviceHelper(const ContextPtr& context,
     , loggerComponent(context.getLogger().getOrAddComponent("NativeDevice"))
     , transportClientHandler(transportProtocolClient)
     , connectionStatus(ClientConnectionStatus::Connected)
-    , acceptNotificationPackets(true)
+    , acceptNotificationPackets(false)
     , configProtocolRequestTimeout(std::chrono::milliseconds(configProtocolRequestTimeout))
     , restoreClientConfigOnReconnect(restoreClientConfigOnReconnect)
     , connectionString(connectionString)
@@ -48,6 +48,7 @@ NativeDeviceHelper::~NativeDeviceHelper()
 DevicePtr NativeDeviceHelper::connectAndGetDevice(const ComponentPtr& parent, uint16_t protocolVersion)
 {
     auto device = configProtocolClient->connect(parent, protocolVersion);
+    acceptNotificationPackets = true;
     deviceRef = device;
     return device;
 }
@@ -69,6 +70,7 @@ void NativeDeviceHelper::unsubscribeFromCoreEvent(const ContextPtr& context)
 
 void NativeDeviceHelper::closeConnectionOnRemoval()
 {
+    acceptNotificationPackets = false;
     configProtocolReconnectionRetryTimer->cancel();
 
     if (transportClientHandler)

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -31,6 +31,7 @@ NativeDeviceHelper::NativeDeviceHelper(const ContextPtr& context,
     , transportClientHandler(transportProtocolClient)
     , connectionStatus(ClientConnectionStatus::Connected)
     , acceptNotificationPackets(false)
+    , subscribedToCoreEvent(false)
     , configProtocolRequestTimeout(std::chrono::milliseconds(configProtocolRequestTimeout))
     , restoreClientConfigOnReconnect(restoreClientConfigOnReconnect)
     , connectionString(connectionString)
@@ -41,14 +42,13 @@ NativeDeviceHelper::NativeDeviceHelper(const ContextPtr& context,
 
 NativeDeviceHelper::~NativeDeviceHelper()
 {
-    configProtocolReconnectionRetryTimer->cancel();
     closeConnectionOnRemoval();
 }
 
 DevicePtr NativeDeviceHelper::connectAndGetDevice(const ComponentPtr& parent, uint16_t protocolVersion)
 {
     auto device = configProtocolClient->connect(parent, protocolVersion);
-    acceptNotificationPackets = true;
+    startAcceptNotificationPackets();
     deviceRef = device;
     return device;
 }
@@ -60,17 +60,27 @@ uint16_t NativeDeviceHelper::getProtocolVersion() const
 
 void NativeDeviceHelper::subscribeToCoreEvent(const ContextPtr& context)
 {
-    context.getOnCoreEvent() += event(this, &NativeDeviceHelper::coreEventCallback);
+    std::scoped_lock lock(flagsSync);
+    if (!subscribedToCoreEvent)
+    {
+        context.getOnCoreEvent() += event(this, &NativeDeviceHelper::coreEventCallback);
+        subscribedToCoreEvent = true;
+    }
 }
 
 void NativeDeviceHelper::unsubscribeFromCoreEvent(const ContextPtr& context)
 {
-    context.getOnCoreEvent() -= event(this, &NativeDeviceHelper::coreEventCallback);
+    std::scoped_lock lock(flagsSync);
+    if (subscribedToCoreEvent)
+    {
+        context.getOnCoreEvent() -= event(this, &NativeDeviceHelper::coreEventCallback);
+        subscribedToCoreEvent = false;
+    }
 }
 
 void NativeDeviceHelper::closeConnectionOnRemoval()
 {
-    acceptNotificationPackets = false;
+    stopAcceptNotificationPackets();
     configProtocolReconnectionRetryTimer->cancel();
 
     if (transportClientHandler)
@@ -88,12 +98,7 @@ void NativeDeviceHelper::closeConnectionOnRemoval()
         reconnectionProcessingIOContextPtr->stop();
     }
 
-    {
-        std::scoped_lock lock(sync);
-        configProtocolClient.reset();
-        transportClientHandler.reset();
-    }
-
+    transportClientHandler.reset();
     cancelPendingConfigRequests(ComponentRemovedException());
 }
 
@@ -271,7 +276,7 @@ void NativeDeviceHelper::connectionStatusChangedHandler(ClientConnectionStatus s
     else
     {
         configProtocolReconnectionRetryTimer->cancel();
-        acceptNotificationPackets = false;
+        stopAcceptNotificationPackets();
         cancelPendingConfigRequests(ConnectionLostException());
         configProtocolClient->disconnectExternalSignals();
 
@@ -283,28 +288,43 @@ void NativeDeviceHelper::tryConfigProtocolReconnect()
 {
     try
     {
-        acceptNotificationPackets = true;
+        startAcceptNotificationPackets();
         configProtocolClient->reconnect(restoreClientConfigOnReconnect);
     }
     catch(const std::exception& e)
     {
-        acceptNotificationPackets = false;
+        stopAcceptNotificationPackets();
         LOG_E("Configuration protocol reconnection failed: {}.", e.what());
 
         configProtocolReconnectionRetryTimer->expires_from_now(reconnectionPeriod);
         configProtocolReconnectionRetryTimer->async_wait(
-            [this, weak_self = weak_from_this()](const boost::system::error_code& ec)
+            [weak_self = weak_from_this()](const boost::system::error_code& ec)
             {
                 if (ec)
                     return;
                 if (auto shared_self = weak_self.lock())
-                    this->tryConfigProtocolReconnect();
+                {
+                    auto device = shared_self->deviceRef.assigned() ? shared_self->deviceRef.getRef() : nullptr;
+                    // retry if device is still alive
+                    if (device.assigned())
+                        shared_self->tryConfigProtocolReconnect();
+                }
             }
         );
         return;
     }
 
     updateConnectionStatus(ClientConnectionStatus::Connected);
+}
+
+void NativeDeviceHelper::startAcceptNotificationPackets()
+{
+    acceptNotificationPackets = true;
+}
+
+void NativeDeviceHelper::stopAcceptNotificationPackets()
+{
+    acceptNotificationPackets = false;
 }
 
 void NativeDeviceHelper::updateConnectionStatus(ClientConnectionStatus status)
@@ -332,7 +352,12 @@ void NativeDeviceHelper::setupProtocolClients(const ContextPtr& context)
     SendDaqPacketCallback sendDaqPacketCallback =
         [this](const PacketPtr& packet, uint32_t signalNumericId)
     {
-        transportClientHandler->sendStreamingPacket(signalNumericId, packet);
+        // send packet using a temporary copy of the transport client
+        // to allow safe disposal of the member variable during device removal.
+        if (auto transportClientHandlerTemp = this->transportClientHandler; transportClientHandlerTemp)
+        {
+            transportClientHandlerTemp->sendStreamingPacket(signalNumericId, packet);
+        }
     };
     configProtocolClient =
         std::make_unique<ConfigProtocolClient<NativeDeviceImpl>>(
@@ -349,10 +374,16 @@ void NativeDeviceHelper::setupProtocolClients(const ContextPtr& context)
         auto packetBufferPtr = std::make_shared<PacketBuffer>(std::move(packetBuffer));
         boost::asio::dispatch(
             *processingIOContextPtr,
-            [this, packetBufferPtr, weak_self = weak_from_this()]()
+            [packetBufferPtr, weak_self = weak_from_this()]()
             {
                 if (auto shared_self = weak_self.lock())
-                    this->processConfigPacket(std::move(*packetBufferPtr));
+                {
+                    auto device = shared_self->deviceRef.assigned() ? shared_self->deviceRef.getRef() : nullptr;
+                    // process incoming config protocol packets if the device connection is not completed yet
+                    // or completed and device is still alive
+                    if (!shared_self->deviceRef.assigned() || device.assigned())
+                        shared_self->processConfigPacket(std::move(*packetBufferPtr));
+                }
             }
         );
     };
@@ -362,10 +393,14 @@ void NativeDeviceHelper::setupProtocolClients(const ContextPtr& context)
     {
         boost::asio::dispatch(
             *reconnectionProcessingIOContextPtr,
-            [this, status, weak_self = weak_from_this()]()
+            [status, weak_self = weak_from_this()]()
             {
                 if (auto shared_self = weak_self.lock())
-                    this->connectionStatusChangedHandler(status);
+                {
+                    auto device = shared_self->deviceRef.assigned() ? shared_self->deviceRef.getRef() : nullptr;
+                    if (device.assigned())
+                        shared_self->connectionStatusChangedHandler(status);
+                }
             }
         );
     };
@@ -420,20 +455,20 @@ PacketBuffer NativeDeviceHelper::doConfigRequestAndGetReply(const PacketBuffer& 
 
 std::future<PacketBuffer> NativeDeviceHelper::registerConfigRequest(uint64_t requestId)
 {
-    std::scoped_lock lock(sync);
+    std::scoped_lock lock(requestReplySync);
     replyPackets.insert({requestId, std::promise<PacketBuffer>()});
     return replyPackets.at(requestId).get_future();
 }
 
 void NativeDeviceHelper::unregisterConfigRequest(uint64_t requestId)
 {
-    std::scoped_lock lock(sync);
+    std::scoped_lock lock(requestReplySync);
     replyPackets.erase(requestId);
 }
 
 void NativeDeviceHelper::cancelPendingConfigRequests(const DaqException& e)
 {
-    std::scoped_lock lock(sync);
+    std::scoped_lock lock(requestReplySync);
     for (auto it = replyPackets.begin(); it != replyPackets.end(); )
     {
         auto& replyPromise = it->second;
@@ -445,11 +480,10 @@ void NativeDeviceHelper::cancelPendingConfigRequests(const DaqException& e)
 
 void NativeDeviceHelper::processConfigPacket(PacketBuffer&& packet)
 {
-    std::scoped_lock lock(sync);
     if (packet.getPacketType() == ServerNotification)
     {
         // allow server notifications only if connected / reconnection started
-        if (acceptNotificationPackets && configProtocolClient != nullptr)
+        if (acceptNotificationPackets && deviceRef.assigned())
         {
             configProtocolClient->triggerNotificationPacket(packet);
         }
@@ -460,6 +494,7 @@ void NativeDeviceHelper::processConfigPacket(PacketBuffer&& packet)
     }
     else
     {
+        std::scoped_lock lock(requestReplySync);
         if(auto it = replyPackets.find(packet.getId()); it != replyPackets.end())
         {
             it->second.set_value(std::move(packet));
@@ -511,10 +546,7 @@ NativeDeviceImpl::NativeDeviceImpl(const config_protocol::ConfigProtocolClientCo
 
 NativeDeviceImpl::~NativeDeviceImpl()
 {
-    if (this->deviceHelper)
-    {
-        this->deviceHelper->unsubscribeFromCoreEvent(this->context);
-    }
+    disconnectAndCleanUp();
 }
 
 void NativeDeviceImpl::initStatuses()
@@ -561,18 +593,22 @@ ErrCode NativeDeviceImpl::Deserialize(ISerializedObject* serialized,
 
 void NativeDeviceImpl::removed()
 {
-    if (this->deviceHelper)
-    {
-        this->deviceHelper->unsubscribeFromCoreEvent(this->context);
-        this->deviceHelper->closeConnectionOnRemoval();
-    }
-
+    disconnectAndCleanUp();
     Super::removed();
 }
 
 void NativeDeviceImpl::attachDeviceHelper(std::shared_ptr<NativeDeviceHelper> deviceHelper)
 {
     this->deviceHelper = std::move(deviceHelper);
+}
+
+void NativeDeviceImpl::disconnectAndCleanUp()
+{
+    if (this->deviceHelper)
+    {
+        this->deviceHelper->unsubscribeFromCoreEvent(this->context);
+        this->deviceHelper->closeConnectionOnRemoval();
+    }
 }
 
 void NativeDeviceImpl::updateDeviceInfo(const StringPtr& connectionString)

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -599,7 +599,7 @@ void NativeDeviceImpl::removed()
 
 void NativeDeviceImpl::attachDeviceHelper(std::shared_ptr<NativeDeviceHelper> deviceHelper)
 {
-    this->deviceHelper = std::move(deviceHelper);
+    this->deviceHelper = deviceHelper;
 }
 
 void NativeDeviceImpl::disconnectAndCleanUp()

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -642,8 +642,15 @@ void ConfigProtocolClientComm::sendNoReplyCommand(const ClientCommand& command, 
 {
     requireMinServerVersion(command);
 
-    auto sendNoReplyCommandRpcRequestPacketBuffer = createNoReplyRpcRequestPacketBuffer(command.getName(), params);
-    sendNoReplyRequestCallback(sendNoReplyCommandRpcRequestPacketBuffer);
+    try
+    {
+        auto sendNoReplyCommandRpcRequestPacketBuffer = createNoReplyRpcRequestPacketBuffer(command.getName(), params);
+        sendNoReplyRequestCallback(sendNoReplyCommandRpcRequestPacketBuffer);
+    }
+    catch (const std::exception& e)
+    {
+        LOG_W("Cannot send no reply command {}: {}", command.getName(), e.what());
+    }
 }
 
 void ConfigProtocolClientComm::setRootDevice(const DevicePtr& rootDevice)


### PR DESCRIPTION
# Brief

Fixes the stability within the native device removal and disposal processes

# Description

- Keeps the strong reference to the top parent device (i.e. the mirrored copy of root device) until last incoming core event notification of RPC reply handled
- Males disconnect and cleanup procedure called explicitly in native device destructor
- Adds graceful handling of failures with sending the config protocol no-reply commands 
