### PR TITLE
Store version info in function blocks and devices in configuration

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -197,6 +197,8 @@ protected:
 
     virtual void onOperationModeChanged(OperationModeType modeType);
 
+    static VersionInfoPtr parseVersionString(const std::string& input);
+
 private:
     EventEmitter<const ComponentPtr, const CoreEventArgsPtr> componentCoreEvent;
 };
@@ -1336,6 +1338,69 @@ void ComponentImpl<Intf, Intfs...>::setComponentStatusWithMessage(const Componen
             LOG_I("{}", logString)
         }
     }
+}
+
+template <class Intf, class... Intfs>
+VersionInfoPtr ComponentImpl<Intf, Intfs...>::parseVersionString(const std::string& input)
+{
+    std::stringstream ss(input);
+    std::string token;
+    int major, minor, patch;
+
+    if (std::getline(ss, token, '.'))
+    {
+        try
+        {
+            major = std::stoi(token);
+        }
+        catch (const std::exception&)
+        {
+            return {};
+        }
+    }
+    else
+    {
+        return {};
+    }
+
+    if (std::getline(ss, token, '.'))
+    {
+        try
+        {
+            minor = std::stoi(token);
+        }
+        catch (const std::exception&)
+        {
+            return {};
+        }
+    }
+    else
+    {
+        return {};
+    }
+
+    if (std::getline(ss, token))
+    {
+        try
+        {
+            patch = std::stoi(token);
+        }
+        catch (const std::exception&)
+        {
+            return {};
+        }
+    }
+    else
+    {
+        return {};
+    }
+
+    if (std::getline(ss, token))
+    {
+        return {};
+    }
+
+    return VersionInfo(major, minor, patch);
 }
 
 using StandardComponent = ComponentImpl<>;

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -47,6 +47,9 @@
 #include <opendaq/connection_status_container_impl.h>
 #include <opendaq/device_network_config.h>
 #include <opendaq/option_helpers.h>
+#include <opendaq/component_type_builder_factory.h>
+#include <opendaq/module_info_factory.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_OPENDAQ
 template <typename TInterface = IDevice, typename... Interfaces>
@@ -214,6 +217,7 @@ protected:
                             const SerializedObjectPtr& item,
                             const BaseObjectPtr& context);
 
+    static void deserializeVersion(const SerializedObjectPtr& serialized, const DeviceInfoPtr& deviceInfo);
     void deserializeCustomObjectValues(const SerializedObjectPtr& serializedObject,
                                        const BaseObjectPtr& context,
                                        const FunctionPtr& factoryCallback) override;
@@ -256,6 +260,7 @@ private:
     DeviceDomainPtr deviceDomain;
     OperationModeType operationMode {OperationModeType::Idle};
     ListPtr<IInteger> availableOperationModes;
+    ModuleInfoPtr getModuleInfoFromDeviceType();
 };
 
 template <typename TInterface, typename... Interfaces>
@@ -1668,6 +1673,18 @@ ErrCode GenericDevice<TInterface, Interfaces...>::revertLockedDevices(
     return status;
 }
 
