### PR TITLE
Add option to set configuration serialization pretty print

### DIFF
--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -46,6 +46,7 @@
 #include <opendaq/connection_status_container_private_ptr.h>
 #include <opendaq/connection_status_container_impl.h>
 #include <opendaq/device_network_config.h>
+#include <opendaq/option_helpers.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 template <typename TInterface = IDevice, typename... Interfaces>
@@ -241,7 +242,6 @@ protected:
     ErrCode updateOperationModeInternal(OperationModeType modeType);
 
     DevicePtr getParentDevice();
-
 private:
     void getChannelsFromFolder(ListPtr<IChannel>& channelList, const FolderPtr& folder, const SearchFilterPtr& searchFilter, bool filterChannels = true);
     ListPtr<ISignal> getSignalsRecursiveInternal(const SearchFilterPtr& searchFilter);
@@ -1694,8 +1694,10 @@ ErrCode GenericDevice<TInterface, Interfaces...>::saveConfiguration(IString** co
 
     const ErrCode errCode = daqTry([this, &configuration]
     {
-        auto serializer = JsonSerializer(True);
-        const ErrCode errCode = this->serialize(serializer);
+        const auto prettyPrint = getPrettyPrintOnSaveConfig(this->context.getOptions());
+        auto serializer = JsonSerializer(prettyPrint);
+
+        const ErrCode errCode = this->serializeForUpdate(serializer);
         OPENDAQ_RETURN_IF_FAILED(errCode);
 
         return serializer->getOutput(configuration);

--- a/core/opendaq/opendaq/src/instance_builder_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_builder_impl.cpp
@@ -29,6 +29,9 @@ DictPtr<IString, IBaseObject> InstanceBuilderImpl::GetDefaultOptions()
             {"DefaultLocalId", ""},
             {"ConnectionString", ""}
         })},
+        {"Configuration", Dict<IString, IBaseObject>({
+            {"SerializePrettyPrint", False}
+        })},
         {"Modules", Dict<IString, IBaseObject>(
         )}
     });

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -16,6 +16,7 @@
 
 #include <opendaq/module_manager_utils_ptr.h>
 #include <opendaq/discovery_server_factory.h>
+#include <opendaq/option_helpers.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -589,7 +590,8 @@ ErrCode InstanceImpl::saveConfiguration(IString** configuration)
 
     const ErrCode errCode = daqTry([this, &configuration]()
     {
-        auto serializer = JsonSerializer(True);
+        const auto prettyPrint = getPrettyPrintOnSaveConfig(this->context.getOptions());
+        auto serializer = JsonSerializer(prettyPrint);
 
         const ErrCode errCode = this->serializeForUpdate(serializer);
         OPENDAQ_RETURN_IF_FAILED(errCode);

--- a/core/opendaq/utility/include/opendaq/option_helpers.h
+++ b/core/opendaq/utility/include/opendaq/option_helpers.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <coretypes/dict_ptr.h>
+#include <coretypes/dictobject.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+inline bool getPrettyPrintOnSaveConfig(const DictObjectPtr<IDict, IString, IBaseObject>& options)
+{
+    const auto configurationOptions = options.get("Configuration").template asPtrOrNull<IDict, DictObjectPtr<IDict, IString, IBaseObject>>(true);
+    if (!configurationOptions.assigned())
+        return false;
+
+    if (configurationOptions.hasKey("SerializePrettyPrint"))
+        return configurationOptions.get("SerializePrettyPrint");
+
+    return false;
+}
+
+
+END_NAMESPACE_OPENDAQ
+

--- a/core/opendaq/utility/include/opendaq/option_helpers.h
+++ b/core/opendaq/utility/include/opendaq/option_helpers.h
@@ -22,6 +22,9 @@ BEGIN_NAMESPACE_OPENDAQ
 
 inline bool getPrettyPrintOnSaveConfig(const DictObjectPtr<IDict, IString, IBaseObject>& options)
 {
+    if (!options.hasKey("Configuration"))
+        return false;
+
     const auto configurationOptions = options.get("Configuration").template asPtrOrNull<IDict, DictObjectPtr<IDict, IString, IBaseObject>>(true);
     if (!configurationOptions.assigned())
         return false;

--- a/core/opendaq/utility/src/CMakeLists.txt
+++ b/core/opendaq/utility/src/CMakeLists.txt
@@ -51,6 +51,7 @@ function(create_component_source_groups_${BASE_NAME})
         ${SDK_HEADERS_DIR}/utility_errors.h
         ${SDK_HEADERS_DIR}/utility_exceptions.h
         ${SDK_SRC_DIR}/utility.natvis
+        ${SDK_HEADERS_DIR}/option_helpers.h
     )
 endfunction()
 
@@ -74,6 +75,7 @@ set(SRC_PublicHeaders_Component
     packet_buffer_builder_impl.h
     mem_pool_allocator.h
     thread_name.h
+    option_helpers.h
     PARENT_SCOPE
 )
 


### PR DESCRIPTION
# Brief

Add an option to set pretty print for the `saveConfiguration` call. Save device configuration with `forUpdate` option.

# Description

The `saveConfiguration` method always uses pretty print. This PR adds an option to switch this off. The preferred method would be to pass this option as a method parameter, but this would break the API. As a workaround, this behaviour can be set through context options.

This PR also fixes issue SHS-233.

# Usage example

In C++ use:

```cpp
builder.getOptions().get("Configuration").asPtrOrNull<IDict, DictPtr<IString, IBaseObject>>(true).set("SerializePrettyPrint", False);
```
