### PR TITLE
CI workflow: Intel LLVM support on Windows

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -87,7 +87,7 @@ runs:
       uses: seanmiddleditch/gha-setup-ninja@v5
 
     - name: Setup MSYS2 MINGW64
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && env.CXX == 'g++'
       id: msys2
       uses: msys2/setup-msys2@v2
       with:
@@ -96,7 +96,7 @@ runs:
         install: mingw-w64-x86_64-crt-git mingw-w64-x86_64-gcc
 
     - name: Add MSYS2 MINGW64 to PATH
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && env.CXX == 'g++'
       shell: bash
       run: |
         echo "${{ steps.msys2.outputs.msys2-location }}/mingw64/bin" >> $GITHUB_PATH
@@ -106,6 +106,10 @@ runs:
     - name: Setup MSVC toolchain
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Setup Intel LLVM compiler
+      if: runner.os == 'Windows' && env.CXX == 'icx'
+      uses: ./.github/actions/setup-compiler-icx
 
     - name: Install Python dependencies
       shell: bash

--- a/.github/actions/setup-compiler-icx/action.yml
+++ b/.github/actions/setup-compiler-icx/action.yml
@@ -1,0 +1,97 @@
+name: Setup Intel LLVM Compiler
+description: Install and configure Intel LLVM C++ compiler (icx) from oneAPI toolkit
+
+runs:
+  using: composite
+  steps:
+    - name: Download installer
+      if: runner.os == 'Windows'
+      id: download-windows
+      shell: pwsh
+      run: |
+        $url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372_offline.exe"
+        $output = "$env:TEMP\oneapi_installer.exe"
+
+        Write-Host "Downloading Intel oneAPI Base Toolkit..."
+        Write-Host "See: https://github.com/oneapi-src/oneapi-ci"
+        Write-Host "URL: $url"
+        Write-Host "Output: $output"
+
+        curl.exe -L -o $output $url --retry 5 --retry-delay 5 --fail --show-error
+
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Download failed with exit code $LASTEXITCODE"
+          exit 1
+        }
+
+        if (-not (Test-Path $output)) {
+          Write-Error "Downloaded file not found: $output"
+          exit 1
+        }
+
+        $size = (Get-Item $output).Length / 1MB
+        Write-Host "Download complete: $([math]::Round($size, 2)) MB"
+
+    - name: Install oneAPI
+      if: runner.os == 'Windows'
+      id: install-windows
+      shell: pwsh
+      run: |
+        Write-Host "Extracting installer..."
+        $extract = Start-Process -Wait -PassThru -FilePath "$env:TEMP\oneapi_installer.exe" `
+          -ArgumentList "-s", "-x", "-f", "$env:TEMP\oneapi_extracted", "--log", "extract.log"
+        if ($extract.ExitCode -ne 0) {
+          Write-Error "Extraction failed with exit code $($extract.ExitCode)"
+          Get-Content extract.log -ErrorAction SilentlyContinue
+          exit 1
+        }
+
+        Write-Host "Installing component: intel.oneapi.win.cpp-dpcpp-common"
+        $installArgs = "-s --action install --eula=accept --components=intel.oneapi.win.cpp-dpcpp-common -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=."
+        Write-Host "Running: bootstrapper.exe $installArgs"
+        $install = Start-Process -Wait -PassThru -FilePath "$env:TEMP\oneapi_extracted\bootstrapper.exe" -ArgumentList $installArgs
+        if ($install.ExitCode -ne 0) {
+          Write-Error "Installation failed with exit code $($install.ExitCode)"
+          Get-ChildItem *.log | ForEach-Object { Write-Host "=== $($_.Name) ==="; Get-Content $_ }
+          exit 1
+        }
+
+        # Verify installation
+        $compilerPath = "C:\Program Files (x86)\Intel\oneAPI\compiler"
+        if (-not (Test-Path $compilerPath)) {
+          Write-Error "Compiler directory not found after installation"
+          Write-Host "Contents of Intel oneAPI directory:"
+          Get-ChildItem "C:\Program Files (x86)\Intel\oneAPI" -ErrorAction SilentlyContinue
+          exit 1
+        }
+        Write-Host "Installation complete"
+        Get-ChildItem $compilerPath
+
+        # Cleanup installer files
+        Remove-Item -Force "$env:TEMP\oneapi_installer.exe" -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force "$env:TEMP\oneapi_extracted" -ErrorAction SilentlyContinue
+
+        # Output scripts for environment setup
+        "scripts<<EOF" >> $env:GITHUB_OUTPUT
+        "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat" >> $env:GITHUB_OUTPUT
+        "C:\Program Files (x86)\Intel\oneAPI\compiler\latest\env\vars.bat" >> $env:GITHUB_OUTPUT
+        "EOF" >> $env:GITHUB_OUTPUT
+
+    - name: Export oneAPI environment
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/source-script
+      with:
+        scripts: ${{ steps.install-windows.outputs.scripts }}
+
+    - name: Verify compiler
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Write-Host "Verifying Intel oneAPI compiler..."
+        $icxPath = Get-Command icx -ErrorAction SilentlyContinue
+        if (-not $icxPath) {
+          Write-Error "icx compiler not found in PATH"
+          exit 1
+        }
+        Write-Host "Found: $($icxPath.Source)"
+        icx --version

--- a/.github/actions/source-script/action.yml
+++ b/.github/actions/source-script/action.yml
@@ -1,0 +1,65 @@
+name: 'Source Script'
+description: 'Run scripts and export environment variable changes to GITHUB_ENV'
+inputs:
+  scripts:
+    description: 'Scripts to run that modify environment (one per line, .bat, .cmd, .sh, etc.)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Source scripts and export env changes
+      shell: pwsh
+      run: |
+        $scripts = @"
+        ${{ inputs.scripts }}
+        "@ -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+
+        # Save current env
+        $before = @{}
+        Get-ChildItem Env: | ForEach-Object { $before[$_.Name] = $_.Value }
+
+        # Run each script
+        foreach ($script in $scripts) {
+          Write-Host "Running: $script"
+
+          $ext = [System.IO.Path]::GetExtension($script).ToLower()
+          if ($ext -in '.bat', '.cmd') {
+            cmd /c "`"$script`"" 2>&1 | Out-Null
+            $output = cmd /c "`"$script`" && set" 2>&1
+          } else {
+            $output = bash -c "source '$script' >/dev/null 2>&1 && env" 2>&1
+          }
+
+          # Update env for next script
+          $output | ForEach-Object {
+            if ($_ -match '^([^=]+)=(.*)$') {
+              [Environment]::SetEnvironmentVariable($Matches[1], $Matches[2], 'Process')
+            }
+          }
+        }
+
+        # Get final env state
+        $after = @{}
+        Get-ChildItem Env: | ForEach-Object { $after[$_.Name] = $_.Value }
+
+        # Export new/changed vars
+        $new = 0; $changed = 0
+        foreach ($key in $after.Keys) {
+          $newVal = $after[$key]
+          $oldVal = $before[$key]
+
+          if ($null -eq $oldVal) {
+            Write-Host "  + $key"
+            $new++
+          } elseif ($oldVal -ne $newVal) {
+            Write-Host "  ~ $key"
+            $changed++
+          } else {
+            continue
+          }
+
+          "$key=$newVal" >> $env:GITHUB_ENV
+        }
+
+        Write-Host "New: $new, Changed: $changed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
       cancel-in-progress: true
     timeout-minutes: 270
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     strategy:
       fail-fast: false
       matrix:
@@ -50,24 +53,33 @@ jobs:
             enable-32bit: true
             enable-tests: true
           - name: Windows Clang Release
+            cc: clang
+            cxx: clang++
             cmake-build-type: Release
-            cmake-defines: >-
-              -DCMAKE_C_COMPILER=clang 
-              -DCMAKE_CXX_COMPILER=clang++
+            cmake-defines:
             cmake-generator: Ninja
             enable-tests: true
           - name: Windows GCC Release
+            cc: gcc
+            cxx: g++
             cmake-build-type: Release
             cmake-defines: >-
-              -DCMAKE_C_COMPILER=gcc
-              -DCMAKE_CXX_COMPILER=g++
               "-DCMAKE_CXX_FLAGS=-Wa,-mbig-obj -Wno-deprecated-declarations -Wno-error=conversion-null"
               "-DCMAKE_C_FLAGS=-Wa,-mbig-obj"
             cmake-generator: Ninja
-            # Tests are disabled due to: 
+            # Tests are disabled due to:
             # - test_device_modules memory corruption
             # - Python tests module resolution issues
-            enable-tests: false 
+            enable-tests: false
+          - name: Windows Intel-LLVM Release
+            cc: icx
+            cxx: icx
+            cmake-build-type: Release
+            cmake-defines: >-
+              -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF
+              -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
+            cmake-generator: Ninja
+            enable-tests: true
 
     steps:
       - name: Checkout
@@ -75,7 +87,6 @@ jobs:
 
       - name: Build and Test
         id: build-and-test
-        if: matrix.name != 'Windows Intel-LLVM Release'
         uses: ./.github/actions/build-sdk
         with:
           cmake-build-type: ${{ matrix.cmake-build-type }}
@@ -102,51 +113,70 @@ jobs:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
       cancel-in-progress: true
     timeout-minutes: 180
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: Ubuntu Latest gcc-9 Release
+            cc: gcc-9
+            cxx: g++-9
             additional-packages: g++-9
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines: -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9
+            cmake-defines:
           - name: Ubuntu Latest gcc-14 Release
+            cc: gcc-14
+            cxx: g++-14
             additional-packages: g++-14
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines: -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14
+            cmake-defines:
           - name: Ubuntu Latest clang-14 Release
+            cc: clang-14
+            cxx: clang++-14
             additional-packages: clang-14
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines: -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14
+            cmake-defines:
           - name: Ubuntu Latest clang-16 Release
+            cc: clang-16
+            cxx: clang++-16
             additional-packages: clang-16
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines: -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16
+            cmake-defines:
           # The Debug configurations are disabled until the problem with test_py_opendaq is resolved.
           # - name: Ubuntu Latest gcc-9 Debug
+          #   cc: gcc-9
+          #   cxx: g++-9
           #   additional-packages: g++-9
           #   cmake-generator: Ninja
           #   cmake-build-type: Debug
-          #   cmake-defines: -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9
+          #   cmake-defines:
           # - name: Ubuntu Latest gcc-14 Debug
+          #   cc: gcc-14
+          #   cxx: g++-14
           #   additional-packages: g++-14
           #   cmake-generator: Ninja
           #   cmake-build-type: Debug
-          #   cmake-defines: -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14
+          #   cmake-defines:
           # - name: Ubuntu Latest clang-14 Debug
+          #   cc: clang-14
+          #   cxx: clang++-14
           #   additional-packages: clang-14
           #   cmake-generator: Ninja
           #   cmake-build-type: Debug
-          #   cmake-defines: -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14
+          #   cmake-defines:
           # - name: Ubuntu Latest clang-16 Debug
+          #   cc: clang-16
+          #   cxx: clang++-16
           #   additional-packages: clang-16
           #   cmake-generator: Ninja
           #   cmake-build-type: Debug
-          #   cmake-defines: -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16
+          #   cmake-defines:
 
     steps:
       - name: Checkout
@@ -180,25 +210,26 @@ jobs:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
       cancel-in-progress: true
     timeout-minutes: 240
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: MacOS Latest Clang Release
+            cc: clang
+            cxx: clang++
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines: >-
-              -DCMAKE_C_COMPILER=clang
-              -DCMAKE_CXX_COMPILER=clang++
-              -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
+            cmake-defines: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
             runner: macos-latest
           - name: MacOS 15 Intel Clang Release
+            cc: clang
+            cxx: clang++
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines: >-
-              -DCMAKE_C_COMPILER=clang
-              -DCMAKE_CXX_COMPILER=clang++
-              -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
+            cmake-defines: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
             runner: macos-15-intel
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,6 +719,8 @@ if(CMAKE_COMPILER_IS_CLANGXX)
         set(CLANG_FLAGS "${CLANG_FLAGS} \
             -Xclang -Wno-delete-non-abstract-non-virtual-dtor"
         )
+        # Use precise floating-point model to avoid aggressive optimizations
+        set(CLANG_FLAGS "${CLANG_FLAGS} /fp:precise")
     endif ()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_FLAGS}")


### PR DESCRIPTION
# Brief

Add Intel LLVM support on Windows

# Description

- Add setup-compiler-icx action to download and install Intel LLVM compiler
- Add source-script action to export environment variables from a script file
- Use CC/CXX environment variables instead of CMake compiler flags
- Use precise floating-point model to avoid aggressive optimizations

# Usage example

N/A

# API changes

N/A

# Required application changes

N/A

# Required module changes

N/A
