### PR TITLE
Fix missing property args header installation

### DIFF
--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -3,7 +3,7 @@
 ## Features
 
 - [#878](https://github.com/openDAQ/openDAQ/pull/878) Licensing interface and reference module + example implementation.
-- [#865](https://github.com/openDAQ/openDAQ/pull/865) onPropertyValueRead events are now supported over native. Suggested and Selection values can be overridden in new onRead events. String properties can now have suggested values.
+- [#865](https://github.com/openDAQ/openDAQ/pull/865), [#882](https://github.com/openDAQ/openDAQ/pull/882) onPropertyValueRead events are now supported over native. Suggested and Selection values can be overridden in new onRead events. String properties can now have suggested values.
 - [#853](https://github.com/openDAQ/openDAQ/pull/853) Parquet writer
 - [#861](https://github.com/openDAQ/openDAQ/pull/861) Add support for list and dictionary item/key type identification in Argument Info.
 - [#849](https://github.com/openDAQ/openDAQ/pull/849) Improving error logging and implementing an error guard.

--- a/core/coreobjects/src/CMakeLists.txt
+++ b/core/coreobjects/src/CMakeLists.txt
@@ -343,6 +343,7 @@ list(APPEND SRC_PublicHeaders  ${ConfigHeader}
                                ${SRC_PermisisonMaskBuilder}
                                ${SRC_Permisisons}
                                ${SRC_ObjectLockGuard}
+                               ${SRC_PropertyMetadataReadArgs}
                                coreobjects.natvis
 )
 


### PR DESCRIPTION
# Brief

Fixes missing `property_metadata_read_args` smart pointer header installation