### PR TITLE
Add support for Intel-LLVM compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
-          cmake -G "%CMAKE_GENERATOR%" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+          cmake -G "%CMAKE_GENERATOR%" -T "Intel C++ Compiler 2022" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
 
       - name: BuildIntel
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,10 @@ jobs:
         if: matrix.name == 'Windows Intel-LLVM Release'
         env:
           GTEST_OUTPUT: "xml:${{ env.test_path }}"
-          CMAKE_PRESET: ${{ env.cmake_preset }}
+          CTEST_PRESET: ${{ env.ctest_preset }}
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          ctest --output-on-failure --preset %CMAKE_PRESET% -C Release --test-dir build
+          ctest --output-on-failure --preset %CTEST_PRESET% -C Release --test-dir build
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
       cancel-in-progress: true
-    timeout-minutes: 260
+    timeout-minutes: 210
     strategy:
       fail-fast: false
       matrix:
@@ -78,12 +78,12 @@ jobs:
             cmake_build_type: Release
             cmake_defines: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
             cpack: NSIS
-          - name: Windows Intel-LLVM Release
-            runner: windows-2022
-            cmake_generator: "Ninja"
-            cmake_build_type: Release
-            cmake_defines: -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
-            cpack: NSIS
+          #- name: Windows Intel-LLVM Release
+          #  runner: windows-2022
+          #  cmake_generator: "Ninja"
+          #  cmake_build_type: Release
+          #  cmake_defines: -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
+          #  cpack: NSIS
 
     outputs:
       # trick for reusable workflow in build_nuget because cannot use env context in "with:"
@@ -300,14 +300,14 @@ jobs:
             apt_packages: clang++-14
             cc: clang-14
             cxx: clang++-14
-          - name: Ubuntu 22.04 Intel-LLVM Release
-            image: ubuntu:22.04
-            cmake_generator: Ninja
-            cmake_build_type: Release
-            cmake_defines: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-            apt_packages: intel-oneapi-compiler-dpcpp-cpp
-            cc: icx
-            cxx: icpx
+         # - name: Ubuntu 22.04 Intel-LLVM Release
+         #   image: ubuntu:22.04
+         #   cmake_generator: Ninja
+         #   cmake_build_type: Release
+         #   cmake_defines: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+         #   apt_packages: intel-oneapi-compiler-dpcpp-cpp
+         #   cc: icx
+         #   cxx: icpx
           # - name: Ubuntu 22.04 clang-14 libc++ Release
             # image: ubuntu:22.04
             # cmake_generator: Ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
       - name: Install basic dependencies
         run: |
           apt-get update
-          apt-get install -y git openssh-client wget gnupg
+          apt-get install -y git openssh-client
 
       - name: Disable git safe directory checks
         run : git config --global --add safe.directory '*'
@@ -355,6 +355,7 @@ jobs:
       - name: Add Intel oneAPI apt repo
         if: matrix.name == 'Ubuntu 22.04 Intel-LLVM Release'
         run: |
+          apt-get install -y wget gnupg
           wget -qO- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
             | gpg --dearmor \
             | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
-          cmake -G "%CMAKE_GENERATOR%" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID=IntelLLVM -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+          cmake -G "%CMAKE_GENERATOR%" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
 
       - name: BuildIntel
         shell: cmd
@@ -391,6 +391,7 @@ jobs:
           cmake --build .
 
       - name: Test
+        shell: bash
         env:
           GTEST_OUTPUT: "xml:/junit_reports/unit/"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             runner: windows-2022
             cmake_generator: Ninja
             cmake_build_type: Release
-            cmake_defines: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
+            cmake_defines: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID=IntelLLVM -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
             cpack: NSIS
 
     outputs:
@@ -184,11 +184,12 @@ jobs:
         env:
           CMAKE_PRESET: ${{ env.cmake_preset }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
+          CMAKE_GENERATOR: ${{ env.cmake_preset }}
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
-          cmake -G Ninja --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_TARGET=x86_64-pc-windows-msvc -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+          cmake -G %CMAKE_GENERATOR% --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID=IntelLLVM -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
 
       - name: BuildIntel
         shell: cmd
@@ -207,6 +208,7 @@ jobs:
 
       - name: Test
         shell: pwsh
+        if: matrix.name != 'Windows Intel-LLVM Release'
         env:
           GTEST_OUTPUT: "xml:${{ env.test_path }}"
         run: |
@@ -217,6 +219,16 @@ jobs:
           } else {
             Write-Output "*** '${{ env.dotnet_test_path }}' not found, no .NET Bindings tests to copy"
           }
+
+      - name: TestIntel
+        shell: cmd
+        if: matrix.name == 'Windows Intel-LLVM Release'
+        env:
+          GTEST_OUTPUT: "xml:${{ env.test_path }}"
+          CMAKE_PRESET: ${{ env.cmake_preset }}
+        run: |
+          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          ctest --output-on-failure --preset %CMAKE_PRESET% -C Release --test-dir build
 
       - name: Upload test results
         if: always()
@@ -305,6 +317,7 @@ jobs:
             cmake_generator: Ninja
             cmake_build_type: Release
             cmake_defines: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            apt_packages: intel-oneapi-compiler-dpcpp-cpp
             cc: icx
             cxx: icpx
           # - name: Ubuntu 22.04 clang-14 libc++ Release
@@ -352,6 +365,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Add Intel oneAPI apt repo
+        if: matrix.name == 'Ubuntu 22.04 Intel-LLVM Release'
         run: |
           wget -qO- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
             | gpg --dearmor \
@@ -367,13 +381,13 @@ jobs:
             lld ninja-build curl \
             python3-dev python3-numpy python3-distutils python3-pip \
             mono-runtime libmono-system-json-microsoft4.0-cil libmono-system-data4.0-cil \
-            libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev \
-            intel-oneapi-compiler-dpcpp-cpp
+            libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev
 
       - name: Install latest CMake
         run: pip install cmake
 
-      - name: Source the oneAPI environment
+      - name: Test source the oneAPI environment
+        if: matrix.name == 'Ubuntu 22.04 Intel-LLVM Release'
         shell: bash
         run: |
           source /opt/intel/oneapi/setvars.sh
@@ -383,7 +397,9 @@ jobs:
       - name: Configure
         shell: bash
         run: |
-          source /opt/intel/oneapi/setvars.sh
+          if [ -f /opt/intel/oneapi/setvars.sh ]; then
+              source /opt/intel/oneapi/setvars.sh
+          fi
           mkdir build
           cd build
           cmake -G ${{ matrix.cmake_generator }} --preset ${{ env.cmake_preset }} ${{ matrix.cmake_defines }} -DCI_GIT_BRANCH=${{ github.head_ref }} -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} ..
@@ -392,13 +408,19 @@ jobs:
         working-directory: ./build
         shell: bash
         run: |
-          source /opt/intel/oneapi/setvars.sh
+          if [ -f /opt/intel/oneapi/setvars.sh ]; then
+              source /opt/intel/oneapi/setvars.sh
+          fi
           cmake --build .
 
       - name: Test
         env:
           GTEST_OUTPUT: "xml:/junit_reports/unit/"
