### PR TITLE
new_websocket_streaming_server_module: support IPv6

### DIFF
--- a/modules/new_websocket_streaming_server_module/src/websocket_server.cpp
+++ b/modules/new_websocket_streaming_server_module/src/websocket_server.cpp
@@ -144,7 +144,7 @@ void daq::ws_streaming::server::thread_main()
             control_socket.set_option(option);
         }
 
-        catch (const std::exception& ex)
+        catch (const std::exception& /*ex*/)
         {
             // IPv6-only option not supported. We can ignore this because it means
             // the acceptors will always support IPv4 and IPv6, which is what we want.

--- a/modules/new_websocket_streaming_server_module/src/websocket_server.cpp
+++ b/modules/new_websocket_streaming_server_module/src/websocket_server.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -133,8 +134,21 @@ void daq::ws_streaming::server::thread_main()
 {
     try
     {
-        boost::asio::ip::tcp::acceptor ws_socket(ioc, boost::asio::ip::tcp::endpoint({}, ws_port), true);
-        boost::asio::ip::tcp::acceptor control_socket(ioc, boost::asio::ip::tcp::endpoint({}, control_port), true);
+        boost::asio::ip::tcp::acceptor ws_socket(ioc, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v6(), ws_port), true);
+        boost::asio::ip::tcp::acceptor control_socket(ioc, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v6(), control_port), true);
+
+        try
+        {
+            boost::asio::ip::v6_only option{false};
+            ws_socket.set_option(option);
+            control_socket.set_option(option);
+        }
+
+        catch (const std::exception& ex)
+        {
+            // IPv6-only option not supported. We can ignore this because it means
+            // the acceptors will always support IPv4 and IPv6, which is what we want.
+        }
 
         ws_socket.listen();
         control_socket.listen();


### PR DESCRIPTION
# Brief

Fix the new WebSocket Streaming server so that it accepts IPv6 as well as IPv4 connections.

# Description

This change adjusts the Boost.Asio TCP acceptors so that they listen on both IPv4 and IPv6 ports.

Previously only IPv4 was supported. This is because passing a default-constructed `ip::address` object implicitly binds to IPv4 (unlike the BSD socket API). Instead we have to pass in a `v6()` protocol object and then attempt to ensure the IPv6-only socket option, if supported, is off (this option appears not to be supported on default Boost installations, which is fine).

# API changes

None, the change is transparent and does not change the API or ABI.

# Required module changes

None.