### PR TITLE
[TBBAS-2107] .NET Bindings - Supplement, improve or add C# examples in the documentation

### DIFF
--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.CI.Test/OpenDAQ_CITests.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.CI.Test/OpenDAQ_CITests.cs
@@ -786,12 +786,12 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 Debug.Print($"+++> {loopNo + 1,2}: AvailableCount={availableCount,-3}");
 
                 //read up to 'count' samples, storing the amount read into array 'samples'
-                reader.Read(samples, ref count, timeoutMs: 5000);
+                using var status = reader.Read(samples, ref count, timeoutMs: 5000);
                 readSamplesCount += count;
 
                 sw.Stop();
 
-                string valueString = (count == 0) ? string.Empty : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000})";
+                string valueString = (count == 0) ? $"(ReadStatus = {status?.ReadStatus})" : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,3} values {valueString}");
             }
         }
@@ -873,12 +873,12 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 Debug.Print($"+++>  {loopNo + 1,2} : AvailableCount={availableCount,-3}");
 
                 //read up to 'count' samples, storing the amount read into array 'samples'
-                reader.Read(samples, ref count);
+                using var status = reader.Read(samples, ref count);
                 readSamplesCount += count;
 
                 sw.Stop();
 
-                string valueString = (count == 0) ? string.Empty : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000})";
+                string valueString = (count == 0) ? $"(ReadStatus = {status?.ReadStatus})" : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,3} values {valueString}");
             }
         }
@@ -942,7 +942,7 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
         using (var reader = OpenDAQFactory.CreateBlockReader<TValue>(signal, blockSize))
         {
             Console.WriteLine($"  ValueReadType = {reader.ValueReadType}, DomainReadType = {reader.DomainReadType}");
-            Console.WriteLine($"  Reading {loopCount} times {maxCount} blocks � {blockSize} values (waiting {sleepTime}ms before reading)");
+            Console.WriteLine($"  Reading {loopCount} times {maxCount} blocks with {blockSize} values (waiting {sleepTime}ms before reading)");
 
             Stopwatch sw = new Stopwatch();
 
@@ -960,14 +960,14 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 nuint availableCount = reader.AvailableCount;
 
                 //read up to 'count' blocks, storing the amount read into array 'samples'
-                reader.Read(samples, ref count, 5000);
+                using var status = reader.Read(samples, ref count, 5000);
                 readBlockCount += count;
                 Debug.Print($"+++>     read {count} blocks");
 
                 sw.Stop();
 
                 nuint valueCount = count * blockSize;
-                string valueString = (count == 0) ? string.Empty : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {valueCount - 1}: {samples[valueCount - 1]:+0.000;-0.000; 0.000})";
+                string valueString = (count == 0) ? $"(ReadStatus = {status?.ReadStatus})" : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {valueCount - 1}: {samples[valueCount - 1]:+0.000;-0.000; 0.000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,2} blocks ({valueCount,3} values) {valueString}");
             }
         }
@@ -1029,12 +1029,12 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 Debug.Print($"+++> {loopNo + 1,2}: AvailableCount={availableCount,-3}");
 
                 //read up to 'count' samples, storing the amount read into array 'samples'
-                reader.Read(samples, ref count/*, timeoutMs: 5000*/);
+                using var status = reader.Read(samples, ref count/*, timeoutMs: 5000*/);
                 readSamplesCount += count;
 
                 sw.Stop();
 
-                string valueString  = (count == 0) ? string.Empty : $"(0: {samples[0][0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[0][count - 1]:+0.000;-0.000; 0.000})";
+                string valueString  = (count == 0) ? $"(ReadStatus = {status?.ReadStatus})" : $"(0: {samples[0][0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[0][count - 1]:+0.000;-0.000; 0.000})";
                 string valueString2 = (count == 0) ? string.Empty : $"(0: {samples[1][0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[1][count - 1]:+0.000;-0.000; 0.000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,3} values {valueString}");
                 Console.WriteLine($"                                                       {valueString2}");
@@ -1101,12 +1101,12 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 Debug.Print($"+++> {loopNo + 1,2}: AvailableCount={availableCount,-3}");
 
                 //read up to 'count' samples, storing the amount read into arrays 'samples' and 'timeStamps'
-                reader.ReadWithDomain(samples, timeStamps, ref count, timeoutMs: 5000);
+                using var status = reader.ReadWithDomain(samples, timeStamps, ref count, timeoutMs: 5000);
                 readSamplesCount += count;
 
                 sw.Stop();
 
-                string valueString = (count == 0) ? string.Empty : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0]:0.0000000} ... {factor * timeStamps[count - 1]:0.0000000})";
+                string valueString = (count == 0) ? $"(ReadStatus = {status.ReadStatus})" : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0]:0.0000000} ... {factor * timeStamps[count - 1]:0.0000000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,3} values {valueString}");
             }
         }
@@ -1170,10 +1170,10 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 Debug.Print($"+++>  {loopNo + 1,2} : AvailableCount={availableCount,-3}");
 
                 //read up to 'count' samples, storing the amount read into arrays 'samples' and 'timeStamps'
-                reader.ReadWithDomain(samples, timeStamps, ref count);
+                using var status = reader.ReadWithDomain(samples, timeStamps, ref count);
                 readSamplesCount += count;
                 sw.Stop();
-                string valueString = (count == 0) ? string.Empty : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0]:0.0000000} ... {factor * timeStamps[count - 1]:0.0000000})";
+                string valueString = (count == 0) ? $"(ReadStatus = {status.ReadStatus})" : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0]:0.0000000} ... {factor * timeStamps[count - 1]:0.0000000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,3} values {valueString}");
             }
         }
