### PR TITLE
Deploy workflow MacOS: replace macos-13 with macOS-15-intel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -624,6 +624,9 @@ jobs:
               3.13
               3.14
 
+      - name: Install brew dependencies
+        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install mono
+
       - name: Make dirs
         run: |
           mkdir -p build


### PR DESCRIPTION
# Brief

Replace deprecated `macos-13` runner with `macos-15-intel` in deploy workflow for x86_64 wheel builds

# Description

- Replace `macos-13` runner with `macos-15-intel` for `deploy_macos_wheels_x86_64` job
- Update matrix job name to reflect the new runner
