### PR TITLE
Rework core event subscription in LT tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,6 @@ jobs:
           GTEST_OUTPUT: "xml:${{ env.test_path }}"
         run: |
           ctest --output-on-failure --preset ${{ env.ctest_preset }} -C ${{ matrix.cmake_build_type }} --test-dir build --verbose
-          ctest --output-on-failure --preset run_tmp_tests -C ${{ matrix.cmake_build_type }} --test-dir build --verbose
           if (Test-Path -Path "${{ env.dotnet_test_path }}") {
             if (! (Test-Path -Path "${{ env.test_path }}")) { mkdir "${{ env.test_path }}" }
             Copy-Item "${{ env.dotnet_test_path }}/*.*" "${{ env.test_path }}"

--- a/CMakeBasePresets.json
+++ b/CMakeBasePresets.json
@@ -322,23 +322,6 @@
                     "name": "test_py_opendaq"
                 }
             }
-        },
-        {
-            "name": "run_tmp_tests",
-            "description": "Run test multiple times",
-            "configurePreset": "ci",
-            "output": {
-                "outputOnFailure": true
-            },
-            "environment": {
-                "GTEST_FILTER": "*WebsocketClientDeviceTestP*",
-                "GTEST_REPEAT": "500"
-            },
-            "filter": {
-                "include": {
-                    "name": "test_websocket_streaming"
-                }
-            }
         }
     ]
 }


### PR DESCRIPTION
# Brief

Replaces range-based `for` loop over `std::vector` of event handlers with index-based loop to prevent false iterator invalidation assertions observed when compiling with Clang + MSVC STL.