-        run: ctest --output-on-failure --preset ${{ env.ctest_preset }} --exclude-regex regression_test -C ${{ matrix.cmake_build_type }} --test-dir build
+        run: |
+          if [ -f /opt/intel/oneapi/setvars.sh ]; then
+              source /opt/intel/oneapi/setvars.sh
+          fi
+          ctest --output-on-failure --preset ${{ env.ctest_preset }} --exclude-regex regression_test -C ${{ matrix.cmake_build_type }} --test-dir build
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
             cpack: NSIS
           - name: Windows Intel-LLVM Release
             runner: windows-2022
-            cmake_generator: "Visual Studio 17 2022"
+            cmake_generator: "Ninja"
             cmake_build_type: Release
-            cmake_defines: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID=IntelLLVM -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
+            cmake_defines: -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
             cpack: NSIS
 
     outputs:
@@ -177,19 +177,22 @@ jobs:
           CMAKE_PRESET: ${{ env.cmake_preset }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
+          CMAKE_DEFINES: ${{ matrix.cmake_defines }}
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
-          cmake -G "%CMAKE_GENERATOR%" -DCMAKE_TOOLCHAIN_FILE="%ONEAPI_ROOT%\compiler\latest\cmake\intel64_win\IntelLLVM.cmake" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+          cmake -G "%CMAKE_GENERATOR%" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% %CMAKE_DEFINES% ..
 
       - name: BuildIntel
         shell: cmd
         if: matrix.name == 'Windows Intel-LLVM Release'
+        env:
+          CMAKE_BUILD_TYPE: ${{ matrix.cmake_build_type }}
         working-directory: ./build
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          cmake --build . --config Release
+          cmake --build . --config %CMAKE_BUILD_TYPE%
 
       - name: Test
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,21 +144,6 @@ jobs:
           Invoke-WebRequest -Uri "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/47a201d7-d4cd-4079-a2d8-0e66b860aaaa/intel-dpcpp-cpp-compiler-2025.2.0.536_offline.exe" -OutFile oneapi.exe
           Start-Process oneapi.exe -ArgumentList '--silent', '--eula=accept' -Wait -NoNewWindow
 
-      - name: Test set up Intel environment
-        shell: cmd
-        if: matrix.name == 'Windows Intel-LLVM Release'
-        run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          icx --version
-          icpx --version
-
-      - name: Temp
-        shell: pwsh
-        if: matrix.name == 'Windows Intel-LLVM Release'
-        run: |
-          & .\oneapi.exe --help
-          & .\oneapi.exe --list-components
-
       - name: Configure
         shell: pwsh
         if: matrix.name != 'Windows Intel-LLVM Release'
@@ -196,7 +181,7 @@ jobs:
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
-          cmake -G %CMAKE_GENERATOR% --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID=IntelLLVM -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+          cmake -G "%CMAKE_GENERATOR%" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID=IntelLLVM -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
 
       - name: BuildIntel
         shell: cmd
@@ -385,14 +370,6 @@ jobs:
 
       - name: Install latest CMake
         run: pip install cmake
-
-      - name: Test source the oneAPI environment
-        if: matrix.name == 'Ubuntu 22.04 Intel-LLVM Release'
-        shell: bash
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          icx --version
-          icpx --version
 
       - name: Configure
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         env:
           CMAKE_PRESET: ${{ env.cmake_preset }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
-          CMAKE_GENERATOR: ${{ env.cmake_preset }}
+          CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           }
 
       - name: Install Intel-LLVM compiler
-        uses: intel/oneapi-ci@v1
+        uses: oneapi-src/oneapi-ci@v1
         with:
           components: "compiler"
 
@@ -330,7 +330,7 @@ jobs:
         run: pip install cmake
 
       - name: Install Intel-LLVM compiler
-        uses: intel/oneapi-ci@v1
+        uses: oneapi-src/oneapi-ci@v1
         with:
           components: "compiler"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,18 +138,21 @@ jobs:
           }
 
       - name: Install Intel-LLVM compiler
-        uses: oneapi-src/oneapi-ci@v1
-        with:
-          components: "compiler"
-
-      - name: Temp
+        shell: pwsh
         run: |
+          winget install --id Intel.oneAPI.DPCPP.Compiler --silent --accept-package-agreements --accept-source-agreements
+
+      - name: Set up Intel environment
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           icx --version
           icpx --version
 
       - name: Configure
-        shell: pwsh
+        shell: cmd
         run: |
+          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
           if ( "${{ matrix.cmake_generator_platform }}" -eq "" )
@@ -162,11 +165,12 @@ jobs:
           }
 
       - name: Build
-        shell: pwsh
+        shell: cmd
         working-directory: ./build
         env:
           dotnetBuildPath: "${{ env.dotnet_bin_path }}/${{ matrix.cmake_generator_platform }}/${{ matrix.cmake_build_type }}"
         run: |
+          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           # for .NET Bindings build
           $env:SHORT_SHA = "${{ env.short_sha }}"
           cmake --build . --config ${{ matrix.cmake_build_type }}
@@ -317,6 +321,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Add Intel oneAPI apt repo
+        run: |
+          wget -qO- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+            | gpg --dearmor \
+            | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+            | tee /etc/apt/sources.list.d/oneapi.list
+          apt-get update
+
       - name: Install additional dependencies
         run: |
           apt-get install -y --no-install-recommends ${{ matrix.apt_packages }} \
@@ -324,30 +337,33 @@ jobs:
             lld ninja-build curl \
             python3-dev python3-numpy python3-distutils python3-pip \
             mono-runtime libmono-system-json-microsoft4.0-cil libmono-system-data4.0-cil \
-            libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev
+            libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev \
+            intel-oneapi-compiler-dpcpp-cpp
 
       - name: Install latest CMake
         run: pip install cmake
 
-      - name: Install Intel-LLVM compiler
-        uses: oneapi-src/oneapi-ci@v1
-        with:
-          components: "compiler"
-
-      - name: Temp
+      - name: Source the oneAPI environment
+        shell: bash
         run: |
+          source /opt/intel/oneapi/setvars.sh
           icx --version
           icpx --version
 
       - name: Configure
+        shell: bash
         run: |
+          source /opt/intel/oneapi/setvars.sh
           mkdir build
           cd build
           cmake -G ${{ matrix.cmake_generator }} --preset ${{ env.cmake_preset }} ${{ matrix.cmake_defines }} -DCI_GIT_BRANCH=${{ github.head_ref }} -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} ..
 
       - name: Build
         working-directory: ./build
-        run: cmake --build .
+        shell: bash
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          cmake --build .
 
       - name: Test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
-          cmake -G Ninja --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+          cmake -G Ninja --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_TARGET=x86_64-pc-windows-msvc -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
 
       - name: BuildIntel
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
       cancel-in-progress: true
-    timeout-minutes: 210
+    timeout-minutes: 260
     strategy:
       fail-fast: false
       matrix:
