### PR TITLE
Set default operation mode for 3.10 native client devices

### DIFF
--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -28,6 +28,7 @@
 
 ## Bug fixes
 
+- [#930](https://github.com/openDAQ/openDAQ/pull/930) Fixes the operation mode of 3.10 native-client devices with no op-mode support to be "Operation" by default
 - [#880](https://github.com/openDAQ/openDAQ/pull/880) Fix OPC UA warnings related to writing default values to a node.
 - [#848](https://github.com/openDAQ/openDAQ/pull/848) Do not throw an exception when getting operation modes on old devices. Return default state instead.
 - [#827](https://github.com/openDAQ/openDAQ/pull/827) Fix setting irrelevant streaming source as active.

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -102,6 +102,8 @@ GenericConfigClientDeviceImpl<TDeviceBase>::GenericConfigClientDeviceImpl(const 
                                                                           const StringPtr& className)
     : Super(configProtocolClientComm, remoteGlobalId, ctx, parent, localId, className)
 {
+    if (this->clientComm->getProtocolVersion() < 9)
+        this->updateOperationModeNoCoreEvent(OperationModeType::Operation);
 }
 
 template <class TDeviceBase>


### PR DESCRIPTION
# Brief

Fixes the operation mode of 3.10 native-client devices with no op-mode support to be "Operation" by default