### PR TITLE
Fix compilation when the GCC toolchain does not need or have `stdc++fs` plugin/addon

### DIFF
--- a/core/opendaq/CMakeLists.txt
+++ b/core/opendaq/CMakeLists.txt
@@ -131,10 +131,6 @@ opendaq_target_include_directories(${MAIN_TARGET}
         ${SRC_PrivateIncludeDirectories}
 )
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-    set(STDCFS_LIBS "stdc++fs")
-endif()
-
 if (MSVC)
     set(MSVC_PRIVATE_COMPILE_OPTIONS
         /wd4324

--- a/core/opendaq/functionblock/tests/CMakeLists.txt
+++ b/core/opendaq/functionblock/tests/CMakeLists.txt
@@ -30,10 +30,6 @@ target_link_libraries(${TEST_APP}
         daq::opendaq_mocks
 )
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-    set(STDCFS_LIBS "stdc++fs")
-endif()
-
 if (MSVC)
     target_compile_options(${TEST_APP} PRIVATE /bigobj)
 endif()

--- a/core/opendaq/modulemanager/src/CMakeLists.txt
+++ b/core/opendaq/modulemanager/src/CMakeLists.txt
@@ -144,10 +144,6 @@ if("${Boost_LIBRARIES}")
     set(BOOST_LIBS ${Boost_LIBRARIES})
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-    set(STDCFS_LIBS "stdc++fs")
-endif()
-
 if (WIN32)
     set(PING_COMPILE_DEFS
         _WIN32_WINNT=${MIN_WINDOWS_VERSION}


### PR DESCRIPTION
# Brief

Fix compilation when the GCC toolchain does not need or have `stdc++fs` plugin/addon

#874 
NI RT linux seems to kill any process that takes CPU to 100% of utilization for more than a second.
This can be fixed by cross-compiling on a developer machine instead of on device.
