### PR TITLE
Increase `timeout-minutes` for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,7 +649,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
       cancel-in-progress: true
-    timeout-minutes: 180
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -587,7 +587,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
-    timeout-minutes: 300
+    timeout-minutes: 400
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -404,7 +404,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
-    timeout-minutes: 300
+    timeout-minutes: 400
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Brief

Increase `timeout-minutes` for macOS due to job failures (caused by creating extra Python wheels in #966)