@@ -139,12 +139,14 @@ jobs:
 
       - name: Install Intel-LLVM compiler
         shell: powershell
+        if: matrix.name == 'Windows Intel-LLVM Release'
         run: |
           Invoke-WebRequest -Uri "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/47a201d7-d4cd-4079-a2d8-0e66b860aaaa/intel-dpcpp-cpp-compiler-2025.2.0.536_offline.exe" -OutFile oneapi.exe
-          Start-Process oneapi.exe -ArgumentList '--silent', '--eula=accept', '--components=cpp-compiler' -Wait -NoNewWindow
+          Start-Process oneapi.exe -ArgumentList '--silent', '--eula=accept' -Wait -NoNewWindow
 
-      - name: Set up Intel environment
+      - name: Test set up Intel environment
         shell: cmd
+        if: matrix.name == 'Windows Intel-LLVM Release'
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           icx --version
@@ -153,17 +155,18 @@ jobs:
       - name: Configure
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          if exist "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" (
+              call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          ) else (
+              echo "setvars.bat not found, skipping"
+          )
           mkdir build
           cd build
-          if ( "${{ matrix.cmake_generator_platform }}" -eq "" )
-          {
-            cmake -G "${{ matrix.cmake_generator }}" --preset ${{ env.cmake_preset }} -DCI_GIT_BRANCH=${{ github.head_ref }} ${{ matrix.cmake_defines }} ..
-          }
-          else
-          {
-            cmake -G "${{ matrix.cmake_generator }}" -A ${{ matrix.cmake_generator_platform }} --preset ${{ env.cmake_preset }} -DCI_GIT_BRANCH=${{ github.head_ref }} ${{ matrix.cmake_defines }} ..
-          }
+          if "%{{ matrix.cmake_generator_platform }}%"=="" (
+              cmake -G "%{{ matrix.cmake_generator }}%" --preset %{{ env.cmake_preset }}% -DCI_GIT_BRANCH=%{{ github.head_ref }}% %{{ matrix.cmake_defines }}% ..
+          ) else (
+              cmake -G "%{{ matrix.cmake_generator }}%" -A %{{ matrix.cmake_generator_platform }}% --preset %{{ env.cmake_preset }}% -DCI_GIT_BRANCH=%{{ github.head_ref }}% %{{ matrix.cmake_defines }}% ..
+          )
 
       - name: Build
         shell: cmd
@@ -171,10 +174,21 @@ jobs:
         env:
           dotnetBuildPath: "${{ env.dotnet_bin_path }}/${{ matrix.cmake_generator_platform }}/${{ matrix.cmake_build_type }}"
         run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          if exist "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" (
+              call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          ) else (
+              echo "setvars.bat not found, skipping"
+          )
           # for .NET Bindings build
-          $env:SHORT_SHA = "${{ env.short_sha }}"
-          cmake --build . --config ${{ matrix.cmake_build_type }}
+          set SHORT_SHA=%{{ env.short_sha }}%
+          cmake --build . --config %{{ matrix.cmake_build_type }}%
+
+      - name: Temp
+        shell: pwsh
+        if: matrix.name == 'Windows Intel-LLVM Release'
+        run: |
+          & .\oneapi.exe --help
+          & .\oneapi.exe --list-components
 
       - name: Test
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,35 +153,50 @@ jobs:
           icpx --version
 
       - name: Configure
-        shell: cmd
+        shell: pwsh
+        if: matrix.name != 'Windows Intel-LLVM Release'
         run: |
-          if exist "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" (
-              call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          ) else (
-              echo "setvars.bat not found, skipping"
-          )
           mkdir build
           cd build
-          if "%{{ matrix.cmake_generator_platform }}%"=="" (
-              cmake -G "%{{ matrix.cmake_generator }}%" --preset %{{ env.cmake_preset }}% -DCI_GIT_BRANCH=%{{ github.head_ref }}% %{{ matrix.cmake_defines }}% ..
-          ) else (
-              cmake -G "%{{ matrix.cmake_generator }}%" -A %{{ matrix.cmake_generator_platform }}% --preset %{{ env.cmake_preset }}% -DCI_GIT_BRANCH=%{{ github.head_ref }}% %{{ matrix.cmake_defines }}% ..
-          )
+          if ( "${{ matrix.cmake_generator_platform }}" -eq "" )
+          {
+            cmake -G "${{ matrix.cmake_generator }}" --preset ${{ env.cmake_preset }} -DCI_GIT_BRANCH=${{ github.head_ref }} ${{ matrix.cmake_defines }} ..
+          }
+          else
+          {
+            cmake -G "${{ matrix.cmake_generator }}" -A ${{ matrix.cmake_generator_platform }} --preset ${{ env.cmake_preset }} -DCI_GIT_BRANCH=${{ github.head_ref }} ${{ matrix.cmake_defines }} ..
+          }
 
       - name: Build
-        shell: cmd
+        shell: pwsh
+        if: matrix.name != 'Windows Intel-LLVM Release'
         working-directory: ./build
         env:
           dotnetBuildPath: "${{ env.dotnet_bin_path }}/${{ matrix.cmake_generator_platform }}/${{ matrix.cmake_build_type }}"
         run: |
-          if exist "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" (
-              call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          ) else (
-              echo "setvars.bat not found, skipping"
-          )
           # for .NET Bindings build
-          set SHORT_SHA=%{{ env.short_sha }}%
-          cmake --build . --config %{{ matrix.cmake_build_type }}%
+          $env:SHORT_SHA = "${{ env.short_sha }}"
+          cmake --build . --config ${{ matrix.cmake_build_type }}
+
+      - name: ConfigureIntel
+        shell: cmd
+        if: matrix.name == 'Windows Intel-LLVM Release'
+        env:
+          CMAKE_PRESET: ${{ env.cmake_preset }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: |
+          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          mkdir build
+          cd build
+          cmake -G Ninja --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+
+      - name: BuildIntel
+        shell: cmd
+        if: matrix.name == 'Windows Intel-LLVM Release'
+        working-directory: ./build
+        run: |
+          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+          cmake --build . --config Release
 
       - name: Temp
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           mkdir build
           cd build
-          cmake -G "%CMAKE_GENERATOR%" -T "Intel C++ Compiler 2022" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
+          cmake -G "%CMAKE_GENERATOR%" -DCMAKE_TOOLCHAIN_FILE="%ONEAPI_ROOT%\compiler\latest\cmake\intel64_win\IntelLLVM.cmake" --preset %CMAKE_PRESET% -DCI_GIT_BRANCH=%GITHUB_HEAD_REF% -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF ..
 
       - name: BuildIntel
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             cpack: NSIS
           - name: Windows Intel-LLVM Release
             runner: windows-2022
-            cmake_generator: Ninja
+            cmake_generator: "Visual Studio 17 2022"
             cmake_build_type: Release
             cmake_defines: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_COMPILER_ID=IntelLLVM -DCMAKE_CXX_COMPILER_ID_RUN_TRUE="" -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
             cpack: NSIS
@@ -152,6 +152,13 @@ jobs:
           icx --version
           icpx --version
 
+      - name: Temp
+        shell: pwsh
+        if: matrix.name == 'Windows Intel-LLVM Release'
+        run: |
+          & .\oneapi.exe --help
+          & .\oneapi.exe --list-components
+
       - name: Configure
         shell: pwsh
         if: matrix.name != 'Windows Intel-LLVM Release'
@@ -198,13 +205,6 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           cmake --build . --config Release
-
-      - name: Temp
-        shell: pwsh
-        if: matrix.name == 'Windows Intel-LLVM Release'
-        run: |
-          & .\oneapi.exe --help
-          & .\oneapi.exe --list-components
 
       - name: Test
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,10 @@ jobs:
           }
 
       - name: Install Intel-LLVM compiler
