### PR TITLE
Rework disabled permission manager

### DIFF
--- a/bindings/c/include/ccoreobjects/permission_manager.h
+++ b/bindings/c/include/ccoreobjects/permission_manager.h
@@ -5,7 +5,7 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 //
-//     RTGen (CGenerator v0.7.0) on 03.06.2025 22:05:13.
+//     RTGen (CGenerator v0.7.0) on 28.08.2025 07:28:15.
 // </auto-generated>
 //------------------------------------------------------------------------------
 
@@ -43,7 +43,6 @@ extern "C"
     daqErrCode EXPORTED daqPermissionManager_setPermissions(daqPermissionManager* self, daqPermissions* permissions);
     daqErrCode EXPORTED daqPermissionManager_isAuthorized(daqPermissionManager* self, daqUser* user, daqPermission permission, daqBool* authorizedOut);
     daqErrCode EXPORTED daqPermissionManager_createPermissionManager(daqPermissionManager** obj, daqPermissionManager* parent);
-    daqErrCode EXPORTED daqPermissionManager_createDisabledPermissionManager(daqPermissionManager** obj);
 
 #ifdef __cplusplus
 }

--- a/bindings/c/src/ccoreobjects/permission_manager.cpp
+++ b/bindings/c/src/ccoreobjects/permission_manager.cpp
@@ -5,7 +5,7 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 //
-//     RTGen (CGenerator v0.7.0) on 03.06.2025 22:05:13.
+//     RTGen (CGenerator v0.7.0) on 28.08.2025 07:28:16.
 // </auto-generated>
 //------------------------------------------------------------------------------
 
