### PR TITLE
Add support for list and dictionary item/key type identification in Argument Info

### DIFF
--- a/bindings/python/core_objects/generated/py_argument_info.cpp
+++ b/bindings/python/core_objects/generated/py_argument_info.cpp
@@ -44,6 +44,10 @@ void defineIArgumentInfo(pybind11::module_ m, PyDaqIntf<daq::IArgumentInfo, daq:
         return daq::ArgumentInfo_Create(getVariantValue<daq::IString*>(name), type);
     }, py::arg("name"), py::arg("type"));
 
+    m.def("ContainerArgumentInfo", [](std::variant<daq::IString*, py::str, daq::IEvalValue*>& name, daq::CoreType type, std::variant<daq::IList*, py::list, daq::IEvalValue*>& containerArgumentInfo){
+        return daq::ContainerArgumentInfo_Create(getVariantValue<daq::IString*>(name), type, getVariantValue<daq::IList*>(containerArgumentInfo));
+    }, py::arg("name"), py::arg("type"), py::arg("container_argument_info"));
+
 
     cls.def_property_readonly("name",
         [](daq::IArgumentInfo *object)
@@ -61,4 +65,13 @@ void defineIArgumentInfo(pybind11::module_ m, PyDaqIntf<daq::IArgumentInfo, daq:
             return objectPtr.getType();
         },
         "Gets the core type of the argument.");
+    cls.def_property_readonly("container_argument_info",
+        [](daq::IArgumentInfo *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::ArgumentInfoPtr::Borrow(object);
+            return objectPtr.getContainerArgumentInfo().detach();
+        },
+        py::return_value_policy::take_ownership,
+        "Gets a list of Argument Info objects that denotes what key/item types are expected in a list/dictionary-type argument");
 }

--- a/bindings/python/core_objects/generated/py_argument_info.cpp
+++ b/bindings/python/core_objects/generated/py_argument_info.cpp
@@ -44,9 +44,13 @@ void defineIArgumentInfo(pybind11::module_ m, PyDaqIntf<daq::IArgumentInfo, daq:
         return daq::ArgumentInfo_Create(getVariantValue<daq::IString*>(name), type);
     }, py::arg("name"), py::arg("type"));
 
-    m.def("ContainerArgumentInfo", [](std::variant<daq::IString*, py::str, daq::IEvalValue*>& name, daq::CoreType type, std::variant<daq::IList*, py::list, daq::IEvalValue*>& containerArgumentInfo){
-        return daq::ContainerArgumentInfo_Create(getVariantValue<daq::IString*>(name), type, getVariantValue<daq::IList*>(containerArgumentInfo));
-    }, py::arg("name"), py::arg("type"), py::arg("container_argument_info"));
+    m.def("ListArgumentInfo", [](std::variant<daq::IString*, py::str, daq::IEvalValue*>& name, daq::CoreType itemType){
+        return daq::ListArgumentInfo_Create(getVariantValue<daq::IString*>(name), itemType);
+    }, py::arg("name"), py::arg("item_type"));
+
+    m.def("DictArgumentInfo", [](std::variant<daq::IString*, py::str, daq::IEvalValue*>& name, daq::CoreType keyType, daq::CoreType itemType){
+        return daq::DictArgumentInfo_Create(getVariantValue<daq::IString*>(name), keyType, itemType);
+    }, py::arg("name"), py::arg("key_type"), py::arg("item_type"));
 
 
     cls.def_property_readonly("name",
@@ -65,13 +69,20 @@ void defineIArgumentInfo(pybind11::module_ m, PyDaqIntf<daq::IArgumentInfo, daq:
             return objectPtr.getType();
         },
         "Gets the core type of the argument.");
-    cls.def_property_readonly("container_argument_info",
+    cls.def_property_readonly("item_type",
         [](daq::IArgumentInfo *object)
         {
             py::gil_scoped_release release;
             const auto objectPtr = daq::ArgumentInfoPtr::Borrow(object);
-            return objectPtr.getContainerArgumentInfo().detach();
+            return objectPtr.getItemType();
         },
-        py::return_value_policy::take_ownership,
-        "Gets a list of Argument Info objects that denotes what key/item types are expected in a list/dictionary-type argument");
+        "Gets the item type of list/dict-type Argument Info objects. The item type specifies the type of values in the list or dictionary arguments.");
+    cls.def_property_readonly("key_type",
+        [](daq::IArgumentInfo *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::ArgumentInfoPtr::Borrow(object);
+            return objectPtr.getKeyType();
+        },
+        "Gets the key type of dict-type Argument Info objects. The item type specifies the type of keys in dictionary arguments.");
 }

--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -1,12 +1,13 @@
 # Changes from 3.20 to 3.30
 
 ## Features
