### PR TITLE
Fix compatibility issue with 3.10 in C2D-streaming

### DIFF
--- a/changelog/changelog_3.20-3.30.md
+++ b/changelog/changelog_3.20-3.30.md
@@ -28,6 +28,7 @@
 
 ## Bug fixes
 
+- [#936](https://github.com/openDAQ/openDAQ/pull/936) Fix compatibility issue with SDK v3.10 in client-to-device-streaming
 - [#930](https://github.com/openDAQ/openDAQ/pull/930) Fixes the operation mode of 3.10 native-client devices with no op-mode support to be "Operation" by default
 - [#925](https://github.com/openDAQ/openDAQ/pull/925) Set of discovery fixes for DNS resolution and enabling of multi-network card devices.
 - [#880](https://github.com/openDAQ/openDAQ/pull/880) Fix OPC UA warnings related to writing default values to a node.

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -231,7 +231,8 @@ public:
                                   const SendNoReplyRequestCallback& sendNoReplyRequestCallback,
                                   const HandleDaqPacketCallback& handleDaqPacketCallback,
                                   const SendPreprocessedPacketsCallback& sendPreprocessedPacketsCb,
-                                  const ServerNotificationReceivedCallback& serverNotificationReceivedCallback);
+                                  const ServerNotificationReceivedCallback& serverNotificationReceivedCallback,
+                                  const DowngradePacketStreamingCallback& downgradePacketStreamingCallback = nullptr);
 
     // called from client module
     DevicePtr connect(const ComponentPtr& parent = nullptr, uint16_t protocolVersion = GetLatestConfigProtocolVersion());
@@ -253,6 +254,7 @@ private:
     ServerNotificationReceivedCallback serverNotificationReceivedCallback;
     DeserializerPtr deserializer;
     ConfigProtocolStreamingProducerPtr streamingProducer;
+    DowngradePacketStreamingCallback downgradePacketStreamingCallback;
 
     ConfigProtocolClientCommPtr clientComm;
     
@@ -273,12 +275,14 @@ ConfigProtocolClient<TRootDeviceImpl>::ConfigProtocolClient(const ContextPtr& da
                                                             const SendNoReplyRequestCallback& sendNoReplyRequestCallback,
                                                             const HandleDaqPacketCallback& handleDaqPacketCallback,
                                                             const SendPreprocessedPacketsCallback& sendPreprocessedPacketsCb,
-                                                            const ServerNotificationReceivedCallback& serverNotificationReceivedCallback)
+                                                            const ServerNotificationReceivedCallback& serverNotificationReceivedCallback,
+                                                            const DowngradePacketStreamingCallback& downgradePacketStreamingCallback)
     : daqContext(daqContext)
     , sendRequestCallback(sendRequestCallback)
     , serverNotificationReceivedCallback(serverNotificationReceivedCallback)
     , deserializer(JsonDeserializer())
     , streamingProducer(std::make_shared<ConfigProtocolStreamingProducer>(daqContext, handleDaqPacketCallback, sendPreprocessedPacketsCb))
+    , downgradePacketStreamingCallback(downgradePacketStreamingCallback)
     , clientComm(
           std::make_shared<ConfigProtocolClientComm>(
               daqContext,
@@ -346,6 +350,10 @@ void ConfigProtocolClient<TRootDeviceImpl>::protocolHandshake(uint16_t protocolV
     // enable signal reading within basic client-to-device streaming
     if (protocolVersion < 18)
         streamingProducer->enableReading();
+
+    // downgrade packet streaming serializer to version 1
+    if (protocolVersion < 10 && downgradePacketStreamingCallback)
+        downgradePacketStreamingCallback(1);
 }
 
 template<class TRootDeviceImpl>

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_streaming_producer.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_streaming_producer.h
@@ -28,6 +28,7 @@ namespace daq::config_protocol
 
 using HandleDaqPacketCallback = std::function<void(PacketPtr&& /*packet*/, SignalNumericIdType /*signalNumericId*/)>;
 using SendPreprocessedPacketsCallback = std::function<void()>;
+using DowngradePacketStreamingCallback = std::function<void(Int /*jsonSerializerVersion*/)>;
 
 class ConfigProtocolStreamingProducer
 {

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_client_handler.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/native_streaming_client_handler.h
@@ -62,6 +62,8 @@ public:
     void pushOneStreamingPacket(SignalNumericIdType signalNumericId, PacketPtr&& packet);
     void sendAvailableStreamingPackets();
 
+    void downgradePacketStreamingServer(Int jsonSerializerVersion);
+
     void resetStreamingHandlers();
     void setStreamingHandlers(const OnSignalAvailableCallback& signalAvailableHandler,
                               const OnSignalUnavailableCallback& signalUnavailableHandler,
@@ -199,6 +201,8 @@ public:
     void sendConfigRequest(const config_protocol::PacketBuffer& packet);
     void sendStreamingRequest();
     void sendStreamingPacket(SignalNumericIdType signalNumericId, PacketPtr&& packet);
+
+    void downgradePacketStreamingServer(Int jsonSerializerVersion);
 
     void resetStreamingHandlers();
     void setStreamingHandlers(const OnSignalAvailableCallback& signalAvailableHandler,

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_client_handler.cpp
@@ -396,6 +396,15 @@ void NativeStreamingClientImpl::sendAvailableStreamingPackets()
     }
 }
 
+void NativeStreamingClientImpl::downgradePacketStreamingServer(Int jsonSerializerVersion)
+{
+    packetStreamingServerPtr =
+        std::make_shared<packet_streaming::PacketStreamingServer>(packet_streaming::PACKET_ZERO_PAYLOAD_SIZE,
+                                                                  packet_streaming::PACKET_RELEASE_THRESHOLD_DEFAULT,
+                                                                  false,
+                                                                  jsonSerializerVersion);
+}
+
 void NativeStreamingClientImpl::onSessionError(const std::string& errorMessage, SessionPtr session)
 {
     LOG_W("Closing connection caused by: {}", errorMessage);
@@ -516,7 +525,6 @@ void NativeStreamingClientImpl::initClientSessionHandler(SessionPtr session)
     };
     sessionHandler->setPacketBufferReceivedHandler(packetBufferReceivedHandler);
 
-    // FIXME keep and reuse packet server when packet retransmission feature will be enabled
     packetStreamingServerPtr =
         std::make_shared<packet_streaming::PacketStreamingServer>(packet_streaming::PACKET_ZERO_PAYLOAD_SIZE,
                                                                   packet_streaming::PACKET_RELEASE_THRESHOLD_DEFAULT,
@@ -687,6 +695,11 @@ void NativeStreamingClientHandler::sendStreamingRequest()
 void NativeStreamingClientHandler::sendStreamingPacket(SignalNumericIdType signalNumericId, PacketPtr&& packet)
 {
     clientHandlerPtr->sendOneStreamingPacket(signalNumericId, std::move(packet));
+}
+
+void NativeStreamingClientHandler::downgradePacketStreamingServer(Int jsonSerializerVersion)
+{
+    clientHandlerPtr->downgradePacketStreamingServer(jsonSerializerVersion);
 }
 
 std::shared_ptr<boost::asio::io_context> NativeStreamingClientHandler::getIoContext()

--- a/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming_server.h
+++ b/shared/libraries/packet_streaming/include/packet_streaming/packet_streaming_server.h
@@ -43,7 +43,8 @@ class PacketStreamingServer
 public:
     PacketStreamingServer(size_t cacheablePacketPayloadSizeMax,
                           size_t releaseThreshold,
-                          bool attachTimestampToPacketBuffer);
+                          bool attachTimestampToPacketBuffer,
+                          Int jsonSerializerVersion = 0);
 
     void addDaqPacket(const uint32_t signalId, const PacketPtr& packet);
     void addDaqPacket(const uint32_t signalId, PacketPtr&& packet);

--- a/shared/libraries/packet_streaming/src/packet_streaming_server.cpp
+++ b/shared/libraries/packet_streaming/src/packet_streaming_server.cpp
@@ -11,8 +11,9 @@ namespace daq::packet_streaming
 
 PacketStreamingServer::PacketStreamingServer(size_t cacheablePacketPayloadSizeMax,
                                              size_t releaseThreshold,
-                                             bool attachTimestampToPacketBuffer)
-    : jsonSerializer(JsonSerializer())
+                                             bool attachTimestampToPacketBuffer,
+                                             Int jsonSerializerVersion)
+    : jsonSerializer(jsonSerializerVersion ? JsonSerializerWithVersion(jsonSerializerVersion) : JsonSerializer())
     , countOfNonCacheableBuffers(0)
     , currentCacheablePacketGroupId(0)
     , packetCollection(std::make_shared<PacketCollection>())


### PR DESCRIPTION
# Brief

Fixes a crash in device applications based on SDK v3.10 that occurred when client-to-device streaming is running and the config protocol version number in use is lower than 10.

# Description

- Enables downgrading the JSON serializer version in the packet streaming server used for client-to-device streaming.