### PR TITLE
Add additional check in toBool to avoid exceptions on discovery

### DIFF
--- a/core/coretypes/src/stringobject_impl.cpp
+++ b/core/coretypes/src/stringobject_impl.cpp
@@ -165,6 +165,12 @@ ErrCode StringImpl::toBool(Bool* val)
     else if (strcasecmp("True", str) == 0)
 #endif
         *val = True;
+#if defined(_WIN32)
+    else if (_stricmp("False", str) == 0)
+#else
+    else if (strcasecmp("False", str) == 0)
+#endif
+        *val = False;
     else
     {
         Int intVal;


### PR DESCRIPTION
# Brief

Add additional check for string equality to "False" in `toBool` to avoid throwing exceptions on discovery.