+template <typename TInterface, typename ... Interfaces>
+ModuleInfoPtr GenericDevice<TInterface, Interfaces...>::getModuleInfoFromDeviceType()
+{
+    if (deviceInfo.assigned())
+    {
+        const auto deviceType = deviceInfo.getDeviceType();
+        if (deviceType.assigned())
+            return deviceType.getModuleInfo();
+    }
+    return nullptr;
+}
+
 template <typename TInterface, typename... Interfaces>
 DevicePtr GenericDevice<TInterface, Interfaces...>::getParentDevice()
 {
@@ -1831,6 +1848,16 @@ inline IoFolderConfigPtr GenericDevice<TInterface, Interfaces...>::addIoFolder(c
 template <typename TInterface, typename ... Interfaces>
 void GenericDevice<TInterface, Interfaces...>::serializeCustomObjectValues(const SerializerPtr& serializer, bool forUpdate)
 {
+    const auto moduleInfo = getModuleInfoFromDeviceType();
+    if (moduleInfo.assigned() && moduleInfo.getVersionInfo().assigned())
+    {
+        const auto version = moduleInfo.getVersionInfo();
+        const auto versionStr = fmt::format("{}.{}.{}", version.getMajor(), version.getMinor(), version.getPatch());
+
+        serializer.key("__version");
+        serializer.writeString(versionStr.c_str(), versionStr.size());
+    }
+
     Super::serializeCustomObjectValues(serializer, forUpdate);
 
     this->serializeFolder(serializer, ioFolder, "IO", forUpdate);
@@ -2074,6 +2101,34 @@ void GenericDevice<TInterface, Interfaces...>::updateIoFolderItem(const FolderPt
                            { updateIoFolderItem(item, itemId, obj, context); });
     }
 }
+
+template <typename TInterface, typename... Interfaces>
+void GenericDevice<TInterface, Interfaces...>::deserializeVersion(const SerializedObjectPtr& serialized, const DeviceInfoPtr& deviceInfo)
+{
+    if (serialized.hasKey("__version"))
+    {
+        const auto version = Super::parseVersionString(serialized.readString("__version"));
+        if (version.assigned())
+        {
+            if (deviceInfo.assigned())
+            {
+                auto devType = deviceInfo.getDeviceType();
+                auto hasDevType = devType.assigned();
+                if (!hasDevType)
+                    devType = DeviceTypeBuilder().setName("__unknown").setId("__unknown").setConnectionStringPrefix("__unknown").build();
+
+                auto moduleInfo = devType.getModuleInfo();
+                if (!moduleInfo.assigned())
+                    moduleInfo = ModuleInfo(version, "__unknown", "_unknown");
+
+                checkErrorInfo(devType.template asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+                if (!hasDevType)
+                    deviceInfo.template asPtr<IDeviceInfoConfig>(true).setDeviceType(devType);
+            }
+        }
+    }
+}
+
 
 template <typename TInterface, typename... Interfaces>
 void GenericDevice<TInterface, Interfaces...>::deserializeCustomObjectValues(const SerializedObjectPtr& serializedObject,

--- a/examples/modules/audio_device_module/include/audio_device_module/audio_device_impl.h
+++ b/examples/modules/audio_device_module/include/audio_device_module/audio_device_impl.h
@@ -29,13 +29,15 @@ BEGIN_NAMESPACE_AUDIO_DEVICE_MODULE
 class AudioDeviceImpl final : public Device
 {
 public:
-    explicit AudioDeviceImpl(const std::shared_ptr<MiniaudioContext>& maContext, const ma_device_id& id, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit AudioDeviceImpl(const ModuleInfoPtr& moduleInfo, const std::shared_ptr<MiniaudioContext>& maContext, const ma_device_id& id, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
     ~AudioDeviceImpl() override;
 
-    static DeviceInfoPtr CreateDeviceInfo(const std::shared_ptr<MiniaudioContext>& maContext, const ma_device_info& deviceInfo);
+    static DeviceInfoPtr CreateDeviceInfo(const ModuleInfoPtr& moduleInfo,
+                                          const std::shared_ptr<MiniaudioContext>& maContext,
+                                          const ma_device_info& deviceInfo);
     static ma_device_id getIdFromConnectionString(std::string connectionString);
     static std::string getConnectionStringFromId(ma_backend backend, ma_device_id id);
-    static DeviceTypePtr createType();
+    static DeviceTypePtr createType(const ModuleInfoPtr& moduleInfo);
 
     // IDevice
     DeviceInfoPtr onGetInfo() override;
@@ -54,6 +56,7 @@ private:
     Int samplesCaptured;
     LoggerPtr logger;
     LoggerComponentPtr loggerComponent;
+    ModuleInfoPtr moduleInfo;
 
     void initProperties();
     void start();

--- a/examples/modules/audio_device_module/include/audio_device_module/wav_reader_fb_impl.h
+++ b/examples/modules/audio_device_module/include/audio_device_module/wav_reader_fb_impl.h
@@ -21,6 +21,7 @@
 #include <opendaq/function_block_impl.h>
 #include <opendaq/input_port_config_ptr.h>
 #include <opendaq/stream_reader_ptr.h>
+#include <opendaq/component_type_private.h>
 
 
 BEGIN_NAMESPACE_AUDIO_DEVICE_MODULE
@@ -28,10 +29,10 @@ BEGIN_NAMESPACE_AUDIO_DEVICE_MODULE
 class WAVReaderFbImpl : public FunctionBlock
 {
 public:
-    explicit WAVReaderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit WAVReaderFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
     ~WAVReaderFbImpl() override;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 
 private:

--- a/examples/modules/audio_device_module/include/audio_device_module/wav_writer_fb_impl.h
+++ b/examples/modules/audio_device_module/include/audio_device_module/wav_writer_fb_impl.h
@@ -28,10 +28,10 @@ BEGIN_NAMESPACE_AUDIO_DEVICE_MODULE
 class WAVWriterFbImpl final : public FunctionBlockImpl<IFunctionBlock, IRecorder>
 {
 public:
-    explicit WAVWriterFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit WAVWriterFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
     ~WAVWriterFbImpl() override;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 private:
     InputPortConfigPtr inputPort;
     std::string fileName;

--- a/examples/modules/audio_device_module/src/audio_device_module_impl.cpp
+++ b/examples/modules/audio_device_module/src/audio_device_module_impl.cpp
@@ -46,7 +46,7 @@ ListPtr<IDeviceInfo> AudioDeviceModule::onGetAvailableDevices()
     auto availableDevices = List<IDeviceInfo>();
     for (size_t i = 0; i < captureDeviceCount; i++)
     {
-        auto info = AudioDeviceImpl::CreateDeviceInfo(maContext, pCaptureDeviceInfos[i]);
+        auto info = AudioDeviceImpl::CreateDeviceInfo(moduleInfo, maContext, pCaptureDeviceInfos[i]);
         availableDevices.pushBack(info);
     }
 
@@ -61,7 +61,7 @@ DictPtr<IString, IDeviceType> AudioDeviceModule::onGetAvailableDeviceTypes()
 {
     auto result = Dict<IString, IDeviceType>();
 
-    auto deviceType = AudioDeviceImpl::createType();
+    auto deviceType = AudioDeviceImpl::createType(moduleInfo);
     result.set(deviceType.getId(), deviceType);
 
     return result;
@@ -77,7 +77,7 @@ DevicePtr AudioDeviceModule::onCreateDevice(const StringPtr& connectionString,
 
     std::string localId = fmt::format("MiniAudioDev{}", deviceIndex++);
 
-    auto devicePtr = createWithImplementation<IDevice, AudioDeviceImpl>(maContext, id, context, parent, StringPtr(localId));
+    auto devicePtr = createWithImplementation<IDevice, AudioDeviceImpl>(moduleInfo, maContext, id, context, parent, StringPtr(localId));
     return devicePtr;
 }
 
@@ -85,8 +85,8 @@ DictPtr<IString, IFunctionBlockType> AudioDeviceModule::onGetAvailableFunctionBl
 {
     auto types = Dict<IString, IFunctionBlockType>();
 
-    auto typeWriter = WAVWriterFbImpl::CreateType();
-    auto typeReader = WAVReaderFbImpl::CreateType();
+    auto typeWriter = WAVWriterFbImpl::CreateType(moduleInfo);
+    auto typeReader = WAVReaderFbImpl::CreateType(moduleInfo);
 
     types.set(typeWriter.getId(), typeWriter);
     types.set(typeReader.getId(), typeReader);
@@ -96,14 +96,14 @@ DictPtr<IString, IFunctionBlockType> AudioDeviceModule::onGetAvailableFunctionBl
 
 FunctionBlockPtr AudioDeviceModule::onCreateFunctionBlock(const StringPtr& id, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config)
 {
-    if (id == WAVWriterFbImpl::CreateType().getId())
+    if (id == WAVWriterFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, WAVWriterFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, WAVWriterFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
-    if (id == WAVReaderFbImpl::CreateType().getId())
+    if (id == WAVReaderFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, WAVReaderFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, WAVReaderFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
 

--- a/examples/modules/audio_device_module/src/wav_reader_fb_impl.cpp
+++ b/examples/modules/audio_device_module/src/wav_reader_fb_impl.cpp
@@ -4,8 +4,11 @@
 
 BEGIN_NAMESPACE_AUDIO_DEVICE_MODULE
 
-WAVReaderFbImpl::WAVReaderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+WAVReaderFbImpl::WAVReaderFbImpl(const ModuleInfoPtr& moduleInfo,
+                                 const ContextPtr& ctx,
+                                 const ComponentPtr& parent,
+                                 const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
     , filePath("")
     , decoderInitialized(false)
     , reading(false)
@@ -78,12 +81,15 @@ void WAVReaderFbImpl::sendPacket(DataPacketPtr packet)
     outputSignal.sendPacket(packet);
 }
 
-FunctionBlockTypePtr WAVReaderFbImpl::CreateType()
+FunctionBlockTypePtr WAVReaderFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType(
+    auto fbType = FunctionBlockType(
         "AudioDeviceModuleWavReader",
         "WAVReader",
         "Readers and creates input signals from WAV files");
+
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 bool WAVReaderFbImpl::initializeDecoder()

--- a/examples/modules/audio_device_module/src/wav_writer_fb_impl.cpp
+++ b/examples/modules/audio_device_module/src/wav_writer_fb_impl.cpp
@@ -1,25 +1,29 @@
 #include <audio_device_module/wav_writer_fb_impl.h>
 #include <opendaq/event_packet_utils.h>
 #include <opendaq/reader_factory.h>
+#include <opendaq/function_block_type_factory.h>
+#include <opendaq/component_type_private.h>
 #include <cstdint>
 
 BEGIN_NAMESPACE_AUDIO_DEVICE_MODULE
 
-WAVWriterFbImpl::WAVWriterFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlockImpl<IFunctionBlock, IRecorder>(CreateType(), ctx, parent, localId, nullptr)
+WAVWriterFbImpl::WAVWriterFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+    : FunctionBlockImpl<IFunctionBlock, IRecorder>(CreateType(moduleInfo), ctx, parent, localId, nullptr)
     , recording(false)   
 {
     createInputPort();
     initProperties();
 }
 
-FunctionBlockTypePtr WAVWriterFbImpl::CreateType()
+FunctionBlockTypePtr WAVWriterFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType(
+    auto fbType = FunctionBlockType(
         "AudioDeviceModuleWavWriter",
         "WAVWriter",
         "Writes input signals to WAV files"
     );
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 ErrCode WAVWriterFbImpl::startRecording()

--- a/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
+++ b/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
@@ -30,11 +30,17 @@ BEGIN_NAMESPACE_REF_DEVICE_MODULE
 class RefDeviceImpl final : public Device
 {
 public:
-    explicit RefDeviceImpl(size_t id, const PropertyObjectPtr& config, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId, const StringPtr& name = nullptr);
+    explicit RefDeviceImpl(const ModuleInfoPtr& moduleInfo,
+                           size_t id,
+                           const PropertyObjectPtr& config,
+                           const ContextPtr& ctx,
+                           const ComponentPtr& parent,
+                           const StringPtr& localId,
+                           const StringPtr& name = nullptr);
     ~RefDeviceImpl() override;
 
-    static DeviceInfoPtr CreateDeviceInfo(size_t id, const StringPtr& serialNumber = nullptr);
-    static DeviceTypePtr CreateType();
+    static DeviceInfoPtr CreateDeviceInfo(const ModuleInfoPtr& moduleInfo, size_t id, const StringPtr& serialNumber = nullptr);
+    static DeviceTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
     // IDevice
     DeviceInfoPtr onGetInfo() override;
@@ -99,6 +105,8 @@ private:
     FolderConfigPtr aiFolder;
     FolderConfigPtr canFolder;
     ComponentPtr syncComponent;
+
+    ModuleInfoPtr moduleInfo;
 
     LoggerPtr logger;
     LoggerComponentPtr loggerComponent;

--- a/examples/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_impl.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <utility>
 #include <opendaq/thread_name.h>
+#include <opendaq/component_type_private.h>
 
 #ifdef DAQMODULES_REF_DEVICE_MODULE_SIMULATOR_ENABLED
 #ifdef __linux__
@@ -31,7 +32,8 @@ BEGIN_NAMESPACE_REF_DEVICE_MODULE
 
 StringPtr ToIso8601(const std::chrono::system_clock::time_point& timePoint);
 
-RefDeviceImpl::RefDeviceImpl(size_t id,
+RefDeviceImpl::RefDeviceImpl(const ModuleInfoPtr& moduleInfo,
+                             size_t id,
                              const PropertyObjectPtr& config,
                              const ContextPtr& ctx,
                              const ComponentPtr& parent,
@@ -44,6 +46,7 @@ RefDeviceImpl::RefDeviceImpl(size_t id,
     , microSecondsFromEpochToDeviceStart(0)
     , acqLoopTime(0)
     , stopAcq(false)
+    , moduleInfo(moduleInfo)
     , logger(ctx.getLogger())
     , loggerComponent( this->logger.assigned()
                           ? this->logger.getOrAddComponent(REF_MODULE_NAME)
@@ -92,7 +95,7 @@ RefDeviceImpl::~RefDeviceImpl()
     acqThread.join();
 }
 
-DeviceInfoPtr RefDeviceImpl::CreateDeviceInfo(size_t id, const StringPtr& serialNumber)
+DeviceInfoPtr RefDeviceImpl::CreateDeviceInfo(const ModuleInfoPtr& moduleInfo, size_t id, const StringPtr& serialNumber)
 {
     auto devInfo = DeviceInfoWithChanegableFields({"userName", "location"});
     devInfo.setName(fmt::format("Device {}", id));
@@ -100,7 +103,7 @@ DeviceInfoPtr RefDeviceImpl::CreateDeviceInfo(size_t id, const StringPtr& serial
     devInfo.setManufacturer("openDAQ");
     devInfo.setModel("Reference device");
     devInfo.setSerialNumber(serialNumber.assigned() && serialNumber.getLength() != 0 ? serialNumber : String(fmt::format("DevSer{}", id)));
-    devInfo.setDeviceType(CreateType());
+    devInfo.setDeviceType(CreateType(moduleInfo));
 
     std::string currentTime = ToIso8601(std::chrono::system_clock::now());
     devInfo.addProperty(StringProperty("SetupDate", currentTime));
@@ -108,7 +111,7 @@ DeviceInfoPtr RefDeviceImpl::CreateDeviceInfo(size_t id, const StringPtr& serial
     return devInfo;
 }
 
-DeviceTypePtr RefDeviceImpl::CreateType()
+DeviceTypePtr RefDeviceImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
     const auto defaultConfig = PropertyObject();
     defaultConfig.addProperty(IntProperty("NumberOfChannels", 2));
@@ -120,16 +123,18 @@ DeviceTypePtr RefDeviceImpl::CreateType()
     defaultConfig.addProperty(StringProperty("Name", ""));
     defaultConfig.addProperty(BoolProperty("UsePacketBuffer", False));
 
-    return DeviceType("daqref",
-                      "Reference device",
-                      "Reference device",
-                      "daqref",
-                      defaultConfig);
+    auto deviceType = DeviceType("daqref",
+                                 "Reference device",
+                                 "Reference device",
+                                 "daqref",
+                                 defaultConfig);
+    checkErrorInfo(deviceType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return deviceType;
 }
 
 DeviceInfoPtr RefDeviceImpl::onGetInfo()
 {
-    return RefDeviceImpl::CreateDeviceInfo(id, serialNumber);
+    return RefDeviceImpl::CreateDeviceInfo(moduleInfo, id, serialNumber);
 }
 
 uint64_t RefDeviceImpl::onGetTicksSinceOrigin()

--- a/examples/modules/ref_device_module/src/ref_device_module_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_module_impl.cpp
@@ -32,14 +32,14 @@ ListPtr<IDeviceInfo> RefDeviceModule::onGetAvailableDevices()
 
     if (serialNumber.assigned())
     {
-        auto info = RefDeviceImpl::CreateDeviceInfo(0, serialNumber);
+        auto info = RefDeviceImpl::CreateDeviceInfo(moduleInfo, 0, serialNumber);
         availableDevices.pushBack(info);
     }
     else
     {
         for (size_t i = 0; i < 2; i++)
         {
-            auto info = RefDeviceImpl::CreateDeviceInfo(i);
+            auto info = RefDeviceImpl::CreateDeviceInfo(moduleInfo, i);
             availableDevices.pushBack(info);
         }
     }
@@ -51,7 +51,7 @@ DictPtr<IString, IDeviceType> RefDeviceModule::onGetAvailableDeviceTypes()
 {
     auto result = Dict<IString, IDeviceType>();
 
-    auto deviceType = RefDeviceImpl::CreateType();
+    auto deviceType = RefDeviceImpl::CreateType(moduleInfo);
     result.set(deviceType.getId(), deviceType);
 
     return result;
@@ -102,7 +102,7 @@ DevicePtr RefDeviceModule::onCreateDevice(const StringPtr& connectionString,
     if (!localId.assigned())
         localId = fmt::format("RefDev{}", id);
 
-    auto devicePtr = createWithImplementation<IDevice, RefDeviceImpl>(id, config, context, parent, localId, name);
+    auto devicePtr = createWithImplementation<IDevice, RefDeviceImpl>(moduleInfo, id, config, context, parent, localId, name);
     devices[id] = devicePtr;
     return devicePtr;
 }

--- a/examples/modules/ref_device_module/tests/test_ref_device_module.cpp
+++ b/examples/modules/ref_device_module/tests/test_ref_device_module.cpp
@@ -124,6 +124,15 @@ TEST_F(RefDeviceModuleTest, CreateDeviceConnectionStringCorrect)
     ASSERT_NO_THROW(device = module.createDevice("daqref://device1", nullptr));
 }
 
+TEST_F(RefDeviceModuleTest, DeviceVersion)
+{
+    auto module = CreateModule();
+
+    auto device = module.createDevice("daqref://device1", nullptr);
+
+    ASSERT_EQ(device.getInfo().getDeviceType().getModuleInfo().getVersionInfo(), module.getModuleInfo().getVersionInfo());
+}
+
 TEST_F(RefDeviceModuleTest, DeviceDomainResolution)
 {
     auto module = CreateModule();

--- a/examples/modules/ref_fb_module/include/ref_fb_module/classifier_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/classifier_fb_impl.h
@@ -33,10 +33,10 @@ namespace Classifier
 class ClassifierFbImpl final : public FunctionBlock
 {
 public:
-    explicit ClassifierFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit ClassifierFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
     ~ClassifierFbImpl() override = default;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 private:
     InputPortPtr inputPort;

--- a/examples/modules/ref_fb_module/include/ref_fb_module/fft_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/fft_fb_impl.h
@@ -33,10 +33,10 @@ constexpr size_t maxSampleReadCount = 100000;
 class FFTFbImpl final : public FunctionBlock
 {
 public:
-    explicit FFTFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit FFTFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
     ~FFTFbImpl() override;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 private:
     InputPortPtr inputPort;

--- a/examples/modules/ref_fb_module/include/ref_fb_module/power_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/power_fb_impl.h
@@ -30,13 +30,13 @@ BEGIN_NAMESPACE_REF_FB_MODULE
 class PowerFbImpl final : public FunctionBlock
 {
 public:
-    explicit PowerFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit PowerFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
     ~PowerFbImpl() override = default;
 
     void onConnected(const InputPortPtr& port) override;
     void onDisconnected(const InputPortPtr& port) override;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 private:
     InputPortPtr voltageInputPort;

--- a/examples/modules/ref_fb_module/include/ref_fb_module/power_reader_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/power_reader_fb_impl.h
@@ -31,10 +31,13 @@ namespace PowerReader
 class PowerReaderFbImpl final : public FunctionBlock
 {
 public:
-    explicit PowerReaderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit PowerReaderFbImpl(const ModuleInfoPtr& moduleInfo,
+                               const ContextPtr& ctx,
+                               const ComponentPtr& parent,
+                               const StringPtr& localId);
     ~PowerReaderFbImpl() override = default;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
     static bool descriptorNotNull(const DataDescriptorPtr& descriptor);
     static void getDataDescriptors(const EventPacketPtr& eventPacket, DataDescriptorPtr& valueDesc, DataDescriptorPtr& domainDesc);
     static bool getDataDescriptor(const EventPacketPtr& eventPacket, DataDescriptorPtr& valueDesc);

--- a/examples/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
@@ -121,13 +121,13 @@ struct SignalContext
 class RendererFbImpl final : public FunctionBlock
 {
 public:
-    explicit RendererFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config);
+    explicit RendererFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config);
     ~RendererFbImpl() override;
 
     void onConnected(const InputPortPtr& port) override;
     void onDisconnected(const InputPortPtr& port) override;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 protected:
     void removed() override;

--- a/examples/modules/ref_fb_module/include/ref_fb_module/scaling_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/scaling_fb_impl.h
@@ -32,10 +32,10 @@ namespace Scaling
 class ScalingFbImpl final : public FunctionBlock
 {
 public:
-    explicit ScalingFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit ScalingFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
     ~ScalingFbImpl() override = default;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 private:
     InputPortPtr inputPort;

--- a/examples/modules/ref_fb_module/include/ref_fb_module/statistics_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/statistics_fb_impl.h
@@ -99,8 +99,12 @@ enum class DomainSignalType
 class StatisticsFbImpl final : public FunctionBlock
 {
 public:
-    StatisticsFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config);
-    static FunctionBlockTypePtr CreateType();
+    StatisticsFbImpl(const ModuleInfoPtr& moduleInfo,
+                     const ContextPtr& ctx,
+                     const ComponentPtr& parent,
+                     const StringPtr& localId,
+                     const PropertyObjectPtr& config);
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 private:
     struct FreeDeleter

--- a/examples/modules/ref_fb_module/include/ref_fb_module/struct_decoder_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/struct_decoder_fb_impl.h
@@ -31,10 +31,13 @@ namespace StructDecoder
 class StructDecoderFbImpl final : public FunctionBlock
 {
 public:
-    explicit StructDecoderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId);
+    explicit StructDecoderFbImpl(const ModuleInfoPtr& moduleInfo,
+                                 const ContextPtr& ctx,
+                                 const ComponentPtr& parent,
+                                 const StringPtr& localId);
     ~StructDecoderFbImpl() override = default;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
     void onPacketReceived(const InputPortPtr& port) override;
     void onDisconnected(const InputPortPtr& port) override;

--- a/examples/modules/ref_fb_module/include/ref_fb_module/trigger_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/trigger_fb_impl.h
@@ -29,10 +29,14 @@ namespace Trigger
 class TriggerFbImpl final : public FunctionBlock
 {
 public:
-    explicit TriggerFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config);
+    explicit TriggerFbImpl(const ModuleInfoPtr& moduleInfo,
+                           const ContextPtr& ctx,
+                           const ComponentPtr& parent,
+                           const StringPtr& localId,
+                           const PropertyObjectPtr& config);
     ~TriggerFbImpl() override = default;
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
 private:
     InputPortPtr inputPort;

--- a/examples/modules/ref_fb_module/include/ref_fb_module/video_player_fb_impl.h
+++ b/examples/modules/ref_fb_module/include/ref_fb_module/video_player_fb_impl.h
@@ -67,12 +67,13 @@ private:
 class VideoPlayerFbImpl final : public FunctionBlock
 {
 public:
-    explicit VideoPlayerFbImpl(const ContextPtr& ctx, 
-                            const ComponentPtr& parent, 
-                            const StringPtr& localId, 
-                            const PropertyObjectPtr& config);
+    explicit VideoPlayerFbImpl(const ModuleInfoPtr& moduleInfo,
+                               const ContextPtr& ctx, 
+                               const ComponentPtr& parent, 
+                               const StringPtr& localId, 
+                               const PropertyObjectPtr& config);
 
-    static FunctionBlockTypePtr CreateType();
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
 
     void onPacketReceived(const InputPortPtr& port) override;
     void handleDataPacket(const DataPacketPtr& packet);

--- a/examples/modules/ref_fb_module/src/classifier_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/classifier_fb_impl.cpp
@@ -16,14 +16,18 @@
 #include <coreobjects/eval_value_factory.h>
 #include <opendaq/dimension_factory.h>
 #include <opendaq/reader_factory.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
 namespace Classifier
 {
 
-ClassifierFbImpl::ClassifierFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+ClassifierFbImpl::ClassifierFbImpl(const ModuleInfoPtr& moduleInfo,
+                                   const ContextPtr& ctx,
+                                   const ComponentPtr& parent,
+                                   const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
 {
     initComponentStatus();
     createInputPorts();
@@ -133,9 +137,11 @@ void ClassifierFbImpl::readProperties()
     }
 }
 
-FunctionBlockTypePtr ClassifierFbImpl::CreateType()
+FunctionBlockTypePtr ClassifierFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType("RefFBModuleClassifier", "Classifier", "Signal classifing");
+    auto fbType = FunctionBlockType("RefFBModuleClassifier", "Classifier", "Signal classifing");
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 bool ClassifierFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inputDataDescriptor, const DataDescriptorPtr& inputDomainDataDescriptor)

--- a/examples/modules/ref_fb_module/src/fft_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/fft_fb_impl.cpp
@@ -13,14 +13,15 @@
 #include <opendaq/sample_type_traits.h>
 #include <opendaq/dimension_factory.h>
 #include <opendaq/reader_factory.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
 namespace FFT
 {
 
-FFTFbImpl::FFTFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+FFTFbImpl::FFTFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
 {
     initComponentStatus();
     initProperties();
@@ -61,9 +62,11 @@ void FFTFbImpl::readProperties()
     inputDomainData.resize(maxBlockReadCount * blockSize);
 }
 
-FunctionBlockTypePtr FFTFbImpl::CreateType()
+FunctionBlockTypePtr FFTFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType("RefFBModuleFFT", "FFT", "Fast Fourier Transform");
+    auto fbType = FunctionBlockType("RefFBModuleFFT", "FFT", "Fast Fourier Transform");
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 bool FFTFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inputDataDescriptor, const DataDescriptorPtr& inputDomainDataDescriptor)

--- a/examples/modules/ref_fb_module/src/power_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/power_fb_impl.cpp
@@ -14,13 +14,14 @@
 #include <opendaq/range_factory.h>
 #include <opendaq/sample_type_traits.h>
 #include <coreobjects/eval_value_factory.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
-    namespace Power
+namespace Power
 {
 
-PowerFbImpl::PowerFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+PowerFbImpl::PowerFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
 {
     initComponentStatus();
     createInputPorts();
@@ -86,9 +87,11 @@ void PowerFbImpl::readProperties()
     powerLowValue = objPtr.getPropertyValue("CustomLowValue");
 }
 
-FunctionBlockTypePtr PowerFbImpl::CreateType()
+FunctionBlockTypePtr PowerFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType("RefFBModulePower", "Power", "Calculates power");
+    auto fbType = FunctionBlockType("RefFBModulePower", "Power", "Calculates power");
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 void PowerFbImpl::onPacketReceived(const InputPortPtr& port)

--- a/examples/modules/ref_fb_module/src/power_reader_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/power_reader_fb_impl.cpp
@@ -15,14 +15,17 @@
 #include <coreobjects/eval_value_factory.h>
 #include <opendaq/reader_factory.h>
 #include <opendaq/reader_config_ptr.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
-
 namespace PowerReader
 {
 
-PowerReaderFbImpl::PowerReaderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+PowerReaderFbImpl::PowerReaderFbImpl(const ModuleInfoPtr& moduleInfo,
+                                     const ContextPtr& ctx,
+                                     const ComponentPtr& parent,
+                                     const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
 {
     initComponentStatus();
     createInputPorts();
@@ -96,9 +99,11 @@ void PowerReaderFbImpl::readProperties()
     tickOffsetToleranceUs = std::chrono::milliseconds(objPtr.getPropertyValue("TickOffsetToleranceUs"));
 }
 
-FunctionBlockTypePtr PowerReaderFbImpl::CreateType()
+FunctionBlockTypePtr PowerReaderFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType("RefFBModulePowerReader", "Power with reader", "Calculates power using multi reader");
+    auto fbType = FunctionBlockType("RefFBModulePowerReader", "Power with reader", "Calculates power using multi reader");
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 bool PowerReaderFbImpl::descriptorNotNull(const DataDescriptorPtr& descriptor)

--- a/examples/modules/ref_fb_module/src/ref_fb_module_impl.cpp
+++ b/examples/modules/ref_fb_module/src/ref_fb_module_impl.cpp
@@ -31,34 +31,34 @@ DictPtr<IString, IFunctionBlockType> RefFBModule::onGetAvailableFunctionBlockTyp
     auto types = Dict<IString, IFunctionBlockType>();
 
 #ifdef OPENDAQ_ENABLE_RENDERER
-    const auto typeRenderer = Renderer::RendererFbImpl::CreateType();
+    const auto typeRenderer = Renderer::RendererFbImpl::CreateType(moduleInfo);
     types.set(typeRenderer.getId(), typeRenderer);
-    const auto typeVideoPlayer = VideoPlayer::VideoPlayerFbImpl::CreateType();
+    const auto typeVideoPlayer = VideoPlayer::VideoPlayerFbImpl::CreateType(moduleInfo);
     types.set(typeVideoPlayer.getId(), typeVideoPlayer);
 #endif
 
-    const auto typeStatistics = Statistics::StatisticsFbImpl::CreateType();
+    const auto typeStatistics = Statistics::StatisticsFbImpl::CreateType(moduleInfo);
     types.set(typeStatistics.getId(), typeStatistics);
 
-    const auto typePower = Power::PowerFbImpl::CreateType();
+    const auto typePower = Power::PowerFbImpl::CreateType(moduleInfo);
     types.set(typePower.getId(), typePower);
 
-    const auto typeScaling = Scaling::ScalingFbImpl::CreateType();
+    const auto typeScaling = Scaling::ScalingFbImpl::CreateType(moduleInfo);
     types.set(typeScaling.getId(), typeScaling);
 
-    const auto typeClassifier = Classifier::ClassifierFbImpl::CreateType();
+    const auto typeClassifier = Classifier::ClassifierFbImpl::CreateType(moduleInfo);
     types.set(typeClassifier.getId(), typeClassifier);
 
-    const auto typeTrigger = Trigger::TriggerFbImpl::CreateType();
+    const auto typeTrigger = Trigger::TriggerFbImpl::CreateType(moduleInfo);
     types.set(typeTrigger.getId(), typeTrigger);
 
-    const auto typeFFT = FFT::FFTFbImpl::CreateType();
+    const auto typeFFT = FFT::FFTFbImpl::CreateType(moduleInfo);
     types.set(typeFFT.getId(), typeFFT);
 
-    const auto typePowerReader = PowerReader::PowerReaderFbImpl::CreateType();
+    const auto typePowerReader = PowerReader::PowerReaderFbImpl::CreateType(moduleInfo);
     types.set(typePowerReader.getId(), typePowerReader);
 
-    const auto typeStructDecoder = StructDecoder::StructDecoderFbImpl::CreateType();
+    const auto typeStructDecoder = StructDecoder::StructDecoderFbImpl::CreateType(moduleInfo);
     types.set(typeStructDecoder.getId(), typeStructDecoder);
 
     const auto timeScaler = TimeDelay::TimeDelayFbImpl::CreateType();
@@ -73,55 +73,55 @@ FunctionBlockPtr RefFBModule::onCreateFunctionBlock(const StringPtr& id,
                                                     const PropertyObjectPtr& config)
 {
 #ifdef OPENDAQ_ENABLE_RENDERER
-    if (id == Renderer::RendererFbImpl::CreateType().getId())
+    if (id == Renderer::RendererFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Renderer::RendererFbImpl>(context, parent, localId, config);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Renderer::RendererFbImpl>(moduleInfo, context, parent, localId, config);
         return fb;
     }
-    if (id == VideoPlayer::VideoPlayerFbImpl::CreateType().getId())
+    if (id == VideoPlayer::VideoPlayerFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, VideoPlayer::VideoPlayerFbImpl>(context, parent, localId, config);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, VideoPlayer::VideoPlayerFbImpl>(moduleInfo, context, parent, localId, config);
         return fb;
     }
 #endif
-    if (id == Statistics::StatisticsFbImpl::CreateType().getId())
+    if (id == Statistics::StatisticsFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Statistics::StatisticsFbImpl>(context, parent, localId, config);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Statistics::StatisticsFbImpl>(moduleInfo, context, parent, localId, config);
         return fb;
     }
-    if (id == Power::PowerFbImpl::CreateType().getId())
+    if (id == Power::PowerFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Power::PowerFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Power::PowerFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
-    if (id == Scaling::ScalingFbImpl::CreateType().getId())
+    if (id == Scaling::ScalingFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Scaling::ScalingFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Scaling::ScalingFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
-    if (id == Classifier::ClassifierFbImpl::CreateType().getId())
+    if (id == Classifier::ClassifierFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Classifier::ClassifierFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Classifier::ClassifierFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
-    if (id == Trigger::TriggerFbImpl::CreateType().getId())
+    if (id == Trigger::TriggerFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Trigger::TriggerFbImpl>(context, parent, localId, config);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, Trigger::TriggerFbImpl>(moduleInfo, context, parent, localId, config);
         return fb;
     }
-    if (id == FFT::FFTFbImpl::CreateType().getId())
+    if (id == FFT::FFTFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, FFT::FFTFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, FFT::FFTFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
-    if (id == PowerReader::PowerReaderFbImpl::CreateType().getId())
+    if (id == PowerReader::PowerReaderFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, PowerReader::PowerReaderFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, PowerReader::PowerReaderFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
-    if (id == StructDecoder::StructDecoderFbImpl::CreateType().getId())
+    if (id == StructDecoder::StructDecoderFbImpl::CreateType(moduleInfo).getId())
     {
-        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, StructDecoder::StructDecoderFbImpl>(context, parent, localId);
+        FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, StructDecoder::StructDecoderFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
     if (id == TimeDelay::TimeDelayFbImpl::CreateType().getId())

--- a/examples/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -12,20 +12,21 @@
 #include <opendaq/thread_name.h>
 #include <date/date.h>
 #include <iomanip>
+#include <opendaq/component_type_private.h>
 #include <opendaq/work_factory.h>
 #include <coreobjects/callable_info_factory.h>
 #include <opendaq/reader_utils.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
-
 namespace Renderer
 {
 
-RendererFbImpl::RendererFbImpl(const ContextPtr& ctx, 
+RendererFbImpl::RendererFbImpl(const ModuleInfoPtr& moduleInfo,
+                               const ContextPtr& ctx, 
                                const ComponentPtr& parent, 
                                const StringPtr& localId,
                                const PropertyObjectPtr& config)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
     , rendererStopRequested(false)
     , resolutionChangedFlag(false)
     , inputPortCount(0)
@@ -66,7 +67,7 @@ RendererFbImpl::~RendererFbImpl()
     LOGP_D("Render thread stopped")
 }
 
-FunctionBlockTypePtr RendererFbImpl::CreateType()
+FunctionBlockTypePtr RendererFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
     auto defaultConfig = PropertyObject();
 #ifdef __APPLE__
@@ -75,12 +76,14 @@ FunctionBlockTypePtr RendererFbImpl::CreateType()
     defaultConfig.addProperty(BoolProperty("UseMainLoopForRenderer", false));
 #endif
 
-    return FunctionBlockType(
+    auto fbType = FunctionBlockType(
         "RefFBModuleRenderer",
         "Renderer",
         "Signal visualization",
         defaultConfig
     );
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 void RendererFbImpl::removed()

--- a/examples/modules/ref_fb_module/src/scaling_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/scaling_fb_impl.cpp
@@ -15,14 +15,15 @@
 #include "opendaq/sample_type_traits.h"
 #include <coreobjects/eval_value_factory.h>
 #include <opendaq/reusable_data_packet_ptr.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
 namespace Scaling
 {
 
-ScalingFbImpl::ScalingFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+ScalingFbImpl::ScalingFbImpl(const ModuleInfoPtr& moduleInfo, const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
 {
     initComponentStatus();
     createInputPorts();
@@ -88,9 +89,11 @@ void ScalingFbImpl::readProperties()
     outputName = static_cast<std::string>(objPtr.getPropertyValue("OutputName"));
 }
 
-FunctionBlockTypePtr ScalingFbImpl::CreateType()
+FunctionBlockTypePtr ScalingFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType("RefFBModuleScaling", "Scaling", "Signal scaling");
+    auto fbType = FunctionBlockType("RefFBModuleScaling", "Scaling", "Signal scaling");
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 void ScalingFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inputDataDescriptor,

--- a/examples/modules/ref_fb_module/src/statistics_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/statistics_fb_impl.cpp
@@ -3,17 +3,19 @@
 #include <opendaq/packet_factory.h>
 #include <ref_fb_module/statistics_fb_impl.h>
 #include <opendaq/module_manager_utils_ptr.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
 namespace Statistics
 {
 
-StatisticsFbImpl::StatisticsFbImpl(const ContextPtr& ctx,
+StatisticsFbImpl::StatisticsFbImpl(const ModuleInfoPtr& moduleInfo,
+                                   const ContextPtr& ctx,
                                    const ComponentPtr& parent,
                                    const StringPtr& localId,
                                    const PropertyObjectPtr& config)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
 {
     initComponentStatus();
     initProperties();
@@ -36,15 +38,17 @@ StatisticsFbImpl::StatisticsFbImpl(const ContextPtr& ctx,
     triggerInput.setNotificationMethod(packetReadyNotification);
 }
 
-FunctionBlockTypePtr StatisticsFbImpl::CreateType()
+FunctionBlockTypePtr StatisticsFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
     auto defaultConfig = PropertyObject();
     defaultConfig.addProperty(BoolProperty("UseMultiThreadedScheduler", true));
 
-    return FunctionBlockType("RefFBModuleStatistics",
-                             "Statistics",
-                             "Calculates statistics",
-                             defaultConfig);
+    auto fbType = FunctionBlockType("RefFBModuleStatistics",
+                                    "Statistics",
+                                    "Calculates statistics",
+                                    defaultConfig);
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 DictPtr<IString, IFunctionBlockType> StatisticsFbImpl::onGetAvailableFunctionBlockTypes()

--- a/examples/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/struct_decoder_fb_impl.cpp
@@ -11,8 +11,10 @@
 #include <opendaq/component_status_container_private_ptr.h>
 #include <opendaq/sample_type_traits.h>
 #include <opendaq/search_filter_factory.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
+
 namespace StructDecoder
 {
 
@@ -20,8 +22,11 @@ static const char* InputDisconnected = "Disconnected";
 static const char* InputConnected = "Connected";
 static const char* InputInvalid = "Invalid";
 
-StructDecoderFbImpl::StructDecoderFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+StructDecoderFbImpl::StructDecoderFbImpl(const ModuleInfoPtr& moduleInfo,
+                                         const ContextPtr& ctx,
+                                         const ComponentPtr& parent,
+                                         const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
     , configured(false)
 {
     initComponentStatus();
@@ -29,9 +34,11 @@ StructDecoderFbImpl::StructDecoderFbImpl(const ContextPtr& ctx, const ComponentP
     initStatuses();
 }
 
-FunctionBlockTypePtr StructDecoderFbImpl::CreateType()
+FunctionBlockTypePtr StructDecoderFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType("RefFBModuleStructDecoder", "Struct decoder", "Decodes signals with struct data type and outputs signal for each struct component.");
+    auto fbType = FunctionBlockType("RefFBModuleStructDecoder", "Struct decoder", "Decodes signals with struct data type and outputs signal for each struct component.");
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 void StructDecoderFbImpl::processSignalDescriptorsChangedEventPacket(const EventPacketPtr& eventPacket)

--- a/examples/modules/ref_fb_module/src/trigger_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/trigger_fb_impl.cpp
@@ -1,6 +1,7 @@
 #include <opendaq/event_packet_params.h>
 #include <ref_fb_module/dispatch.h>
 #include <ref_fb_module/trigger_fb_impl.h>
+#include <opendaq/component_type_private.h>
 #include "opendaq/packet_factory.h"
 #include "opendaq/sample_type_traits.h"
 
@@ -9,8 +10,12 @@ BEGIN_NAMESPACE_REF_FB_MODULE
 namespace Trigger
 {
 
-TriggerFbImpl::TriggerFbImpl(const ContextPtr& ctx, const ComponentPtr& parent, const StringPtr& localId, const PropertyObjectPtr& config)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+TriggerFbImpl::TriggerFbImpl(const ModuleInfoPtr& moduleInfo,
+                             const ContextPtr& ctx,
+                             const ComponentPtr& parent,
+                             const StringPtr& localId,
+                             const PropertyObjectPtr& config)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
 {
     initComponentStatus();
 
@@ -45,12 +50,14 @@ void TriggerFbImpl::readProperties()
     threshold = objPtr.getPropertyValue("Threshold");
 }
 
-FunctionBlockTypePtr TriggerFbImpl::CreateType()
+FunctionBlockTypePtr TriggerFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
     auto defaultConfig = PropertyObject();
     defaultConfig.addProperty(BoolProperty("UseMultiThreadedScheduler", true));
 
-    return FunctionBlockType("RefFBModuleTrigger", "Trigger", "Trigger", defaultConfig);
+    auto fbType = FunctionBlockType("RefFBModuleTrigger", "Trigger", "Trigger", defaultConfig);
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
 }
 
 void TriggerFbImpl::processSignalDescriptorChanged(const DataDescriptorPtr& inputDataDescriptor,

--- a/examples/modules/ref_fb_module/src/video_player_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/src/video_player_fb_impl.cpp
@@ -3,17 +3,19 @@
 #include <opendaq/work_factory.h>
 #include <opendaq/event_packet_params.h>
 #include <coreobjects/callable_info_factory.h>
+#include <opendaq/component_type_private.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 
 namespace VideoPlayer
 {
 
-VideoPlayerFbImpl::VideoPlayerFbImpl(const ContextPtr& ctx, 
+VideoPlayerFbImpl::VideoPlayerFbImpl(const ModuleInfoPtr& moduleInfo,
+                                     const ContextPtr& ctx, 
                                      const ComponentPtr& parent, 
                                      const StringPtr& localId,
                                      const PropertyObjectPtr& config)
-    : FunctionBlock(CreateType(), ctx, parent, localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
     , texture()
     , sprite(texture)
     , font(ARIAL_TTF, sizeof(ARIAL_TTF))
@@ -32,12 +34,16 @@ VideoPlayerFbImpl::VideoPlayerFbImpl(const ContextPtr& ctx,
     timestampText.setOutlineThickness(2);
 }
 
-FunctionBlockTypePtr VideoPlayerFbImpl::CreateType()
+FunctionBlockTypePtr VideoPlayerFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
 {
-    return FunctionBlockType("RefFBModuleVideoPlayer",
-                             "Video Player",
-                             "Video playback and visualization"
+    auto fbType = FunctionBlockType("RefFBModuleVideoPlayer",
+                                    "Video Player",
+                                    "Video playback and visualization"
     );
+
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+
+    return fbType;
 }
 
 void VideoPlayerFbImpl::initProperties()

--- a/examples/modules/ref_fb_module/tests/test_ref_fb_module.cpp
+++ b/examples/modules/ref_fb_module/tests/test_ref_fb_module.cpp
@@ -220,6 +220,14 @@ TEST_F(RefFbModuleTest, GetAvailableComponentTypes)
     }
 }
 
+TEST_F(RefFbModuleTest, ScalingVersion)
+{
+    auto module = CreateModule();
+    
+    auto fb = module.createFunctionBlock("RefFBModuleScaling", nullptr, "fb");
+    ASSERT_EQ(fb.getFunctionBlockType().getModuleInfo().getVersionInfo(), module.getModuleInfo().getVersionInfo());
+}
+
 TEST_F(RefFbModuleTest, CreateFunctionBlockNotFound)
 {
     const auto module = CreateModule();

--- a/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
+++ b/modules/native_streaming_client_module/include/native_streaming_client_module/native_device_impl.h
@@ -121,9 +121,6 @@ public:
     void INTERFACE_FUNC completeInitialization(std::shared_ptr<NativeDeviceHelper> deviceHelper, const StringPtr& connectionString) override;
     void INTERFACE_FUNC updateDeviceInfo(const StringPtr& connectionString) override;
 
-    // ISerializable
-    static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
-
     // IComponentPrivate
     ErrCode INTERFACE_FUNC getComponentConfig(IPropertyObject** config) override;
 

--- a/modules/native_streaming_client_module/src/native_device_impl.cpp
+++ b/modules/native_streaming_client_module/src/native_device_impl.cpp
@@ -460,21 +460,6 @@ void NativeDeviceImpl::completeInitialization(std::shared_ptr<NativeDeviceHelper
     this->connectionStatusContainer.addConfigurationConnectionStatus(deviceInfo.getConnectionString(), statusInitValue);
 }
 
-ErrCode NativeDeviceImpl::Deserialize(ISerializedObject* serialized,
-                                      IBaseObject* context,
-                                      IFunction* factoryCallback,
-                                      IBaseObject** obj)
-{
-    OPENDAQ_PARAM_NOT_NULL(context);
-
-    const ErrCode errCode = daqTry([&obj, &serialized, &context, &factoryCallback]()
-    {
-        *obj = Super::Super::template DeserializeConfigComponent<IDevice, NativeDeviceImpl>(serialized, context, factoryCallback).detach();
-    });
-    OPENDAQ_RETURN_IF_FAILED(errCode);
-    return errCode;
-}
-
 void NativeDeviceImpl::removed()
 {
     disconnectAndCleanUp();

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -71,6 +71,7 @@ public:
     ErrCode INTERFACE_FUNC setOperationModeRecursive(OperationModeType modeType) override;
     ErrCode INTERFACE_FUNC getOperationMode(OperationModeType* modeType) override;
 
+    template <class Implementation>
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 
 protected:
@@ -379,6 +380,7 @@ inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::getOperationMode(Oper
 }
 
 template <class TDeviceBase>
+template <class Implementation>
 ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::Deserialize(ISerializedObject* serialized,
                                                                 IBaseObject* context,
                                                                 IFunction* factoryCallback,
@@ -388,7 +390,11 @@ ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::Deserialize(ISerializedObjec
 
     const ErrCode errCode = daqTry([&obj, &serialized, &context, &factoryCallback]
     {
-        *obj = Super::template DeserializeConfigComponent<IDevice, ConfigClientDeviceImpl>(serialized, context, factoryCallback).detach();
+        auto device = Super::template DeserializeConfigComponent<IDevice, Implementation>(serialized, context, factoryCallback).template asPtr<IDevice>();
+
+        Super::deserializeVersion(serialized, device.getInfo());
+
+        *obj = device.detach();
     });
     OPENDAQ_RETURN_IF_FAILED(errCode);
     return errCode;

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_function_block_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_function_block_impl.h
@@ -109,6 +109,8 @@ ErrCode ConfigClientBaseFunctionBlockImpl<Impl>::Deserialize(ISerializedObject* 
 
                         const auto fbType = FunctionBlockType(typeId, typeId, "", nullptr);
 
+                        Super::deserializeVersion(serialized, fbType);
+
                         bool isRecorder = false;
                         if (serialized.hasKey("isRecorder"))
                             isRecorder = serialized.readBool("isRecorder");

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -291,7 +291,7 @@ ConfigProtocolClient<TRootDeviceImpl>::ConfigProtocolClient(const ContextPtr& da
               streamingProducer,
               [](ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj)
               {
-                  return TRootDeviceImpl::Deserialize(serialized, context, factoryCallback, obj);
+                  return TRootDeviceImpl::template Deserialize<TRootDeviceImpl>(serialized, context, factoryCallback, obj);
               }))
 {
 }

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -582,7 +582,7 @@ BaseObjectPtr ConfigProtocolClientComm::deserializeConfigComponent(const StringP
     if (typeId == "Device" || typeId == "Instance")
     {
         BaseObjectPtr obj;
-        checkErrorInfo(ConfigClientDeviceImpl::Deserialize(serObj, context, factoryCallback, &obj));
+        checkErrorInfo(ConfigClientDeviceImpl::Deserialize<ConfigClientDeviceImpl>(serObj, context, factoryCallback, &obj));
         return obj;
     }
 

--- a/shared/libraries/config_protocol/tests/test_config_serialization.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_serialization.cpp
@@ -762,7 +762,7 @@ TEST_F(ConfigProtocolSerializationTest, Device)
                                      if (typeId == "Device")
                                      {
                                          BaseObjectPtr obj;
-                                         checkErrorInfo(ConfigClientDeviceImpl::Deserialize(serObj, context, factoryCallback, &obj));
+                                         checkErrorInfo(ConfigClientDeviceImpl::Deserialize<ConfigClientDeviceImpl>(serObj, context, factoryCallback, &obj));
                                          configComponentInstantiated++;
                                          return obj;
                                      }

--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -3595,6 +3595,18 @@ TEST_F(NativeDeviceModulesTest, AddNestedFB)
     ASSERT_EQ(fb.getFunctionBlocks().getCount(), 0u);
 }
 
+TEST_F(NativeDeviceModulesTest, StatisticsFunctionBlockVersion)
+{
+    const auto server = CreateServerInstance();
+    ASSERT_EQ(server.getFunctionBlocks()[0].getFunctionBlockType().getId(), "RefFBModuleStatistics");
+
+    const auto client = Instance();
+    auto dev = client.addDevice("daq.nd://127.0.0.1");
+    auto fb = dev.getFunctionBlocks()[0];
+    ASSERT_EQ(fb.getFunctionBlockType().getId(), "RefFBModuleStatistics");
+    ASSERT_EQ(fb.getFunctionBlockType().getModuleInfo().getVersionInfo(), server.getFunctionBlocks()[0].getFunctionBlockType().getModuleInfo().getVersionInfo());
+}
+
 TEST_F(NativeDeviceModulesTest, TestEnumerationPropertyRemote)
 {
     InstancePtr serverInstance;


### PR DESCRIPTION
# Brief

Store version info of function blocks and devices in the configuration.

# Description

Store module version info with each function block and device. This will enable us to maintain backward compatibility in the future. Reworked reference modules to return their function blocks' and devices' version properly. This rework is optional and maintains source and binary compatibility.

# Usage example