-        shell: cmd
+        shell: powershell
         run: |
-          winget install --id Intel.oneAPI.DPCPP.Compiler --silent --accept-package-agreements --accept-source-agreements
+          Invoke-WebRequest -Uri "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/47a201d7-d4cd-4079-a2d8-0e66b860aaaa/intel-dpcpp-cpp-compiler-2025.2.0.536_offline.exe" -OutFile oneapi.exe
+          Start-Process oneapi.exe -ArgumentList '--silent', '--eula=accept', '--components=cpp-compiler' -Wait -NoNewWindow
 
       - name: Set up Intel environment
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
             cmake_build_type: Release
             cmake_defines: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
             cpack: NSIS
+          - name: Windows Intel-LLVM Release
+            runner: windows-2022
+            cmake_generator: Ninja
+            cmake_build_type: Release
+            cmake_defines: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
+            cpack: NSIS
 
     outputs:
       # trick for reusable workflow in build_nuget because cannot use env context in "with:"
@@ -130,6 +136,16 @@ jobs:
             Write-Output "Installing numpy for Python $version"
             Invoke-Expression "py -$version -m pip install numpy"
           }
+
+      - name: Install Intel-LLVM compiler
+        uses: intel/oneapi-ci@v1
+        with:
+          components: "compiler"
+
+      - name: Temp
+        run: |
+          icx --version
+          icpx --version
 
       - name: Configure
         shell: pwsh
@@ -250,6 +266,13 @@ jobs:
             apt_packages: clang++-14
             cc: clang-14
             cxx: clang++-14
+          - name: Ubuntu 22.04 Intel-LLVM Release
+            image: ubuntu:22.04
+            cmake_generator: Ninja
+            cmake_build_type: Release
+            cmake_defines: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            cc: icx
+            cxx: icpx
           # - name: Ubuntu 22.04 clang-14 libc++ Release
             # image: ubuntu:22.04
             # cmake_generator: Ninja
@@ -305,6 +328,16 @@ jobs:
 
       - name: Install latest CMake
         run: pip install cmake
+
+      - name: Install Intel-LLVM compiler
+        uses: intel/oneapi-ci@v1
+        with:
+          components: "compiler"
+
+      - name: Temp
+        run: |
+          icx --version
+          icpx --version
 
       - name: Configure
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           }
 
       - name: Install Intel-LLVM compiler
-        shell: pwsh
+        shell: cmd
         run: |
           winget install --id Intel.oneAPI.DPCPP.Compiler --silent --accept-package-agreements --accept-source-agreements
 
@@ -313,7 +313,7 @@ jobs:
       - name: Install basic dependencies
         run: |
           apt-get update
-          apt-get install -y git openssh-client
+          apt-get install -y git openssh-client wget gnupg
 
       - name: Disable git safe directory checks
         run : git config --global --add safe.directory '*'

--- a/CMakeBasePresets.json
+++ b/CMakeBasePresets.json
@@ -34,6 +34,14 @@
             }
         },
         {
+            "name": "intel-llvm",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "icx",
+                "CMAKE_CXX_COMPILER": "icpx"
+            }
+        },
+        {
             "name": "ninja",
             "hidden": true,
             "generator": "Ninja"
@@ -267,6 +275,24 @@
             "inherits": [
                 "full/release",
                 "clang",
+                "ninja"
+            ]
+        },
+        {
+            "name": "x64/intel-llvm/full/debug",
+            "displayName": "[IntelLLVM] Full - Debug",
+            "inherits": [
+                "full/debug",
+                "intel-llvm",
+                "ninja"
+            ]
+        },
+        {
+            "name": "x64/intel-llvm/full/release",
+            "displayName": "[IntelLLVM] Full - Release",
+            "inherits": [
+                "full/release",
+                "intel-llvm",
                 "ninja"
             ]
         }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -702,7 +702,11 @@ if(CMAKE_COMPILER_IS_CLANGXX)
     if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
         set(CLANG_FLAGS "${CLANG_FLAGS} \
             -Rno-debug-disables-optimization \
-            -Wno-deprecated-literal-operator"
+            -Wno-deprecated-literal-operator \
+            -Wno-missing-field-initializers \
+            -Wno-self-assign-overloaded \
+            -Wno-logical-op-parentheses \
+            -Wno-misleading-indentation"
         )
     endif()
 
@@ -711,8 +715,11 @@ if(CMAKE_COMPILER_IS_CLANGXX)
         # cmd-line options might be mixed - suppress warnings
         set(CLANG_FLAGS "${CLANG_FLAGS} \
             -Wno-unknown-argument \
-            -Wno-unused-command-line-argument \
-            -Wno-misleading-indentation"
+            -Wno-unused-command-line-argument"
+        )
+        # suppress warning in MSVC toolchain header file
+        set(CLANG_FLAGS "${CLANG_FLAGS} \
+            -Wno-delete-non-abstract-non-virtual-dtor"
         )
     endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,9 @@ if (COMMAND get_mode)
     message(STATUS "CMake Mode is ${CMAKE_MODE}")
 endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|IntelLLVM)$")
     set(CMAKE_COMPILER_IS_CLANGXX On CACHE INTERNAL "Compiler is LLVM Clang")
+    message(STATUS "Compiler is LLVM Clang")
 endif ()
 
 if (UNIX AND (CMAKE_COMPILER_IS_CLANGXX OR CMAKE_COMPILER_IS_GNUXX))
@@ -696,6 +697,13 @@ if(CMAKE_COMPILER_IS_CLANGXX)
         -Wno-misleading-indentation \
         -Wno-missing-field-initializers"
     )
+
+    # Append Intel-LLVM-specific suppressions
+    if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+        set(CLANG_FLAGS "${CLANG_FLAGS} \
+            -Rno-debug-disables-optimization"
+        )
+    endif()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_FLAGS}")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ endif()
 if (OPENDAQ_CI_RUNNER)
     message("Configured as CI runner")
     add_compile_definitions(DS_CI_RUNNER=1)
