### PR TITLE
[TBBAS-2430] Fix: Can not set dictionary device property on python client

### DIFF
--- a/examples/python/GUI Application/gui_demo/utils.py
+++ b/examples/python/GUI Application/gui_demo/utils.py
@@ -10,10 +10,8 @@ import opendaq as daq
 yes_no = ['No', 'Yes']
 
 yes_no_inv = {
-    'No':  False,
-    'no': False,
-    'Yes': True,
     'yes': True,
+    'no': False,
     'y': True,
     'n': False,
     'none': False,


### PR DESCRIPTION
# Brief
Fixed: Can not set dictionary device property on **Python GUI App** by extending `str` to `bool` mappings
# Description
- Add various mappings `str` -> `bool` in **Python GUI App** for more convenient use
# Usage example
You can use 
- **y**, **n**
- **true**, **false**
- **on**, **off**
-  **1**, **0**
- **none** 
in addition to **yes** **no** to set **boolean** properties
# API changes
None
# Required application changes
None
# Required module changes
None