@@ -1219,7 +1219,7 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
         using (var reader = OpenDAQFactory.CreateBlockReader<double>(signal, blockSize))
         {
             Console.WriteLine($"  ValueReadType = {reader.ValueReadType}, DomainReadType = {reader.DomainReadType}");
-            Console.WriteLine($"  Reading {loopCount} times {maxCount} blocks � {blockSize} values (waiting {sleepTime}ms before reading)");
+            Console.WriteLine($"  Reading {loopCount} times {maxCount} blocks with {blockSize} values (waiting {sleepTime}ms before reading)");
 
             Stopwatch sw = new Stopwatch();
 
@@ -1238,14 +1238,14 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 Debug.Print($"+++> {loopNo + 1,2}: AvailableCount={availableCount,-3}");
 
                 //read up to 'count' blocks, storing the amount read into arrays 'samples' and 'timeStamps'
-                reader.ReadWithDomain(samples, timeStamps, ref count, 5000);
+                using var status = reader.ReadWithDomain(samples, timeStamps, ref count, 5000);
                 readBlockCount += count;
                 Debug.Print($"+++>     read {count} blocks");
 
                 sw.Stop();
 
                 nuint valueCount = count * blockSize;
-                string valueString = (count == 0) ? string.Empty : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {valueCount - 1}: {samples[valueCount - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0]:0.0000000} ... {factor * timeStamps[count - 1]:0.0000000})";
+                string valueString = (count == 0) ? $"(ReadStatus = {status.ReadStatus})" : $"(0: {samples[0]:+0.000;-0.000; 0.000} ... {valueCount - 1}: {samples[valueCount - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0]:0.0000000} ... {factor * timeStamps[count - 1]:0.0000000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,2} blocks ({valueCount,3} values) {valueString}");
             }
         }
@@ -1310,14 +1310,14 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
                 Debug.Print($"+++> {loopNo + 1,2}: AvailableCount={availableCount,-3}");
 
                 //read up to 'count' samples, storing the amount read into arrays 'samples' and 'timeStamps'
-                //reader.Read(samples, ref count, timeoutMs: 5000);
-                reader.ReadWithDomain(samples, timeStamps, ref count, timeoutMs: 5000);
+                //using var status = reader.Read(samples, ref count, timeoutMs: 5000);
+                using var status = reader.ReadWithDomain(samples, timeStamps, ref count, timeoutMs: 5000);
                 readSamplesCount += count;
 
                 sw.Stop();
 
-                string valueString  = (count == 0) ? string.Empty : $"(0: {samples[0][0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[0][count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0][0]:0.0000000} ... {factor * timeStamps[0][count - 1]:0.0000000})";
-                string valueString2 = (count == 0) ? string.Empty : $"(0: {samples[1][0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[1][count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[1][0]:0.0000000} ... {factor * timeStamps[1][count - 1]:0.0000000})";
+                string valueString  = (count == 0) ? $"(ReadStatus = {status?.ReadStatus})" : $"(0: {samples[0][0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[0][count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[0][0]:0.0000000} ... {factor * timeStamps[0][count - 1]:0.0000000})";
+                string valueString2 = (count == 0) ? string.Empty                           : $"(0: {samples[1][0]:+0.000;-0.000; 0.000} ... {count - 1,3}: {samples[1][count - 1]:+0.000;-0.000; 0.000} @ {factor * timeStamps[1][0]:0.0000000} ... {factor * timeStamps[1][count - 1]:0.0000000})";
                 Console.WriteLine($"  Loop {loopNo + 1,2} {sw.Elapsed.TotalMilliseconds,7:0.000}ms before AvailableCount={availableCount,-3} but read {count,3} values {valueString}");
                 Console.WriteLine($"                                                       {valueString2}");
             }