-    set(OPENDAQ_DEBUG_WARNINGS_AS_ERRORS ON)
+    set(OPENDAQ_DEBUG_WARNINGS_AS_ERRORS OFF)
 endif()
 
 if (COMMAND get_mode)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,7 +701,7 @@ if(CMAKE_COMPILER_IS_CLANGXX)
     # Append Intel-LLVM-specific suppressions
     if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
         set(CLANG_FLAGS "${CLANG_FLAGS} \
-            -Rno-debug-disables-optimization \
+            -Xclang -Rno-debug-disables-optimization \
             -Wno-deprecated-literal-operator \
             -Wno-missing-field-initializers \
             -Wno-self-assign-overloaded \
@@ -714,12 +714,12 @@ if(CMAKE_COMPILER_IS_CLANGXX)
         message(STATUS "IntelLLVM Compiler is detected but MSVC is also set")
         # cmd-line options might be mixed - suppress warnings
         set(CLANG_FLAGS "${CLANG_FLAGS} \
-            -Wno-unknown-argument \
+            -Xclang -Wno-unknown-argument \
             -Wno-unused-command-line-argument"
         )
         # suppress warning in MSVC toolchain header file
         set(CLANG_FLAGS "${CLANG_FLAGS} \
-            -Wno-delete-non-abstract-non-virtual-dtor"
+            -Xclang -Wno-delete-non-abstract-non-virtual-dtor"
         )
     endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ if (OPENDAQ_FORCE_LLD_LINKER)
     message(STATUS "Forcing the use of LLVM LLD linker. Make sure it is installed and available.")
 endif()
 
-if (MSVC)
+if (MSVC AND NOT CMAKE_COMPILER_IS_CLANGXX)
     # As above CMAKE_CXX_STANDARD but for VS
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++17>)
 
@@ -703,10 +703,7 @@ if(CMAKE_COMPILER_IS_CLANGXX)
         set(CLANG_FLAGS "${CLANG_FLAGS} \
             -Xclang -Rno-debug-disables-optimization \
             -Wno-deprecated-literal-operator \
-            -Wno-missing-field-initializers \
-            -Wno-self-assign-overloaded \
-            -Wno-logical-op-parentheses \
-            -Wno-misleading-indentation"
+            -Wno-self-assign-overloaded"
         )
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,6 @@ if (NOT DEFINED CMAKE_INSTALL_RPATH)
     set(CMAKE_INSTALL_RPATH ${LIB_LOAD_ORIGIN} ${LIB_LOAD_ORIGIN}/${RPATH_DIR})
 endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM" AND MSVC)
-    message(STATUS "IntelLLVM Compiler is detected but MSVC is also set")
-endif ()
-
 if (NOT MSVC)
     option(OPENDAQ_FORCE_COMPILE_32BIT "Compile 32Bit on non MSVC" OFF)
 endif()
@@ -709,6 +705,16 @@ if(CMAKE_COMPILER_IS_CLANGXX)
             -Wno-deprecated-literal-operator"
         )
     endif()
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM" AND MSVC)
+        message(STATUS "IntelLLVM Compiler is detected but MSVC is also set")
+        # cmd-line options might be mixed - suppress warnings
+        set(CLANG_FLAGS "${CLANG_FLAGS} \
+            -Wno-unknown-argument \
+            -Wno-unused-command-line-argument \
+            -Wno-misleading-indentation"
+        )
+    endif ()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_FLAGS}")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ if (COMMAND get_mode)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|IntelLLVM)$")
-    set(CMAKE_COMPILER_IS_CLANGXX On CACHE INTERNAL "Compiler is LLVM Clang")
+    set(CMAKE_COMPILER_IS_CLANGXX On CACHE INTERNAL "Compiler is LLVM")
     message(STATUS "Compiler is LLVM Clang")
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ endif()
 if (OPENDAQ_CI_RUNNER)
     message("Configured as CI runner")
     add_compile_definitions(DS_CI_RUNNER=1)
-    set(OPENDAQ_DEBUG_WARNINGS_AS_ERRORS OFF)
+    set(OPENDAQ_DEBUG_WARNINGS_AS_ERRORS ON)
 endif()
 
 if (COMMAND get_mode)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ if (NOT DEFINED CMAKE_INSTALL_RPATH)
     set(CMAKE_INSTALL_RPATH ${LIB_LOAD_ORIGIN} ${LIB_LOAD_ORIGIN}/${RPATH_DIR})
 endif()
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM" AND MSVC)
+    message(STATUS "IntelLLVM Compiler is detected but MSVC is also set")
+endif ()
+
 if (NOT MSVC)
     option(OPENDAQ_FORCE_COMPILE_32BIT "Compile 32Bit on non MSVC" OFF)
 endif()
@@ -238,7 +242,7 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|IntelLLVM)$")
     set(CMAKE_COMPILER_IS_CLANGXX On CACHE INTERNAL "Compiler is LLVM")
-    message(STATUS "Compiler is LLVM Clang")
+    message(STATUS "Compiler is LLVM")
 endif ()
 
 if (UNIX AND (CMAKE_COMPILER_IS_CLANGXX OR CMAKE_COMPILER_IS_GNUXX))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,7 +701,8 @@ if(CMAKE_COMPILER_IS_CLANGXX)
     # Append Intel-LLVM-specific suppressions
     if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
         set(CLANG_FLAGS "${CLANG_FLAGS} \
-            -Rno-debug-disables-optimization"
+            -Rno-debug-disables-optimization \
+            -Wno-deprecated-literal-operator"
         )
     endif()
 

--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -37,6 +37,7 @@
 
 ## Misc
 
