### PR TITLE
other/delete_source_manager_on_remove

### DIFF
--- a/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
@@ -219,6 +219,8 @@ void MirroredDeviceBase<Interfaces...>::removed()
     // disconnects all streaming connections
     streamingSources.clear();
 
+    streamingSourceManager.reset();
+
     Super::removed();
 }
 


### PR DESCRIPTION
# Brief

Fix streaming initialization failure if a device is removed and re-added, but the old device reference is still alive.

# Description

The following sequence fails to initialize streaming:
- add native device
- stream some data from device (via multireader)
- stop streaming (destroy multireader)
- reboot device (after FW upgrade)
- wait until the device reconnects
- remove the device (but keep the reference to the device in the client code)
- add the same device
- streaming fails to initialize

The reference to the old device causes core events to trigger on the old device, which stops streaming initialization from continuing.