### PR TITLE
Generate SBOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         include:
           - name: Windows VS 2022 x64 Release
             cmake-build-type: Release
-            cmake-defines:
+            cmake-defines: -DOPENDAQ_ENABLE_SBOM=ON
             cmake-generator: "Visual Studio 17 2022"
             enable-tests: true
           - name: Windows VS 2022 x64 Debug
@@ -104,6 +104,31 @@ jobs:
           name: Unit Test Results (${{ matrix.name }})
           path: ${{ steps.build-and-test.outputs.gtest-xml-path }}
 
+      - name: Install SBOM verification dependency
+        if: matrix.name == 'Windows VS 2022 x64 Release'
+        shell: powershell
+        run: |
+          python -m pip install `
+            reuse `
+            "poetry-core; python_version < '3.9'" `
+            "spdx-tools>=0.8.0" `
+            ntia-conformance-checker
+
+      - name: Install (Generate SBOM)
+        working-directory: ./build
+        shell: powershell
+        if: matrix.name == 'Windows VS 2022 x64 Release'
+        run: |
+          cmake --install . --prefix ./_install
+
+      - name: Upload SBOM
+        if: matrix.name == 'Windows VS 2022 x64 Release'
+        working-directory: ./build
+        uses: actions/upload-artifact@v4
+        with:
+          name: SBOM (${{ matrix.name }})
+          path: ./_install/share/openDAQ/*.spdx
+
   build_linux:
     runs-on: ubuntu-latest
     name: ${{ matrix.name }}
@@ -133,7 +158,7 @@ jobs:
             additional-packages: g++-14
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines:
+            cmake-defines: -DOPENDAQ_ENABLE_SBOM=ON
           - name: Ubuntu Latest clang-14 Release
             cc: clang-14
             cxx: clang++-14
@@ -211,6 +236,30 @@ jobs:
         with:
           name: Unit Test Results (${{ matrix.name }})
           path: ${{ steps.build-and-test.outputs.gtest-xml-path }}
+
+      - name: Install SBOM verification dependency
+        if: matrix.name == 'Ubuntu Latest gcc-14 Release'
+        run: |
+          pip install \
+            reuse \
+            "poetry-core; python_version < '3.9'" \
+            "spdx-tools>=0.8.0" \
+            ntia-conformance-checker
+
+      - name: Install (Generate SBOM)
+        if: matrix.name == 'Ubuntu Latest gcc-14 Release'
+        working-directory: ./build
+        shell: bash
+        run: |
+          cmake --install . --prefix ./_install
+
+      - name: Upload SBOM
+        if: matrix.name == 'Ubuntu Latest gcc-14 Release'
+        working-directory: ./build
+        uses: actions/upload-artifact@v4
+        with:
+          name: SBOM (${{ matrix.name }})
+          path: ./_install/share/openDAQ/*.spdx
 
   build_macos:
     name: ${{ matrix.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,6 +710,36 @@ if (WIN32)
     add_compile_definitions(WIN32_LEAN_AND_MEAN)
 endif()
 
+# --- SBOM generation (cmake-sbom) ---
+option(OPENDAQ_ENABLE_SBOM "Generate SPDX SBOM during install" OFF)
+
+if (OPENDAQ_ENABLE_SBOM)
+  include(FetchContent)
+
+  # Fetch cmake-sbom (modules live in its /cmake directory)
+  # Use SOURCE_SUBDIR to prevent it from being added as a subproject
+  FetchContent_Declare(cmake_sbom
+    GIT_REPOSITORY https://github.com/DEMCON/cmake-sbom.git
+    GIT_TAG        v1.4.0
+    GIT_SHALLOW    TRUE
+    SOURCE_SUBDIR  cmake            # important: prevents add_subdirectory()
+  )
+  FetchContent_MakeAvailable(cmake_sbom)
+
+  list(APPEND CMAKE_MODULE_PATH "${cmake_sbom_SOURCE_DIR}/cmake")
+  include(sbom)
+
+  # Start SBOM collection early so opendaq_dependency() can call sbom_add(PACKAGE ...)
+  sbom_generate(
+    SUPPLIER     "openDAQ"
+    SUPPLIER_URL "https://opendaq.com"
+    PROJECT      "${SDK_NAME}"
+    VERSION      "${OPENDAQ_PACKAGE_VERSION_WITH_SHA}"
+    # OUTPUT     "opendaq.spdx"   # optional; default is in CMAKE_INSTALL_PREFIX
+  )
+endif()
+
+
 # libraries needed before the core is read
 add_subdirectory(external)
 
@@ -860,3 +890,7 @@ endif()
 set(OPENDAQ_CONFIGURED_ONCE TRUE CACHE INTERNAL "A flag showing that CMake has configured at least once.")
 
 include(cmake/Packing.cmake)
+
+if (OPENDAQ_ENABLE_SBOM)
+  sbom_finalize()
+endif()


### PR DESCRIPTION
# Brief

Generate the initial SBOM (software bill of materials) for openDAQ

# Description

- In "Build and Test openDAQ" workflow (`ci.yml`) generate SBOM for "Windows VS 2022 x64 Release" and "Ubuntu Latest gcc-14 Release" in SPDX 2.3 tag-value format, which is an internationally recognized SBOM standard (ISO/IEC 5962:2021)
- Current SBOM focuses on first-level dependencies included in the build
- The individual entries in the output files are essentially added via CMake in `opendaq_dependency` macro
- Could be improved to provide a more complete overview of all libraries used in the project, such as those used in Python, C# bindings, CI, etc. For CI and C#, GitHub generated SBOM is already available at https://github.com/openDAQ/openDAQ/network/dependencies. Additionally, if we provide a `requirements.txt` for for Python or `conanfile.txt`, if we use Conan in the future, GitHub will pick that up automatically.

# Compliance 
- **EU CRA Alignment**: Covers top-level components and is likely compliant with current draft expectations.
- **NTIA Compliance**: Meets most required fields (name, version, relationships, author, timestamp) but needs improvements:
    - Supplier info = 'Anonymous'
    - License = NOASSERTION
    - Unique IDs = missing or incorrect

# Partial SPDX SBOM for Ubuntu 22.04 gcc-12 Release

```
PackageName: open62541
SPDXID: SPDXRef-open62541-0
ExternalRef: SECURITY cpe23Type cpe:2.3:o:canonical:ubuntu_linux:-:*:*:*:*:*:x86_64:*
PackageDownloadLocation: https://github.com/openDAQ/open62541.git
PackageLicenseDeclared: NOASSERTION
PackageCopyrightText: NOASSERTION
PackageVersion: 1.3.6-opendaq-4
PackageSupplier: Person: Anonymous
FilesAnalyzed: false
PackageLicenseConcluded: NOASSERTION
Relationship: SPDXRef-Package-openDAQ DEPENDS_ON SPDXRef-open62541-0
Relationship: SPDXRef-open62541-0 CONTAINS NOASSERTION

PackageName: Boost
SPDXID: SPDXRef-Boost-1
ExternalRef: SECURITY cpe23Type cpe:2.3:o:canonical:ubuntu_linux:-:*:*:*:*:*:x86_64:*
PackageDownloadLocation: NOASSERTION
PackageLicenseDeclared: NOASSERTION
PackageCopyrightText: NOASSERTION
PackageVersion: 1.71.0
PackageSupplier: Person: Anonymous
FilesAnalyzed: false
PackageLicenseConcluded: NOASSERTION
Relationship: SPDXRef-Package-openDAQ DEPENDS_ON SPDXRef-Boost-1
Relationship: SPDXRef-Boost-1 CONTAINS NOASSERTION

PackageName: date
SPDXID: SPDXRef-date-2
ExternalRef: SECURITY cpe23Type cpe:2.3:o:canonical:ubuntu_linux:-:*:*:*:*:*:x86_64:*
PackageDownloadLocation: https://github.com/HowardHinnant/date
PackageLicenseDeclared: NOASSERTION
PackageCopyrightText: NOASSERTION
PackageVersion: f94b8f3
PackageSupplier: Person: Anonymous
FilesAnalyzed: false
PackageLicenseConcluded: NOASSERTION
Relationship: SPDXRef-Package-openDAQ DEPENDS_ON SPDXRef-date-2
Relationship: SPDXRef-date-2 CONTAINS NOASSERTION

PackageName: fmt
SPDXID: SPDXRef-fmt-3
ExternalRef: SECURITY cpe23Type cpe:2.3:o:canonical:ubuntu_linux:-:*:*:*:*:*:x86_64:*
PackageDownloadLocation: https://github.com/fmtlib/fmt.git
PackageLicenseDeclared: NOASSERTION
PackageCopyrightText: NOASSERTION
PackageVersion: 12.1.0
PackageSupplier: Person: Anonymous
FilesAnalyzed: false
PackageLicenseConcluded: NOASSERTION
Relationship: SPDXRef-Package-openDAQ DEPENDS_ON SPDXRef-fmt-3
Relationship: SPDXRef-fmt-3 CONTAINS NOASSERTION
```