### PR TITLE
Update external lib boost

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -18,13 +18,13 @@
 
 ## Bug fixes
 
--[#1015](https://github.com/openDAQ/openDAQ/pull/1015) IPropertyObject::hasProperty returns false instead of throwing not found error if the parent property does not exists
+- [#1015](https://github.com/openDAQ/openDAQ/pull/1015) IPropertyObject::hasProperty returns false instead of throwing not found error if the parent property does not exists
 
 ## Misc
 
 - [#979](https://github.com/openDAQ/openDAQ/pull/979) Relocate and install dependency management cmake helpers, install daq::test_utils and rename "bb" to "daq" in testultils/daq_memcheck_listener.h
 - [#974](https://github.com/openDAQ/openDAQ/pull/974) Reorganizes the audio device implementation for greater clarity. Adds automatic device/FB version info setting.
-- [#967](https://github.com/openDAQ/openDAQ/pull/967), [#994](https://github.com/openDAQ/openDAQ/pull/994), [#993](https://github.com/openDAQ/openDAQ/pull/993), [#995](https://github.com/openDAQ/openDAQ/pull/995), [#1001](https://github.com/openDAQ/openDAQ/pull/1001), [1025](https://github.com/openDAQ/openDAQ/pull/1025), [#1026](https://github.com/openDAQ/openDAQ/pull/1026), [#1020](https://github.com/openDAQ/openDAQ/pull/1020) Update external libraries:
+- [#967](https://github.com/openDAQ/openDAQ/pull/967), [#994](https://github.com/openDAQ/openDAQ/pull/994), [#993](https://github.com/openDAQ/openDAQ/pull/993), [#995](https://github.com/openDAQ/openDAQ/pull/995), [#1001](https://github.com/openDAQ/openDAQ/pull/1001), [1025](https://github.com/openDAQ/openDAQ/pull/1025), [#1026](https://github.com/openDAQ/openDAQ/pull/1026), [#1020](https://github.com/openDAQ/openDAQ/pull/1020), [#1028](https://github.com/openDAQ/openDAQ/pull/1028) Update external libraries:
     - gtest from 1.12.1 to 1.17.0
     - date from 3.0.1 to 3.0.4
     - pybind11 from 2.13.1 to 3.0.1
@@ -39,6 +39,7 @@
     - rapidjson from unknown to latest master
     - thrift from 0.20.0 to 0.22.0
     - arrow from 20.0.0 to 22.0.0
+    - boost from 1.82.0 to 1.90.0
 
 ## Required application changes
 

--- a/external/boost/CMakeLists.txt
+++ b/external/boost/CMakeLists.txt
@@ -65,9 +65,9 @@ set(BOOST_INCLUDE_LIBRARIES "${NEEDED_LIBRARIES}"
 
 opendaq_dependency(
     NAME                Boost
-    REQUIRED_VERSION    1.71.0
-    URL                 https://github.com/boostorg/boost/releases/download/boost-1.82.0/boost-1.82.0.tar.xz
-    URL_HASH            SHA256=fd60da30be908eff945735ac7d4d9addc7f7725b1ff6fcdcaede5262d511d21e
+    REQUIRED_VERSION    1.90.0
+    URL                 https://github.com/boostorg/boost/releases/download/boost-1.90.0/boost-1.90.0-cmake.tar.xz
+    URL_HASH            SHA256=aca59f889f0f32028ad88ba6764582b63c916ce5f77b31289ad19421a96c555f
     EXPECT_TARGET       Boost::headers
     OVERRIDE_FIND_PACKAGE
 )

--- a/external/native_streaming/CMakeLists.txt
+++ b/external/native_streaming/CMakeLists.txt
@@ -1,7 +1,7 @@
 opendaq_dependency(
     NAME                native_streaming
-    REQUIRED_VERSION    1.0.19
+    REQUIRED_VERSION    1.0.20
     GIT_REPOSITORY      https://github.com/openDAQ/libNativeStreaming.git
-    GIT_REF             v1.0.19
+    GIT_REF             v1.0.20
     EXPECT_TARGET       daq::native_streaming
 )


### PR DESCRIPTION
# Brief

Update external lib boost from 1.71.0 to 1.90.0

# Description

* Update external lib boost from 1.71.0 to 1.90.0
* Update [openDAQ/libNativeStreaming](https://github.com/openDAQ/libNativeStreaming ) from 1.0.19 to 1.0.20
    * openDAQ/libNativeStreaming/pull/27

# TODO
* Update [openDAQ/streaming-protocol-lt](https://github.com/openDAQ/streaming-protocol-lt)
    * Update [openDAQ/libstream](https://github.com/openDAQ/libstream) from 1.0.3 to 1.0.4
        * openDAQ/libstream/pull/8
* Fix all errors
* Test with `DAQMODULES_PARQUET_RECORDER_MODULE` turned ON
    * May require #1020 to be merged first