### PR TITLE
Fix installation (`mutex_impl.h` and `module_authenticator_impl.h`)

### DIFF
--- a/core/coreobjects/src/CMakeLists.txt
+++ b/core/coreobjects/src/CMakeLists.txt
@@ -290,6 +290,7 @@ set(SRC_PublicHeaders coreobjects.h
                       mutex.h
                       mutex_factory.h
 					  mutex_ptr.custom.h
+					  mutex_impl.h
 )
 
 set(SRC_PrivateHeaders eval_value_impl.h
@@ -319,7 +320,6 @@ set(SRC_PrivateHeaders eval_value_impl.h
                        permission_mask_builder_impl.h
                        search_filter_impl.h
                        property_metadata_read_args_impl.h
-                       mutex_impl.h
 )
 
 prepend_include(${TARGET_FOLDER_NAME} SRC_PrivateHeaders)

--- a/core/opendaq/opendaq/src/CMakeLists.txt
+++ b/core/opendaq/opendaq/src/CMakeLists.txt
@@ -86,13 +86,13 @@ set(SRC_PublicHeaders_Component
     config_provider_factory.h
     client_type.h
 	module_authenticator.h
+	module_authenticator_impl.h
     PARENT_SCOPE
 )
 
 set(SRC_PrivateHeaders_Component
     opendaq_config.h.in
     instance_impl.h
-	module_authenticator_impl.h
     client_impl.h
     opendaq_init.h
     instance_builder_impl.h


### PR DESCRIPTION
# Brief

Make `mutex_impl.h` and `module_authenticator_impl.h` a part of the installation.

I've tested this by creating and using the Windows installer locally and it appears to fix the issue.