### PR TITLE
[TBBAS-2707] Serialization: SyncComponent

### DIFF
--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1946,7 +1946,11 @@ void GenericDevice<TInterface, Interfaces...>::serializeCustomObjectValues(const
     if (syncComponent.assigned())
     {
         serializer.key("Synchronization");
-        syncComponent.serialize(serializer);
+        if(forUpdate) {
+            syncComponent.template asPtr<IUpdatable>(true).serializeForUpdate(serializer);
+        } else {
+            syncComponent.serialize(serializer);
+        }
     }
 
     serializer.key("UserLock");


### PR DESCRIPTION
# Brief
SyncComponent serialization for update in saveConfiguration
# Description
File size diff: ~60 lines
# Usage example
None
# API changes
> [!NOTE]
> Possible compatibility break with old OpenDAQ using newly saved config 
# Required application changes
None
# Required module changes
None