### PR TITLE
CI workflow: refactor build_windows to use build-sdk action

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Run tests after build'
     required: false
     default: 'false'
+  python-versions:
+    description: 'Python version(s) to install (newline-separated for multiple versions)'
+    required: false
+    default: ''
 
 outputs:
   gtest-xml-path:
@@ -41,18 +45,21 @@ runs:
           exit 1
         fi
 
-    # NOTE: Keep python-version list in sync with PYTHON_VERSIONS in "Install Python dependencies" step
+    - name: Prepare Python versions
+      id: python-versions
+      if: inputs.python-versions != ''
+      shell: bash
+      run: |
+        VERSIONS=$(echo '${{ inputs.python-versions }}' | tr ' ' '\n' | grep -v '^$')
+        echo "list<<EOF" >> $GITHUB_OUTPUT
+        echo "$VERSIONS" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
     - name: Set up Python
+      if: inputs.python-versions != ''
       uses: actions/setup-python@v5
       with:
-        python-version: |
-            3.8
-            3.9
-            3.10
-            3.11
-            3.12
-            3.13
-            3.14
+        python-version: ${{ steps.python-versions.outputs.list }}
 
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2
@@ -79,16 +86,14 @@ runs:
       run: mv 'C:\Program Files\LLVM' 'C:\Program Files\LLVM_old'
 
     - name: Install Python dependencies
+      if: inputs.python-versions != ''
       shell: bash
       env:
         PYTHON_CMD: ${{ runner.os == 'Windows' && 'py -' || 'python' }}
       run: |
-        echo "PYTHON_CMD=$PYTHON_CMD"
-        echo "RUNNER_OS=$RUNNER_OS"
-        PYTHON_VERSIONS=(3.8 3.9 3.10 3.11 3.12 3.13 3.14)
-        echo "PYTHON_VERSIONS=${PYTHON_VERSIONS[*]}"
-        for version in "${PYTHON_VERSIONS[@]}"; do
-          echo "Installing numpy for Python $version"
+        PYTHON_VERSIONS='${{ inputs.python-versions }}'
+        echo "Installing numpy for Python versions: $PYTHON_VERSIONS"
+        for version in $PYTHON_VERSIONS; do
           echo "Running: $PYTHON_CMD$version -m pip install numpy"
           $PYTHON_CMD$version -m pip install numpy
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
           - name: Windows VS 2022 Win32 Release
             runner: windows-2022
             cmake_generator: "Visual Studio 17 2022"
-            cmake_generator_platform: Win32
             cmake_build_type: Release
             cmake_defines: -A Win32 -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
             cpack: NSIS
@@ -115,6 +114,7 @@ jobs:
           cmake-config-args: ${{ matrix.cmake_defines }}
           cmake-build-type: ${{ matrix.cmake_build_type }}
           enable-tests: true
+          python-versions: ${{ env.python_versions }}
 
       - name: ConfigureIntel
         shell: cmd


### PR DESCRIPTION
# Brief

Refactor build_windows job to use reusable build-sdk composite action

# Description

- Add `.github/actions/build-sdk` composite action that encapsulates SDK build and test logic
- Move dependency installation steps (Python, CMake, NSIS, Ninja, MSVC toolchain) into the action
- Refactor `build_windows` job to use the new action instead of inline steps
- All other steps remain untouched

# Usage example

N/A

# API changes

N/A

# Required application changes

N/A

# Required module changes

N/A

