### PR TITLE
added protected setter for ctObjects when overriding config properties

### DIFF
--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -1474,8 +1474,18 @@ void ModuleManagerImpl::overrideConfigProperties(PropertyObjectPtr& targetConfig
         if (sourceConfig.hasProperty(name))
         {
             const auto sourcePropValue = sourceConfig.getPropertyValue(name);
+            auto property = targetConfig.getProperty(name);
             if (targetConfig.getPropertyValue(name) != sourcePropValue)
-                targetConfig.setPropertyValue(name, sourcePropValue);
+            {
+                if (property.getValueType() == ctObject)
+                {
+                    targetConfig.asPtr<IPropertyObjectProtected>().setProtectedPropertyValue(name, sourcePropValue);
+                }
+                else
+                {
+                    targetConfig.setPropertyValue(name, sourcePropValue);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Brief

Added protected set property value call.

# Description

`setPropertyValueInternal` throws `ACCESS_DENIED` when trying to change `ctObjects` so I added a protected call as per Nikolai's suggestion.

