### PR TITLE
Fix and stabilize native device removal and disposal flow 3.20

### DIFF
--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -85,10 +85,12 @@ private:
     WeakRefPtr<IDevice> deviceRef;
     EnumerationPtr connectionStatus;
     bool acceptNotificationPackets;
+    bool subscribedToCoreEvent;
     std::chrono::milliseconds configProtocolRequestTimeout;
     Bool restoreClientConfigOnReconnect;
     const StringPtr connectionString;
-    std::mutex sync;
+    std::mutex requestReplySync;
+    std::mutex flagsSync;
 
     std::shared_ptr<boost::asio::steady_timer> configProtocolReconnectionRetryTimer;
     std::chrono::milliseconds reconnectionPeriod;
@@ -131,6 +133,7 @@ protected:
 
 private:
     void attachDeviceHelper(std::shared_ptr<NativeDeviceHelper> deviceHelper);
+    void disconnectAndCleanUp();
 
     std::shared_ptr<NativeDeviceHelper> deviceHelper;
 };

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -734,8 +734,15 @@ void ConfigProtocolClientComm::sendNoReplyCommand(const ClientCommand& command, 
 {
     requireMinServerVersion(command);
 
-    auto sendNoReplyCommandRpcRequestPacketBuffer = createNoReplyRpcRequestPacketBuffer(command.getName(), params);
-    sendNoReplyRequestCallback(sendNoReplyCommandRpcRequestPacketBuffer);
+    try
+    {
+        auto sendNoReplyCommandRpcRequestPacketBuffer = createNoReplyRpcRequestPacketBuffer(command.getName(), params);
+        sendNoReplyRequestCallback(sendNoReplyCommandRpcRequestPacketBuffer);
+    }
+    catch (const std::exception& e)
+    {
+        LOG_W("Cannot send no reply command {}: {}", command.getName(), e.what());
+    }
 }
 
 void ConfigProtocolClientComm::setRootDevice(const DevicePtr& rootDevice)


### PR DESCRIPTION


# Brief

Fixes the stability within the native device removal and disposal processes

# Description

- Keeps the strong reference to the top parent device (i.e. the mirrored copy of root device) until last incoming core event notification of RPC reply handled
- Males disconnect and cleanup procedure called explicitly in native device destructor
- Adds graceful handling of failures with sending the config protocol no-reply commands 