-- [#759](https://github.com/openDAQ/openDAQ/pull/759) Bulk create data packets 
+- [#861](https://github.com/openDAQ/openDAQ/pull/861) Add support for list and dictionary item/key type identification in Argument Info.
 - [#837](https://github.com/openDAQ/openDAQ/pull/837) Add main thread event loop, SFML 3.0 migration, and renderer window control
 - [#838](https://github.com/openDAQ/openDAQ/pull/838) Set of multi reader improvements.
 - [#828](https://github.com/openDAQ/openDAQ/pull/828) Parallel device connection.
 - [#810](https://github.com/openDAQ/openDAQ/pull/810) Load individual modules.
 - [#788](https://github.com/openDAQ/openDAQ/pull/788) Component property search.
+- [#759](https://github.com/openDAQ/openDAQ/pull/759) Bulk create data packets 
 
 
 ## Python

--- a/core/coreobjects/include/coreobjects/argument_info.h
+++ b/core/coreobjects/include/coreobjects/argument_info.h
@@ -53,20 +53,25 @@ DECLARE_OPENDAQ_INTERFACE(IArgumentInfo, IBaseObject)
      */
     virtual ErrCode INTERFACE_FUNC getType(CoreType* type) = 0;
 
-    // [elementType(containerArgumentInfo, IArgumentInfo)]
     /*!
-     * @brief Gets a list of Argument Info objects that denotes what key/item types are expected in a
-     * list/dictionary-type argument
-     * @param[out] containerArgumentInfo List of Argument Info objects
+     * @brief Gets the item type of list/dict-type Argument Info objects. The item type specifies the
+     * type of values in the list or dictionary arguments.
+     * @param[out] itemType The item type of the list/dictionary argument.
      *
-     * In list-type Argument Info, the type of each item of the Container Argument Info list corresponds
-     * to the expected argument type of the function.
+     * In list-type Argument Info, the type of each item corresponds to the item type.
      *
-     * In dictionary-type Argument Info, the name of the argument corresponds to the string key of the
-     * dictionary, while the type corresponds to the expected argument type. Do note that dictionary
-     * entries with non-string keys can not be represented by Argument Info objects.
+     * In dict-type Argument Info, the type of each value in the <key, value> pairing corresponds to the
+     * item type.
      */
-    virtual ErrCode INTERFACE_FUNC getContainerArgumentInfo(IList** containerArgumentInfo) = 0;
+    virtual ErrCode INTERFACE_FUNC getItemType(CoreType* itemType) = 0;
+
+    /*!
+     * @brief Gets the key type of dict-type Argument Info objects. The item type specifies the type of
+     * keys in dictionary arguments.
+     *
+     * @param[out] keyType The key type of the dictionary argument.
+     */
+    virtual ErrCode INTERFACE_FUNC getKeyType(CoreType* keyType) = 0;
 };
 
 /*!@}*/
@@ -88,25 +93,31 @@ OPENDAQ_DECLARE_CLASS_FACTORY(
 );
 
 /*!
- * @brief Creates an Argument info object with the specified name, type, and container argument info.
- * The type must be either List or Dictionary.
+ * @brief Creates a list-type Argument info object with the specified name and item type.
+ *
  * @param name The name of the argument.
- * @param type The type expected of the argument. Must be ctList or ctDict.
- * @param[out] containerArgumentInfo List of Argument Info objects that convey the expected member types of the list/dictionary argument.
- *
- * In list-type Argument Info, the type of each item of the Container Argument Info list corresponds
- * to the expected argument type of the function.
- *
- * In dictionary-type Argument Info, the name of the argument corresponds to the string key of the
- * dictionary, while the type corresponds to the expected argument type. Do note that dictionary
- * entries with non-string keys can not be represented by Argument Info objects.
+ * @param itemType Corresponds to the expected type of items in the list argument.
  */
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     LIBRARY_FACTORY,
-    ContainerArgumentInfo, IArgumentInfo,
+    ListArgumentInfo, IArgumentInfo,
     IString*, name,
-    CoreType, type,
-    IList*, containerArgumentInfo
+    CoreType, itemType
+);
+
+/*!
+ * @brief Creates a dict-type Argument info object with the specified name, key type and item type.
+ *
+ * @param name The name of the argument.
+ * @param keyType Corresponds to the expected type of key in the dictionary argument.
+ * @param itemType Corresponds to the expected type of items in the dictionary argument.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY,
+    DictArgumentInfo, IArgumentInfo,
+    IString*, name,
+    CoreType, keyType,
+    CoreType, itemType
 );
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/argument_info.h
+++ b/core/coreobjects/include/coreobjects/argument_info.h
@@ -18,6 +18,7 @@
 #include <coretypes/baseobject.h>
 #include <coretypes/stringobject.h>
 #include <coretypes/coretype.h>
+#include <coretypes/listobject.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -51,6 +52,21 @@ DECLARE_OPENDAQ_INTERFACE(IArgumentInfo, IBaseObject)
      * of the function/procedure.
      */
     virtual ErrCode INTERFACE_FUNC getType(CoreType* type) = 0;
+
+    // [elementType(containerArgumentInfo, IArgumentInfo)]
+    /*!
+     * @brief Gets a list of Argument Info objects that denotes what key/item types are expected in a
+     * list/dictionary-type argument
+     * @param[out] containerArgumentInfo List of Argument Info objects
+     *
+     * In list-type Argument Info, the type of each item of the Container Argument Info list corresponds
+     * to the expected argument type of the function.
+     *
+     * In dictionary-type Argument Info, the name of the argument corresponds to the string key of the
+     * dictionary, while the type corresponds to the expected argument type. Do note that dictionary
+     * entries with non-string keys can not be represented by Argument Info objects.
+     */
+    virtual ErrCode INTERFACE_FUNC getContainerArgumentInfo(IList** containerArgumentInfo) = 0;
 };
 
 /*!@}*/
@@ -69,6 +85,28 @@ OPENDAQ_DECLARE_CLASS_FACTORY(
     LIBRARY_FACTORY, ArgumentInfo,
     IString*, name,
     CoreType, type
+);
+
+/*!
+ * @brief Creates an Argument info object with the specified name, type, and container argument info.
+ * The type must be either List or Dictionary.
+ * @param name The name of the argument.
+ * @param type The type expected of the argument. Must be ctList or ctDict.
+ * @param[out] containerArgumentInfo List of Argument Info objects that convey the expected member types of the list/dictionary argument.
+ *
+ * In list-type Argument Info, the type of each item of the Container Argument Info list corresponds
+ * to the expected argument type of the function.
+ *
+ * In dictionary-type Argument Info, the name of the argument corresponds to the string key of the
+ * dictionary, while the type corresponds to the expected argument type. Do note that dictionary
+ * entries with non-string keys can not be represented by Argument Info objects.
+ */
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
+    LIBRARY_FACTORY,
+    ContainerArgumentInfo, IArgumentInfo,
+    IString*, name,
+    CoreType, type,
+    IList*, containerArgumentInfo
 );
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/argument_info_factory.h
+++ b/core/coreobjects/include/coreobjects/argument_info_factory.h
@@ -32,9 +32,28 @@ BEGIN_NAMESPACE_OPENDAQ
  * @param name The name of the argument.
  * @param type The type expected of the argument.
  */
-inline ArgumentInfoPtr ArgumentInfo(StringPtr name, CoreType type)
+inline ArgumentInfoPtr ArgumentInfo(const StringPtr& name, CoreType type)
 {
     return ArgumentInfoPtr::Adopt(ArgumentInfo_Create(name, type));
+}
+
+/*!
+ * @brief Creates an Argument info object with the specified name, type, and container argument info.
+ * The type must be either List or Dictionary.
+ * @param name The name of the argument.
+ * @param type The type expected of the argument. Must be ctList or ctDict.
+ * @param containerArgumentInfo List of Argument Info objects that convey the expected member types of the list/dictionary argument.
+ *
+ * In list-type Argument Info, the type of each item of the Container Argument Info list corresponds
+ * to the expected argument type of the function.
+ *
+ * In dictionary-type Argument Info, the name of the argument corresponds to the string key of the
+ * dictionary, while the type corresponds to the expected argument type. Do note that dictionary
+ * entries with non-string keys can not be represented by Argument Info objects.
+ */
+inline ArgumentInfoPtr ContainerArgumentInfo(const StringPtr& name, CoreType type, const ListPtr<IArgumentInfo>& containerArgumentInfo)
+{
+    return ArgumentInfoPtr::Adopt(ContainerArgumentInfo_Create(name, type, containerArgumentInfo));
 }
 
 /*!
@@ -43,9 +62,9 @@ inline ArgumentInfoPtr ArgumentInfo(StringPtr name, CoreType type)
 inline StructTypePtr ArgumentInfoStructType()
 {
     return StructType("ArgumentInfo",
-                      List<IString>("Name", "Type"),
-                      List<IBaseObject>("", static_cast<Int>(ctUndefined)),
-                      List<IType>(SimpleType(ctString), SimpleType(ctInt)));
+                      List<IString>("Name", "Type", "ContainerArgumentInfo"),
+                      List<IBaseObject>("", static_cast<Int>(ctUndefined), List<IArgumentInfo>()),
+                      List<IType>(SimpleType(ctString), SimpleType(ctInt), SimpleType(ctList)));
 }
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/argument_info_factory.h
+++ b/core/coreobjects/include/coreobjects/argument_info_factory.h
@@ -38,22 +38,26 @@ inline ArgumentInfoPtr ArgumentInfo(const StringPtr& name, CoreType type)
 }
 
 /*!
- * @brief Creates an Argument info object with the specified name, type, and container argument info.
- * The type must be either List or Dictionary.
+ * @brief Creates a list-type Argument info object with the specified name and item type.
+ *
  * @param name The name of the argument.
- * @param type The type expected of the argument. Must be ctList or ctDict.
- * @param containerArgumentInfo List of Argument Info objects that convey the expected member types of the list/dictionary argument.
- *
- * In list-type Argument Info, the type of each item of the Container Argument Info list corresponds
- * to the expected argument type of the function.
- *
- * In dictionary-type Argument Info, the name of the argument corresponds to the string key of the
- * dictionary, while the type corresponds to the expected argument type. Do note that dictionary
- * entries with non-string keys can not be represented by Argument Info objects.
+ * @param itemType Corresponds to the expected type of items in the list argument.
  */
-inline ArgumentInfoPtr ContainerArgumentInfo(const StringPtr& name, CoreType type, const ListPtr<IArgumentInfo>& containerArgumentInfo)
+inline ArgumentInfoPtr ListArgumentInfo(const StringPtr& name, CoreType itemType)
 {
-    return ArgumentInfoPtr::Adopt(ContainerArgumentInfo_Create(name, type, containerArgumentInfo));
+    return ArgumentInfoPtr::Adopt(ListArgumentInfo_Create(name, itemType));
+}
+
+/*!
+ * @brief Creates a dict-type Argument info object with the specified name, key type and item type.
+ *
+ * @param name The name of the argument.
+ * @param keyType Corresponds to the expected type of key in the dictionary argument.
+ * @param itemType Corresponds to the expected type of items in the dictionary argument.
+ */
+inline ArgumentInfoPtr DictArgumentInfo(const StringPtr& name, CoreType keyType, CoreType itemType)
+{
+    return ArgumentInfoPtr::Adopt(DictArgumentInfo_Create(name, keyType, itemType));
 }
 
 /*!
@@ -62,9 +66,9 @@ inline ArgumentInfoPtr ContainerArgumentInfo(const StringPtr& name, CoreType typ
 inline StructTypePtr ArgumentInfoStructType()
 {
     return StructType("ArgumentInfo",
-                      List<IString>("Name", "Type", "ContainerArgumentInfo"),
-                      List<IBaseObject>("", static_cast<Int>(ctUndefined), List<IArgumentInfo>()),
-                      List<IType>(SimpleType(ctString), SimpleType(ctInt), SimpleType(ctList)));
+                      List<IString>("Name", "Type", "KeyType", "ItemType"),
+                      List<IBaseObject>("", static_cast<Int>(ctUndefined), static_cast<Int>(ctUndefined), static_cast<Int>(ctUndefined)),
+                      List<IType>(SimpleType(ctString), SimpleType(ctInt), SimpleType(ctInt), SimpleType(ctInt)));
 }
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/argument_info_impl.h
+++ b/core/coreobjects/include/coreobjects/argument_info_impl.h
@@ -27,11 +27,12 @@ BEGIN_NAMESPACE_OPENDAQ
 class ArgumentInfoImpl : public GenericStructImpl<IArgumentInfo, IStruct>
 {
 public:
-    ArgumentInfoImpl(const StringPtr& name, CoreType type, const ListPtr<IArgumentInfo>& containerArgumentInfo);
+    ArgumentInfoImpl(const StringPtr& name, CoreType type, CoreType keyType, CoreType itemType);
 
     ErrCode INTERFACE_FUNC getName(IString** argName) override;
     ErrCode INTERFACE_FUNC getType(CoreType* type) override;
-    ErrCode INTERFACE_FUNC getContainerArgumentInfo(IList** containerArgumentInfo) override;
+    ErrCode INTERFACE_FUNC getItemType(CoreType* itemType) override;
+    ErrCode INTERFACE_FUNC getKeyType(CoreType* keyType) override;
 
     ErrCode INTERFACE_FUNC equals(IBaseObject* other, Bool* equal) const override;
 
@@ -45,7 +46,8 @@ public:
 private:
     StringPtr name;
     CoreType argType;
-    ListPtr<IArgumentInfo> containerArgumentInfo;
+    CoreType keyType;
+    CoreType itemType;
 };
 
 OPENDAQ_REGISTER_DESERIALIZE_FACTORY(ArgumentInfoImpl)

--- a/core/coreobjects/include/coreobjects/argument_info_impl.h
+++ b/core/coreobjects/include/coreobjects/argument_info_impl.h
@@ -20,16 +20,18 @@
 #include <coretypes/intfs.h>
 #include <coretypes/string_ptr.h>
 #include <coretypes/struct_impl.h>
+#include <coreobjects/argument_info_ptr.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
 class ArgumentInfoImpl : public GenericStructImpl<IArgumentInfo, IStruct>
 {
 public:
-    ArgumentInfoImpl(StringPtr name, CoreType type);
+    ArgumentInfoImpl(const StringPtr& name, CoreType type, const ListPtr<IArgumentInfo>& containerArgumentInfo);
 
     ErrCode INTERFACE_FUNC getName(IString** argName) override;
     ErrCode INTERFACE_FUNC getType(CoreType* type) override;
+    ErrCode INTERFACE_FUNC getContainerArgumentInfo(IList** containerArgumentInfo) override;
 
     ErrCode INTERFACE_FUNC equals(IBaseObject* other, Bool* equal) const override;
 
@@ -43,6 +45,7 @@ public:
 private:
     StringPtr name;
     CoreType argType;
+    ListPtr<IArgumentInfo> containerArgumentInfo;
 };
 
 OPENDAQ_REGISTER_DESERIALIZE_FACTORY(ArgumentInfoImpl)

--- a/core/coreobjects/tests/test_argument_info.cpp
+++ b/core/coreobjects/tests/test_argument_info.cpp
@@ -77,61 +77,36 @@ TEST_F(ArgumentInfoTest, SerializeDeserialize)
 
 TEST_F(ArgumentInfoTest, SerializeDeserializeList)
 {
-    auto argInfo1 = ArgumentInfo("Int", ctInt);
-    auto argInfo2 = ArgumentInfo("Float", ctFloat);
-    const auto argInfoList = ContainerArgumentInfo("Name", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
+    auto argInfo = ListArgumentInfo("List", ctFloat);
 
     const auto serializer = JsonSerializer();
-    argInfoList.serialize(serializer);
+    argInfo.serialize(serializer);
 
     const auto jsonStr = serializer.getOutput();
 
     const auto deserializer = JsonDeserializer();
 
-    const ArgumentInfoPtr argInfo = deserializer.deserialize(jsonStr);
-    ASSERT_EQ(argInfo.getName(), argInfoList.getName());
-    ASSERT_EQ(argInfo.getType(), argInfoList.getType());
-    ASSERT_EQ(argInfo.getContainerArgumentInfo(), argInfoList.getContainerArgumentInfo());
+    const ArgumentInfoPtr argInfoDeserialized = deserializer.deserialize(jsonStr);
+    ASSERT_EQ(argInfo.getName(), argInfoDeserialized.getName());
+    ASSERT_EQ(argInfo.getType(), argInfoDeserialized.getType());
+    ASSERT_EQ(argInfo.getKeyType(), argInfoDeserialized.getKeyType());
+    ASSERT_EQ(argInfo.getItemType(), argInfoDeserialized.getItemType());
 }
 
 TEST_F(ArgumentInfoTest, SerializeDeserializeDict)
 {
-    auto argInfo1 = ArgumentInfo("Int", ctInt);
-    auto argInfo2 = ArgumentInfo("Float", ctFloat);
-    const auto argInfoDict = ContainerArgumentInfo("Name", CoreType::ctDict, List<IArgumentInfo>(argInfo1, argInfo2));
+    auto argInfo = DictArgumentInfo("Dict", ctInt, ctFloat);
 
     const auto serializer = JsonSerializer();
-    argInfoDict.serialize(serializer);
+    argInfo.serialize(serializer);
 
     const auto jsonStr = serializer.getOutput();
 
     const auto deserializer = JsonDeserializer();
 
-    const ArgumentInfoPtr argInfo = deserializer.deserialize(jsonStr);
-    ASSERT_EQ(argInfo.getName(), argInfoDict.getName());
-    ASSERT_EQ(argInfo.getType(), argInfoDict.getType());
-    ASSERT_EQ(argInfo.getContainerArgumentInfo(), argInfoDict.getContainerArgumentInfo());
-}
-
-TEST_F(ArgumentInfoTest, SerializeDeserializeListNested)
-{
-    auto argInfo1 = ArgumentInfo("Int", ctInt);
-
-    auto argInfoInner1 = ArgumentInfo("Enum", ctEnumeration);
-    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
-    auto argInfo2 = ContainerArgumentInfo("Float", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
-
-    const auto argInfoList = ContainerArgumentInfo("Name", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
-
-    const auto serializer = JsonSerializer();
-    argInfoList.serialize(serializer);
-
-    const auto jsonStr = serializer.getOutput();
-
-    const auto deserializer = JsonDeserializer();
-
-    const ArgumentInfoPtr argInfo = deserializer.deserialize(jsonStr);
-    ASSERT_EQ(argInfo.getName(), argInfoList.getName());
-    ASSERT_EQ(argInfo.getType(), argInfoList.getType());
-    ASSERT_EQ(argInfo.getContainerArgumentInfo(), argInfoList.getContainerArgumentInfo());
+    const ArgumentInfoPtr argInfoDeserialized = deserializer.deserialize(jsonStr);
+    ASSERT_EQ(argInfo.getName(), argInfoDeserialized.getName());
+    ASSERT_EQ(argInfo.getType(), argInfoDeserialized.getType());
+    ASSERT_EQ(argInfo.getKeyType(), argInfoDeserialized.getKeyType());
+    ASSERT_EQ(argInfo.getItemType(), argInfoDeserialized.getItemType());
 }

--- a/core/coreobjects/tests/test_argument_info.cpp
+++ b/core/coreobjects/tests/test_argument_info.cpp
@@ -74,3 +74,64 @@ TEST_F(ArgumentInfoTest, SerializeDeserialize)
     ASSERT_EQ(argInfo.getName(), argInfo1.getName());
     ASSERT_EQ(argInfo.getType(), argInfo1.getType());
 }
+
+TEST_F(ArgumentInfoTest, SerializeDeserializeList)
+{
+    auto argInfo1 = ArgumentInfo("Int", ctInt);
+    auto argInfo2 = ArgumentInfo("Float", ctFloat);
+    const auto argInfoList = ContainerArgumentInfo("Name", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
+
+    const auto serializer = JsonSerializer();
+    argInfoList.serialize(serializer);
+
+    const auto jsonStr = serializer.getOutput();
+
+    const auto deserializer = JsonDeserializer();
+
+    const ArgumentInfoPtr argInfo = deserializer.deserialize(jsonStr);
+    ASSERT_EQ(argInfo.getName(), argInfoList.getName());
+    ASSERT_EQ(argInfo.getType(), argInfoList.getType());
+    ASSERT_EQ(argInfo.getContainerArgumentInfo(), argInfoList.getContainerArgumentInfo());
+}
+
+TEST_F(ArgumentInfoTest, SerializeDeserializeDict)
+{
+    auto argInfo1 = ArgumentInfo("Int", ctInt);
+    auto argInfo2 = ArgumentInfo("Float", ctFloat);
+    const auto argInfoDict = ContainerArgumentInfo("Name", CoreType::ctDict, List<IArgumentInfo>(argInfo1, argInfo2));
+
+    const auto serializer = JsonSerializer();
+    argInfoDict.serialize(serializer);
+
+    const auto jsonStr = serializer.getOutput();
+
+    const auto deserializer = JsonDeserializer();
+
+    const ArgumentInfoPtr argInfo = deserializer.deserialize(jsonStr);
+    ASSERT_EQ(argInfo.getName(), argInfoDict.getName());
+    ASSERT_EQ(argInfo.getType(), argInfoDict.getType());
+    ASSERT_EQ(argInfo.getContainerArgumentInfo(), argInfoDict.getContainerArgumentInfo());
+}
+
+TEST_F(ArgumentInfoTest, SerializeDeserializeListNested)
+{
+    auto argInfo1 = ArgumentInfo("Int", ctInt);
+
+    auto argInfoInner1 = ArgumentInfo("Enum", ctEnumeration);
+    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
+    auto argInfo2 = ContainerArgumentInfo("Float", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
+
+    const auto argInfoList = ContainerArgumentInfo("Name", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
+
+    const auto serializer = JsonSerializer();
+    argInfoList.serialize(serializer);
+
+    const auto jsonStr = serializer.getOutput();
+
+    const auto deserializer = JsonDeserializer();
+
+    const ArgumentInfoPtr argInfo = deserializer.deserialize(jsonStr);
+    ASSERT_EQ(argInfo.getName(), argInfoList.getName());
+    ASSERT_EQ(argInfo.getType(), argInfoList.getType());
+    ASSERT_EQ(argInfo.getContainerArgumentInfo(), argInfoList.getContainerArgumentInfo());
+}

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -2188,3 +2188,71 @@ TEST_F(PropertyObjectTest, DotAccessSelectionValue)
     parent.setPropertyValue("child.child.foo", 1);
     ASSERT_EQ(parent.getPropertySelectionValue("child.child.foo"), "b");
 }
+
+TEST_F(PropertyObjectTest, ProcedurePropWithListArg)
+{
+    auto obj = PropertyObject();
+
+    auto argInfo1 = ArgumentInfo("Int", ctInt);
+
+    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
+    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
+    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
+
+    const auto argInfoList = ContainerArgumentInfo("List", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
+
+    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
+    obj.addProperty(prop);
+    auto proc = Procedure(
+        [](const ListPtr<IBaseObject>& list)
+        {
+            ASSERT_EQ(list[0].getCoreType(), ctInt);
+            ASSERT_EQ(list[1].getCoreType(), ctList);
+            ListPtr<IBaseObject> listInner = list[1];
+            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
+            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
+    });
+
+    obj.setPropertyValue("ProcedureProp", proc);
+    proc = obj.getPropertyValue("ProcedureProp");
+
+    ASSERT_EQ(obj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
+
+    auto listArg = List<IBaseObject>(Integer(1), List<IBaseObject>(Integer(2), Floating(2.5)));
+    proc(listArg);
+}
+
+TEST_F(PropertyObjectTest, ProcedurePropWithDictArg)
+{
+    auto obj = PropertyObject();
+
+    auto argInfo1 = ArgumentInfo("Int", ctInt);
+
+    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
+    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
+    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
+
+    const auto argInfoList = ContainerArgumentInfo("Dict", CoreType::ctDict, List<IArgumentInfo>(argInfo1, argInfo2));
+
+    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
+    obj.addProperty(prop);
+    auto proc = Procedure(
+        [](const DictPtr<IString, IBaseObject>& dict)
+        {
+            ASSERT_TRUE(dict.hasKey("Int"));
+            ASSERT_TRUE(dict.hasKey("List"));
+            ASSERT_EQ(dict.get("Int").getCoreType(), ctInt);
+            ASSERT_EQ(dict.get("List").getCoreType(), ctList);
+            ListPtr<IBaseObject> listInner = dict.get("List");
+            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
+            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
+    });
+
+    obj.setPropertyValue("ProcedureProp", proc);
+    proc = obj.getPropertyValue("ProcedureProp");
+
+    ASSERT_EQ(obj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
+
+    auto dictArg = Dict<IString, IBaseObject>({{"Int", Integer(0)}, {"List", List<IBaseObject>(Integer(2), Floating(2.5))}});
+    proc(dictArg);
+}

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -17,6 +17,7 @@
 #include <coreobjects/argument_info_factory.h>
 #include <coreobjects/property_object_internal_ptr.h>
 #include <coretypes/listobject_factory.h>
+#include <list>
 #include <thread>
 
 using namespace daq;

--- a/core/coreobjects/tests/test_property_object.cpp
+++ b/core/coreobjects/tests/test_property_object.cpp
@@ -2189,70 +2189,61 @@ TEST_F(PropertyObjectTest, DotAccessSelectionValue)
     ASSERT_EQ(parent.getPropertySelectionValue("child.child.foo"), "b");
 }
 
-TEST_F(PropertyObjectTest, ProcedurePropWithListArg)
+TEST_F(PropertyObjectTest, FunctionPropWithListArg)
 {
     auto obj = PropertyObject();
 
-    auto argInfo1 = ArgumentInfo("Int", ctInt);
+    auto argInfo = ListArgumentInfo("List", ctInt);
 
-    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
-    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
-    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
-
-    const auto argInfoList = ContainerArgumentInfo("List", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
-
-    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
+    auto prop = FunctionProperty("SumList", FunctionInfo(ctInt,List<IArgumentInfo>(argInfo)));
     obj.addProperty(prop);
-    auto proc = Procedure(
+    auto func = Function(
         [](const ListPtr<IBaseObject>& list)
         {
-            ASSERT_EQ(list[0].getCoreType(), ctInt);
-            ASSERT_EQ(list[1].getCoreType(), ctList);
-            ListPtr<IBaseObject> listInner = list[1];
-            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
-            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
-    });
+            Int sum = 0;
+            for (const auto& val : list)
+                sum += static_cast<Int>(val);
+            return sum;
+        });
 
-    obj.setPropertyValue("ProcedureProp", proc);
-    proc = obj.getPropertyValue("ProcedureProp");
+    obj.setPropertyValue("SumList", func);
+    func = obj.getPropertyValue("SumList");
 
-    ASSERT_EQ(obj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
+    ASSERT_EQ(obj.getProperty("SumList").getCallableInfo().getArguments()[0], argInfo);
 
-    auto listArg = List<IBaseObject>(Integer(1), List<IBaseObject>(Integer(2), Floating(2.5)));
-    proc(listArg);
+    auto listArg = List<IInteger>(1, 1, 2, 3, 5, 8);
+    ASSERT_EQ(func(listArg), 20);
 }
 
-TEST_F(PropertyObjectTest, ProcedurePropWithDictArg)
+TEST_F(PropertyObjectTest, FunctionPropWithDictArg)
 {
     auto obj = PropertyObject();
 
-    auto argInfo1 = ArgumentInfo("Int", ctInt);
+    auto argInfo = DictArgumentInfo("Dict", ctInt, ctString);
 
-    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
-    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
-    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
-
-    const auto argInfoList = ContainerArgumentInfo("Dict", CoreType::ctDict, List<IArgumentInfo>(argInfo1, argInfo2));
-
-    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
+    auto prop = FunctionProperty("SortDictValues", FunctionInfo(ctList, List<IArgumentInfo>(argInfo)));
     obj.addProperty(prop);
-    auto proc = Procedure(
-        [](const DictPtr<IString, IBaseObject>& dict)
+    auto func = Function(
+        [](const DictPtr<IInteger, IString>& dict)
         {
-            ASSERT_TRUE(dict.hasKey("Int"));
-            ASSERT_TRUE(dict.hasKey("List"));
-            ASSERT_EQ(dict.get("Int").getCoreType(), ctInt);
-            ASSERT_EQ(dict.get("List").getCoreType(), ctList);
-            ListPtr<IBaseObject> listInner = dict.get("List");
-            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
-            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
-    });
+            auto sortedItems = List<IString>();
 
-    obj.setPropertyValue("ProcedureProp", proc);
-    proc = obj.getPropertyValue("ProcedureProp");
+            std::list<int> keys;
+            for (int key : dict.getKeyList())
+                keys.push_back(key);
 
-    ASSERT_EQ(obj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
+            keys.sort();
+            for (const auto& key : keys)
+                sortedItems.pushBack(dict.get(key));
+            
+            return sortedItems;
+        });
 
-    auto dictArg = Dict<IString, IBaseObject>({{"Int", Integer(0)}, {"List", List<IBaseObject>(Integer(2), Floating(2.5))}});
-    proc(dictArg);
+    obj.setPropertyValue("SortDictValues", func);
+    func = obj.getPropertyValue("SortDictValues");
+
+    ASSERT_EQ(obj.getProperty("SortDictValues").getCallableInfo().getArguments()[0], argInfo);
+
+    auto dictArg = Dict<IInteger, IString>({{5, "blueberry"}, {2, "banana"}, {8, "pear"}, {1, "apple"}});
+    ASSERT_EQ(func(dictArg), List<IString>("apple", "banana", "blueberry", "pear"));
 }

--- a/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/modules/ref_device_module/src/ref_device_impl.cpp
@@ -152,17 +152,29 @@ std::chrono::microseconds RefDeviceImpl::getMicroSecondsSinceDeviceStart() const
 
 PropertyObjectPtr RefDeviceImpl::createProtectedObject() const
 {
-    const auto func = Function([](Int a, Int b) { return a + b; });
-
-    const auto funcProp =
+    const auto sumFunc = Function([](Int a, Int b) { return a + b; });
+    const auto sumProp =
         FunctionPropertyBuilder("Sum", FunctionInfo(ctInt, List<IArgumentInfo>(ArgumentInfo("A", ctInt), ArgumentInfo("B", ctInt))))
             .setReadOnly(false)
             .build();
 
+    const auto sumListProp = FunctionProperty("SumList", FunctionInfo(ctInt,List<IArgumentInfo>(ListArgumentInfo("List", ctInt))));
+    const auto sumListFunc = Function(
+        [](const ListPtr<IBaseObject>& list)
+        {
+            Int sum = 0;
+            for (const auto& val : list)
+                sum += static_cast<Int>(val);
+            return sum;
+        });
+
     auto protectedObject = PropertyObject();
     protectedObject.addProperty(StringProperty("Owner", "openDAQ TM"));
-    protectedObject.addProperty(funcProp);
-    protectedObject.setPropertyValue("Sum", func);
+    protectedObject.addProperty(sumProp);
+    protectedObject.setPropertyValue("Sum", sumFunc);
+
+    protectedObject.addProperty(sumListProp);
+    protectedObject.setPropertyValue("SumList", sumListFunc);
 
     // group "everyone" has a read-only access to the protected object
     // group "admin" can change the protected object and call methods on it

--- a/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
+++ b/shared/libraries/config_protocol/tests/test_nested_property_objects.cpp
@@ -17,11 +17,13 @@
 #include <opendaq/sync_component_ptr.h>
 #include <opendaq/sync_component_private_ptr.h>
 #include <opendaq/mock/advanced_components_setup_utils.h>
-#include "config_protocol/config_protocol_server.h"
-#include "config_protocol/config_protocol_client.h"
-#include "config_protocol/config_client_device_impl.h"
+#include <config_protocol/config_protocol_server.h>
+#include <config_protocol/config_protocol_client.h>
+#include <config_protocol/config_client_device_impl.h>
 #include <coreobjects/property_object_class_factory.h>
 #include <coreobjects/user_factory.h>
+#include <coreobjects/callable_info_factory.h>
+#include <coreobjects/argument_info_factory.h>
 
 using namespace daq;
 using namespace daq::config_protocol;
@@ -788,4 +790,71 @@ TEST_F(ConfigNestedPropertyObjectTest, ThrowExeptionRestoringValuePartialy)
     ASSERT_THROW(clientDevice.setPropertyValue("param1", -1), OutOfRangeException);
     ASSERT_EQ(clientDevice.getPropertyValue("param1"), 0);
     ASSERT_EQ(clientDevice.getPropertyValue("param2"), -1);
+}
+
+TEST_F(ConfigNestedPropertyObjectTest, ProcedurePropWithListArg)
+{
+    auto argInfo1 = ArgumentInfo("Int", ctInt);
+
+    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
+    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
+    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
+
+    const auto argInfoList = ContainerArgumentInfo("List", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
+
+    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
+
+    serverDevice.addProperty(prop);
+
+    auto proc = Procedure(
+        [](const ListPtr<IBaseObject>& list)
+        {
+            ASSERT_EQ(list[0].getCoreType(), ctInt);
+            ASSERT_EQ(list[1].getCoreType(), ctList);
+            ListPtr<IBaseObject> listInner = list[1];
+            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
+            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
+    });
+
+    serverDevice.setPropertyValue("ProcedureProp", proc);
+
+    proc = clientDevice.getPropertyValue("ProcedureProp");
+    ASSERT_EQ(clientDevice.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
+
+    auto listArg = List<IBaseObject>(Integer(1), List<IBaseObject>(Integer(2), Floating(2.5)));
+    proc(listArg);
+}
+
+TEST_F(ConfigNestedPropertyObjectTest, ProcedurePropWithDictArg)
+{
+    auto argInfo1 = ArgumentInfo("Int", ctInt);
+
+    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
+    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
+    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
+
+    const auto argInfoList = ContainerArgumentInfo("Dict", CoreType::ctDict, List<IArgumentInfo>(argInfo1, argInfo2));
+
+    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
+    serverDevice.addProperty(prop);
+
+    auto proc = Procedure(
+        [](const DictPtr<IString, IBaseObject>& dict)
+        {
+            ASSERT_TRUE(dict.hasKey("Int"));
+            ASSERT_TRUE(dict.hasKey("List"));
+            ASSERT_EQ(dict.get("Int").getCoreType(), ctInt);
+            ASSERT_EQ(dict.get("List").getCoreType(), ctList);
+            ListPtr<IBaseObject> listInner = dict.get("List");
+            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
+            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
+    });
+
+    serverDevice.setPropertyValue("ProcedureProp", proc);
+
+    proc = clientDevice.getPropertyValue("ProcedureProp");
+    ASSERT_EQ(clientDevice.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
+
+    auto dictArg = Dict<IString, IBaseObject>({{"Int", Integer(0)}, {"List", List<IBaseObject>(Integer(2), Floating(2.5))}});
+    proc(dictArg);
 }

--- a/shared/libraries/opcuatms/opcuatms/src/converters/argument_converter.cpp
+++ b/shared/libraries/opcuatms/opcuatms/src/converters/argument_converter.cpp
@@ -30,6 +30,10 @@ OpcUaObject<UA_Argument> StructConverter<IArgumentInfo, UA_Argument>::ToTmsType(
     OpcUaObject<UA_Argument> uaArg;
     uaArg->description = UA_LOCALIZEDTEXT_ALLOC("", "");
     uaArg->name = UA_STRING_ALLOC(object.getName().getCharPtr());
+
+    auto type = object.getType();
+    if (type == ctList || type == ctDict)
+        throw InvalidTypeException{"The OPC UA server does not yet support list or dictionary type arguments."};
     uaArg->dataType = CoreTypeToUANodeID(object.getType()).getDetachedValue();
 
     // TODO: handle list and dict

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
@@ -77,7 +77,7 @@ TmsServerComponent<Ptr>::TmsServerComponent(const ComponentPtr& object, const Op
             tmsComponentConfig = std::make_unique<TmsServerPropertyObject>(componentConfig, this->server, this->daqContext, this->tmsContext, "ComponentConfig");
     }
     
-    this->loggerComponent = this->daqContext.getLogger().getOrAddComponent("OPCUAServer_" + object.getGlobalId());
+    this->loggerComponent = this->daqContext.getLogger().getOrAddComponent("OPCUAServerComponent");
 }
 
 template <typename Ptr>

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_component.h
@@ -76,6 +76,8 @@ TmsServerComponent<Ptr>::TmsServerComponent(const ComponentPtr& object, const Op
         if (componentConfig.assigned())
             tmsComponentConfig = std::make_unique<TmsServerPropertyObject>(componentConfig, this->server, this->daqContext, this->tmsContext, "ComponentConfig");
     }
+    
+    this->loggerComponent = this->daqContext.getLogger().getOrAddComponent("OPCUAServer_" + object.getGlobalId());
 }
 
 template <typename Ptr>

--- a/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
+++ b/shared/libraries/opcuatms/opcuatms_server/include/opcuatms_server/objects/tms_server_object.h
@@ -147,6 +147,7 @@ protected:
     uint32_t numberInList;
     TmsServerContextPtr tmsContext;
     std::unordered_map<std::string, opcua::OpcUaObject<UA_ReferenceDescription>> references;
+    LoggerComponentPtr loggerComponent;
 
 private:
     void bindCallbacksInternal();

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_object.cpp
@@ -16,6 +16,9 @@ TmsServerObject::TmsServerObject(const OpcUaServerPtr& server, const ContextPtr&
     , daqContext(context)
     , numberInList(0)
     , tmsContext(tmsContext)
+    , loggerComponent(daqContext.getLogger().assigned()
+                          ? daqContext.getLogger().getOrAddComponent("OPCUAServerComponent")
+                          : throw ArgumentNullException("Logger must not be null"))
 {
 }
 

--- a/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
+++ b/shared/libraries/opcuatms/opcuatms_server/src/objects/tms_server_property_object.cpp
@@ -12,6 +12,7 @@
 #include <open62541/daqbsp_nodeids.h>
 #include <open62541/daqbt_nodeids.h>
 #include <open62541/types_generated.h>
+#include <opendaq/custom_log.h>
 
 BEGIN_NAMESPACE_OPENDAQ_OPCUA_TMS
 
@@ -25,6 +26,7 @@ TmsServerPropertyObject::TmsServerPropertyObject(const PropertyObjectPtr& object
     : Super(object, server, context, tmsContext)
     , ignoredProps(ignoredProps)
 {
+    loggerComponent = daqContext.getLogger().getOrAddComponent("OPCUAServerPropertyObject");
 }
 
 TmsServerPropertyObject::TmsServerPropertyObject(const PropertyObjectPtr& object,
@@ -242,6 +244,7 @@ void TmsServerPropertyObject::registerEvalValueNode(const std::string& nodeName,
     childEvalValues.insert({childNodeId, serverObject});
 }
 
+// TODO: Procedure/Function properties with list/dictionary types are not yet supported over OPC UA!
 void TmsServerPropertyObject::addMethodPropertyNode(const PropertyPtr& prop, uint32_t numberInList)
 {
     const auto name = prop.getName();
@@ -283,9 +286,13 @@ void TmsServerPropertyObject::addMethodPropertyNode(const PropertyPtr& prop, uin
 
         methodProps.insert({methodNodeId, {name, prop.getValueType()}});
     }
-    catch(...)
+    catch(const std::exception& e)
     {
-        // TODO: Log failure to add method node
+        LOG_W("Failed to add method property node {}: {}", name, e.what());
+    }
+    catch (...)
+    {
+        LOG_W("Failed to add method property node {}.", name);
     }
 }
 

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_property_object.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_property_object.cpp
@@ -356,76 +356,59 @@ TEST_F(TmsPropertyObjectTest, DotAccessClientServerChange)
 TEST_F(TmsPropertyObjectTest, ProcedurePropWithListArg)
 {
     PropertyObjectPtr obj = PropertyObject();
-    auto argInfo1 = ArgumentInfo("Int", ctInt);
+    auto argInfo = ListArgumentInfo("Int", ctInt);
 
-    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
-    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
-    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
-
-    const auto argInfoList = ContainerArgumentInfo("List", CoreType::ctList, List<IArgumentInfo>(argInfo1, argInfo2));
-
-    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
-
+    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfo)));
     obj.addProperty(prop);
-
     auto proc = Procedure(
         [](const ListPtr<IBaseObject>& list)
         {
-            ASSERT_EQ(list[0].getCoreType(), ctInt);
-            ASSERT_EQ(list[1].getCoreType(), ctList);
-            ListPtr<IBaseObject> listInner = list[1];
-            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
-            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
+            for (const auto& val : list)
+                ASSERT_EQ(val.getCoreType(), ctInt);
     });
 
     obj.setPropertyValue("ProcedureProp", proc);
-    
     auto [serverObj, clientObj] = registerPropertyObject(obj);
     
     ASSERT_FALSE(clientObj.hasProperty("ProcedureProp"));
     
     // TODO: Procedure/Function properties with list/dictionary types are not yet supported over OPC UA!
     //proc = clientObj.getPropertyValue("ProcedureProp");
-    //ASSERT_EQ(clientObj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
 
-    //auto listArg = List<IBaseObject>(Integer(1), List<IBaseObject>(Integer(2), Floating(2.5)));
+    //ASSERT_EQ(clientObj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfo);
+
+    //auto listArg = List<IBaseObject>(Integer(1), Integer(2));
     //proc(listArg);
 }
 TEST_F(TmsPropertyObjectTest, ProcedurePropWithDictArg)
 {
     PropertyObjectPtr obj = PropertyObject();
-    auto argInfo1 = ArgumentInfo("Int", ctInt);
+    auto argInfo = DictArgumentInfo("Int", ctInt, ctString);
 
-    auto argInfoInner1 = ArgumentInfo("Int", ctInt);
-    auto argInfoInner2 = ArgumentInfo("Float", ctFloat);
-    auto argInfo2 = ContainerArgumentInfo("List", ctList, List<IArgumentInfo>(argInfoInner1, argInfoInner2));
-
-    const auto argInfoList = ContainerArgumentInfo("Dict", CoreType::ctDict, List<IArgumentInfo>(argInfo1, argInfo2));
-
-    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfoList)));
+    auto prop = FunctionProperty("ProcedureProp", ProcedureInfo(List<IArgumentInfo>(argInfo)));
     obj.addProperty(prop);
-
     auto proc = Procedure(
-        [](const DictPtr<IString, IBaseObject>& dict)
+        [](const DictPtr<IInteger, IString>& dict)
         {
-            ASSERT_TRUE(dict.hasKey("Int"));
-            ASSERT_TRUE(dict.hasKey("List"));
-            ASSERT_EQ(dict.get("Int").getCoreType(), ctInt);
-            ASSERT_EQ(dict.get("List").getCoreType(), ctList);
-            ListPtr<IBaseObject> listInner = dict.get("List");
-            ASSERT_EQ(listInner[0].getCoreType(), ctInt);
-            ASSERT_EQ(listInner[1].getCoreType(), ctFloat);
-    });
+            for (const auto& [key, val] : dict)
+            {
+                ASSERT_EQ(key.getCoreType(), ctInt);
+                ASSERT_EQ(val.getCoreType(), ctString);
+            }
+        });
 
     obj.setPropertyValue("ProcedureProp", proc);
-    auto [serverObj, clientObj] = registerPropertyObject(obj);
 
+    auto [serverObj, clientObj] = registerPropertyObject(obj);
+    
     ASSERT_FALSE(clientObj.hasProperty("ProcedureProp"));
 
     // TODO: Procedure/Function properties with list/dictionary types are not yet supported over OPC UA!
-    //ASSERT_EQ(clientObj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfoList);
+    //proc = clientObj.getPropertyValue("ProcedureProp");
 
-    //auto dictArg = Dict<IString, IBaseObject>({{"Int", Integer(0)}, {"List", List<IBaseObject>(Integer(2), Floating(2.5))}});
+    //ASSERT_EQ(clientObj.getProperty("ProcedureProp").getCallableInfo().getArguments()[0], argInfo);
+
+    //auto dictArg = Dict<IInteger, IString>({{0, "foo"}, {1, "bar"}});
     //proc(dictArg);
 }
 


### PR DESCRIPTION
# Brief

When publishing Procedure or Function-type properties it was not possible to define what kinds of elements are expected in list and dictionary function arguments. This PR implements the option to add such info.

# Description

`IArgumentInfo` can now be constructed with a list of `IArgumentInfo` objects as a factory parameter. The Argument Info types in said list denote the expected parameter types of procedures/functions that accept `ctList` type arguments. The names of said Argument Info objects in the list denote the keys of `ctDict` type arguments.

NOTE: This does not work over OPC UA as list and dict-type arguments are not supported there (and were not supported up until now either).

# API Changes
```diff
+ [function] IArgumentInfo::getItemType(CoreType* itemType)
+ [function] IArgumentInfo::getKeyType(CoreType* keyType)
+ [factory] ListArgumentInfo(const StringPtr& name, CoreType itemType)
+ [factory] DictArgumentInfo(const StringPtr& name, CoreType keyType, CoreType itemType)
```

# Usage examples

## List-type argument function property
```cpp
auto obj = PropertyObject();

auto argInfo = ListArgumentInfo("IntList", ctInt);

auto prop = FunctionProperty("SumList", FunctionInfo(ctInt,List<IArgumentInfo>(argInfo)));
obj.addProperty(prop);
auto func = Function(
    [](const ListPtr<IBaseObject>& list)
    {
        Int sum = 0;
        for (const auto& val : list)
            sum += static_cast<Int>(val);
        return sum;
    });

obj.setPropertyValue("SumList", func);
func = obj.getPropertyValue("SumList");

auto listArg = List<IInteger>(1, 1, 2, 3, 5, 8);
assert(func(listArg) == 20);
```

## Dictionary-type argument function property
```cpp
auto obj = PropertyObject();

auto argInfo = DictArgumentInfo("IntStringDict", ctInt, ctString);

auto prop = FunctionProperty("SortDictValues", FunctionInfo(ctList, List<IArgumentInfo>(argInfo)));
obj.addProperty(prop);
auto func = Function(
    [](const DictPtr<IInteger, IString>& dict)
    {
        auto sortedItems = List<IString>();

        std::list<int> keys;
        for (int key : dict.getKeyList())
            keys.push_back(key);

        keys.sort();
        for (const auto& key : keys)
            sortedItems.pushBack(dict.get(key));
        
        return sortedItems;
    });

obj.setPropertyValue("SortDictValues", func);
func = obj.getPropertyValue("SortDictValues");

auto dictArg = Dict<IInteger, IString>({{5, "blueberry"}, {2, "banana"}, {8, "pear"}, {1, "apple"}});
assert(func(dictArg) == List<IString>("apple", "banana", "blueberry", "pear"));
```