### PR TITLE
Other/inherited locking

### DIFF
--- a/core/coreobjects/include/coreobjects/mutex.h
+++ b/core/coreobjects/include/coreobjects/mutex.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/common.h>
+#include <coretypes/baseobject.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+
+/*!
+ * @ingroup objects_property_object
+ * @addtogroup objects_mutex Mutex
+ * @{
+ */
+
+/*!
+ * @brief Mutex wrapper interface.
+ */
+DECLARE_OPENDAQ_INTERFACE(IMutex, IBaseObject)
+{
+    virtual ErrCode INTERFACE_FUNC lock() = 0;
+    virtual ErrCode INTERFACE_FUNC tryLock(Bool* succeeded) = 0;
+    virtual ErrCode INTERFACE_FUNC unlock() = 0;
+};
+
+/*!@}*/
+
+OPENDAQ_DECLARE_CLASS_FACTORY(LIBRARY_FACTORY, Mutex)
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/mutex_factory.h
+++ b/core/coreobjects/include/coreobjects/mutex_factory.h
@@ -21,7 +21,7 @@ BEGIN_NAMESPACE_OPENDAQ
 
 inline MutexPtr Mutex()
 {
-    return MutexPtr(Mutex_Create());
+    return { Mutex_Create() };
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/mutex_factory.h
+++ b/core/coreobjects/include/coreobjects/mutex_factory.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coreobjects/mutex_ptr.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+inline MutexPtr Mutex()
+{
+    return MutexPtr(Mutex_Create());
+}
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/mutex_impl.h
+++ b/core/coreobjects/include/coreobjects/mutex_impl.h
@@ -23,8 +23,6 @@ BEGIN_NAMESPACE_OPENDAQ
 class MutexImpl : public ImplementationOf<IMutex>
 {
 public:
-    explicit MutexImpl() = default;
-
     ErrCode INTERFACE_FUNC lock() override;
     ErrCode INTERFACE_FUNC tryLock(Bool* succeeded) override;
     ErrCode INTERFACE_FUNC unlock() override;

--- a/core/coreobjects/include/coreobjects/mutex_impl.h
+++ b/core/coreobjects/include/coreobjects/mutex_impl.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/intfs.h>
+#include <coreobjects/mutex.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+class MutexImpl : public ImplementationOf<IMutex>
+{
+public:
+    explicit MutexImpl() = default;
+
+    ErrCode INTERFACE_FUNC lock() override;
+    ErrCode INTERFACE_FUNC tryLock(Bool* succeeded) override;
+    ErrCode INTERFACE_FUNC unlock() override;
+
+    std::mutex mutex;
+};
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/mutex_ptr.h
+++ b/core/coreobjects/include/coreobjects/mutex_ptr.h
@@ -1,0 +1,99 @@
+#pragma once
+#include <coretypes/coretypes.h>
+#include "coreobjects/mutex.h"
+#include <coretypes/objectptr.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+class MutexPtr;
+
+template <>
+struct InterfaceToSmartPtr<daq::IMutex>
+{
+    using SmartPtr = daq::MutexPtr;
+};
+
+class MutexPtr : public daq::ObjectPtr<IMutex>
+{
+public:
+    using daq::ObjectPtr<IMutex>::ObjectPtr;
+
+
+    MutexPtr()
+        : daq::ObjectPtr<IMutex>()
+
+    {
+    }
+
+    MutexPtr(daq::ObjectPtr<IMutex>&& ptr)
+        : daq::ObjectPtr<IMutex>(std::move(ptr))
+
+    {
+    }
+
+    MutexPtr(const daq::ObjectPtr<IMutex>& ptr)
+        : daq::ObjectPtr<IMutex>(ptr)
+
+    {
+    }
+
+    MutexPtr(const MutexPtr& other)
+        : daq::ObjectPtr<IMutex>(other)
+
+    {
+    }
+
+    MutexPtr(MutexPtr&& other) noexcept
+        : daq::ObjectPtr<IMutex>(std::move(other))
+
+    {
+    }
+    
+    MutexPtr& operator=(const MutexPtr& other)
+    {
+        daq::ObjectPtr<IMutex>::operator =(other);
+
+
+        return *this;
+    }
+
+    MutexPtr& operator=(MutexPtr&& other) noexcept
+    {
+
+        daq::ObjectPtr<IMutex>::operator =(std::move(other));
+
+        return *this;
+    }
+
+    void lock() const
+    {
+        if (this->object == nullptr)
+            DAQ_THROW_EXCEPTION(daq::InvalidParameterException);
+
+        auto errCode = this->object->lock();
+        daq::checkErrorInfo(errCode);
+    }
+
+    bool try_lock() const
+    {
+        if (this->object == nullptr)
+            DAQ_THROW_EXCEPTION(daq::InvalidParameterException);
+
+        Bool lock;
+        auto errCode = this->object->tryLock(&lock);
+        daq::checkErrorInfo(errCode);
+
+        return lock;
+    }
+
+    void unlock() const
+    {
+        if (this->object == nullptr)
+            DAQ_THROW_EXCEPTION(daq::InvalidParameterException);
+
+        auto errCode = this->object->lock();
+        daq::checkErrorInfo(errCode);
+    }
+};
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/include/coreobjects/mutex_ptr.h
+++ b/core/coreobjects/include/coreobjects/mutex_ptr.h
@@ -91,7 +91,7 @@ public:
         if (this->object == nullptr)
             DAQ_THROW_EXCEPTION(daq::InvalidParameterException);
 
-        auto errCode = this->object->lock();
+        auto errCode = this->object->unlock();
         daq::checkErrorInfo(errCode);
     }
 };

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -980,7 +980,7 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::coerceMinMax(co
 template <class PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setProtectedPropertyValue(IString* propertyName, IBaseObject* value)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return setPropertyValueInternal(propertyName, value, true, true, updateCount > 0);
 }
 
@@ -993,7 +993,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setProtected
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyValue(IString* propertyName, IBaseObject* value)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return setPropertyValueNoLock(propertyName, value);
 }
 
@@ -1728,7 +1728,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyA
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyValue(IString* propertyName, IBaseObject** value)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return getPropertyValueNoLock(propertyName, value);
 }
 
@@ -1741,7 +1741,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyV
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertySelectionValue(IString* propertyName, IBaseObject** value)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return getPropertySelectionValueNoLock(propertyName, value);
 }
 
@@ -1755,7 +1755,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
 template <class PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearProtectedPropertyValue(IString* propertyName)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return clearPropertyValueInternal(propertyName, true, updateCount > 0);
 }
 
@@ -1869,7 +1869,7 @@ std::unique_lock<MutexPtr> GenericPropertyObjectImpl<PropObjInterface, Interface
 template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropertyValue(IString* propertyName)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return clearPropertyValueNoLock(propertyName);
 }
 
@@ -2201,7 +2201,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::removeProper
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
     }
 
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
 
     if (localProperties.find(propertyName) == localProperties.cend())
     {
@@ -2235,7 +2235,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getAllProper
 template <class PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyOrderInternal(IList* orderedPropertyNames, bool isUpdating)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     if (frozen)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
 
@@ -2431,7 +2431,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getOnAnyProp
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::beginUpdate()
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return beginUpdateInternal(true);
 }
 
@@ -2627,14 +2627,14 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::onUpdatableUpda
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::endUpdate()
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return endUpdateInternal(true);
 }
 
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getUpdating(Bool* updating)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return getUpdatingInternal(updating);
 }
 
@@ -2756,7 +2756,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForRefe
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkForReferences(IProperty* property, Bool* isReferenced)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     return checkForReferencesNoLock(property, isReferenced);
 }
 
@@ -2817,7 +2817,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getCoreEvent
 {
     OPENDAQ_PARAM_NOT_NULL(trigger);
     
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     *trigger = this->triggerCoreEvent.addRefAndReturn();
     return OPENDAQ_SUCCESS;
 }
@@ -2825,7 +2825,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getCoreEvent
 template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setCoreEventTrigger(IProcedure* trigger)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     this->triggerCoreEvent = trigger;
     return OPENDAQ_SUCCESS;
 }
