### PR TITLE
Merge device capabilities only for non-root devices

### DIFF
--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -655,7 +655,7 @@ ErrCode ModuleManagerImpl::createDevice(IDevice** device, IString* connectionStr
             checkErrorInfo(err);
 
             const auto devicePtr = DevicePtr::Borrow(*device);
-            if (devicePtr.assigned())
+            if (devicePtr.assigned() && devicePtr.assigned())
             {
                 onCompleteCapabilities(devicePtr, discoveredDeviceInfo);
                 if (const auto & componentPrivate = devicePtr.asPtrOrNull<IComponentPrivate>(true); componentPrivate.assigned())


### PR DESCRIPTION
# Brief

Bugfix: Merge device capabilities only for non-root devices

# Description

When device discovery was enabled, the same device could be detected by both the `DeviceModule` and the `OpendaqNativeStreamingClientModule`. As a result, capabilities were added as soon as `setRootDevice()` was called, which made it impossible to add a server to that device afterward.

