### PR TITLE
Bugfix: Permissions memleak

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -71,8 +71,7 @@ namespace object_utils
         bool try_lock() { return true; }
     };
 
-    static const auto UnrestrictedPermissions =
-        PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
+    inline const auto createUnrestrictedPermissions() { return PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build(); }
 }
 
 class RecursiveConfigLockGuard : public std::enable_shared_from_this<RecursiveConfigLockGuard>
@@ -636,7 +635,7 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
 
     this->permissionManager = PermissionManager();
-    this->permissionManager.setPermissions(object_utils::UnrestrictedPermissions);
+    this->permissionManager.setPermissions(object_utils::createUnrestrictedPermissions());
 
     PropertyValueEventEmitter readEmitter;
     PropertyValueEventEmitter writeEmitter;

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -71,7 +71,12 @@ namespace object_utils
         bool try_lock() { return true; }
     };
 
-    inline const auto createUnrestrictedPermissions() { return PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build(); }
+    inline const auto UnrestrictedPermissions = []() { 
+        daqDisableObjectTracking();
+        auto permissions = PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
+        daqEnableObjectTracking();
+        return permissions;
+    }();
 }
 
 class RecursiveConfigLockGuard : public std::enable_shared_from_this<RecursiveConfigLockGuard>
@@ -635,7 +640,7 @@ GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::GenericPropertyObjec
     objPtr = this->template borrowPtr<PropertyObjectPtr>();
 
     this->permissionManager = PermissionManager();
-    this->permissionManager.setPermissions(object_utils::createUnrestrictedPermissions());
+    this->permissionManager.setPermissions(object_utils::UnrestrictedPermissions);
 
     PropertyValueEventEmitter readEmitter;
     PropertyValueEventEmitter writeEmitter;

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -12,7 +12,13 @@ BEGIN_NAMESPACE_OPENDAQ
 
 namespace detail
 {
-    static const auto DefaultPermissions = PermissionsBuilder().inherit(true).build();
+    static const auto DefaultPermissions = []()
+    {
+        daqDisableObjectTracking();
+        auto permissions = PermissionsBuilder().inherit(true).build();
+        daqEnableObjectTracking();
+        return permissions;
+    }();
 }
 
 PermissionManagerImpl::PermissionManagerImpl(const PermissionManagerPtr& parent)

--- a/core/coretypes/include/coretypes/intfs.h
+++ b/core/coretypes/include/coretypes/intfs.h
@@ -39,6 +39,8 @@ extern "C" PUBLIC_EXPORT void daqPrintTrackedObjects();
 extern "C" PUBLIC_EXPORT void daqClearTrackedObjects();
 extern "C" PUBLIC_EXPORT daq::Bool daqIsTrackingObjects();
 extern "C" PUBLIC_EXPORT void daqPrepareHeapAlloc();
+extern "C" PUBLIC_EXPORT void daqDisableObjectTracking();
+extern "C" PUBLIC_EXPORT void daqEnableObjectTracking();
 
 BEGIN_NAMESPACE_OPENDAQ
 


### PR DESCRIPTION
# Brief
Replace static `Permissions` object to factory function to get rid of memory leak 
# Description
None
# Usage example
None
# API changes
```diff
+ extern "C" PUBLIC_EXPORT void daqDisableObjectTracking();
+ extern "C" PUBLIC_EXPORT void daqEnableObjectTracking();
```
# Required application changes
None