@@ -2862,7 +2862,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPath(IStr
 {
     OPENDAQ_PARAM_NOT_NULL(path);
 
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     if (this->path.getLength())
         return OPENDAQ_IGNORED;
 
@@ -2875,7 +2875,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPath(IStr
 {
     OPENDAQ_PARAM_NOT_NULL(path);
 
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
 
     *path = this->path.addRefAndReturn();
     return OPENDAQ_SUCCESS;

--- a/core/coreobjects/include/coreobjects/property_object_internal.h
+++ b/core/coreobjects/include/coreobjects/property_object_internal.h
@@ -16,17 +16,22 @@
 
 #pragma once
 #include <coreobjects/property.h>
-#include <coreobjects/property_object.h>
+#include <coreobjects/mutex.h>
 #include <coreobjects/object_lock_guard.h>
 
 BEGIN_NAMESPACE_OPENDAQ
-
 
 /*!
  * @ingroup objects_property_object
  * @addtogroup objects_property_object_obj PropertyObjectInternal
  * @{
  */
+
+enum class LockingStrategy : EnumType
+{
+    OwnLock = 0,
+    InheritLock
+};
 
 /*#
  * [interfaceSmartPtr(ILockGuard, LockGuardPtr, "<coreobjects/object_lock_guard_ptr.h>")]
@@ -49,10 +54,13 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObjectInternal, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getPropertyValueNoLock(IString* name, IBaseObject** value) = 0;
     virtual ErrCode INTERFACE_FUNC getPropertySelectionValueNoLock(IString* name, IBaseObject** value) = 0;
     virtual ErrCode INTERFACE_FUNC setPropertyValueNoLock(IString* name, IBaseObject* value) = 0;
+    virtual ErrCode INTERFACE_FUNC setProtectedPropertyValueNoLock(IString* name, IBaseObject* value) = 0;
     virtual ErrCode INTERFACE_FUNC clearPropertyValueNoLock(IString* name) = 0;
 
     virtual ErrCode INTERFACE_FUNC getLockGuard(ILockGuard** lockGuard) = 0;
     virtual ErrCode INTERFACE_FUNC getRecursiveLockGuard(ILockGuard** lockGuard) = 0;
+    virtual ErrCode INTERFACE_FUNC setLockingStrategy(LockingStrategy strategy) = 0;
+    virtual ErrCode INTERFACE_FUNC getMutex(IMutex** mutex) = 0;
 };
 
 /*!@}*/

--- a/core/coreobjects/include/coreobjects/property_object_internal.h
+++ b/core/coreobjects/include/coreobjects/property_object_internal.h
@@ -30,7 +30,8 @@ BEGIN_NAMESPACE_OPENDAQ
 enum class LockingStrategy : EnumType
 {
     OwnLock = 0,
-    InheritLock
+    InheritLock,
+    ForwardOwnerLockOwn
 };
 
 /*#
@@ -60,7 +61,9 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObjectInternal, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getLockGuard(ILockGuard** lockGuard) = 0;
     virtual ErrCode INTERFACE_FUNC getRecursiveLockGuard(ILockGuard** lockGuard) = 0;
     virtual ErrCode INTERFACE_FUNC setLockingStrategy(LockingStrategy strategy) = 0;
+    virtual ErrCode INTERFACE_FUNC getLockingStrategy(LockingStrategy* strategy) = 0;
     virtual ErrCode INTERFACE_FUNC getMutex(IMutex** mutex) = 0;
+    virtual ErrCode INTERFACE_FUNC getMutexOwner(IPropertyObjectInternal** owner) = 0;
 };
 
 /*!@}*/

--- a/core/coreobjects/src/CMakeLists.txt
+++ b/core/coreobjects/src/CMakeLists.txt
@@ -197,6 +197,13 @@ source_group("permission_builder" FILES ${SDK_HEADERS_DIR}/permissions_builder.h
                                         permissions_impl.cpp
 )
 
+source_group("mutex" FILES ${SDK_HEADERS_DIR}/mutex.h
+                           ${SDK_HEADERS_DIR}/mutex_factory.h
+                           ${SDK_HEADERS_DIR}/mutex_impl.h
+                           ${SDK_HEADERS_DIR}/mutex_ptr.h
+                           mutex_impl.cpp
+)
+
 set(SRC_Cpp version.cpp
             eval_value_impl.cpp
             eval_value_lexer.cpp
@@ -227,6 +234,7 @@ set(SRC_Cpp version.cpp
             permission_mask_builder_impl.cpp
             search_filter_impl.cpp
             property_metadata_read_args_impl.cpp
+            mutex_impl.cpp
 )
 
 set(SRC_PublicHeaders coreobjects.h
@@ -278,6 +286,9 @@ set(SRC_PublicHeaders coreobjects.h
                       search_filter_factory.h
                       property_metadata_read_args.h
                       property_metadata_read_args_factory.h
+                      mutex.h
+                      mutex_factory.h
+					  mutex_ptr.h
 )
 
 set(SRC_PrivateHeaders eval_value_impl.h
@@ -307,6 +318,7 @@ set(SRC_PrivateHeaders eval_value_impl.h
                        permission_mask_builder_impl.h
                        search_filter_impl.h
                        property_metadata_read_args_impl.h
+                       mutex_impl.h
 )
 
 prepend_include(${TARGET_FOLDER_NAME} SRC_PrivateHeaders)

--- a/core/coreobjects/src/mutex_impl.cpp
+++ b/core/coreobjects/src/mutex_impl.cpp
@@ -1,0 +1,50 @@
+#include <coreobjects/mutex_impl.h>
+#include <fmt/format.h>
+#include <coretypes/impl.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+ErrCode MutexImpl::lock()
+{
+    try
+    {
+        this->mutex.lock();
+    }
+    catch (std::exception& e)
+    {
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_GENERALERROR, fmt::format("Failed to lock mutex: {}", e.what()));
+    }
+
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode MutexImpl::tryLock(Bool* succeeded)
+{
+    try
+    {
+        *succeeded = this->mutex.try_lock();
+    }
+    catch (std::exception& e)
+    {
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_GENERALERROR, fmt::format("Failed to try_lock mutex: {}", e.what()));
+    }
+
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode MutexImpl::unlock()
+{
+    try
+    {
+        this->mutex.unlock();
+    }
+    catch (std::exception& e)
+    {
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_GENERALERROR, fmt::format("Failed to unlock mutex: {}", e.what()));
+    }
+
+    return OPENDAQ_SUCCESS;
+}
+
+OPENDAQ_DEFINE_CLASS_FACTORY(LIBRARY_FACTORY, Mutex)
+
+END_NAMESPACE_OPENDAQ

--- a/core/coreobjects/src/mutex_impl.cpp
+++ b/core/coreobjects/src/mutex_impl.cpp
@@ -3,6 +3,7 @@
 #include <coretypes/impl.h>
 
 BEGIN_NAMESPACE_OPENDAQ
+
 ErrCode MutexImpl::lock()
 {
     try

--- a/core/coreobjects/src/property_object_impl.cpp
+++ b/core/coreobjects/src/property_object_impl.cpp
@@ -11,10 +11,10 @@ OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(
     IString*, className
 )
 
-template class GenericRecursiveConfigLockGuard<std::mutex>;
+template class GenericRecursiveConfigLockGuard<MutexPtr>;
 template class GenericRecursiveConfigLockGuard<object_utils::NullMutex>;
 
-template class RecursiveLockGuardImpl<std::mutex>;
+template class RecursiveLockGuardImpl<MutexPtr>;
 template class RecursiveLockGuardImpl<object_utils::NullMutex>;
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -79,6 +79,7 @@ public:
 
     // IPropertyObjectInternal
     ErrCode INTERFACE_FUNC enableCoreEventTrigger() override;
+    ErrCode INTERFACE_FUNC getRecursiveLockGuard(ILockGuard** lockGuard) override;
 
     // IComponent
     ErrCode INTERFACE_FUNC getLocalId(IString** localId) override;
@@ -278,6 +279,23 @@ ErrCode ComponentImpl<Intf, Intfs...>::enableCoreEventTrigger()
     }
 
     return Super::enableCoreEventTrigger();
+}
+
+template <class Intf, class ... Intfs>
+ErrCode ComponentImpl<Intf, Intfs...>::getRecursiveLockGuard(ILockGuard** lockGuard)
+{
+    OPENDAQ_PARAM_NOT_NULL(lockGuard);
+
+    if (this->lockingStrategy == LockingStrategy::InheritLock)
+    {
+        PropertyObjectInternalPtr lockOwnerPtr;
+        OPENDAQ_RETURN_IF_FAILED(this->getMutexOwner(&lockOwnerPtr));
+
+        this->setLockOwner(lockOwnerPtr);
+        this->setMutex(lockOwnerPtr.getMutex());
+    }
+
+    return Super::getRecursiveLockGuard(lockGuard);
 }
 
 template <class Intf, class ... Intfs>

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -77,6 +77,9 @@ public:
                   const StringPtr& className = nullptr,
                   const StringPtr& name = nullptr);
 
+    // IPropertyObjectInternal
+    ErrCode INTERFACE_FUNC enableCoreEventTrigger() override;
+
     // IComponent
     ErrCode INTERFACE_FUNC getLocalId(IString** localId) override;
     ErrCode INTERFACE_FUNC getGlobalId(IString** globalId) override;
@@ -260,6 +263,21 @@ ComponentImpl<Intf, Intfs...>::ComponentImpl(
         const auto parentManager = parent.getPermissionManager();
         this->permissionManager.template asPtr<IPermissionManagerInternal>(true).setParent(parentManager);
     }
+}
+
+template <class Intf, class ... Intfs>
+ErrCode ComponentImpl<Intf, Intfs...>::enableCoreEventTrigger()
+{
+    if (this->lockingStrategy == LockingStrategy::InheritLock)
+    {
+        ComponentPtr parentObj;
+        OPENDAQ_RETURN_IF_FAILED(getParent(&parentObj));
+
+        if (parentObj.assigned())
+            this->setMutex(parentObj.asPtr<IPropertyObjectInternal>().getMutex());
+    }
+
+    return Super::enableCoreEventTrigger();
 }
 
 template <class Intf, class ... Intfs>

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -321,7 +321,7 @@ ErrCode ComponentImpl<Intf, Intfs ...>::getActive(Bool* active)
 {
     OPENDAQ_PARAM_NOT_NULL(active);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     *active = this->active;
     return OPENDAQ_SUCCESS;
@@ -334,7 +334,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setActive(Bool active)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->isComponentRemoved)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -418,7 +418,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setName(IString* name)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->isComponentRemoved)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -469,7 +469,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setDescription(IString* description)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->isComponentRemoved)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -530,7 +530,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setVisible(Bool visible)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->isComponentRemoved)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -578,7 +578,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::lockAttributes(IList* attributes)
     if (!attributes)
         return OPENDAQ_SUCCESS;
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (this->isComponentRemoved)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -598,7 +598,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::lockAttributes(IList* attributes)
 template <class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs...>::lockAllAttributes()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (this->isComponentRemoved)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -612,7 +612,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::unlockAttributes(IList* attributes)
     if (!attributes)
         return OPENDAQ_SUCCESS;
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (this->isComponentRemoved)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -632,7 +632,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::unlockAttributes(IList* attributes)
 template <class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs...>::unlockAllAttributes()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (this->isComponentRemoved)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -646,7 +646,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::getLockedAttributes(IList** attributes)
 {
     OPENDAQ_PARAM_NOT_NULL(attributes);
     
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (this->isComponentRemoved)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
@@ -704,7 +704,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::findProperties(IList** properties, ISearc
 {
     OPENDAQ_PARAM_NOT_NULL(properties);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ErrCode errCode = daqTry([&properties, &propertyFilter, &componentFilter, this]
     {
@@ -758,7 +758,7 @@ void ComponentImpl<Intf, Intfs...>::onOperationModeChanged(OperationModeType /* 
 template <class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs...>::updateOperationMode(OperationModeType modeType)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     const ErrCode errCode = wrapHandler(this, &Self::onOperationModeChanged, modeType);
     OPENDAQ_RETURN_IF_FAILED(errCode);
     return errCode;
@@ -818,7 +818,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::findComponent(IString* id, IComponent** o
 template<class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs ...>::remove()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (isComponentRemoved)
         return OPENDAQ_IGNORED;

--- a/core/opendaq/component/include/opendaq/folder_impl.h
+++ b/core/opendaq/component/include/opendaq/folder_impl.h
@@ -144,7 +144,7 @@ ErrCode FolderImpl<Intf, Intfs...>::getItems(IList** items, ISearchFilter* searc
 {
     OPENDAQ_PARAM_NOT_NULL(items);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (searchFilter)
     {
@@ -181,7 +181,7 @@ ErrCode FolderImpl<Intf, Intfs...>::getItem(IString* localId, IComponent** item)
     OPENDAQ_PARAM_NOT_NULL(localId);
     OPENDAQ_PARAM_NOT_NULL(item);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto it = items.find(StringPtr::Borrow(localId).toStdString());
     if (it == items.end())
@@ -206,7 +206,7 @@ ErrCode FolderImpl<Intf, Intfs...>::hasItem(IString* localId, Bool* value)
 {
     OPENDAQ_PARAM_NOT_NULL(localId);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const auto it = items.find(StringPtr::Borrow(localId).toStdString());
     if (it == items.end())
@@ -239,7 +239,7 @@ ErrCode FolderImpl<Intf, Intfs...>::addItem(IComponent* item)
     ComponentPtr component = ComponentPtr::Borrow(item);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         const ErrCode err = daqTry([this, &component]
         {
@@ -276,7 +276,7 @@ ErrCode FolderImpl<Intf, Intfs...>::removeItem(IComponent* item)
     const auto str = ComponentPtr::Borrow(item).getLocalId().toStdString();
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         const ErrCode err = daqTry([this, &str]
         {
@@ -309,7 +309,7 @@ ErrCode FolderImpl<Intf, Intfs...>::removeItemWithLocalId(IString* localId)
     const auto str = StringPtr::Borrow(localId).toStdString();
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         const ErrCode err = daqTry([this, &str]
         {
@@ -337,7 +337,7 @@ ErrCode FolderImpl<Intf, Intfs...>::removeItemWithLocalId(IString* localId)
 template <class Intf, class... Intfs>
 ErrCode FolderImpl<Intf, Intfs...>::clear()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     clearInternal();
 
     return OPENDAQ_SUCCESS;

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -349,7 +349,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::setAsRoot()
     if (this->isComponentRemoved)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     this->isRootDevice = true;
     this->updateOperationMode(OperationModeType::Unknown);
@@ -365,7 +365,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::setDeviceConfig(IPropertyObjec
 template <typename TInterface, typename... Interfaces>
 ErrCode GenericDevice<TInterface, Interfaces...>::lock(IUser* user)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     ListPtr<IDevice> devices;
     ErrCode status = this->getDevices(&devices, search::Any());
@@ -406,7 +406,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::lock(IUser* user)
 template <typename TInterface, typename... Interfaces>
 ErrCode GenericDevice<TInterface, Interfaces...>::unlock(IUser* user)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     ErrCode status = unlockInternal(user);
     OPENDAQ_RETURN_IF_FAILED(status);
@@ -455,7 +455,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::isLockedInternal(Bool* locked)
 template <typename TInterface, typename... Interfaces>
 ErrCode GenericDevice<TInterface, Interfaces...>::forceUnlock()
 {
-    auto syncLock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     ErrCode status = forceUnlockInternal();
     OPENDAQ_RETURN_IF_FAILED(status);
@@ -789,7 +789,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::getAvailableFunctionBlockTypes
 template <typename TInterface, typename... Interfaces>
 DictPtr<IString, IFunctionBlockType> GenericDevice<TInterface, Interfaces...>::onGetAvailableFunctionBlockTypes()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     auto availableTypes = Dict<IString, IFunctionBlockType>();
 
     if (!this->isRootDevice && !allowAddFunctionBlocksFromModules())
@@ -820,7 +820,7 @@ template <typename TInterface, typename... Interfaces>
 FunctionBlockPtr GenericDevice<TInterface, Interfaces...>::onAddFunctionBlock(const StringPtr& typeId,
                                                                               const PropertyObjectPtr& config)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     if (!this->isRootDevice && !allowAddFunctionBlocksFromModules())
         return nullptr;
 
@@ -1017,7 +1017,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::isLocked(Bool* locked)
 {
     OPENDAQ_PARAM_NOT_NULL(locked);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     return isLockedInternal(locked);
 }
 
@@ -1289,7 +1289,7 @@ ListPtr<IDeviceInfo> GenericDevice<TInterface, Interfaces...>::onGetAvailableDev
     if (!allowAddDevicesFromModules())
         return List<IDeviceInfo>();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     const ModuleManagerUtilsPtr managerUtils = this->context.getModuleManager().template asPtr<IModuleManagerUtils>();
     return managerUtils.getAvailableDevices();
 }
@@ -1316,7 +1316,7 @@ DictPtr<IString, IDeviceType> GenericDevice<TInterface, Interfaces...>::onGetAva
     if (!allowAddDevicesFromModules())
         return Dict<IString, IDeviceType>();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     const ModuleManagerUtilsPtr managerUtils = this->context.getModuleManager().template asPtr<IModuleManagerUtils>();
     return managerUtils.getAvailableDeviceTypes();
 }
@@ -1377,7 +1377,7 @@ DevicePtr GenericDevice<TInterface, Interfaces...>::onAddDevice(const StringPtr&
     if (!allowAddDevicesFromModules())
         return nullptr;
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ModuleManagerUtilsPtr managerUtils = this->context.getModuleManager().template asPtr<IModuleManagerUtils>();
     auto device = managerUtils.createDevice(connectionString, devices, config);
@@ -1415,7 +1415,7 @@ ServerPtr GenericDevice<TInterface, Interfaces...>::onAddServer(const StringPtr&
     const ModuleManagerUtilsPtr managerUtils = this->context.getModuleManager().template asPtr<IModuleManagerUtils>();
     ServerPtr server = managerUtils.createServer(typeId, this->template thisPtr<DevicePtr>(), config);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     if (!this->isRootDevice)
         DAQ_THROW_EXCEPTION(NotFoundException, "Device does not allow adding/removing servers.");
     this->servers.addItem(server);
@@ -1426,7 +1426,7 @@ ServerPtr GenericDevice<TInterface, Interfaces...>::onAddServer(const StringPtr&
 template <typename TInterface, typename... Interfaces>
 void GenericDevice<TInterface, Interfaces...>::onRemoveServer(const ServerPtr& server)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (!this->isRootDevice)
         DAQ_THROW_EXCEPTION(NotFoundException, "Device does not allow adding/removing servers.");
@@ -1475,7 +1475,7 @@ DictPtr<IString, IDevice> GenericDevice<TInterface, Interfaces...>::onAddDevices
         return nullptr;
     }
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ModuleManagerUtilsPtr managerUtils = this->context.getModuleManager().template asPtr<IModuleManagerUtils>();
     auto createdDevices = managerUtils.createDevices(connectionArgs, devices, errCodes, errorInfos);

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -284,14 +284,14 @@ GenericDevice<TInterface, Interfaces...>::GenericDevice(const ContextPtr& ctx,
     this->defaultComponents.insert("Srv");
     this->allowNonDefaultComponents = true;
 
-    devices = this->template addFolder<IDevice>("Dev", nullptr, LockingStrategy::InheritLock);
+    devices = this->template addFolder<IDevice>("Dev", nullptr, LockingStrategy::ForwardOwnerLockOwn);
     ioFolder = this->addIoFolder("IO", nullptr);
 
     auto syncComponentObj = SyncComponent(ctx, this->template thisPtr<ComponentPtr>(), "Synchronization");
-    syncComponentObj.template asPtr<IPropertyObjectInternal>().setLockingStrategy(LockingStrategy::InheritLock);
+    syncComponentObj.template asPtr<IPropertyObjectInternal>().setLockingStrategy(LockingStrategy::ForwardOwnerLockOwn);
     syncComponent = this->addExistingComponent(syncComponentObj.detach());
 
-    servers = this->template addFolder<IComponent>("Srv", nullptr, LockingStrategy::InheritLock);
+    servers = this->template addFolder<IComponent>("Srv", nullptr, LockingStrategy::ForwardOwnerLockOwn);
 
     devices.asPtr<IComponentPrivate>().lockAllAttributes();
     ioFolder.asPtr<IComponentPrivate>().lockAllAttributes();

--- a/core/opendaq/device/include/opendaq/device_info_impl.h
+++ b/core/opendaq/device/include/opendaq/device_info_impl.h
@@ -1210,7 +1210,7 @@ ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::setOwner(IPropertyObjec
     if (parent.supportsInterface<IMirroredDevice>())
         return errCode;
     
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     for (const StringPtr& propertyName: {String("userName"), String("location")})
     {
         PropertyPtr property;

--- a/core/opendaq/functionblock/include/opendaq/function_block_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block_impl.h
@@ -488,7 +488,7 @@ ErrCode FunctionBlockImpl<TInterface, Interfaces...>::removeFunctionBlock(IFunct
 template <typename TInterface, typename... Interfaces>
 void FunctionBlockImpl<TInterface, Interfaces...>::onRemoveFunctionBlock(const FunctionBlockPtr& functionBlock)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
     this->functionBlocks.removeItem(functionBlock);
 }
 

--- a/core/opendaq/functionblock/include/opendaq/function_block_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block_impl.h
@@ -93,7 +93,8 @@ protected:
                                              PacketReadyNotification notificationMethod,
                                              BaseObjectPtr customData = nullptr,
                                              bool requestGapPackets = false,
-                                             const PermissionsPtr& permissions = nullptr);
+                                             const PermissionsPtr& permissions = nullptr,
+                                             LockingStrategy lockingStrategy = LockingStrategy::OwnLock);
 
     void addInputPort(const InputPortPtr& inputPort);
     void removeInputPort(const InputPortConfigPtr& inputPort);
@@ -135,7 +136,7 @@ FunctionBlockImpl<TInterface, Interfaces...>::FunctionBlockImpl(const FunctionBl
                                                            : throw ArgumentNullException("Logger must not be null"))
 {
     this->defaultComponents.insert("IP");
-    inputPorts = this->template addFolder<IInputPort>("IP", nullptr);
+    inputPorts = this->template addFolder<IInputPort>("IP", nullptr, LockingStrategy::InheritLock);
     inputPorts.asPtr<IComponentPrivate>().lockAllAttributes();
     inputPorts.asPtr<IComponentPrivate>().unlockAttributes(List<IString>("Active"));
 }
@@ -541,9 +542,12 @@ InputPortConfigPtr FunctionBlockImpl<TInterface, Interfaces...>::createAndAddInp
                                                                                        PacketReadyNotification notificationMethod,
                                                                                        BaseObjectPtr customData,
                                                                                        bool requestGapPackets,
-                                                                                       const PermissionsPtr& permissions)
+                                                                                       const PermissionsPtr& permissions,
+                                                                                       LockingStrategy lockingStrategy)
 {
     InputPortConfigPtr inputPort = InputPort(this->context, inputPorts, localId, requestGapPackets);
+    if (lockingStrategy != LockingStrategy::OwnLock)
+        inputPort.asPtr<IPropertyObjectInternal>().setLockingStrategy(lockingStrategy);
 
     inputPort.setListener(this->template borrowPtr<InputPortNotificationsPtr>());
     inputPort.setNotificationMethod(notificationMethod);

--- a/core/opendaq/functionblock/include/opendaq/function_block_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block_impl.h
@@ -136,7 +136,7 @@ FunctionBlockImpl<TInterface, Interfaces...>::FunctionBlockImpl(const FunctionBl
                                                            : throw ArgumentNullException("Logger must not be null"))
 {
     this->defaultComponents.insert("IP");
-    inputPorts = this->template addFolder<IInputPort>("IP", nullptr, LockingStrategy::InheritLock);
+    inputPorts = this->template addFolder<IInputPort>("IP", nullptr, LockingStrategy::ForwardOwnerLockOwn);
     inputPorts.asPtr<IComponentPrivate>().lockAllAttributes();
     inputPorts.asPtr<IComponentPrivate>().unlockAttributes(List<IString>("Active"));
 }

--- a/core/opendaq/functionblock/include/opendaq/function_block_wrapper_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block_wrapper_impl.h
@@ -121,7 +121,7 @@ ErrCode FunctionBlockWrapperImpl::setOverridenObject(
         std::unordered_map<std::string, TSmartPtr>& objects,
         TInterface* object)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ErrCode errCode = daqTry([this, &propertyName, &objects, &object]()
     {

--- a/core/opendaq/functionblock/src/function_block_wrapper_impl.cpp
+++ b/core/opendaq/functionblock/src/function_block_wrapper_impl.cpp
@@ -27,7 +27,7 @@ ErrCode FunctionBlockWrapperImpl::includeObject(IString* objectName,
 {
     const auto objectNameStr = StringPtr::Borrow(objectName).toStdString();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (includeObjectsByDefault)
     {
@@ -58,7 +58,7 @@ ErrCode FunctionBlockWrapperImpl::excludeObject(IString* objectName,
 {
     const auto objectNameStr = StringPtr::Borrow(objectName).toStdString();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (!includeObjectsByDefault)
     {
@@ -157,7 +157,7 @@ ErrCode FunctionBlockWrapperImpl::setPropertySelectionValues(IString* propertyNa
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ErrCode errCode = daqTry([this, &propertyName, &enumValues]()
     {
@@ -230,7 +230,7 @@ ErrCode FunctionBlockWrapperImpl::getInputPorts(IList** ports, ISearchFilter* se
 
     const auto innerPorts = functionBlock.getInputPorts(searchFilter);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto portList = getObjects<IInputPort>(innerPorts,
                                                  includedInputPorts,
@@ -247,7 +247,7 @@ ErrCode FunctionBlockWrapperImpl::getSignals(IList** signals, ISearchFilter* sea
 
     const auto innerSignals = functionBlock.getSignals(searchFilter);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto signalList = getObjects<ISignal>(innerSignals,
                                            includedSignals,
@@ -264,7 +264,7 @@ ErrCode FunctionBlockWrapperImpl::getFunctionBlocks(IList** functionBlocks, ISea
 
     const auto innerFbs = functionBlock.getFunctionBlocks(searchFilter);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto fbList = getObjects<IFunctionBlock>(
         innerFbs,
@@ -299,7 +299,7 @@ ErrCode FunctionBlockWrapperImpl::setPropertyValue(IString* propertyName, IBaseO
 
     auto propertyNameStr = StringPtr::Borrow(propertyName);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ErrCode errCode = daqTry([this, &propertyNameStr, &value]()
     {
@@ -347,7 +347,7 @@ ErrCode FunctionBlockWrapperImpl::getPropertyValue(IString* propertyName, IBaseO
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->getPropertyValue(propertyName, value);
@@ -359,7 +359,7 @@ ErrCode FunctionBlockWrapperImpl::getPropertySelectionValue(IString* propertyNam
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->getPropertySelectionValue(propertyName, value);
@@ -371,7 +371,7 @@ ErrCode FunctionBlockWrapperImpl::clearPropertyValue(IString* propertyName)
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->clearPropertyValue(propertyName);
@@ -383,7 +383,7 @@ ErrCode FunctionBlockWrapperImpl::hasProperty(IString* propertyName, Bool* hasPr
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (isPropertyVisible(propertyName))
         return functionBlock->hasProperty(propertyName, hasProperty);
@@ -425,7 +425,7 @@ ErrCode FunctionBlockWrapperImpl::getProperty(IString* propertyName, IProperty**
 
     auto propertyNamePtr = StringPtr::Borrow(propertyName);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ErrCode errCode = daqTry([this, &propertyNamePtr, &property]()
     {
@@ -455,7 +455,7 @@ ErrCode FunctionBlockWrapperImpl::getProperties(const ListPtr<IProperty>& innerP
 {
     assert(properties != nullptr);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const auto propertyList = getObjects<IProperty>(innerProperties,
                                                     includedProperties,

--- a/core/opendaq/functionblock/tests/test_function_block.cpp
+++ b/core/opendaq/functionblock/tests/test_function_block.cpp
@@ -202,7 +202,7 @@ public:
     
     void onPacketReceived(const daq::InputPortPtr& /*port*/) override
     {
-        auto lock = getAcquisitionLock();
+        auto lock = getAcquisitionLock2();
     }
 };
 

--- a/core/opendaq/opendaq/mocks/mock_fb_dynamic_input_ports.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb_dynamic_input_ports.cpp
@@ -26,13 +26,13 @@ daq::FunctionBlockTypePtr MockFunctionBlockDynamicInputPortImpl::CreateType()
 
 void MockFunctionBlockDynamicInputPortImpl::onConnected(const daq::InputPortPtr& /* port */)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     updateInputPorts();
 }
 
 void MockFunctionBlockDynamicInputPortImpl::onDisconnected(const daq::InputPortPtr& port)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     removeInputPort(port);
 }
 

--- a/core/opendaq/opendaq/mocks/mock_fb_dynamic_output_ports.cpp
+++ b/core/opendaq/opendaq/mocks/mock_fb_dynamic_output_ports.cpp
@@ -42,7 +42,7 @@ void MockFunctionBlockDynamicOutputPortImpl::onPacketReceived(const daq::InputPo
 
 void MockFunctionBlockDynamicOutputPortImpl::onDisconnected(const daq::InputPortPtr& /* port */)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     this->signals.clear();
 }
 

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -579,15 +579,6 @@ TEST_F(InstanceTest, InstanceBuilderGetDefault)
     ASSERT_EQ(instance.getRootDevice().getName(), "MockPhysicalDevice");
 }
 
-TEST_F(InstanceTest, AddServerBackwardsCompat)
-{
-    auto instance = Instance();
-
-    ASSERT_NO_THROW(instance.addServer("openDAQ Native Streaming", nullptr));
-    ASSERT_NO_THROW(instance.addServer("openDAQ LT Streaming", nullptr));
-    ASSERT_NO_THROW(instance.addServer("openDAQ OpcUa", nullptr));
-}
-
 TEST_F(InstanceTest, SaveLoadRestoreDevice)
 {
     std::map<std::string, std::string> devicesNames;

--- a/core/opendaq/reader/include/opendaq/reader_factory.h
+++ b/core/opendaq/reader/include/opendaq/reader_factory.h
@@ -100,10 +100,10 @@ inline PacketReaderPtr PacketReaderFromPort(InputPortConfigPtr port)
  * @param timeoutType The type of time-out to use. See @see ReadTimeoutType.
  */
 inline StreamReaderPtr StreamReaderFromPort(InputPortConfigPtr port,
-                                    SampleType valueReadType,
-                                    SampleType domainReadType,
-                                    ReadMode mode = ReadMode::Scaled,
-                                    ReadTimeoutType timeoutType = ReadTimeoutType::All)
+                                            SampleType valueReadType,
+                                            SampleType domainReadType,
+                                            ReadMode mode = ReadMode::Scaled,
+                                            ReadTimeoutType timeoutType = ReadTimeoutType::All)
 {
     return StreamReaderFromPort_Create(port, valueReadType, domainReadType, mode, timeoutType);
 }

--- a/core/opendaq/signal/include/opendaq/input_port_impl.h
+++ b/core/opendaq/signal/include/opendaq/input_port_impl.h
@@ -226,7 +226,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::disconnect()
     {
         ConnectionPtr connection;
         {
-            auto lock = this->getRecursiveConfigLock();
+            auto lock = this->getRecursiveConfigLock2();
             connection = getConnectionNoLock();
             connectionRef.release();
         }
@@ -243,7 +243,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getSignal(ISignal** signal)
 {
     OPENDAQ_PARAM_NOT_NULL(signal);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     *signal = getSignalNoLock().detach();
 
@@ -265,7 +265,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getConnection(IConnection** connect
 {
     OPENDAQ_PARAM_NOT_NULL(connection);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ErrCode errCode = daqTry([this, &connection] { *connection = getConnectionNoLock().detach(); });
     OPENDAQ_RETURN_IF_FAILED(errCode);
@@ -275,7 +275,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getConnection(IConnection** connect
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setNotificationMethod(PacketReadyNotification method)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if ((method == PacketReadyNotification::Scheduler || method == PacketReadyNotification::SchedulerQueueWasEmpty) && !scheduler.assigned())
     {
@@ -403,7 +403,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::notifyPacketEnqueuedWithScheduler()
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setListener(IInputPortNotifications* port)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (auto connection = getConnectionNoLock(); connection.assigned())
     {
@@ -442,7 +442,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getCustomData(IBaseObject** data)
 {
     OPENDAQ_PARAM_NOT_NULL(data);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     *data = this->customData.addRefAndReturn();
 
@@ -452,7 +452,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getCustomData(IBaseObject** data)
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setCustomData(IBaseObject* data)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     this->customData = data;
 
     return OPENDAQ_SUCCESS;
@@ -465,7 +465,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::disconnectWithoutSignalNotification
     {
         ConnectionPtr connection;
         {
-            auto lock = this->getRecursiveConfigLock();
+            auto lock = this->getRecursiveConfigLock2();
             connection = getConnectionNoLock();
             connectionRef.release();
         }
@@ -525,7 +525,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getActive(Bool* active)
 {
     OPENDAQ_PARAM_NOT_NULL(active);
 
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     *active = this->active;
     return OPENDAQ_SUCCESS;
@@ -590,7 +590,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::connectInternal(ISignal* signal, bo
 
         InputPortNotificationsPtr inputPortListener;
         {
-            auto lock = this->getRecursiveConfigLock();
+            auto lock = this->getRecursiveConfigLock2();
             if (this->isComponentRemoved)
                 return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Cannot connect signal to removed input port");
 
@@ -750,7 +750,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getRequiresSignal(Bool* requiresSig
 {
     OPENDAQ_PARAM_NOT_NULL(requiresSignal);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     *requiresSignal = this->requiresSignal;
     return OPENDAQ_SUCCESS;
@@ -759,7 +759,7 @@ ErrCode GenericInputPortImpl<Interfaces...>::getRequiresSignal(Bool* requiresSig
 template <class... Interfaces>
 ErrCode GenericInputPortImpl<Interfaces...>::setRequiresSignal(Bool requiresSignal)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     this->requiresSignal = requiresSignal;
     return OPENDAQ_SUCCESS;

--- a/core/opendaq/signal/include/opendaq/signal_container_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_container_impl.h
@@ -165,8 +165,8 @@ GenericSignalContainerImpl<Intf, Intfs...>::GenericSignalContainerImpl(const Con
     defaultComponents.insert("Sig");
     defaultComponents.insert("FB");
 
-    signals = addFolder<ISignal>("Sig", nullptr, LockingStrategy::InheritLock);
-    functionBlocks = addFolder<IFunctionBlock>("FB", nullptr, LockingStrategy::InheritLock);
+    signals = addFolder<ISignal>("Sig", nullptr, LockingStrategy::ForwardOwnerLockOwn);
+    functionBlocks = addFolder<IFunctionBlock>("FB", nullptr, LockingStrategy::ForwardOwnerLockOwn);
 
     signals.asPtr<IComponentPrivate>().lockAllAttributes();
     functionBlocks.asPtr<IComponentPrivate>().lockAllAttributes();

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -226,7 +226,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::getPublic(Bool* isPublic)
 {
     OPENDAQ_PARAM_NOT_NULL(isPublic);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     *isPublic = this->isPublic;
     return OPENDAQ_SUCCESS;
@@ -239,7 +239,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setPublic(Bool isPublic)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->lockedAttributes.count("Public"))
         {
@@ -273,7 +273,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::getDescriptor(IDataDescriptor** d
 {
     OPENDAQ_PARAM_NOT_NULL(descriptor);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     
     DataDescriptorPtr dataDescriptorPtr;
     const ErrCode errCode = wrapHandlerReturn(this, &Self::onGetDescriptor, dataDescriptorPtr);
@@ -398,7 +398,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDescriptor(IDataDescriptor* de
     bool success;
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         dataDescriptor = descriptorPtr;
         const auto packet = DataDescriptorChangedEventPacket(descriptorToEventPacketParam(dataDescriptor), nullptr);
@@ -461,7 +461,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::getDomainSignal(ISignal** signal)
 {
     OPENDAQ_PARAM_NOT_NULL(signal);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     SignalPtr signalPtr;
     const ErrCode errCode = wrapHandlerReturn(this, &Self::onGetDomainSignal, signalPtr);
@@ -475,7 +475,7 @@ template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::setDomainSignal(ISignal* signal)
 {
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
         
         if (this->lockedAttributes.count("DomainSignal"))
         {
@@ -519,7 +519,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::getRelatedSignals(IList** signals
 {
     OPENDAQ_PARAM_NOT_NULL(signals);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     ListPtr<ISignal> signalsPtr{relatedSignals};
     *signals = signalsPtr.detach();
@@ -533,7 +533,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setRelatedSignals(IList* signals)
     OPENDAQ_PARAM_NOT_NULL(signals);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->lockedAttributes.count("RelatedSignals"))
         {
@@ -566,7 +566,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::addRelatedSignal(ISignal* signal)
     auto signalPtr = ObjectPtr(signal);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->lockedAttributes.count("RelatedSignals"))
         {
@@ -600,7 +600,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::removeRelatedSignal(ISignal* sign
     const auto signalPtr = ObjectPtr<ISignal>::Borrow(signal);
 
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 
         if (this->lockedAttributes.count("RelatedSignals"))
         {
@@ -630,7 +630,7 @@ template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::clearRelatedSignals()
 {
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
         relatedSignals.clear();
     }
     
@@ -643,7 +643,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::getConnections(IList** connection
 {
     OPENDAQ_PARAM_NOT_NULL(connections);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto connectionsPtr = List<IConnection>();
     for (const auto& conn : this->connections)
@@ -746,13 +746,13 @@ bool SignalBase<TInterface, Interfaces...>::keepLastPacketAndEnqueue(Packet&& pa
 
     if (!recursiveLock)
     {
-        auto lock = this->getAcquisitionLock();
+        auto lock = this->getAcquisitionLock2();
         if (!checkKeepLastPacketAndBuildConnections(packet, tempConnections))
             return false;
     }
     else
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
         if (!checkKeepLastPacketAndBuildConnections(packet, tempConnections))
             return false;
     }
@@ -772,7 +772,7 @@ bool SignalBase<TInterface, Interfaces...>::keepLastPacketAndEnqueueMultiple(Lis
     {
         size_t cnt = packets.getCount();
 
-        auto lock = this->getAcquisitionLock();
+        auto lock = this->getAcquisitionLock2();
 
         if (!this->active || cnt == 0)
             return false;
@@ -848,7 +848,7 @@ ErrCode INTERFACE_FUNC SignalBase<TInterface, Interfaces...>::sendPacketsAndStea
 template <typename TInterface, typename ... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::setLastValue(IBaseObject* lastValue)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     setLastValueFromPacket(nullptr);
     this->lastDataValue = lastValue;
@@ -862,7 +862,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::listenerConnectedInternal(IConnec
 
     const auto connectionPtr = ConnectionPtr::Borrow(connection);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (connectionPtr.isRemote())
     {
@@ -992,7 +992,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::listenerDisconnected(IConnection*
 
     const auto connectionPtr = ObjectPtr<IConnection>::Borrow(connection);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (connectionPtr.isRemote())
     {
@@ -1028,7 +1028,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::domainSignalReferenceSet(ISignal*
     if (!signalPtr.assigned())
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOINTERFACE, "Signal does not implement ISignalConfig interface.");
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     for (const auto& refSignal : domainSignalReferences)
     {
         if (refSignal.getRef() == signalPtr)
@@ -1042,7 +1042,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::domainSignalReferenceSet(ISignal*
 template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::domainSignalReferenceRemoved(ISignal* signal)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const auto signalPtr = SignalPtr::Borrow(signal).asPtrOrNull<ISignalConfig>(true);
     if (!signalPtr.assigned())
@@ -1064,7 +1064,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::domainSignalReferenceRemoved(ISig
 template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::clearDomainSignalWithoutNotification()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     domainSignal = nullptr;
 
@@ -1237,7 +1237,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::lockAllAttributesInternal()
 template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::enableKeepLastValue(Bool enabled)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     keepLastValue = enabled;
 
     setKeepLastPacket();
@@ -1259,7 +1259,7 @@ template <typename TInterface, typename... Interfaces>
 ErrCode SignalBase<TInterface, Interfaces...>::getLastValue(IBaseObject** value)
 {
     OPENDAQ_PARAM_NOT_NULL(value);
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (lastDataValue.assigned())
     {
@@ -1292,7 +1292,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::getKeepLastValue(Bool* keepLastVa
 {
     OPENDAQ_PARAM_NOT_NULL(keepLastValue);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     *keepLastValue = this->keepLastValue ? True : False;
     return OPENDAQ_SUCCESS;

--- a/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
@@ -88,7 +88,7 @@ ErrCode MirroredDeviceBase<Interfaces...>::getStreamingSources(IList** streaming
 
     auto streamingSourcesPtr = List<IStreaming>();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     for (const auto& streaming : this->streamingSources)
     {
         streamingSourcesPtr.pushBack(streaming);
@@ -106,7 +106,7 @@ ErrCode MirroredDeviceBase<Interfaces...>::addStreamingSource(IStreaming* stream
     const auto streamingPtr = StreamingPtr::Borrow(streamingSource);
     const auto connectionString = streamingPtr.getConnectionString();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto it = std::find_if(streamingSources.begin(),
                            streamingSources.end(),
@@ -153,7 +153,7 @@ ErrCode MirroredDeviceBase<Interfaces...>::removeStreamingSource(IString* stream
 {
     OPENDAQ_PARAM_NOT_NULL(streamingConnectionString);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const auto streamingConnectionStringPtr = StringPtr::Borrow(streamingConnectionString);
 
@@ -229,7 +229,7 @@ ErrCode MirroredDeviceBase<Interfaces...>::setComponentConfig(IPropertyObject* c
 template <typename... Interfaces>
 StreamingPtr MirroredDeviceBase<Interfaces...>::onAddStreaming(const StringPtr& connectionString, const PropertyObjectPtr& config)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto it = std::find_if(streamingSources.begin(),
                            streamingSources.end(),

--- a/core/opendaq/streaming/include/opendaq/mirrored_signal_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_signal_impl.h
@@ -224,7 +224,7 @@ ErrCode MirroredSignalBase<Interfaces...>::addStreamingSource(IStreaming* stream
     const auto streamingPtr = StreamingPtr::Borrow(streaming);
     const auto connectionString = streamingPtr.getConnectionString();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto it = std::find_if(streamingSourcesRefs.begin(),
                            streamingSourcesRefs.end(),
@@ -254,7 +254,7 @@ ErrCode MirroredSignalBase<Interfaces...>::removeStreamingSource(IString* stream
 {
     OPENDAQ_PARAM_NOT_NULL(streamingConnectionString);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const auto streamingConnectionStringPtr = StringPtr::Borrow(streamingConnectionString);
 
@@ -350,7 +350,7 @@ ErrCode MirroredSignalBase<Interfaces...>::unsubscribeCompletedInternal(IString*
 
     if (syncLock)
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
         this->lastDataValue = nullptr;
     }
     else
@@ -471,7 +471,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getStreamingSources(IList** streaming
 
     auto stringsPtr = List<IString>();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     for (const auto& [connectionString, streamingRef] : streamingSourcesRefs)
     {
         auto streamingSource = streamingRef.getRef();
@@ -492,7 +492,7 @@ ErrCode MirroredSignalBase<Interfaces...>::setActiveStreamingSource(IString* str
     const auto connectionStringPtr = StringPtr::Borrow(streamingConnectionString);
     auto thisPtr = this->template borrowPtr<MirroredSignalConfigPtr>();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto activeStreamingSource = activeStreamingSourceRef.assigned() ? activeStreamingSourceRef.getRef() : nullptr;
     if (activeStreamingSource.assigned() &&
@@ -552,7 +552,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getActiveStreamingSource(IString** st
 {
     OPENDAQ_PARAM_NOT_NULL(streamingConnectionString);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     auto activeStreamingSource = activeStreamingSourceRef.assigned() ? activeStreamingSourceRef.getRef() : nullptr;
     if (activeStreamingSource.assigned())
         *streamingConnectionString = activeStreamingSource.getConnectionString().addRefAndReturn();
@@ -567,7 +567,7 @@ ErrCode MirroredSignalBase<Interfaces...>::deactivateStreaming()
 {
     auto thisPtr = this->template borrowPtr<MirroredSignalConfigPtr>();
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     ErrCode errCode = OPENDAQ_SUCCESS;
     if (listened && streamed)
@@ -689,7 +689,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getStreamed(Bool* streamed)
 {
     OPENDAQ_PARAM_NOT_NULL(streamed);
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     *streamed = this->streamed;
     return OPENDAQ_SUCCESS;
 }
@@ -697,7 +697,7 @@ ErrCode MirroredSignalBase<Interfaces...>::getStreamed(Bool* streamed)
 template <typename... Interfaces>
 ErrCode MirroredSignalBase<Interfaces...>::setStreamed(Bool streamed)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (static_cast<bool>(streamed) == this->streamed)
         return OPENDAQ_IGNORED;

--- a/examples/modules/audio_device_module/src/audio_channel_impl.cpp
+++ b/examples/modules/audio_device_module/src/audio_channel_impl.cpp
@@ -19,7 +19,7 @@ void AudioChannelImpl::configure(const ma_device& device, const SignalPtr& timeS
     auto dataDescriptor =
         DataDescriptorBuilder().setSampleType(SampleType::Float32).setValueRange(Range(-1.0, 1.0)).setName(channelName).build();
 
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
 
     outputSignal.setDomainSignal(timeSignal);
     outputSignal.setDescriptor(dataDescriptor);

--- a/examples/modules/audio_device_module/src/wav_writer_fb_impl.cpp
+++ b/examples/modules/audio_device_module/src/wav_writer_fb_impl.cpp
@@ -24,7 +24,7 @@ FunctionBlockTypePtr WAVWriterFbImpl::CreateType()
 
 ErrCode WAVWriterFbImpl::startRecording()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     assert(!recording);
 
@@ -48,7 +48,7 @@ ErrCode WAVWriterFbImpl::startRecording()
 
 ErrCode WAVWriterFbImpl::stopRecording()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (!stopRecordingInternal())
         return OPENDAQ_FAILED(OPENDAQ_ERR_INVALIDSTATE);
@@ -58,7 +58,7 @@ ErrCode WAVWriterFbImpl::stopRecording()
 
 ErrCode WAVWriterFbImpl::getIsRecording(Bool* isRecording)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     if (!isRecording)
     {
@@ -216,7 +216,7 @@ void WAVWriterFbImpl::processEventPacket(const EventPacketPtr& packet)
 
 void WAVWriterFbImpl::processInputData()
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
     SizeT availableData = reader.getAvailableCount();
     size_t dataSize = 1;
     std::vector<unsigned char> inputData;

--- a/examples/modules/basic_csv_recorder_module/src/basic_csv_recorder_impl.cpp
+++ b/examples/modules/basic_csv_recorder_module/src/basic_csv_recorder_impl.cpp
@@ -38,7 +38,7 @@ BasicCsvRecorderImpl::BasicCsvRecorderImpl(
 
 ErrCode BasicCsvRecorderImpl::startRecording()
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     recordingActive = true;
     reconfigure();
 
@@ -47,7 +47,7 @@ ErrCode BasicCsvRecorderImpl::startRecording()
 
 ErrCode BasicCsvRecorderImpl::stopRecording()
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     recordingActive = false;
     reconfigure();
 
@@ -58,7 +58,7 @@ ErrCode BasicCsvRecorderImpl::getIsRecording(Bool *isRecording)
 {
     OPENDAQ_PARAM_NOT_NULL(isRecording);
     
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     *isRecording = recordingActive;
 
     return OPENDAQ_SUCCESS;
@@ -66,14 +66,14 @@ ErrCode BasicCsvRecorderImpl::getIsRecording(Bool *isRecording)
 
 void BasicCsvRecorderImpl::onConnected(const InputPortPtr& port)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     addInputPort();
     reconfigure();
 }
 
 void BasicCsvRecorderImpl::onDisconnected(const InputPortPtr& port)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
 
     while (portCount >= 2)
     {
@@ -179,7 +179,7 @@ void BasicCsvRecorderImpl::reconfigure()
 std::shared_ptr<BasicCsvRecorderThread> BasicCsvRecorderImpl::findThreadForSignal(IInputPort *port)
 {
     std::shared_ptr<BasicCsvRecorderThread> thread;
-    auto lock = getAcquisitionLock();
+    auto lock = getAcquisitionLock2();
     auto it = threads.find(port);
     if (it != threads.end())
         thread = it->second;

--- a/examples/modules/ref_device_module/src/ref_can_channel_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_can_channel_impl.cpp
@@ -64,7 +64,7 @@ void RefCANChannelImpl::propChanged()
 
 void RefCANChannelImpl::collectSamples(std::chrono::microseconds curTime)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
     const auto duration = static_cast<int64_t>(curTime.count() - lastCollectTime.count());
 
     if (duration > 0 && valueSignal.getActive())

--- a/examples/modules/ref_device_module/src/ref_channel_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_channel_impl.cpp
@@ -163,7 +163,7 @@ void RefChannelImpl::initProperties()
     objPtr.addProperty(getCurrentAndSetCounterProp);
     objPtr.setPropertyValue("GetAndSetCounter", Function([this](Int val)
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
         const auto cnt = counter;
         this->setCounter(val, false);
         return cnt;
@@ -276,7 +276,7 @@ void RefChannelImpl::signalTypeChangedInternal()
 
 void RefChannelImpl::resetCounter()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     counter = 0;
 }
 
@@ -284,7 +284,7 @@ void RefChannelImpl::setCounter(uint64_t cnt, bool shouldLock)
 {
     if (shouldLock)
     {
-        auto lock = this->getRecursiveConfigLock();
+        auto lock = this->getRecursiveConfigLock2();
 	    counter = cnt;
     }
     else
@@ -299,7 +299,7 @@ uint64_t RefChannelImpl::getSamplesSinceStart(std::chrono::microseconds time) co
 
 void RefChannelImpl::collectSamples(std::chrono::microseconds curTime)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
     if (!acqActive)
         return;
 
@@ -522,7 +522,7 @@ void RefChannelImpl::createSignals()
 
 void RefChannelImpl::globalSampleRateChanged(double newGlobalSampleRate)
 {
-    const auto lock = getRecursiveConfigLock();
+    const auto lock = getRecursiveConfigLock2();
     globalSampleRate = coerceSampleRate(newGlobalSampleRate);
     signalTypeChanged();
 }

--- a/examples/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_impl.cpp
@@ -84,7 +84,7 @@ RefDeviceImpl::RefDeviceImpl(size_t id,
 RefDeviceImpl::~RefDeviceImpl()
 {
     {
-        auto lock = this->getAcquisitionLock();
+        auto lock = this->getAcquisitionLock2();
         stopAcq = true;
     }
     cv.notify_one();
@@ -452,7 +452,7 @@ void RefDeviceImpl::enableProtectedChannel()
 
 void RefDeviceImpl::updateGlobalSampleRate()
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
 
     configureTimeSignal();
     updateSamplesGenerated();
@@ -510,7 +510,7 @@ StringPtr ToIso8601(const std::chrono::system_clock::time_point& timePoint)
 ListPtr<ILogFileInfo> RefDeviceImpl::onGetLogFileInfos()
 {
     {
-        auto lock = getAcquisitionLock();
+        auto lock = getAcquisitionLock2();
         if (!loggingEnabled)
         {
             return List<ILogFileInfo>();
@@ -548,7 +548,7 @@ ListPtr<ILogFileInfo> RefDeviceImpl::onGetLogFileInfos()
 StringPtr RefDeviceImpl::onGetLog(const StringPtr& id, Int size, Int offset)
 {
     {
-        auto lock = getAcquisitionLock();
+        auto lock = getAcquisitionLock2();
         if (!loggingEnabled)
             return "";
 

--- a/examples/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -275,7 +275,7 @@ void ClassifierFbImpl::configure()
 
 void ClassifierFbImpl::processData()
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
     while (!linearReader.getEmpty())
     {
         size_t blocksToRead = 1;

--- a/examples/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -197,7 +197,7 @@ void FFTFbImpl::processEventPacket(const EventPacketPtr& packet)
 
 void FFTFbImpl::calculate()
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     while (!linearReader.getEmpty())
     {

--- a/examples/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -115,7 +115,7 @@ void PowerFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& voltag
 
 void PowerFbImpl::processPackets()
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     PacketPtr voltagePacket;
     PacketPtr currentPacket;
@@ -488,13 +488,13 @@ void PowerFbImpl::createSignals()
 
 void PowerFbImpl::onConnected(const InputPortPtr& inputPort)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     LOG_T("Connected to port {}", inputPort.getLocalId())
 }
 
 void PowerFbImpl::onDisconnected(const InputPortPtr& inputPort)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
     LOG_T("Disconnected from port {}", inputPort.getLocalId())
 }
 

--- a/examples/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -78,7 +78,7 @@ void PowerReaderFbImpl::initProperties()
 
 void PowerReaderFbImpl::propertyChanged(bool configure)
 {
-    auto lock = getRecursiveConfigLock();
+    auto lock = getRecursiveConfigLock2();
     readProperties();
     if (configure)
         this->configure(nullptr, nullptr, nullptr);
@@ -137,7 +137,7 @@ bool PowerReaderFbImpl::getDomainDescriptor(const EventPacketPtr& eventPacket, D
 
 void PowerReaderFbImpl::onDataReceived()
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     SizeT cnt = reader.getAvailableCount();
     const auto voltageData = std::make_unique<double[]>(cnt);

--- a/examples/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -696,7 +696,7 @@ void RendererFbImpl::renderSignal(SignalContext& signalContext, sf::RenderTarget
 
 void RendererFbImpl::onConnected(const InputPortPtr& inputPort)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     subscribeToSignalCoreEvent(inputPort.getSignal());
     updateInputPorts();
@@ -705,7 +705,7 @@ void RendererFbImpl::onConnected(const InputPortPtr& inputPort)
 
 void RendererFbImpl::onDisconnected(const InputPortPtr& inputPort)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     updateInputPorts();
     LOG_T("Disconnected from port {}", inputPort.getLocalId());

--- a/examples/modules/ref_fb_module/src/scaling_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/scaling_fb_impl.cpp
@@ -182,7 +182,7 @@ void ScalingFbImpl::onPacketReceived(const InputPortPtr& port)
     auto outQueue = List<IPacket>();
     auto outDomainQueue = List<IPacket>();
     
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     PacketPtr packet;
     const auto connection = inputPort.getConnection();

--- a/examples/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -60,7 +60,7 @@ FunctionBlockPtr StatisticsFbImpl::onAddFunctionBlock(const StringPtr& typeId, c
 {
     FunctionBlockPtr nestedFunctionBlock;
     {
-        auto lock = this->getAcquisitionLock();
+        auto lock = this->getAcquisitionLock2();
         if (this->functionBlocks.getItems().getCount())
         {
             setComponentStatusWithMessage(ComponentStatus::Error, "Only one nested function block is supported");
@@ -685,7 +685,7 @@ void StatisticsFbImpl::onPacketReceived(const InputPortPtr& port)
 
 void StatisticsFbImpl::processTriggerPackets(const InputPortPtr& port)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     const auto conn = port.getConnection();
     if (!conn.assigned())
@@ -719,7 +719,7 @@ void StatisticsFbImpl::processTriggerPackets(const InputPortPtr& port)
 
 void StatisticsFbImpl::processInputPackets(const InputPortPtr& port)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     const auto conn = port.getConnection();
     if (!conn.assigned())

--- a/examples/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
@@ -117,7 +117,7 @@ void StructDecoderFbImpl::configure()
 
 void StructDecoderFbImpl::onPacketReceived(const InputPortPtr& port)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     const auto connection = inputPort.getConnection();
     if (!connection.assigned())
@@ -283,7 +283,7 @@ void StructDecoderFbImpl::setInputStatus(const StringPtr& value) const
 
 void StructDecoderFbImpl::onDisconnected(const InputPortPtr& inputPort)
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     signals.clear();
 

--- a/examples/modules/ref_fb_module/src/trigger_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/trigger_fb_impl.cpp
@@ -105,7 +105,7 @@ void TriggerFbImpl::configure()
 
 void TriggerFbImpl::onPacketReceived(const InputPortPtr& port)
 {
-    auto lock = this->getAcquisitionLock();
+    auto lock = this->getAcquisitionLock2();
 
     PacketPtr packet;
     const auto connection = inputPort.getConnection();

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -279,7 +279,7 @@ ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::lock(IUser* user)
         DAQLOGF_I(this->loggerComponent, "The specified user was ignored when locking a remote device. A session user was used instead.");
     }
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     const ErrCode errCode = daqTry([this] { this->clientComm->lock(this->remoteGlobalId); });
     OPENDAQ_RETURN_IF_FAILED(errCode);
@@ -294,7 +294,7 @@ ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::unlock(IUser* user)
         DAQLOGF_I(this->loggerComponent, "The specified user was ignored when unlocking a remote device. A session user was used instead.");
     }
 
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto parentDevice = this->getParentDevice();
 
@@ -309,7 +309,7 @@ ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::unlock(IUser* user)
 template <class TDeviceBase>
 inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::forceUnlock()
 {
-    auto lock = this->getRecursiveConfigLock();
+    auto lock = this->getRecursiveConfigLock2();
 
     auto parentDevice = this->getParentDevice();
 

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_input_port_impl.h
@@ -87,7 +87,7 @@ inline ErrCode ConfigClientInputPortImpl::connect(ISignal* signal)
                     signalPtr.getGlobalId());
         }
         {
-            auto lock = this->getRecursiveConfigLock();
+            auto lock = this->getRecursiveConfigLock2();
 
             const auto connectedSignal = getConnectedSignal();
             if (connectedSignal == signalPtr)


### PR DESCRIPTION
# Brief

(Concise one-line description of what changed and what was added/removed, maybe even why)



# Description

(Individual high-level changes)

- Add Python GUI Demo functionality
- Rename a function
- ...

# Usage example

In C++ use:

```cpp
auto variable = "foo";
```

In terminal use:

```shell
cd folder
```

# API changes

> [!NOTE]
> Modifying, removing, or adding a function to an interface inherited by another, breaks binary compatibility of module shared libraries

(An overview of changes on the interface level (abstract structs with pure virtual functions), if any, one function per line)

```diff
+ this
- that
```

# Required application changes

(Changes required in openDAQ applications/executables)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```

# Required module changes

(Changes required in openDAQ shared libraries/modules)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```
