### PR TITLE
fixed multi-reader external listener transfer

### DIFF
--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -101,6 +101,7 @@ MultiReaderImpl::MultiReaderImpl(MultiReaderImpl* old, SampleType valueReadType,
     notificationMethodsList = old->notificationMethodsList;
     context = old->context;
     portsConnected = old->portsConnected;
+    externalListener = old->externalListener;
     
     this->internalAddRef();
     try


### PR DESCRIPTION
# Brief

Added external listener assignment to MultiReader constructor from old MultiReader.
No changes to any existing API or example code required