### PR TITLE
Stop crashing gui_demo on startup when executing manually with old openDAQ package

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -867,7 +867,8 @@ if __name__ == '__main__':
         '--config', help='Saved config', type=str, default='')
     parser.add_argument(
         '--module_path', help='Additional modules path', type=str, default='')
-    parser.add_argument('-v', '--version', action='version', version=f'{os.path.dirname(__file__)} {daq.__version__}')
+    parser.add_argument('-v', '--version', action='version', 
+        version=f'{os.path.dirname(__file__)} {daq.__dict__.get("__version__", "@VERSION@").replace("@VERSION@", "Unknown version")}')
 
     app = App(parser.parse_args())
     app.mainloop()


### PR DESCRIPTION
# Brief

gui_demo.py was changed to use __version__ for returning the openDAQ version string; but if you are running it manually and are using an old openDAQ package that doesn't support __version__, this will crash on startup.
