### PR TITLE
Support multiple paths in OPENDAQ_MODULES_PATH

### DIFF
--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -190,7 +190,18 @@ ErrCode ModuleManagerImpl::loadModules(IContext* context)
     if (envPath != nullptr)
     {
         LOG_D("Environment variable OPENDAQ_MODULES_PATH found, moduler search folder overriden to {}", envPath)
-        paths = {envPath};
+
+#if defined(_WIN32) || defined(_WIN64)
+        const char sep = ';';
+#else
+        const char sep = ':';
+#endif
+
+        std::stringstream ss(envPath);
+        std::string token;
+
+        while (std::getline(ss, token, sep))
+            paths.push_back(token);
     }
     else
     {


### PR DESCRIPTION
Previously only a single directory was accepted when the environment variable OPENDAQ_MODULES_PATH was set. This change adds support for multiple paths separated by the platform-specific separator (';' on Windows, ':' on Unix-like systems). Each parsed path is now appended to the module search list.