### PR TITLE
Properly adjust renderer wait time in render loop

### DIFF
--- a/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -858,8 +858,11 @@ void RendererFbImpl::renderLoop()
     auto lock = getUniqueLock();
     while (!rendererStopRequested && window)
     {
-        if (cv.wait_until(lock, waitTime, [this] { return rendererStopRequested || !window; }))
+        cv.wait_until(lock, waitTime);
+        if (rendererStopRequested || !window)
             continue;
+
+        waitTime += defaultWaitTime;
 
         if (resolutionChangedFlag)
         {


### PR DESCRIPTION
# Brief

Fixes issue where renderer does not increase its wait time in its render loop.