### PR TITLE
Cleanup unnecessary log outputs "Active attribute of {} is locked"

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -322,6 +322,9 @@ ErrCode ComponentImpl<Intf, Intfs...>::setActive(Bool active)
         if (this->isComponentRemoved)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
     
+        if (static_cast<bool>(active) == this->active)
+            return OPENDAQ_IGNORED;
+
         if (lockedAttributes.count("Active"))
         {
             if (context.assigned() && context.getLogger().assigned())
@@ -334,9 +337,6 @@ ErrCode ComponentImpl<Intf, Intfs...>::setActive(Bool active)
 
             return OPENDAQ_IGNORED;
         }
-
-        if (static_cast<bool>(active) == this->active)
-            return OPENDAQ_IGNORED;
 
         if (active && isComponentRemoved)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE);


### PR DESCRIPTION
# Brief

I changed the order of two ignored cases in ComponentImpl::setActive. Functionally, the code is the same.

# Description

We have a channel with a subfunction block and a signal. Their active attribute is locked and the same as the channel’s.
When we change the active on the channel, we also switch the active on subcomponents. So most of the time, setActiveRecursive does nothing. I don’t want to see log outputs in that case.