@@ -1467,7 +1467,7 @@ public class OpenDAQ_CITests : OpenDAQTestsBase
             }
             else if (status?.ReadStatus == ReadStatus.Event)
             {
-                Console.WriteLine($"            event occurred'");
+                Console.WriteLine($"            event occurred");
             }
             else
             {

--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/OpenDaqExplanationsTests.cs
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net.Test/OpenDaqExplanationsTests.cs
@@ -1,6 +1,7 @@
 // Ignore Spelling: Opc Ua nullable daqref
 
 
+using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Reflection;
@@ -818,7 +819,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05211_FeaturesPropertySystemAddingRemovingPropertiesTest()
+    public void Test_0521_FeaturesPropertySystemAddingRemovingPropertiesTest()
     {
         OpenDaqException ex = Assert.Throws<OpenDaqException>(() =>
         {
@@ -838,7 +839,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05212_FeaturesPropertySystemListingPropertiesTest()
+    public void Test_0522_FeaturesPropertySystemListingPropertiesTest()
     {
         var propObj = CoreObjectsFactory.CreatePropertyObject();
         propObj.AddProperty(PropertyFactory.StringProperty("String", "foo"));
@@ -860,7 +861,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05213_FeaturesPropertySystemReadingWritingPropertyValuesTest()
+    public void Test_0523_FeaturesPropertySystemReadingWritingPropertyValuesTest()
     {
         var propObj = CoreObjectsFactory.CreatePropertyObject();
         propObj.AddProperty(PropertyFactory.StringProperty("String", "foo"));
@@ -874,7 +875,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05214_FeaturesPropertySystemRWNestedPropertyObjectsTest()
+    public void Test_0524_FeaturesPropertySystemRWNestedPropertyObjectsTest()
     {
         var propObj = CoreObjectsFactory.CreatePropertyObject();
         var child1 = CoreObjectsFactory.CreatePropertyObject();
@@ -892,7 +893,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05215_FeaturesPropertySystemRWSelectionPropertiesTest()
+    public void Test_0525_FeaturesPropertySystemRWSelectionPropertiesTest()
     {
         var propObj = CoreObjectsFactory.CreatePropertyObject();
 
@@ -906,7 +907,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05216_FeaturesPropertySystemRWListPropertiesTest1()
+    public void Test_0526_FeaturesPropertySystemRWListPropertiesTest1()
     {
         var propObj = CoreObjectsFactory.CreatePropertyObject();
 
@@ -928,7 +929,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05217_FeaturesPropertySystemRWListPropertiesTest2()
+    public void Test_0527_FeaturesPropertySystemRWListPropertiesTest2()
     {
         #region just for the test to compile
         var propObj = CoreObjectsFactory.CreatePropertyObject();
@@ -948,7 +949,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05218_FeaturesPropertySystemRWDictionaryPropertiesTest()
+    public void Test_0528_FeaturesPropertySystemRWDictionaryPropertiesTest()
     {
         var propObj = CoreObjectsFactory.CreatePropertyObject();
 
@@ -964,7 +965,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     //[Test]
     [Category(SKIP_SETUP)]
-    public void Test_05219_FeaturesPropertySystemRWEventsTest()
+    public void Test_0529_FeaturesPropertySystemRWEventsTest()
     {
         /*
             [NOTE]
@@ -1011,7 +1012,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05311_FeaturesPropertySystemPropertyObjectClassTest()
+    public void Test_0531_FeaturesPropertySystemPropertyObjectClassTest()
     {
         var list = CoreTypesFactory.CreateList<StringObject>("Banana", "Apple", "Kiwi");
 
@@ -1022,7 +1023,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05312_FeaturesPropertySystemPOCManageTest()
+    public void Test_0532_FeaturesPropertySystemPOCManageTest()
     {
         TypeManager manager = CoreTypesFactory.CreateTypeManager();
 
@@ -1041,7 +1042,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     [Test]
     [Category(SKIP_SETUP)]
-    public void Test_05314_FeaturesPropertySystemPOCClassInheritanceTest()
+    public void Test_0534_FeaturesPropertySystemPOCClassInheritanceTest()
     {
         TypeManager manager = CoreTypesFactory.CreateTypeManager();
 
@@ -1064,7 +1065,7 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
 
     //[Test]
     [Category(SKIP_SETUP)]
-    public void Test_05315_FeaturesPropertySystemPOCPropertyEventsOnClassesTest()
+    public void Test_0535_FeaturesPropertySystemPOCPropertyEventsOnClassesTest()
     {
 #if !supports_events
         /*
@@ -1101,4 +1102,265 @@ public class OpenDaqExplanationsTests : OpenDAQTestsBase
     #endregion Property Object Class
 
     #endregion Property system
+
+    #region Readers ./Antora/modules/explanations/pages/readers.adoc
+
+    [Test]
+    public void Test_0601_ConstructingAReaderTest()
+    {
+        // These calls all create the same Reader (e.g. for a Stream Reader)
+        var reader1 = OpenDAQFactory.CreateStreamReader(signal);
+        var reader2 = OpenDAQFactory.CreateStreamReader<double, long>(signal);
+        // right now there exists no factory function using `SampleType` as parameters
+    }
+
+    #endregion Readers ./Antora/modules/explanations/pages/readers.adoc
+
+    #region Multi Reader ./Antora/modules/explanations/pages/multireader_spec.adoc
+
+    [Test]
+    [Category(SKIP_SETUP)]
+    public void Test_0701_MultiReaderExampleTest()
+    {
+        var instance  = OpenDAQFactory.Instance();
+        var refDevice = instance.AddDevice("daqref://device0");
+        var signals   = refDevice.GetSignalsRecursive();
+
+        // Create reader that converts values to `double` and time data to `int64`
+        var multiReader = OpenDAQFactory.CreateMultiReader<double, long>(signals);
+
+        // Allocate buffers for each signal
+        int   signalsCount = signals.Count;
+        nuint kBufferSize  = 0;
+
+        var dataBuffers   = new double[signalsCount][];
+        var domainBuffers = new long[signalsCount][];
+
+        // read data every 50ms, up to a maximum of kBufferSize samples
+        for (int readCount = 0; readCount < 20; readCount++)
+        {
+            var dataAvailable = multiReader.AvailableCount;
+            var count         = Math.Min(kBufferSize, dataAvailable);
+            var status        = multiReader.ReadWithDomain(dataBuffers, domainBuffers, ref count);
+
+            if (status.ReadStatus == ReadStatus.Event)
+            {
+                // Set buffer size based on sample rate, allocate buffers
+                // Buffers have 100ms worth of memory for each signal
+                //ToDo: reader::getSampleRate() not available in .NET Bindings
+                //var sampleRate = reader::getSampleRate(
+                //    status.MainDescriptor.Parameters["DomainDataDescriptor"]);
+                // simplified for the example:
+                var sampleRate = GetSampleRate(status.MainDescriptor
+                                                     .Parameters["DomainDataDescriptor"]
+                                                     .Cast<DataDescriptor>());
+
+                kBufferSize = sampleRate / 10;
+
+                for (int i = 0; i < signalsCount; ++i)
+                {
+                    dataBuffers[i]   = new double[kBufferSize];
+                    domainBuffers[i] = new long[kBufferSize];
+                }
+            }
+            else if ((status.ReadStatus == ReadStatus.Ok) && (count > 0))
+            {
+                Console.Write("Data: ");
+                foreach (var buf in dataBuffers)
+                    Console.Write($"{buf[0]}; ");
+                Console.WriteLine();
+            }
+
+            System.Threading.Thread.Sleep(50);
+        }
+
+        nuint GetSampleRate(DataDescriptor dataDescriptor)
+        {
+            var resolution = dataDescriptor.TickResolution;
+            var delta      = (NumberObject)1;
+            var rule       = dataDescriptor.Rule;
+
+            if ((rule != null) && (rule.Type != DataRuleType.Linear))
+            {
+                throw new NotSupportedException("Only signals with implicit linear-rule as a domain are supported.");
+            }
+            else if (rule != null)
+            {
+                delta = rule.Parameters["delta"].Cast<NumberObject>();
+            }
+
+            double sampleRate = (double)resolution.Denominator
+                              / (double)resolution.Numerator
+                              * (double)delta;
+            if (sampleRate != (double)(ulong)sampleRate)
+            {
+                throw new NotSupportedException($"Only signals with integral sample-rate are supported but found signal with {sampleRate} Hz");
+            }
+
+            return (nuint)Convert.ToUInt64(sampleRate);
+        }
+    }
+
+    //[Test]
+    [Category(SKIP_SETUP)]
+    public void Test_0702_MultiReaderReusingDomainDataTest()
+    {
+        #region just for the test to compile
+        //OpenDAQFactory.CreateMultiReaderStatus(EventPacket mainDescriptor, IDictObject < BaseObject, BaseObject > eventPackets, bool valid, NumberObject offset);
+        MultiReaderStatus status  = OpenDAQFactory.CreateMultiReaderStatus(mainDescriptor: null, eventPackets: null, valid: false, offset: 0);
+        Context           context = null;
+        Component         parent  = null;
+        #endregion
+
+        var eventPacket            = status.MainDescriptor;
+        var outputDomainDescriptor = eventPacket.Parameters["DomainDataDescriptor"].Cast<DataDescriptor>();
+        var outputDomainSignal     = OpenDAQFactory.CreateSignalWithDescriptor(context, outputDomainDescriptor, parent, "outputDomainSignal", "Signal");
+    }
+
+    //[Test]
+    [Category(SKIP_SETUP)]
+    public void Test_0703_MultiReaderReusingDomainDataTest()
+    {
+        #region just for the test to compile
+        //OpenDAQFactory.CreateMultiReaderStatus(EventPacket mainDescriptor, IDictObject < BaseObject, BaseObject > eventPackets, bool valid, NumberObject offset);
+        MultiReaderStatus status  = OpenDAQFactory.CreateMultiReaderStatus(mainDescriptor: null, eventPackets: null, valid: false, offset: 0);
+        Context           context = null;
+        Component         parent  = null;
+
+        var eventPacket = status.MainDescriptor;
+        var outputDomainDescriptor = eventPacket.Parameters["DomainDataDescriptor"].Cast<DataDescriptor>();
+        var outputDomainSignal = OpenDAQFactory.CreateSignalWithDescriptor(context, outputDomainDescriptor, parent, "outputDomainSignal", "Signal");
+
+        nuint count = 1;
+        #endregion
+
+        // `count` corresponds to the amount of samples read
+        var outputDomainPacket = OpenDAQFactory.CreateDataPacket(outputDomainDescriptor, count, status.Offset);
+        outputDomainSignal.SendPacket(outputDomainPacket);
+    }
+
+    //[Test]
+    [Category(SKIP_SETUP)]
+    public void Test_0704_MultiReaderDifferentSampleRatesTest()
+    {
+        #region just for the test to compile
+        var instance  = OpenDAQFactory.Instance();
+        var refDevice = instance.AddDevice("daqref://device0");
+        var signals   = refDevice.GetSignalsRecursive();
+
+        // Create reader that converts values to `double` and time data to `int64`
+        var multiReader = OpenDAQFactory.CreateMultiReader<double, long>(signals);
+
+        // Allocate buffers for each signal
+        int   signalsCount = signals.Count;
+        nuint kBufferSize  = 0;
+
+        var dataBuffers   = new double[signalsCount][];
+        var domainBuffers = new long[signalsCount][];
+
+        // read data every 50ms, up to a maximum of kBufferSize samples
+        for (int readCount = 0; readCount < 20; readCount++)
+        {
+        #endregion
+
+            List<long> dividers = new();
+
+            var dataAvailable = multiReader.AvailableCount;
+            var count = Math.Min(kBufferSize, dataAvailable);
+            var status = multiReader.ReadWithDomain(dataBuffers, domainBuffers, ref count);
+
+            if (status.ReadStatus == ReadStatus.Event)
+            {
+                var packets = status.EventPackets;
+                if (!(packets.Values.First().EventId == "DATA_DESCRIPTOR_CHANGED"))
+                    continue;
+
+                // SRDiv calculation
+                long commonSampleRate = multiReader.CommonSampleRate;
+                dividers.Clear();
+                Console.Write("Dividers: ");
+                foreach (var eventPacket in packets.Values)
+                {
+                    var descriptor = eventPacket.Parameters["DomainDataDescriptor"].Cast<DataDescriptor>();
+                    var sampleRate = GetSampleRate(descriptor);
+                    dividers.Add(commonSampleRate / (long)sampleRate);
+                    Console.Write($"{dividers.Last()}, ");
+                }
+                Console.WriteLine();
+
+                // Allocate buffers for 100ms according to commonSampleRate
+                long lcm = 1;
+                foreach (var div in dividers)
+                    lcm = GetLeastCommonMultiple(lcm, div); // https://stackoverflow.com/a/20824923
+
+                // Calculate k as the minimum number of LCM-size blocks to read ~100ms of data
+                long k = Math.Max(commonSampleRate / lcm / 10, 1);
+                kBufferSize = (nuint)(k * lcm);
+
+                Console.Write("Buffer sizes: ");
+                for (int i = 0; i < signalsCount; ++i)
+                {
+                    dataBuffers[i]   = new double[(long)kBufferSize / dividers[i]];
+                    domainBuffers[i] = new long[(long)kBufferSize / dividers[i]];
+                    Console.Write($"{(long)kBufferSize / dividers[i]}, ");
+                }
+                Console.WriteLine();
+            }
+
+        #region just for the test to compile
+        }
+
+        nuint GetSampleRate(DataDescriptor dataDescriptor)
+        {
+            var resolution = dataDescriptor.TickResolution;
+            var delta      = (NumberObject)1;
+            var rule       = dataDescriptor.Rule;
+
+            if ((rule != null) && (rule.Type != DataRuleType.Linear))
+            {
+                throw new NotSupportedException("Only signals with implicit linear-rule as a domain are supported.");
+            }
+            else if (rule != null)
+            {
+                delta = rule.Parameters["delta"].Cast<NumberObject>();
+            }
+
+            double sampleRate = (double)resolution.Denominator
+                              / (double)resolution.Numerator
+                              * (double)delta;
+            if (sampleRate != (double)(ulong)sampleRate)
+            {
+                throw new NotSupportedException($"Only signals with integral sample-rate are supported but found signal with {sampleRate} Hz");
+            }
+
+            return (nuint)Convert.ToUInt64(sampleRate);
+        }
+
+        static long GetLeastCommonMultiple(long a, long b)
+        {
+            return (a / gcf(a, b)) * b;
+
+            static long gcf(long a, long b)
+            {
+                while (b != 0)
+                {
+                    long temp = b;
+                    b = a % b;
+                    a = temp;
+                }
+                return a;
+            }
+        }
+        #endregion
+    }
+
+    #endregion Multi Reader ./Antora/modules/explanations/pages/multireader_spec.adoc
+
+
+    //[Test]
+    //[Category(SKIP_SETUP)]
+    //public void Test_aabb_Test()
+    //{
+
+    //}
 }

--- a/docs/Antora/modules/explanations/pages/multireader_spec.adoc
+++ b/docs/Antora/modules/explanations/pages/multireader_spec.adoc
@@ -49,7 +49,7 @@ int main()
             // Buffers have 100ms worth of memory for each signal
             auto sampleRate = reader::getSampleRate(
                 status.getMainDescriptor().getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR));
-            
+
             kBufferSize = sampleRate / 10;
 
             for (size_t i = 0; i < signalsCount; ++i)
@@ -69,7 +69,88 @@ int main()
         std::this_thread::sleep_for(50ms);
     }
 }
+----
+C#::
++
+[source,csharp]
+----
+var instance  = OpenDAQFactory.Instance();
+var refDevice = instance.AddDevice("daqref://device0");
+var signals   = refDevice.GetSignalsRecursive();
 
+// Create reader that converts values to `double` and time data to `int64`
+var multiReader = OpenDAQFactory.CreateMultiReader<double, long>(signals);
+
+// Allocate buffers for each signal
+int   signalsCount = signals.Count;
+nuint kBufferSize  = 0;
+
+var dataBuffers   = new double[signalsCount][];
+var domainBuffers = new long[signalsCount][];
+
+// read data every 50ms, up to a maximum of kBufferSize samples
+for (int readCount = 0; readCount < 20; readCount++)
+{
+    var dataAvailable = multiReader.AvailableCount;
+    var count         = Math.Min(kBufferSize, dataAvailable);
+    var status        = multiReader.ReadWithDomain(dataBuffers, domainBuffers, ref count);
+
+    if (status.ReadStatus == ReadStatus.Event)
+    {
+        // Set buffer size based on sample rate, allocate buffers
+        // Buffers have 100ms worth of memory for each signal
+        //ToDo: reader::getSampleRate() not available in .NET Bindings
+        //var sampleRate = reader::getSampleRate(
+        //    status.MainDescriptor.Parameters["DomainDataDescriptor"]);
+        // simplified for the example:
+        var sampleRate = GetSampleRate(status.MainDescriptor
+                                             .Parameters["DomainDataDescriptor"]
+                                             .Cast<DataDescriptor>());
+
+        kBufferSize = sampleRate / 10;
+
+        for (int i = 0; i < signalsCount; ++i)
+        {
+            dataBuffers[i]   = new double[kBufferSize];
+            domainBuffers[i] = new long[kBufferSize];
+        }
+    }
+    else if ((status.ReadStatus == ReadStatus.Ok) && (count > 0))
+    {
+        Console.Write("Data: ");
+        foreach (var buf in dataBuffers)
+            Console.Write($"{buf[0]}; ");
+        Console.WriteLine();
+    }
+
+    System.Threading.Thread.Sleep(50);
+}
+
+nuint GetSampleRate(DataDescriptor dataDescriptor)
+{
+    var resolution = dataDescriptor.TickResolution;
+    var delta      = (NumberObject)1;
+    var rule       = dataDescriptor.Rule;
+
+    if ((rule != null) && (rule.Type != DataRuleType.Linear))
+    {
+        throw new NotSupportedException("Only signals with implicit linear-rule as a domain are supported.");
+    }
+    else if (rule != null)
+    {
+        delta = rule.Parameters["delta"].Cast<NumberObject>();
+    }
+
+    double sampleRate = (double)resolution.Denominator
+                      / (double)resolution.Numerator
+                      * (double)delta;
+    if (sampleRate != (double)(ulong)sampleRate)
+    {
+        throw new NotSupportedException($"Only signals with integral sample-rate are supported but found signal with {sampleRate} Hz");
+    }
+
+    return (nuint)Convert.ToUInt64(sampleRate);
+}
 ----
 ====
 
@@ -117,6 +198,18 @@ for (const auto& inputPort : inputPorts)
     multiReaderBuilderPorts.addInputPort(inputPort);
 auto multiReaderPorts = multiReaderBuilderPorts.build();
 ----
+C#::
++
+[source,csharp]
+----
+// -> currently there are no reader-builders available in C#
+
+// Creating a reader from signals
+var multiReaderSignals = OpenDAQFactory.CreateMultiReader(signals);
+
+// Creating a reader from ports
+// -> currently not available in C#
+----
 ====
 
 ==== Domain signal requirements
@@ -151,6 +244,20 @@ if (status.getReadStatus() == ReadStatus::Event)
     std::cout << "Event received\n";
 }
 ----
+C#::
++
+[source,csharp]
+----
+var dataAvailable = multiReader.AvailableCount;
+var count         = Math.Min(kBufferSize, dataAvailable);
+
+// Read and check for whether an event was encountered.
+var status = multiReader.ReadWithDomain(dataBuffers, domainBuffers, ref count);
+if (status.ReadStatus == ReadStatus.Event)
+{
+    Console.WriteLine("Event received");
+}
+----
 ====
 
 When an event is encountered, the signal descriptors can be obtained from the read status. They can be used to validate signal compatibility with the user application, and used to calculate optimal buffer sizes.
@@ -168,6 +275,50 @@ if (status.getReadStatus() == ReadStatus::Event)
     auto sampleRate = reader::getSampleRate(
         status.getMainDescriptor().getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR));
     kBufferSize = sampleRate / 10;
+}
+----
+C#::
++
+[source,csharp]
+----
+if (status.ReadStatus == ReadStatus.Event)
+{
+    // Set buffer size based on sample rate (in hertz), allocate buffers
+    // Buffers have 100ms worth of memory for each signal
+    //ToDo: reader::getSampleRate() not available in .NET Bindings
+    //var sampleRate = reader::getSampleRate(
+    //    status.MainDescriptor.Parameters["DomainDataDescriptor"]);
+    // simplified for the example:
+    var sampleRate = GetSampleRate(status.MainDescriptor
+                                         .Parameters["DomainDataDescriptor"]
+                                         .Cast<DataDescriptor>());
+    kBufferSize = sampleRate / 10;
+}
+
+nuint GetSampleRate(DataDescriptor dataDescriptor)
+{
+    var resolution = dataDescriptor.TickResolution;
+    var delta      = (NumberObject)1;
+    var rule       = dataDescriptor.Rule;
+
+    if ((rule != null) && (rule.Type != DataRuleType.Linear))
+    {
+        throw new NotSupportedException("Only signals with implicit linear-rule as a domain are supported.");
+    }
+    else if (rule != null)
+    {
+        delta = rule.Parameters["delta"].Cast<NumberObject>();
+    }
+
+    double sampleRate = (double)resolution.Denominator
+                      / (double)resolution.Numerator
+                      * (double)delta;
+    if (sampleRate != (double)(ulong)sampleRate)
+    {
+        throw new NotSupportedException($"Only signals with integral sample-rate are supported but found signal with {sampleRate} Hz");
+    }
+
+    return (nuint)Convert.ToUInt64(sampleRate);
 }
 ----
 ====
@@ -193,6 +344,21 @@ if (status.getReadStatus() == ReadStatus::Event)
     {
         dataBuffers[i] = std::calloc(kBufferSize, getSampleSize(SampleType::Float64));
         domainBuffers[i] = std::calloc(kBufferSize, getSampleSize(SampleType::Int64));
+    }
+}
+----
+C#::
++
+[source,csharp]
+----
+if (status.ReadStatus == ReadStatus.Event)
+{
+    // ...
+
+    for (int i = 0; i < signalsCount; ++i)
+    {
+        dataBuffers[i]   = new double[kBufferSize];
+        domainBuffers[i] = new long[kBufferSize];
     }
 }
 ----
@@ -227,6 +393,31 @@ for (size_t readCount = 0; readCount < 20; readCount++)
     }
 
     std::this_thread::sleep_for(50ms);
+}
+----
+C#::
++
+[source,csharp]
+----
+for (int readCount = 0; readCount < 20; readCount++)
+{
+    var dataAvailable = multiReader.AvailableCount;
+    var count         = Math.Min(kBufferSize, dataAvailable);
+    var status        = multiReader.ReadWithDomain(dataBuffers, domainBuffers, ref count);
+
+    if (status.ReadStatus == ReadStatus.Event)
+    {
+        // ...
+    }
+    else if ((status.ReadStatus == ReadStatus.Ok) && (count > 0))
+    {
+        Console.Write("Data: ");
+        foreach (var buf in dataBuffers)
+            Console.Write($"{buf[0]}; ");
+        Console.WriteLine();
+    }
+
+    System.Threading.Thread.Sleep(50);
 }
 ----
 ====
@@ -279,6 +470,12 @@ multiReader.setOnDataAvailable(readData);
     running = false;
 }
 ----
+C#::
++
+[source,csharp]
+----
+// callbacks are not yet supported in C#
+----
 ====
 
 ==== Reusing domain data
@@ -301,6 +498,14 @@ auto eventPacket = status.getMainDescriptor();
 auto outputDomainDescriptor = eventPacket.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
 auto outputDomainSignal = SignalWithDescriptor(context, outputDomainDescriptor, parent, "outputDomainSignal");
 ----
+C#::
++
+[source,csharp]
+----
+var eventPacket            = status.MainDescriptor;
+var outputDomainDescriptor = eventPacket.Parameters["DomainDataDescriptor"].Cast<DataDescriptor>();
+var outputDomainSignal     = OpenDAQFactory.CreateSignalWithDescriptor(context, outputDomainDescriptor, parent, "outputDomainSignal", "Signal");
+----
 ====
 
 // TODO: Once multi reader supports Explicit rule signals, the following section should be adapted.
@@ -315,6 +520,14 @@ Cpp::
 // `count` corresponds to the amount of samples read
 auto outputDomainPacket = DataPacket(outputDomainDescriptor, count, status.getOffset());
 outputDomainSignal.sendPacket(outputDomainPacket);
+----
+C#::
++
+[source,csharp]
+----
+// `count` corresponds to the amount of samples read
+var outputDomainPacket = OpenDAQFactory.CreateDataPacket(outputDomainDescriptor, count, status.Offset);
+outputDomainSignal.SendPacket(outputDomainPacket);
 ----
 ====
 
@@ -383,7 +596,7 @@ if (status.getReadStatus() == ReadStatus::Event)
     // Calculate k as the minimum number of LCM-size blocks to read ~100ms of data
     size_t k = std::max(commonSampleRate / lcm / 10, static_cast<size_t>(1));
     kBufferSize = k * lcm;
-    
+
     std::cout << "Buffer sizes: ";
     for (size_t i = 0; i < signalsCount; ++i)
     {
@@ -392,6 +605,56 @@ if (status.getReadStatus() == ReadStatus::Event)
         std::cout << kBufferSize / dividers[i] << ", ";
     }
     std::cout << "\n";
+}
+----
+C#::
++
+[source,csharp]
+----
+// ... in the for loop of the first example
+
+List<long> dividers = new();
+
+var dataAvailable = multiReader.AvailableCount;
+var count = Math.Min(kBufferSize, dataAvailable);
+var status = multiReader.ReadWithDomain(dataBuffers, domainBuffers, ref count);
+
+if (status.ReadStatus == ReadStatus.Event)
+{
+    var packets = status.EventPackets;
+    if (!(packets.Values.First().EventId == "DATA_DESCRIPTOR_CHANGED"))
+        continue;
+
+    // SRDiv calculation
+    long commonSampleRate = multiReader.CommonSampleRate;
+    dividers.Clear();
+    Console.Write("Dividers: ");
+    foreach (var eventPacket in packets.Values)
+    {
+        var descriptor = eventPacket.Parameters["DomainDataDescriptor"].Cast<DataDescriptor>();
+        var sampleRate = GetSampleRate(descriptor);
+        dividers.Add(commonSampleRate / (long)sampleRate);
+        Console.Write($"{dividers.Last()}, ");
+    }
+    Console.WriteLine();
+
+    // Allocate buffers for 100ms according to commonSampleRate
+    long lcm = 1;
+    foreach (var div in dividers)
+        lcm = GetLeastCommonMultiple(lcm, div); // https://stackoverflow.com/a/20824923
+
+    // Calculate k as the minimum number of LCM-size blocks to read ~100ms of data
+    long k = Math.Max(commonSampleRate / lcm / 10, 1);
+    kBufferSize = (nuint)(k * lcm);
+
+    Console.Write("Buffer sizes: ");
+    for (int i = 0; i < signalsCount; ++i)
+    {
+        dataBuffers[i]   = new double[(long)kBufferSize / dividers[i]];
+        domainBuffers[i] = new long[(long)kBufferSize / dividers[i]];
+        Console.Write($"{(long)kBufferSize / dividers[i]}, ");
+    }
+    Console.WriteLine();
 }
 ----
 ====
@@ -474,7 +737,7 @@ int main()
     channels[2].setPropertyValue("SampleRate", 500);
     std::cout << "\nDifferent rate data:\n";
     readDataDifferentRates(signals);
-    
+
     std::cout << "\nPress \"enter\" to exit the application..." << std::endl;
     std::cin.get();
     return 0;
@@ -524,8 +787,8 @@ void readDataSameRatesSignals(const ListPtr<ISignal>& signals)
         }
 
         std::this_thread::sleep_for(50ms);
-    } 
-    
+    }
+
     for (size_t i = 0; i < signalsCount; ++i)
     {
         free(dataBuffers[i]);
@@ -615,15 +878,15 @@ void readDataSameRatesPortsAndOutput(const ListPtr<ISignal>& signals)
             outputDomainSignal.sendPacket(domainPacket);
         }
     };
-    
+
     // Set read callback
     multiReader.setOnDataAvailable(readData);
-    
+
 
     // Connect signals to ports
     for (size_t i = 0; i < signalsCount; ++i)
         ports[i].connect(signals[i]);
-    
+
     // Read avg data with stream reader, pre-allocate 100ms of data, assuming 1KHz rates
     auto streamReader = StreamReader<double, int64_t>(outputSignal);
     double avgValues[100];
@@ -643,7 +906,7 @@ void readDataSameRatesPortsAndOutput(const ListPtr<ISignal>& signals)
         std::scoped_lock lock(mutex);
         running = false;
     }
-        
+
     for (size_t i = 0; i < signalsCount; ++i)
     {
         free(dataBuffers[i]);
@@ -700,7 +963,7 @@ void readDataDifferentRates(const ListPtr<ISignal>& signals)
             // Calculate k as the minimum number of LCM-size blocks to read ~100ms of data
             size_t k = std::max(commonSampleRate / lcm / 10, static_cast<size_t>(1));
             kBufferSize = k * lcm;
-            
+
             std::cout << "Buffer sizes: ";
             for (size_t i = 0; i < signalsCount; ++i)
             {
@@ -719,13 +982,20 @@ void readDataDifferentRates(const ListPtr<ISignal>& signals)
         }
 
         std::this_thread::sleep_for(50ms);
-    } 
-    
+    }
+
     for (size_t i = 0; i < signalsCount; ++i)
     {
         free(dataBuffers[i]);
         free(domainBuffers[i]);
     }
 }
+----
+C#::
++
+[source,csharp]
+----
+// ToDo: Implement the C# equivalent of the C++ example.
+//       Please refer to the other C# examples in this document.
 ----
 ====

--- a/docs/Antora/modules/explanations/pages/property_system.adoc
+++ b/docs/Antora/modules/explanations/pages/property_system.adoc
@@ -745,8 +745,8 @@ Cpp::
 ----
 auto propObj = PropertyObject();
 
-auto arguments = List<IArgumentInfo>(ArgumentInfo("Val1", ctInt), ArgumentInfo("Val2", ctInt), true);
-propObj.addProperty(FunctionProperty("SumFunction", FunctionInfo(ctInt, arguments)));
+auto arguments = List<IArgumentInfo>(ArgumentInfo("Val1", ctInt), ArgumentInfo("Val2", ctInt));
+propObj.addProperty(FunctionProperty("SumFunction", FunctionInfo(ctInt, arguments, true)));
 
 auto func = Function([](IntegerPtr val1, IntegerPtr val2)
 {

--- a/docs/Antora/modules/explanations/pages/readers.adoc
+++ b/docs/Antora/modules/explanations/pages/readers.adoc
@@ -28,6 +28,10 @@ As a parameter, they receive the xref:explanations:signals.adoc[Signal] to read 
 
 [#example-constructor]
 .Constructing a reader
+[tabs]
+====
+Cpp::
++
 [source,cpp,caption="Example {counter:example-nr:1.} "]
 ----
 // Standard factory signature with signal as input argument
@@ -39,10 +43,20 @@ Reader(inputPort, SampleType::Float64, SampleType::Int64);
 // In C++ there is also a templated helper
 Reader<double, std::int64_t>(signal);
 ----
+C#::
++
+[source,csharp]
+----
+// These calls all create the same Reader (e.g. for a Stream Reader)
+var reader1 = OpenDAQFactory.CreateStreamReader(signal);
+var reader2 = OpenDAQFactory.CreateStreamReader<double, long>(signal);
+// right now there exists no factory function using `SampleType` as parameters
+----
+====
 
 [CAUTION]
 ====
-There is also a way to construct a Reader without knowing the sample-types in advance by using `SampleType::Undefined`.
+There is also a way to construct a Reader without knowing the sample-types in advance by using `SampleType::Undefined` (not applicable in C#).
 
 .Reading without knowing the sample-types in advance
 ----
@@ -105,11 +119,23 @@ In addition to these two operations, Readers also define their own methods to re
 
 [#example-read]
 .Read calls function signature
+[tabs]
+====
+Cpp::
++
 [source,cpp,caption="Example {counter:example-nr:1.} "]
 ----
 ReaderStatusPtr read(void* values, std::size_t* count);
 ReaderStatusPtr readWithDomain(void* values, void* domain, std::size_t* count);
 ----
+C#::
++
+[source,csharp]
+----
+ReaderStatus Read(TValue[] samples, ref nuint count, nuint timeoutMs = 0);
+ReaderStatus ReadWithDomain(TValue[] samples, TDomain[] domain, ref nuint count, nuint timeoutMs = 0);
+----
+====
 The way to use the read calls is to have a memory buffer of a desired size and type pre-allocated.
 Then you pass it into the call where it will get filled with at maximum `count` elements.
 The Reader returns a ReaderStatusPtr object, indicating whether the reading process was successful or if there is an event packet that needs to be handled. Moreover, if the data type has changed, the Reader will include in the status whether the new type is convertible by the Reader or not.
@@ -132,14 +158,16 @@ The Sample Reader provides another four operations:
 [#value_read_type]
 * `getValueReadType()` / `getDomainReadType()` reports the sample-type of samples the Reader outputs on _read_ calls.
 This should be the same as the one passed in on construction except in the case where `SampleType::Undefined` was used.
-There it is the Signal's data type.
+There it is the Signal's data type. +
+In C# property getters `ValueReadType` / `DomainReadType` return the `SampleType` equivalent to the types passed in on construction.
 
 [#transform_callback]
-* `setValueTransformFunction(callback)` / `setDomainTransformFunction(callback)` enables custom user transformation of raw signal data specific to the programming language or use case. See the chapter <<custom_conversion>> for more info.
+* `setValueTransformFunction(callback)` / `setDomainTransformFunction(callback)` enables custom user transformation of raw signal data specific to the programming language or use case. See the chapter <<custom_conversion>> for more info. +
+In C# the `callback` parameter is a custom user generated `Function`.
 
 [NOTE]
 ====
-If there is a custom transform function assigned the corresponding value or domain `SampleType` requested at construction is completely ignored and the Reader directly returns whatever data the callback produces.
+If there is a custom transform function assigned the corresponding value or domain `SampleType` requested at construction is completely ignored and the Reader directly returns whatever data the callback produces. +
 No additional processing is done except to advance the reading position if required.
 ====
 
@@ -164,6 +192,10 @@ This event contains new xref:explanations:signals.adoc[Data Descriptor]s for bot
 The processing of event packets in our system occurs dynamically through the reader, not immediately upon reception, but rather during the reading process.
 
 To illustrate, consider a scenario with a queue containing 10 packets. One of these is an event packet positioned in the middle, while the remaining packets are data packets, each containing two samples. In a user scenario where reading up to 5 packets is requested, the event packet will not be included in the processing list. However, if the user attempts to read more than 5 samples, the reader will return 5 samples, update the types of internal readers, and provide a reading status. This status will include information about the event packet, and whether the reader can convert new data or not.
+[tabs]
+====
+Cpp::
++
 [source,cpp]
 ----
 auto reader = StreamReader<double, Int>(signal);
@@ -194,14 +226,19 @@ signal.sendPacket(packet1);
 
 SizeT count{10};
 double values[10]{};
-ReaderStatusPtr status = reader.read(values, &count);  
+ReaderStatusPtr status = reader.read(values, &count);
 // count = 5, values = { 1.0, 2.0, 3.0, 4.0, 5.0 }
 // status.getReadStatus() == ReadStatus::Event
 
 // reading remaining data
 count = 5;
-reader.read(&values[5], &count);  
+reader.read(&values[5], &count);
 ----
+C#::
++
+[NOTE]
+Currently this functionality cannot be translated to C# (signal and data simulation not possible).
+====
 
 [NOTE]
 ====
@@ -236,6 +273,10 @@ The callback signature is shown <<transform_callback_signatrue,below>> where `in
 
 [#transform_callback_signatrue]
 .The transform callback signature
+[tabs]
+====
+Cpp::
++
 [source,cpp]
 ----
 bool callback(Int inputBuffer,
@@ -243,6 +284,13 @@ bool callback(Int inputBuffer,
               SizeT toRead,
               DataDescriptor descriptor)
 ----
+C#::
++
+[source,csharp]
+----
+// not yet available in C#
+----
+====
 
 [#packet_reader]
 == Packet Reader


### PR DESCRIPTION
# Brief

C# example additions to `readers.adoc` and `multireaders_spec.adoc`.



# Description

In this PR you find the C# additions to `readers.adoc` and `multireaders_spec.adoc`.

Some examples were skipped though always a comment has been added.

Additions:
1. Added (local) function `GetSampleRate()` as substitute to C++ helper function `reader::getSampleRate()` which never gets RTGened. Perhaps it should just be implemented directly in the MultiReader as `getSampleRateHelper(DataDescriptor descriptor)`.
2. Substituted C++ code `std::lcm` by a fictive function `GetLeastCommonMultiple()` and added a comment to a stackoverflow answer with a nice example.  
Of course, when this is unwanted, the comment has to be changed to "please implement function yourself".
3. Not done examples where it is impossible to translate to C#. Some things are not yet implemented like the reader-builders, some things just technically won't do (call-backs, simulated data).
4. Not done the MultiReader full example as I simply did not have the time anymore before my vacation.
5. Missing also adding C# examples to `modules.adoc` for the same reason as in 4.

There's also some improvement in the CI tests concerning having always events with readers (no reader-builders in C# to turn that off).


# Usage example

n/a

# API changes

n/a

# Required application changes

n/a

# Required module changes

n/a