@@ -31,14 +31,6 @@ daqErrCode daqPermissionManager_createPermissionManager(daqPermissionManager** o
 {
     daq::IPermissionManager* ptr = nullptr;
     daqErrCode err = daq::createPermissionManager(&ptr, reinterpret_cast<daq::IPermissionManager*>(parent));
-    *obj = reinterpret_cast<daqPermissionManager*>(ptr);
-    return err;
-}
-
-daqErrCode daqPermissionManager_createDisabledPermissionManager(daqPermissionManager** obj)
-{
-    daq::IPermissionManager* ptr = nullptr;
-    daqErrCode err = daq::createDisabledPermissionManager(&ptr);
     *obj = reinterpret_cast<daqPermissionManager*>(ptr);
     return err;
 }

--- a/bindings/python/core_objects/generated/py_permission_manager.cpp
+++ b/bindings/python/core_objects/generated/py_permission_manager.cpp
@@ -41,7 +41,6 @@ void defineIPermissionManager(pybind11::module_ m, PyDaqIntf<daq::IPermissionMan
     cls.doc() = "A class which is responsible for managing permissions on an object level. Given a user's group, it is possible to restrict or allow read, write and execute permissions for each object. It is also possible to specify if permissions are inherited from parent object";
 
     m.def("PermissionManager", &daq::PermissionManager_Create);
-    m.def("DisabledPermissionManager", &daq::DisabledPermissionManager_Create);
 
     cls.def_property("permissions",
         nullptr,

--- a/core/coreobjects/include/coreobjects/permission_manager.h
+++ b/core/coreobjects/include/coreobjects/permission_manager.h
@@ -59,12 +59,4 @@ DECLARE_OPENDAQ_INTERFACE(IPermissionManager, IBaseObject)
  */
 OPENDAQ_DECLARE_CLASS_FACTORY(LIBRARY_FACTORY, PermissionManager, IPermissionManager*, parent)
 
-/*!
- * @brief Creates a permission manager which never restricts any access to any object.
- */
-OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(LIBRARY_FACTORY,
-                                                            DisabledPermissionManager,
-                                                            IPermissionManager,
-                                                            createDisabledPermissionManager)
-
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/permission_manager_factory.h
+++ b/core/coreobjects/include/coreobjects/permission_manager_factory.h
@@ -43,15 +43,6 @@ inline PermissionManagerPtr PermissionManager(const PermissionManagerPtr& parent
     return obj;
 }
 
-/*!
- * @brief Creates a permission manager which never restricts any access to any object.
- */
-inline PermissionManagerPtr DisabledPermissionManager()
-{
-    PermissionManagerPtr obj(DisabledPermissionManager_Create());
-    return obj;
-}
-
 /*!@}*/
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/permission_manager_impl.h
+++ b/core/coreobjects/include/coreobjects/permission_manager_impl.h
@@ -25,7 +25,7 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-// PermissionManagerImpl
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
 
 class PermissionManagerImpl : public ImplementationOfWeak<IPermissionManager, IPermissionManagerInternal, ICloneable>
 {
@@ -54,12 +54,14 @@ private:
     PermissionsPtr localPermissions;
 };
 
-// DisabledPermissionManagerImpl
+#else
 
-class DisabledPermissionManagerImpl : public ImplementationOfWeak<IPermissionManager, IPermissionManagerInternal, ICloneable>
+// permission manager which never restricts any access to any object.
+
+class PermissionManagerImpl : public ImplementationOfWeak<IPermissionManager, IPermissionManagerInternal, ICloneable>
 {
 public:
-    explicit DisabledPermissionManagerImpl();
+    explicit PermissionManagerImpl(const PermissionManagerPtr& parent);
 
     ErrCode INTERFACE_FUNC setPermissions(IPermissions* permissions) override;
     ErrCode INTERFACE_FUNC isAuthorized(IUser* user, Permission permission, Bool* authorizedOut) override;
@@ -72,5 +74,7 @@ protected:
     ErrCode INTERFACE_FUNC getPermissions(IPermissions** permisisonConfigOut) override;
     ErrCode INTERFACE_FUNC updateInheritedPermissions() override;
 };
+
+#endif
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -575,13 +575,9 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
     this->internalAddRef();
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
 
-#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
     this->permissionManager = PermissionManager();
     this->permissionManager.setPermissions(
         PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build());
-#else
-    this->permissionManager = DisabledPermissionManager();
-#endif
 
     PropertyValueEventEmitter readEmitter;
     PropertyValueEventEmitter writeEmitter;
@@ -2966,11 +2962,9 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::serializeLoc
         serializerPtr.startList();
         for (const auto& prop : localProperties)
         {
-#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
             bool isObjectProp = prop.second.template asPtr<IPropertyInternal>().getValueTypeUnresolved() == ctObject;
             if (isObjectProp && !hasUserReadAccess(serializerPtr.getUser(), prop.second.getDefaultValue()))
                 continue;
-#endif
 
             const ErrCode errCode = serializeProperty(prop.second, serializer);
             OPENDAQ_RETURN_IF_FAILED(errCode);

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -8,12 +8,12 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
+
 namespace detail
 {
     static const auto DefaultPermissions = PermissionsBuilder().inherit(true).build();
 }
-
-// PermissionManagerImpl
 
 PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent)
     : permissions(detail::DefaultPermissions)
@@ -165,63 +165,62 @@ PermissionManagerInternalPtr PermissionManagerImpl::getParentManager()
     return nullptr;
 }
 
-// DisabledPermissionManagerImpl
+#else
 
-DisabledPermissionManagerImpl::DisabledPermissionManagerImpl()
+// permission manager which never restricts any access to any object.
+
+PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& /*parent*/)
 {
 }
 
-ErrCode DisabledPermissionManagerImpl::setPermissions(IPermissions* /*permissions*/)
+ErrCode PermissionManagerImpl::setPermissions(IPermissions* /*permissions*/)
 {
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode DisabledPermissionManagerImpl::isAuthorized(IUser* /*user*/, Permission /*permission*/, Bool* authorizedOut)
+ErrCode PermissionManagerImpl::isAuthorized(IUser* /*user*/, Permission /*permission*/, Bool* authorizedOut)
 {
     OPENDAQ_PARAM_NOT_NULL(authorizedOut);
     *authorizedOut = true;
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode DisabledPermissionManagerImpl::clone(IBaseObject** cloneOut)
+ErrCode PermissionManagerImpl::clone(IBaseObject** cloneOut)
 {
-    auto manager = DisabledPermissionManager();
+    auto manager = PermissionManager();
     *cloneOut = manager.addRefAndReturn();
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode DisabledPermissionManagerImpl::setParent(IPermissionManager* /*parentManager*/)
+ErrCode PermissionManagerImpl::setParent(IPermissionManager* /*parentManager*/)
 {
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode DisabledPermissionManagerImpl::addChildManager(IPermissionManager* /*childManager*/)
+ErrCode PermissionManagerImpl::addChildManager(IPermissionManager* /*childManager*/)
 {
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode DisabledPermissionManagerImpl::removeChildManager(IPermissionManager* /*childManager*/)
+ErrCode PermissionManagerImpl::removeChildManager(IPermissionManager* /*childManager*/)
 {
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode DisabledPermissionManagerImpl::getPermissions(IPermissions** /*permisisonConfigOut*/)
+ErrCode PermissionManagerImpl::getPermissions(IPermissions** /*permisisonConfigOut*/)
 {
     return OPENDAQ_SUCCESS;
 }
 
-ErrCode DisabledPermissionManagerImpl::updateInheritedPermissions()
+ErrCode PermissionManagerImpl::updateInheritedPermissions()
 {
     return OPENDAQ_SUCCESS;
 }
+
+#endif
 
 // Factories
 
 OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, PermissionManager, IPermissionManager*, parent)
-
-OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(LIBRARY_FACTORY,
-                                                               DisabledPermissionManagerImpl,
-                                                               IPermissionManager,
-                                                               createDisabledPermissionManager)
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/tests/test_permission_manager.cpp
+++ b/core/coreobjects/tests/test_permission_manager.cpp
@@ -9,6 +9,8 @@ using namespace daq;
 
 using PermissionManagerTest = testing::Test;
 
+#ifdef OPENDAQ_ENABLE_ACCESS_CONTROL
+
 TEST_F(PermissionManagerTest, Create)
 {
     auto manager = PermissionManager();
@@ -279,11 +281,13 @@ TEST_F(PermissionManagerTest, AssignAddPermission)
     ASSERT_TRUE(manager.isAuthorized(admin, Permission::Execute));
 }
 
+#else
+
 TEST_F(PermissionManagerTest, CreateDisabledPermissionManager)
 {
     auto admin = User("admin", "password", List<IString>("admin"));
 
-    auto permissionManager = DisabledPermissionManager();
+    auto permissionManager = PermissionManager();
     permissionManager.setPermissions(nullptr);
 
     ASSERT_TRUE(permissionManager.isAuthorized(admin, Permission::Read));
@@ -294,3 +298,5 @@ TEST_F(PermissionManagerTest, CreateDisabledPermissionManager)
     ASSERT_TRUE(permissionManager.isAuthorized(nullptr, Permission::Write));
     ASSERT_TRUE(permissionManager.isAuthorized(nullptr, Permission::Execute));
 }
+
+#endif


### PR DESCRIPTION
# Brief

Enable or disable access control without requiring module rebuilds.

# Description

Previously, toggling the CMake option `OPENDAQ_ENABLE_ACCESS_CONTROL` and rebuilding the openDAQ core libraries also required rebuilding device and function block modules. Without this, a mismatch occurred between the regular and disabled permission managers when inheriting from a parent to a child component. This led to `NotAssignedException` **" Parameter config must not be null in the function `extend`"**, since one manager allowed `nullptr` permission objects while the other disallowed them.

The introduced changes remove the disabled permission manager and provide a single permission manager factory. This factory conditionally instantiates either the regular or the former disabled permission manager, depending on the `OPENDAQ_ENABLE_ACCESS_CONTROL` setting.

This approach eliminates conditional `#ifdef` branching in the `PropertyObject` implementation, making module code independent of the `OPENDAQ_ENABLE_ACCESS_CONTROL` option and thus compatible with both variants of the openDAQ core libraries (built with the option ON or OFF).

# Required module changes

No changes to module source code are required. However, modules must be rebuilt using the patched openDAQ include files and updated core library binaries for the fix to take effect.