### PR TITLE
bug fix: BasicRecorder: close recording files when recording is stopped

### DIFF
--- a/modules/basic_csv_recorder_module/src/basic_csv_recorder_impl.cpp
+++ b/modules/basic_csv_recorder_module/src/basic_csv_recorder_impl.cpp
@@ -122,7 +122,7 @@ void BasicCsvRecorderImpl::reconfigure()
 
     if (recordingActive)
     {
-        // We will update the 'signals' map by emplacing new BasicCsvRecorderSignal objects for
+        // We will update the 'threads' map by emplacing new BasicCsvRecorderSignal objects for
         // newly-connected input ports, and destroying BasicCsvRecorderSignal objects for ports
         // that are gone or no longer connected. Notably, we will not disturb
         // BasicCsvRecorderSignal objects for input ports that have not changed.
@@ -172,7 +172,7 @@ void BasicCsvRecorderImpl::reconfigure()
 
     else
     {
-        signals.clear();
+        threads.clear();
     }
 }
 


### PR DESCRIPTION
# Brief

This PR fixes a bug in the BasicRecorder module where recording files (CSV files) are not closed when the recording is stopped. It would be great if we can include this fix in the next 3.20.x release (and of course in 3.30).

# Description

The cause of the bug was that a member variable used to exist called `signals`, which hid an underlying member variable of the SignalContainerImpl class. This member variable was refactored/renamed to `threads` but the code still refers to `signals` which now refers to the un-masked base class member variable.

# Required application changes

None, the fix is transparent.

# Required module changes

None, the fix is transparent.