### PR TITLE
Fix crash on connect to native protocol version 6

### DIFF
--- a/core/opendaq/device/include/opendaq/device_info_impl.h
+++ b/core/opendaq/device/include/opendaq/device_info_impl.h
@@ -1200,7 +1200,16 @@ ErrCode DeviceInfoConfigImpl<TInterface, Interfaces...>::setOwner(IPropertyObjec
     if (!coreEvent.assigned())
     {
         parent.getContext()->getOnCoreEvent(&coreEvent);
-        ProcedurePtr procedure = [this](const CoreEventArgsPtr& args) { this->triggerCoreEventMethod(args); };
+
+        auto thisWeakRef = this->template getWeakRefInternal<IDeviceInfoConfig>();
+        ProcedurePtr procedure = [this, thisWeakRef](const CoreEventArgsPtr& args)
+        {
+            const auto thisRef = thisWeakRef.getRef();
+            if (!thisRef.assigned())
+                return;
+            this->triggerCoreEventMethod(args);
+        };
+
         this->setCoreEventTrigger(procedure);
         this->enableCoreEventTrigger(); // enables core event trigger for nested property objects
     }


### PR DESCRIPTION
# Brief

Fix crash on connect to native protocol version 6

# Description

Connecting to a device with protocol version 6 causes a crash of a client openDAQ application