+- [#908](https://github.com/openDAQ/openDAQ/pull/908) Add support for Intel-LLVM compiler
 - [#903](https://github.com/openDAQ/openDAQ/pull/903) Enable suppressed type conversion warnings on Windows
 - [#893](https://github.com/openDAQ/openDAQ/pull/893) Rework disabled permission manager, making module code independent of the OPENDAQ_ENABLE_ACCESS_CONTROL option
 - [#835](https://github.com/openDAQ/openDAQ/pull/835) Removes the opendaq_dev target.

--- a/core/corecontainers/src/listobject_impl.cpp
+++ b/core/corecontainers/src/listobject_impl.cpp
@@ -137,7 +137,7 @@ ErrCode INTERFACE_FUNC ListImpl::equals(IBaseObject* other, Bool* equal) const
         const auto otherItem = otherList.getItemAt(i);
 
         Bool eq{};
-        if (!(item == otherItem || OPENDAQ_SUCCEEDED(item->equals(otherItem, &eq)) && eq))
+        if (!(item == otherItem || (OPENDAQ_SUCCEEDED(item->equals(otherItem, &eq)) && eq)))
         {
             *equal = false;
             return OPENDAQ_SUCCESS;

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -1046,7 +1046,7 @@ public:
         if (refProp.assigned())
         {
             bool valid = valueType == ctUndefined;
-            valid = valid && !description.assigned() || description == "";
+            valid = (valid && !description.assigned()) || description == "";
             valid = valid && !readOnly;
             valid = valid && !selectionValues.assigned() && !suggestedValues.assigned();
             valid = valid && !coercer.assigned() && !validator.assigned();

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -1053,7 +1053,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkContain
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, "Only base Property Object object-type values are allowed");
     }
 
-    auto iterate = [this](const IterablePtr<IBaseObject>& it, CoreType type) {
+    auto iterate = [](const IterablePtr<IBaseObject>& it, CoreType type) {
         for (const auto& key : it)
         {
             auto ct = key.getCoreType();

--- a/core/coretypes/include/coretypes/intfs.h
+++ b/core/coretypes/include/coretypes/intfs.h
@@ -28,7 +28,7 @@
 #include <cassert>
 #include <string>
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(_MSC_VER)
 #include <cxxabi.h>
 #endif
 
@@ -333,7 +333,7 @@ public:
         OPENDAQ_PARAM_NOT_NULL(implementationName);
 
         auto id = typeid(*this).name();
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(_MSC_VER)
         int status{};
         std::unique_ptr<char, MallocDeleter> demangled(abi::__cxa_demangle(id, nullptr, nullptr, &status));
         if (status == 0)

--- a/core/coretypes/tests/test_json_deserializer.cpp
+++ b/core/coretypes/tests/test_json_deserializer.cpp
@@ -84,7 +84,8 @@ TEST_F(JsonDeserializerTest, floatMax)
 TEST_F(JsonDeserializerTest, floatMin)
 {
     FloatPtr deserialized = deserializer.deserialize("2.2250738585072014e-308");
-    ASSERT_EQ(deserialized.getValue<Float>(-1), floatMin);
+    double d = std::stod("2.2250738585072014e-308");
+    ASSERT_EQ(deserialized.getValue<Float>(-1), floatMin) << "debug double min val: " << std::setprecision(20) << d << std::endl;
 }
 
 TEST_F(JsonDeserializerTest, floatNaN)

--- a/core/coretypes/tests/test_json_deserializer.cpp
+++ b/core/coretypes/tests/test_json_deserializer.cpp
@@ -84,8 +84,7 @@ TEST_F(JsonDeserializerTest, floatMax)
 TEST_F(JsonDeserializerTest, floatMin)
 {
     FloatPtr deserialized = deserializer.deserialize("2.2250738585072014e-308");
-    double d = std::stod("2.2250738585072014e-308");
-    ASSERT_EQ(deserialized.getValue<Float>(-1), floatMin) << "debug double min val: " << std::setprecision(20) << d << std::endl;
+    ASSERT_EQ(deserialized.getValue<Float>(-1), floatMin);
 }
 
 TEST_F(JsonDeserializerTest, floatNaN)

--- a/core/opendaq/reader/src/signal_reader.cpp
+++ b/core/opendaq/reader/src/signal_reader.cpp
@@ -408,7 +408,7 @@ bool SignalReader::sync(const Comparable& commonStart, std::chrono::system_clock
     }
 
     SizeT startPackets = info.prevSampleIndex;
-    Int droppedPackets = 0;
+    [[maybe_unused]] Int droppedPackets = 0;
 
     while (info.dataPacket.assigned())
     {

--- a/examples/modules/audio_device_module/tests/test_fb_wav_reader.cpp
+++ b/examples/modules/audio_device_module/tests/test_fb_wav_reader.cpp
@@ -143,7 +143,7 @@ TEST_F(WavReaderTest, ReadFile)
     reader.readWithDomain(data.data(), time.data(), &count, 10000);
     ASSERT_EQ(count, 100);
 
-    while (bool framesAvailable = !fb.getPropertyValue("EOF"))
+    while (!static_cast<bool>(fb.getPropertyValue("EOF")))
     {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }

--- a/examples/modules/ref_device_module/include/ref_device_module/ref_can_channel_impl.h
+++ b/examples/modules/ref_device_module/include/ref_device_module/ref_can_channel_impl.h
@@ -62,8 +62,6 @@ private:
     int32_t upperLimit;
     int32_t counter1;
     int32_t counter2;
-    size_t index;
-    std::chrono::microseconds startTime;
     std::chrono::microseconds microSecondsFromEpochToStartTime;
     std::chrono::microseconds lastCollectTime;
     SignalConfigPtr valueSignal;

--- a/examples/modules/ref_device_module/include/ref_device_module/ref_can_channel_impl.h
+++ b/examples/modules/ref_device_module/include/ref_device_module/ref_can_channel_impl.h
@@ -63,12 +63,9 @@ private:
     int32_t counter1;
     int32_t counter2;
     size_t index;
-    double globalSampleRate;
-    uint64_t deltaT;
     std::chrono::microseconds startTime;
     std::chrono::microseconds microSecondsFromEpochToStartTime;
     std::chrono::microseconds lastCollectTime;
-    uint64_t samplesGenerated;
     SignalConfigPtr valueSignal;
     SignalConfigPtr timeSignal;
 

--- a/examples/modules/ref_device_module/include/ref_device_module/ref_channel_impl.h
+++ b/examples/modules/ref_device_module/include/ref_device_module/ref_channel_impl.h
@@ -92,7 +92,6 @@ private:
     uint64_t packetSize;
     StringPtr referenceDomainId;
     PacketBufferPtr packetBuffer;
-    daq::IdsParser* idp;
     bool acqActive;
 
     void packetBufferSetup();

--- a/examples/modules/ref_device_module/src/ref_can_channel_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_can_channel_impl.cpp
@@ -28,7 +28,6 @@ RefCANChannelImpl::RefCANChannelImpl(const ContextPtr& context,
     , startTime(init.startTime)
     , microSecondsFromEpochToStartTime(init.microSecondsFromEpochToStartTime)
     , lastCollectTime(0)
-    , samplesGenerated(0)
 {
     objPtr.asPtr<IPropertyObjectInternal>().setLockingStrategy(LockingStrategy::InheritLock);
 

--- a/examples/modules/ref_device_module/src/ref_can_channel_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_can_channel_impl.cpp
@@ -25,7 +25,6 @@ RefCANChannelImpl::RefCANChannelImpl(const ContextPtr& context,
                                      const StringPtr& localId,
                                      const RefCANChannelInit& init)
     : ChannelImpl(FunctionBlockType("RefCANChannel",  "CAN", ""), context, parent, localId)
-    , startTime(init.startTime)
     , microSecondsFromEpochToStartTime(init.microSecondsFromEpochToStartTime)
     , lastCollectTime(0)
 {

--- a/examples/modules/ref_fb_module/include/ref_fb_module/power_reader_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/power_reader_fb_impl.h
@@ -51,9 +51,6 @@ private:
     DataDescriptorPtr powerDataDescriptor;
     DataDescriptorPtr powerDomainDataDescriptor;
 
-    SampleType voltageSampleType;
-    SampleType currentSampleType;
-
     SignalConfigPtr powerSignal;
     SignalConfigPtr powerDomainSignal;
 

--- a/examples/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
@@ -161,7 +161,6 @@ private:
     size_t custom2dMaxRange;
     sf::Vector2f topLeft;
     sf::Vector2f bottomRight;
-    size_t signalContextIndex;
     int inputPortCount;
 
     double lastDomainValue;

--- a/examples/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -27,7 +27,6 @@ RendererFbImpl::RendererFbImpl(const ContextPtr& ctx,
     : FunctionBlock(CreateType(), ctx, parent, localId)
     , rendererStopRequested(false)
     , resolutionChangedFlag(false)
-    , signalContextIndex(0)
     , inputPortCount(0)
     , axisColor(150, 150, 150)
     , futureComponentStatus(ComponentStatus::Ok)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -26,6 +26,48 @@ if (MSVC AND NOT CMAKE_COMPILER_IS_CLANGXX)
     endforeach()
 endif()
 
+if(CMAKE_COMPILER_IS_CLANGXX)
+    set(CLANG_FLAGS "\
+        -Wno-unused-variable \
+        -Wno-missing-braces \
+        -Wno-unused-function \
+        -Wno-logical-op-parentheses \
+        -Wno-unused-variable \
+        -Werror=return-type \
+        -Wno-deprecated-declarations \
+        -Wno-undef \
+        -Wno-incompatible-pointer-types \
+        -Wno-unused-parameter \
+        -Wno-misleading-indentation \
+        -Wno-missing-field-initializers"
+    )
+
+    # Append Intel-LLVM-specific suppressions
+    if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+        set(CLANG_FLAGS "${CLANG_FLAGS} \
+            -Xclang -Rno-debug-disables-optimization \
+            -Wno-deprecated-literal-operator \
+            -Wno-self-assign-overloaded"
+        )
+    endif()
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM" AND MSVC)
+        message(STATUS "IntelLLVM Compiler is detected but MSVC is also set")
+        # cmd-line options might be mixed - suppress warnings
+        set(CLANG_FLAGS "${CLANG_FLAGS} \
+            -Xclang -Wno-unknown-argument \
+            -Wno-unused-command-line-argument"
+        )
+        # suppress warning in MSVC toolchain header file
+        set(CLANG_FLAGS "${CLANG_FLAGS} \
+            -Xclang -Wno-delete-non-abstract-non-virtual-dtor"
+        )
+    endif ()
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_FLAGS}")
+endif()
+
 if (MSVC AND NOT CMAKE_COMPILER_IS_CLANGXX)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
 else()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -7,7 +7,7 @@ include(opendaq_dependency.cmake)
 list(APPEND CMAKE_MESSAGE_CONTEXT external)
 set(CURR_MESSAGE_CONTEXT ${CMAKE_MESSAGE_CONTEXT})
 
-if (MSVC)
+if (MSVC AND NOT CMAKE_COMPILER_IS_CLANGXX)
     # As above CMAKE_CXX_STANDARD but for VS
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++17>)
 
@@ -26,7 +26,7 @@ if (MSVC)
     endforeach()
 endif()
 
-if (MSVC)
+if (MSVC AND NOT CMAKE_COMPILER_IS_CLANGXX)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
 else()
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-error>)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -26,48 +26,6 @@ if (MSVC AND NOT CMAKE_COMPILER_IS_CLANGXX)
     endforeach()
 endif()
 
-if(CMAKE_COMPILER_IS_CLANGXX)
-    set(CLANG_FLAGS "\
-        -Wno-unused-variable \
-        -Wno-missing-braces \
-        -Wno-unused-function \
-        -Wno-logical-op-parentheses \
-        -Wno-unused-variable \
-        -Werror=return-type \
-        -Wno-deprecated-declarations \
-        -Wno-undef \
-        -Wno-incompatible-pointer-types \
-        -Wno-unused-parameter \
-        -Wno-misleading-indentation \
-        -Wno-missing-field-initializers"
-    )
-
-    # Append Intel-LLVM-specific suppressions
-    if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
-        set(CLANG_FLAGS "${CLANG_FLAGS} \
-            -Xclang -Rno-debug-disables-optimization \
-            -Wno-deprecated-literal-operator \
-            -Wno-self-assign-overloaded"
-        )
-    endif()
-
-    if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM" AND MSVC)
-        message(STATUS "IntelLLVM Compiler is detected but MSVC is also set")
-        # cmd-line options might be mixed - suppress warnings
-        set(CLANG_FLAGS "${CLANG_FLAGS} \
-            -Xclang -Wno-unknown-argument \
-            -Wno-unused-command-line-argument"
-        )
-        # suppress warning in MSVC toolchain header file
-        set(CLANG_FLAGS "${CLANG_FLAGS} \
-            -Xclang -Wno-delete-non-abstract-non-virtual-dtor"
-        )
-    endif ()
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_FLAGS}")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_FLAGS}")
-endif()
-
 if (MSVC AND NOT CMAKE_COMPILER_IS_CLANGXX)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/WX->)
 else()

--- a/external/taskflow/CMakeLists.txt
+++ b/external/taskflow/CMakeLists.txt
@@ -13,4 +13,5 @@ opendaq_dependency(
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-TBBAS-280-Fix-Executor-async-functions-to-set-except.patch
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0002-Implement-fallback-uncaught-exception-handler.patch
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0003-Ignore-False-Positive-Mem-Leak.patch
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/0004-IntelLLVM-Support.patch
 )

--- a/external/taskflow/patches/0004-IntelLLVM-Support.patch
+++ b/external/taskflow/patches/0004-IntelLLVM-Support.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ccba973..8b2cbf2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,6 +70,11 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+     message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
+     message(FATAL_ERROR "\nTaskflow requires icpc at least v19.0.1")
+   endif()
++elseif (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
++  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "2021.1.0")
++    message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
++    message(FATAL_ERROR "\nTaskflow requires icpx at least v2021.1.0")
++  endif()
+ else()
+   message(FATAL_ERROR "\n\
+ Taskflow currently supports the following compilers:\n\
+@@ -78,6 +83,7 @@ Taskflow currently supports the following compilers:\n\
+   - MSVC++ v19.14 or above\n\
+   - AppleClang v8 or above\n\
+   - Intel v19.0.1 or above\n\
++  - IntelLLVM v2021.1.0 or above\n\
+ ")
+ endif()
+ 
+@@ -372,4 +378,3 @@ install(
+         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+ )
+-

--- a/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_streaming_client_module_impl.cpp
@@ -464,7 +464,7 @@ bool NativeStreamingClientModule::acceptsConnectionParameters(const StringPtr& c
     }
 
     if (config.assigned() &&
-        (pseudoDevicePrefixFound && !validateConnectionConfig(config) || devicePrefixFound && !validateDeviceConfig(config)))
+        ((pseudoDevicePrefixFound && !validateConnectionConfig(config)) || (devicePrefixFound && !validateDeviceConfig(config))))
     {
         LOG_W("Connection string \"{}\" is accepted but config is incomplete", connectionString);
         return false;

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -505,7 +505,7 @@ BaseObjectPtr ConfigClientPropertyObjectBaseImpl<Impl>::getValueFromServer(const
     PropertyPtr prop;
     Impl::getProperty(propName, &prop);
     setValue = false;
-    switch (const auto vt = prop.getValueType())
+    switch (prop.getValueType())
     {
         case ctProc:
             return createWithImplementation<IProcedure, ConfigClientProcedureImpl>(clientComm, remoteGlobalId, this->path, propName);
@@ -925,7 +925,7 @@ template <class Impl>
 void ConfigClientPropertyObjectBaseImpl<Impl>::checkCanSetPropertyValue(const StringPtr& propName)
 {
     const auto prop = this->objPtr.getProperty(propName);
-    switch (const auto vt = prop.getValueType())
+    switch (prop.getValueType())
     {
         case ctProc:
         case ctFunc:

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -106,7 +106,7 @@ private:
     void checkCanSetPropertyValue(const StringPtr& propName);
     bool isBasePropertyObject(const PropertyObjectPtr& propObj);
 
-    std::string getPath();
+    std::string getPathInternal();
     void applyUpdatingPropsAndValuesProtocolVer0();
 };
 
@@ -720,7 +720,7 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::beginApplyUpdate()
     if (remoteUpdating)
         return Impl::beginApplyUpdate();
 
-    clientComm->beginUpdate(remoteGlobalId, getPath());
+    clientComm->beginUpdate(remoteGlobalId, getPathInternal());
 }
 
 template <class Impl>
@@ -751,7 +751,7 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::endApplyUpdate()
 
     this->updatingPropsAndValues.clear();
 
-    clientComm->endUpdate(remoteGlobalId, getPath(), propsAndValuesEx);
+    clientComm->endUpdate(remoteGlobalId, getPathInternal(), propsAndValuesEx);
 }*/
 
 template <class Impl>
@@ -945,7 +945,7 @@ bool ConfigClientPropertyObjectBaseImpl<Impl>::isBasePropertyObject(const Proper
 
 
 template <class Impl>
-std::string ConfigClientPropertyObjectBaseImpl<Impl>::getPath()
+std::string ConfigClientPropertyObjectBaseImpl<Impl>::getPathInternal()
 {
     std::string path{};
     if (this->path.assigned())

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_integration.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_integration.cpp
@@ -378,10 +378,13 @@ TEST_F(TmsIntegrationTest, InputPortMultipleServers)
     auto clientDevice1 = instance.addDevice("daq.opcua://127.0.0.1:4001");
     auto clientDevice2 = instance.addDevice("daq.opcua://127.0.0.1:4002");
 
-    auto inputPort1 = clientDevice1.getChannelsRecursive().getItemAt(0).getInputPorts().getItemAt(0);
-    auto inputPort2 = clientDevice2.getChannelsRecursive().getItemAt(0).getInputPorts().getItemAt(0);
-    auto signal1 = clientDevice1.getSignalsRecursive().getItemAt(0);
-    auto signal2 = clientDevice2.getSignalsRecursive().getItemAt(0);
+    InputPortPtr inputPort1, inputPor2;
+    SignalPtr signal1, signal2;
+    ASSERT_NO_THROW(inputPort1 = clientDevice1.getChannelsRecursive().getItemAt(0).getInputPorts().getItemAt(0));
+    ASSERT_NO_THROW(inputPort2 = clientDevice2.getChannelsRecursive().getItemAt(0).getInputPorts().getItemAt(0));
+    ASSERT_NO_THROW(signal1 = clientDevice1.getSignalsRecursive().getItemAt(0));
+    ASSERT_NO_THROW(signal2 = clientDevice2.getSignalsRecursive().getItemAt(0));
+
     SignalPtr portSignal;
 
     ASSERT_NO_THROW(inputPort1.connect(signal1));

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_integration.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_integration.cpp
@@ -378,7 +378,7 @@ TEST_F(TmsIntegrationTest, InputPortMultipleServers)
     auto clientDevice1 = instance.addDevice("daq.opcua://127.0.0.1:4001");
     auto clientDevice2 = instance.addDevice("daq.opcua://127.0.0.1:4002");
 
-    InputPortPtr inputPort1, inputPor2;
+    InputPortPtr inputPort1, inputPort2;
     SignalPtr signal1, signal2;
     ASSERT_NO_THROW(inputPort1 = clientDevice1.getChannelsRecursive().getItemAt(0).getInputPorts().getItemAt(0));
     ASSERT_NO_THROW(inputPort2 = clientDevice2.getChannelsRecursive().getItemAt(0).getInputPorts().getItemAt(0));

--- a/shared/libraries/packet_streaming/src/packet_streaming_client.cpp
+++ b/shared/libraries/packet_streaming/src/packet_streaming_client.cpp
@@ -66,8 +66,8 @@ void PacketStreamingClient::addEventPacketBuffer(const PacketBufferPtr& packetBu
 
         const auto dataDescIt = dataDescriptors.find(signalId);
         const auto domainDescIt = domainDescriptors.find(signalId);
-        if (valueDescriptorChanged && dataDescIt != dataDescriptors.end() && dataDescIt->second != newValueDescriptor ||
-            domainDescriptorChanged && domainDescIt != domainDescriptors.end() && domainDescIt->second != newDomainDescriptors ||
+        if ((valueDescriptorChanged && dataDescIt != dataDescriptors.end() && dataDescIt->second != newValueDescriptor) ||
+            (domainDescriptorChanged && domainDescIt != domainDescriptors.end() && domainDescIt->second != newDomainDescriptors) ||
             dataDescIt == dataDescriptors.end() ||
             domainDescIt == domainDescriptors.end())
         {

--- a/shared/libraries/websocket_streaming/src/streaming_server.cpp
+++ b/shared/libraries/websocket_streaming/src/streaming_server.cpp
@@ -593,8 +593,8 @@ void StreamingServer::handleDataDescriptorChanges(OutputSignalBasePtr& outputSig
 
     if (auto placeholderValueSignal = std::dynamic_pointer_cast<OutputNullSignal>(outputSignal))
     {
-        if (valueDescriptorChanged && newValueDescriptor.assigned() ||
-            domainDescriptorChanged && newDomainDescriptor.assigned())
+        if ((valueDescriptorChanged && newValueDescriptor.assigned()) ||
+            (domainDescriptorChanged && newDomainDescriptor.assigned()))
             updateOutputPlaceholderSignal(outputSignal, outputSignals, writer, subscribed);
     }
     else


### PR DESCRIPTION
# Brief

Enable building openDAQ with the Intel oneAPI LLVM compiler

# Description

- Patch TaskFlow to resolve issues with Intel-LLVM compiler detection  
- Add CMake build presets for Intel-LLVM compiler  
- Provide necessary build flags for Intel oneAPI LLVM compiler  
- Remove unused class members in reference modules and address other warnings  
- Fix `cxxabi.h` include errors  
- Introduce Ubuntu and Windows CI jobs for Intel-LLVM compiler — verified as passing, then disabled

### Known issues

- `test_core_types` fails on Ubuntu 22.04 in `TEST_F(JsonDeserializerTest, floatMin)` during float minimum deserialization. This is possibly caused by a bug in the Intel math runtime library. However, the same test passes locally on Ubuntu 20.04.  
