### PR TITLE
Fix macOS 15 tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,7 +563,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
       cancel-in-progress: true
-    timeout-minutes: 180
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
@@ -631,7 +631,7 @@ jobs:
           python$last_version -m venv build/venv
           . build/venv/bin/activate
           pip install build/pip/packages/opendaq*.whl
-          ctest --output-on-failure --preset ${{ env.ctest_preset }} -C ${{ matrix.cmake_build_type }} --test-dir build
+          sudo -E ctest --output-on-failure --preset ${{ env.ctest_preset }} -C ${{ matrix.cmake_build_type }} --test-dir build
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
# Brief

Fix macOS tests run and build job timeout

# Description

- Run macOS tests with sudo because of LNP/mDNS access restrictions
- Increase build-macos job timeout from 180 to 240 minutes

# Usage example

N/A

# API changes

N/A

# Required application changes

N/A

# Required module changes

N/A

