### PR TITLE
fixed module manager relative path module search

### DIFF
--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -1767,8 +1767,6 @@ void GetModulesPath(std::vector<fs::path>& modulesPath, const LoggerComponentPtr
     if (!fs::is_directory(searchFolder, errCode))
         DAQ_THROW_EXCEPTION(InvalidParameterException, fmt::format(R"(The specified path "{}" is not a folder.)", searchFolder));
 
-    fs::recursive_directory_iterator dirIterator(searchFolder);
-
     [[maybe_unused]]
     Finally onExit([workingDir = fs::current_path()]
     {
@@ -1776,6 +1774,7 @@ void GetModulesPath(std::vector<fs::path>& modulesPath, const LoggerComponentPtr
     });
 
     fs::current_path(searchFolder);
+    fs::recursive_directory_iterator dirIterator(fs::current_path());
 
     const auto endIter = fs::recursive_directory_iterator();
     while (dirIterator != endIter)

--- a/core/opendaq/modulemanager/tests/module_manager_test.cpp
+++ b/core/opendaq/modulemanager/tests/module_manager_test.cpp
@@ -115,7 +115,7 @@ TEST_F(ModuleManagerTest, EnumDriver)
     ListPtr<IModule> moduleDrivers = moduleManager.getModules();
     auto count = moduleDrivers.getCount();
 
-    ASSERT_EQ(count, 0u);
+    ASSERT_EQ(count, 1u);
 
     std::cout << "Module driver count: " << count << std::endl;
 


### PR DESCRIPTION
# Brief

Fixed relative path search in ModuleManagerImpl::GetModulesPath.
Changed one module manager test to match new result.

