### PR TITLE
Fix filename of Ubuntu zips uploaded to AWS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -382,6 +382,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           rename 's/-Linux/-ubuntu22.04-${{ matrix.arch }}_${{ steps.short-sha.outputs.sha }}/' *.zip
+          rename 's/openDAQ/opendaq/' *.zip
 
       - name: Rename package
         working-directory: ${{ env.package_path_rel }}
@@ -396,6 +397,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           rename 's/-Linux/-ubuntu22.04-${{ matrix.arch }}/' *.zip
+          rename 's/openDAQ/opendaq/' *.zip
 
       - name: Read openDAQ version
         id: daq_version


### PR DESCRIPTION
# Brief

The filenames of Ubuntu zips uploaded to AWS on the main branch are incorrect (the capitalization is wrong).
This is needed on the main branch, because that's what perf-testing framework uses.