### PR TITLE
Prevent error when removing a device with a subdevice in Python GUI application

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -46,7 +46,6 @@ class AppContext(object):
         
         self.instance = daq.InstanceFromBuilder(builder)
         self.instance.context.on_core_event + daq.QueuedEventHandler(self.on_core_event)
-        self.enabled_devices = {}
         self.connection_string = ''
         self.signals = {}
         self.on_needs_refresh: Optional[Callable[[], None]] = None
@@ -59,11 +58,7 @@ class AppContext(object):
 
         device = parent_device.add_device(
             device_info.connection_string, config)
-        if device:
-            device_info.name = device.local_id
-            device_info.serial_number = device.info.serial_number
-            self.enabled_devices[device.info.connection_string] = {
-                'device_info': device_info, 'device': device}
+
         return device
 
     def remove_device(self, device):
@@ -72,14 +67,7 @@ class AppContext(object):
         parent_device = utils.get_nearest_device(device.parent)
         if parent_device is None:
             return
-
-        subdevices = utils.list_all_subdevices(device)
-        for subdevice in subdevices:
-            del self.enabled_devices[subdevice.info.connection_string]
-
-        conn_string = device.info.connection_string
         parent_device.remove_device(device)
-        del self.enabled_devices[conn_string]
 
     def add_first_available_device(self):
         device_info = DeviceInfoLocal(self.connection_string)

--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -51,16 +51,6 @@ class AppContext(object):
         self.signals = {}
         self.on_needs_refresh: Optional[Callable[[], None]] = None
 
-    def register_device(self, device_info):
-        conn = device_info.connection_string
-        # ignore reference devices unless explicitly requested
-        if not self.include_reference_devices and 'daqref' in conn:
-            return
-        # only add device to the list if it isn't there already
-        if not conn in self.enabled_devices:
-            self.enabled_devices[conn] = {
-                'device_info': device_info, 'device': None}
-
     def add_device(self, device_info, parent_device: daq.IDevice, config=None):
         if device_info is None:
             return None
@@ -90,12 +80,6 @@ class AppContext(object):
         conn_string = device.info.connection_string
         parent_device.remove_device(device)
         del self.enabled_devices[conn_string]
-
-    def scan_devices(self, parent_device=None):
-        parent_device = parent_device or self.instance
-
-        for device_info in parent_device.available_devices:
-            self.register_device(device_info)
 
     def add_first_available_device(self):
         device_info = DeviceInfoLocal(self.connection_string)

--- a/examples/applications/python/GUI Application/gui_demo/components/add_device_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_device_dialog.py
@@ -48,8 +48,8 @@ class AddDeviceDialog(Dialog):
 
         right_side_frame = ttk.Frame(self)
         device_tree_frame = ttk.Frame(right_side_frame)
-        device_tree = ttk.Treeview(device_tree_frame, columns=('used', 'name', 'conn'), displaycolumns=(
-            'used', 'name', 'conn'), show='tree headings', selectmode=tk.BROWSE)
+        device_tree = ttk.Treeview(device_tree_frame, columns=('name', 'conn'), displaycolumns=(
+            'name', 'conn'), show='tree headings', selectmode=tk.BROWSE)
 
         device_scroll_bar = ttk.Scrollbar(
             device_tree_frame, orient=tk.VERTICAL, command=device_tree.yview)
@@ -59,12 +59,10 @@ class AddDeviceDialog(Dialog):
         self.device_tree = device_tree
         self.parent_device_tree = parent_device_tree
 
-        device_tree.heading('used', text='Used', anchor=tk.W)
         device_tree.heading('name', text='Name', anchor=tk.W)
         device_tree.heading('conn', text='Connection string', anchor=tk.W)
 
         device_tree.column('#0', width=0, stretch=False)
-        device_tree.column('used', anchor=tk.W, minwidth=60, width=60)
         device_tree.column('name', anchor=tk.W, minwidth=200)
         device_tree.column('conn', anchor=tk.W, minwidth=300)
 
@@ -136,19 +134,19 @@ class AddDeviceDialog(Dialog):
             return
         item = self.device_tree.item(selected_item)
 
-        connection_string = item['values'][2]
-        if connection_string not in self.context.enabled_devices:
-            config = None
+        connection_string = item['values'][1]
 
-            if self.is_add_with_config():
-                add_config_dialog = AddConfigDialog(
-                    self, self.context, connection_string)
-                add_config_dialog.show()
-                config = add_config_dialog.device_config
-                if config is None:
-                    return
+        config = None
 
-            self.add_device(connection_string, config)
+        if self.is_add_with_config():
+            add_config_dialog = AddConfigDialog(
+                self, self.context, connection_string)
+            add_config_dialog.show()
+            config = add_config_dialog.device_config
+            if config is None:
+                return
+
+        self.add_device(connection_string, config)
 
     def handle_right_click(self, event):
         utils.treeview_select_item(self.device_tree, event)
@@ -225,10 +223,9 @@ class AddDeviceDialog(Dialog):
             device_info = daq.IDeviceInfo.cast_from(device_info)
             name = device_info.name
             conn = device_info.connection_string
-            used = conn in self.context.enabled_devices
 
             tree.insert('', tk.END, iid=conn, values=(
-                utils.yes_no[used], name, conn))
+                name, conn))
 
     def update_parent_devices(self, tree, parent_id, component):
         tree.delete(*tree.get_children())


### PR DESCRIPTION
# Brief

Prevent error when removing a device with a subdevice in Python GUI application

# Description

- Remove the concept of "used" device (as it doesn't work correctly) and `enabled_devices` from Python GUI application
- Delete unused methods
