### PR TITLE
<TBBAS-2595> Add building packages and uploading them as artifacts

### DIFF
--- a/.github/actions/build-artifact/action.yml
+++ b/.github/actions/build-artifact/action.yml
@@ -1,0 +1,219 @@
+name: Build and Upload openDAQ Artifacts
+description: Build openDAQ framework and create distribution packages
+
+inputs:
+  cmake-compiler:
+    description: "CMake compiler configuration (e.g., '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER_LAUNCHER=ccache')"
+    required: true
+  cmake-config-name:
+    description: "CMake build configuration name (Release, Debug, RelWithDebInfo, MinSizeRel)"
+    required: false
+    default: Release
+  cmake-defines:
+    description: "CMake configuration flags (e.g., '-DOPENDAQ_ENABLE_TESTS=OFF -DOPENDAQ_BUILD_DOCUMENTATION=OFF')"
+    required: true
+  cmake-generator:
+    description: "CMake build system generator (e.g., 'Ninja', 'Unix Makefiles', 'Visual Studio 17 2022')"
+    required: true
+  cmake-preset:
+    description: "CMake preset command (e.g., '--preset \"x64/gcc/full/debug\"'). Pass full command, not just preset name."
+    required: false
+    default: ''
+  cmake-parallel:
+    description: "CMake parallel build flags (e.g., '-j 4' or '--parallel 4')"
+    required: false
+    default: ''
+  cpack-generator:
+    description: "CPack package generator (e.g., 'DEB', 'RPM', 'NSIS', 'TGZ', 'ZIP')"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "::group::Installing Linux dependencies"
+        sudo apt-get update
+        sudo apt-get install -y \
+            ccache \
+            freeglut3-dev \
+            libfreetype6-dev \
+            libgl1-mesa-dev \
+            libudev-dev \
+            libx11-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxrandr-dev \
+            mesa-common-dev \
+            mono-complete \
+            python3-pip \
+            python3.12-dev
+        echo "::endgroup::"
+        echo "✓ Linux dependencies installed"
+
+    - name: Install dependencies Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Write-Host "::group::Installing Windows dependencies"
+        choco install ccache ninja nsis vswhere -y
+        Write-Host "::endgroup::"
+        Write-Host "✓ Windows dependencies installed"
+
+    - name: Install dependencies MacOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        echo "::group::Installing macOS dependencies"
+        brew install ccache
+        echo "::endgroup::"
+        echo "✓ macOS dependencies installed"
+
+    - name: Setup MSVC environment
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Write-Host "::group::Setting up MSVC environment"
+        $vsPath = vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (-not $vsPath) {
+          Write-Host "::error::Visual Studio not found"
+          exit 1
+        }
+        Write-Host "Visual Studio found at: $vsPath"
+
+        $vcvarsall = Join-Path $vsPath 'VC\Auxiliary\Build\vcvarsall.bat'
+        if (-not (Test-Path $vcvarsall)) {
+          Write-Host "::error::vcvarsall.bat not found at $vcvarsall"
+          exit 1
+        }
+        Write-Host "Using vcvarsall.bat: $vcvarsall"
+
+        $envVars = @{}
+        cmd /c "`"$vcvarsall`" x64 && set" | ForEach-Object {
+          if ($_ -match "^(.*?)=(.*)$") {
+            $name = $matches[1]
+            $value = $matches[2]
+            $envVars[$name] = $value
+            echo "$name=$value" >> $env:GITHUB_ENV
+          }
+        }
+        Write-Host "::endgroup::"
+
+        Write-Host "✓ MSVC environment configured"
+        Write-Host "Key variables:"
+        Write-Host "  Platform: $($envVars['Platform'])"
+        Write-Host "  VSCMD_ARG_TGT_ARCH: $($envVars['VSCMD_ARG_TGT_ARCH'])"
+        Write-Host "  VisualStudioVersion: $($envVars['VisualStudioVersion'])"
+        Write-Host "  VCToolsVersion: $($envVars['VCToolsVersion'])"
+        Write-Host "Total variables set: $($envVars.Count)"
+
+    - name: Configure openDAQ CMake build
+      shell: bash
+      run: |
+        echo "CMake Configuration:"
+        echo "  Generator: ${{ inputs.cmake-generator }}"
+        echo "  Config: ${{ inputs.cmake-config-name }}"
+        echo "  Preset: ${{ inputs.cmake-preset }}"
+        echo ""
+        echo "::group::CMake Configuration Output"
+        cmake -S . -B build -G "${{ inputs.cmake-generator }}" ${{ inputs.cmake-preset }} ${{ inputs.cmake-defines }} ${{ inputs.cmake-compiler }} -DCMAKE_BUILD_TYPE=${{ inputs.cmake-config-name }}
+        echo "::endgroup::"
+        echo "✓ CMake configuration completed"
+
+    - name: Perform openDAQ CMake build
+      shell: bash
+      run: |
+        echo "CMake Build:"
+        echo "  Config: ${{ inputs.cmake-config-name }}"
+        echo "  Parallel: ${{ inputs.cmake-parallel }}"
+        echo ""
+        echo "::group::CMake Build Output"
+        cmake --build build --config ${{ inputs.cmake-config-name }} ${{ inputs.cmake-parallel }}
+        echo "::endgroup::"
+        echo "✓ Build completed successfully"
+
+    - name: Package openDAQ CPack
+      shell: bash
+      run: |
+        echo "CPack Packaging:"
+        echo "  Generator: ${{ inputs.cpack-generator }}"
+        echo ""
+        echo "::group::CPack Output"
+        cpack --config build/CPackConfig.cmake -G ${{ inputs.cpack-generator }}
+        echo "::endgroup::"
+        echo "✓ Package created successfully"
+
+    - name: Read openDAQ version
+      id: opendaq-framework-version
+      shell: bash
+      run: |
+        version=$(cat opendaq_version)
+        version="v${version%%dev}"
+        echo "Head openDAQ version: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Compose openDAQ framework filename
+      id: opendaq-framework-filename
+      uses: openDAQ/actions/framework-compose-filename@jira/TBBAS-2680-opendaq-gh-actions-github-api-wrapper-unit-tests
+      with:
+        version: ${{ steps.opendaq-framework-version.outputs.version }}
+        packaging: ${{ inputs.cpack-generator }}
+
+    - name: Rename openDAQ framework package to artifact
+      shell: bash
+      env:
+        OPENDAQ_FRAMEWORK_FILENAME: ${{ steps.opendaq-framework-filename.outputs.filename }}
+      run: |
+        echo "Preparing Artifact:"
+        echo "  Target: $OPENDAQ_FRAMEWORK_FILENAME"
+        echo ""
+
+        echo "::group::Searching for package file"
+        echo "Search directory: build/_packages"
+        echo "Search pattern: opendaq*"
+        ls -lah build/_packages/ || echo "Directory not found or empty"
+        echo "::endgroup::"
+
+        source=$(find build/_packages -type f -iname 'opendaq*' | head -n1)
+
+        if [ -z "$source" ]; then
+          echo "::error::No package file found matching pattern 'opendaq*' in build/_packages"
+          exit 1
+        fi
+
+        echo "Found: $source ($(du -h "$source" | cut -f1))"
+
+        target="$OPENDAQ_FRAMEWORK_FILENAME"
+        cp "$source" "./$target"
+
+        if [ -f "./$target" ]; then
+          echo "✓ Artifact prepared successfully"
+          ls -lh "./$target"
+        else
+          echo "::error::Failed to copy artifact from '$source' to '$target'"
+          exit 1
+        fi
+
+    - name: Upload artifact
+      id: opendaq-upload-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.opendaq-framework-filename.outputs.filename }}
+        path: ${{ steps.opendaq-framework-filename.outputs.filename }}
+        retention-days: 30
+
+    - name: Verify artifact upload
+      shell: bash
+      run: |
+        echo "✓ Artifact uploaded successfully"
+        echo "  Name: ${{ steps.opendaq-framework-filename.outputs.filename }}"
+        echo "  Retention: 30 days"
+
+    - name: Print compiler cache stats
+      shell: bash
+      run: |
+        echo "::group::Compiler cache statistics"
+        ccache -s -v
+        echo "::endgroup::"

--- a/.github/workflows/package-artifact-trigger.yml
+++ b/.github/workflows/package-artifact-trigger.yml
@@ -1,0 +1,128 @@
+name: Build and Upload Artifacts and trigger downstream
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  artifacts-prepare:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            cmake-compiler:
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+              -DCMAKE_C_COMPILER=gcc
+              -DCMAKE_CXX_COMPILER=g++
+            cmake-defines: ''
+            cmake-generator: Ninja
+            cmake-preset: ''
+            cmake-parallel: ''
+            cpack-generator: DEB
+          - os: macos-13
+            cmake-compiler:
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+            cmake-defines: ''
+            cmake-generator: Ninja
+            cmake-preset: ''
+            cmake-parallel: ''
+            cpack-generator: TGZ
+          - os: windows-latest
+            cmake-compiler:
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+              -DCMAKE_C_COMPILER=cl
+              -DCMAKE_CXX_COMPILER=cl
+            cmake-defines: ''
+            cmake-generator: Ninja
+            cmake-preset: ''
+            cmake-parallel: ''
+            cpack-generator: NSIS
+
+    steps:
+      - name: Checkout openDAQ repository
+        uses: actions/checkout@v4
+
+      - name: Setup compiler cache directory
+        id: ccache-config
+        shell: bash
+        run: |
+          # Default for Linux/macOS
+          CCACHE_PATH="$GITHUB_WORKSPACE/.ccache"
+
+          # Windows-specific settings
+          if command -v cygpath &> /dev/null; then
+            CCACHE_PATH="$(cygpath -w "$GITHUB_WORKSPACE/.ccache")"
+            BASEDIR_PATH="$(cygpath -w "$GITHUB_WORKSPACE")"
+            echo "CCACHE_BASEDIR=$BASEDIR_PATH" >> "$GITHUB_ENV"
+            echo "CCACHE_SLOPPINESS=pch_defines,time_macros" >> "$GITHUB_ENV"
+          fi
+
+          echo "CCACHE_DIR=$CCACHE_PATH" >> "$GITHUB_ENV"
+          echo "dir=$CCACHE_PATH" >> "$GITHUB_OUTPUT"
+          echo "Using CCACHE_DIR: $CCACHE_PATH"
+
+      - name: Restore compiler cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.ccache-config.outputs.dir }}
+          key: ccache-${{ runner.os }}-${{ hashFiles('**/*.c','**/*.cpp') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+
+      - name: Build and package openDAQ
+        uses: ./.github/actions/build-artifact
+        with:
+          cmake-compiler: ${{ matrix.cmake-compiler }}
+          cmake-config-name: Release
+          cmake-defines: >-
+            -DOPENDAQ_ENABLE_TESTS=OFF
+            -DOPENDAQ_BUILD_DOCUMENTATION=OFF
+            -DDAQSIMULATOR_ENABLE_SIMULATOR_APP=OFF
+            -DDAQMODULES_REF_FB_MODULE=OFF
+            -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF
+            -DDAQMODULES_REF_DEVICE_MODULE=OFF
+            -DDAQMODULES_AUDIO_DEVICE_MODULE=OFF
+            -DDAQMODULES_OPENDAQ_CLIENT_MODULE=OFF
+            -DDAQMODULES_OPENDAQ_SERVER_MODULE=OFF
+            -DDAQMODULES_BASIC_CSV_RECORDER_MODULE=OFF
+            -DOPENDAQ_ENABLE_OPCUA=OFF
+            -DOPENDAQ_ENABLE_WEBSOCKET_STREAMING=OFF
+            -DOPENDAQ_ENABLE_NATIVE_STREAMING=OFF
+            ${{ matrix.cmake-defines }}
+          cmake-generator: ${{ matrix.cmake-generator }}
+          cmake-preset: ${{ matrix.cmake-preset }}
+          cmake-parallel: ${{ matrix.cmake-parallel }}
+          cpack-generator: ${{ matrix.cpack-generator }}
+
+  artifacts-test:
+    needs: artifacts-prepare
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            file-name: opendaq-3.31.0-ubuntu24.04-x86_64.deb
+          - os: windows-latest
+            file-name: opendaq-3.31.0-win64.exe
+
+    uses: openDAQ/SimpleDeviceModule/.github/workflows/ci-framework.yml@jira/TBBAS-2554_add_example_module_ci_framework
+    with:
+      runner: ${{ matrix.os }}
+      branch: 'jira/TBBAS-2554_add_example_module_ci_framework'
+      artifact-run-id: ${{ github.run_id }}
+      artifact-name: ${{ matrix.file-name }}
+      file-name: ${{ matrix.file-name }}
+    permissions:
+      contents: read


### PR DESCRIPTION
# Brief

Add CI workflow for building and uploading openDAQ package artifacts across multiple platforms.

# Dependencies
- Depends on openDAQ/actions#16 
- Depends on openDAQ/SimpleDeviceModule#6

# Description

- Added composite action `.github/actions/build-artifact/` for building and packaging openDAQ
- Added trigger workflow `.github/workflows/package-artifact-trigger.yml` with platform matrix (Ubuntu, macOS, Windows)
- Configured ccache integration for faster builds (3-6 min vs 15-20 min)
- Configured CPack generators: DEB (Ubuntu), NSIS (Windows), TGZ (macOS)
- Artifacts uploaded with 30-day retention

# Usage example

Workflow runs automatically on:
- Push to `main` branch
- Pull requests targeting `main`

Manual trigger:
```bash
gh workflow run package-artifact-trigger.yml
```

Download artifacts:
```bash
gh run download <run-id>
```

# API changes

N/A – no API changes introduced.

# Required application changes

N/A – applications remain unaffected.

# Required module changes

N/A – modules remain unaffected.
