### PR TITLE
remove creating username and location property on device

### DIFF
--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -149,22 +149,6 @@ public:
     }
 };
 
-
-TEST_F(DeviceTest, DeviceInfoNameLocationSync)
-{
-    auto device = daq::createWithImplementation<daq::IDevice, TestDevice>();
-    auto info = device.getInfo();
-
-    ASSERT_EQ(info.getLocation(), "test");
-    ASSERT_EQ(info.getName(), "dev");
-
-    device.setPropertyValue("location", "new_loc");
-    device.setName("new_name");
-
-    ASSERT_EQ(info.getLocation(), "new_loc");
-    ASSERT_EQ(info.getName(), "new_name");
-}
-
 TEST_F(DeviceTest, DeviceInfoForwardCallbacks)
 {
     auto device = daq::createWithImplementation<daq::IDevice, TestDevice>();

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -632,8 +632,8 @@ TEST_F(ConfigProtocolIntegrationTest, DeviceInfoChanges)
     const auto clientDeviceInfo = clientSubDevice.getInfo();
 
     // set fields on server
-    serverSubDevice.setPropertyValue("userName", "new_name");
-    serverSubDevice.setPropertyValue("location", "new_location");
+    serverDeviceInfo.setPropertyValue("userName", "new_name");
+    serverDeviceInfo.setPropertyValue("location", "new_location");
 
     ASSERT_EQ("new_name", serverDeviceInfo.getPropertyValue("userName"));
     ASSERT_EQ("new_location", serverDeviceInfo.getLocation());
@@ -642,8 +642,8 @@ TEST_F(ConfigProtocolIntegrationTest, DeviceInfoChanges)
     ASSERT_EQ(serverDeviceInfo.getLocation(), clientDeviceInfo.getLocation());
 
     // set fields on client
-    clientSubDevice.setPropertyValue("userName", "new_client_name");
-    clientSubDevice.setPropertyValue("location", "new_client_location");
+    clientDeviceInfo.setPropertyValue("userName", "new_client_name");
+    clientDeviceInfo.setPropertyValue("location", "new_client_location");
 
     ASSERT_EQ("new_client_name", clientDeviceInfo.getPropertyValue("userName"));
     ASSERT_EQ("new_client_location", clientDeviceInfo.getLocation());

--- a/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
+++ b/shared/libraries/opcuatms/tests/opcuatms_integration/test_tms_device.cpp
@@ -523,7 +523,7 @@ TEST_F(TmsDeviceTest, DeviceInfoChanges)
     ASSERT_EQ(serverDeviceInfo.getLocation(), clientDeviceInfo.getLocation());
 
     clientSubDevice.setName("new_name");
-    clientSubDevice.setPropertyValue("location", "new_location");
+    clientDeviceInfo.setPropertyValue("location", "new_location");
     
     ASSERT_EQ("new_name", clientDeviceInfo.getName());
     ASSERT_EQ("new_location", clientDeviceInfo.getLocation());

--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -3053,30 +3053,22 @@ TEST_F(NativeDeviceModulesTest, UpdateEditableFiledsDeviceInfo)
     auto serverInfo = server.getInfo();
     auto clientInfo = clientDevice.getInfo();
     
-    server.setPropertyValue("userName", "user1");
-    server.setPropertyValue("location", "location1");
+    serverInfo.setPropertyValue("userName", "user1");
+    serverInfo.setPropertyValue("location", "location1");
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    ASSERT_EQ(server.getPropertyValue("userName"), "user1");
-    ASSERT_EQ(server.getPropertyValue("location"), "location1");
     ASSERT_EQ(serverInfo.getPropertyValue("userName"), "user1");
     ASSERT_EQ(serverInfo.getPropertyValue("location"), "location1");
 
-    ASSERT_EQ(clientDevice.getPropertyValue("userName"), "user1");
-    ASSERT_EQ(clientDevice.getPropertyValue("location"), "location1");
     ASSERT_EQ(clientInfo.getPropertyValue("userName"), "user1");
     ASSERT_EQ(clientInfo.getPropertyValue("location"), "location1");
 
-    clientDevice.setPropertyValue("userName", "user2");
-    clientDevice.setPropertyValue("location", "location2");
+    clientInfo.setPropertyValue("userName", "user2");
+    clientInfo.setPropertyValue("location", "location2");
 
-    ASSERT_EQ(clientDevice.getPropertyValue("userName"), "user2");
-    ASSERT_EQ(clientDevice.getPropertyValue("location"), "location2");
     ASSERT_EQ(clientInfo.getPropertyValue("userName"), "user2");
     ASSERT_EQ(clientInfo.getPropertyValue("location"), "location2");
 
-    ASSERT_EQ(server.getPropertyValue("userName"), "user2");
-    ASSERT_EQ(server.getPropertyValue("location"), "location2");
     ASSERT_EQ(serverInfo.getPropertyValue("userName"), "user2");
     ASSERT_EQ(serverInfo.getPropertyValue("location"), "location2");
 }


### PR DESCRIPTION
# Brief

(Concise one-line description of what changed and what was added/removed, maybe even why)



# Description

(Individual high-level changes)

- Add Python GUI Demo functionality
- Rename a function
- ...

# Usage example

In C++ use:

```cpp
auto variable = "foo";
```

In terminal use:

```shell
cd folder
```

# API changes

> [!NOTE]
> Modifying, removing, or adding a function to an interface inherited by another, breaks binary compatibility of module shared libraries

(An overview of changes on the interface level (abstract structs with pure virtual functions), if any, one function per line)

```diff
+ this
- that
```

# Required application changes

(Changes required in openDAQ applications/executables)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```

# Required module changes

(Changes required in openDAQ shared libraries/modules)

- (E.g. change renamed function name)
- ...

Instead of:

```cpp
foo();
```

Do:

```cpp
bar();
```
