### PR TITLE
[TBBAS-2483] Serialization: component config

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1207,7 +1207,7 @@ Bool ComponentImpl<Intf, Intfs...>::shouldSerializeComponentConfig(const Propert
             else
             {
                 const auto& defaultValue = property.getDefaultValue();
-                result |= (value != defaultValue);
+                result |= static_cast<Bool>(value != defaultValue);
             }
             if (result)
             {

--- a/core/opendaq/functionblock/include/opendaq/function_block_impl.h
+++ b/core/opendaq/functionblock/include/opendaq/function_block_impl.h
@@ -29,6 +29,7 @@
 #include <opendaq/recorder.h>
 #include <opendaq/component_type_private.h>
 #include <opendaq/module_info_factory.h>
+#include "opendaq/module_manager_ptr.h"
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -358,6 +359,20 @@ void FunctionBlockImpl<TInterface, Interfaces...>::updateFunctionBlock(const std
         PropertyObjectPtr config;
         if (serializedFunctionBlock.hasKey("ComponentConfig"))
             config = serializedFunctionBlock.readObject("ComponentConfig");
+        else if (serializedFunctionBlock.hasKey("ComponentConfig2"))
+        {
+            const SerializedObjectPtr serializedConfig = serializedFunctionBlock.readSerializedObject("ComponentConfig2");
+            const ModuleManagerPtr moduleManager = this->context.getModuleManager().template asPtr<IModuleManager>();
+            
+            for(const auto& module : moduleManager.getModules()) {
+                if(module.getAvailableFunctionBlockTypes().hasKey(typeId)) {
+                    const FunctionBlockTypePtr& fbType = module.getAvailableFunctionBlockTypes()[typeId];
+                    config = fbType.createDefaultConfig();
+                    this->updateComponentConfig(config, serializedConfig);
+                    break;
+                }
+            }
+        }
         else
             config = PropertyObject();
         


### PR DESCRIPTION
# Brief
`ComponentConfig` serialization of **FunctionBlock** and **Device** for update reworked
# Description
- Old de-serialization path left for backward compatibility 
- Serialization of FB and Device for update changed
- File size difference: ~4800 lines
# Usage example
None
# API changes
> [!NOTE]
> New `ComponentConfig` **JSON** representation is not compatible with older versions of **OpenDAQ**
# Required application changes
None
# Required module changes
None