### PR TITLE
Fix Python IIterator binding

### DIFF
--- a/bindings/python/core_types/src/py_iterator.cpp
+++ b/bindings/python/core_types/src/py_iterator.cpp
@@ -1,3 +1,4 @@
+#include <pybind11/pytypes.h>
 #include "py_core_types/py_core_types.h"
 
 PyDaqIntf<daq::IIterator> declareIIterator(pybind11::module_ m)
@@ -8,6 +9,12 @@ PyDaqIntf<daq::IIterator> declareIIterator(pybind11::module_ m)
 void defineIIterator(pybind11::module_ m, PyDaqIntf<daq::IIterator> cls)
 {
     cls.doc() = "Interface to iterate through items of a container object.";
+
+    cls.def("__iter__",
+        [](pybind11::object self)
+        {
+            return self;
+        });
 
     cls.def("__next__",
         [](daq::IIterator* it)

--- a/bindings/python/tests/test_core_types.py
+++ b/bindings/python/tests/test_core_types.py
@@ -282,6 +282,8 @@ class TestIterable(opendaq_test.TestCase):
             self.assertEqual(item, i)
             i = i + 1
 
+        self.assertEqual([x for x in l], [1, 2, 3])
+
     def test_from_list(self):
         l = daq.List()
         l.push_back(1)

--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -13,6 +13,7 @@
 - [#987](https://github.com/openDAQ/openDAQ/pull/987) Make Enumeration Properties editable in Python GUI demo application
 - [#991](https://github.com/openDAQ/openDAQ/pull/991) Add Function Block configuration to Python GUI demo app
 - [#1007](https://github.com/openDAQ/openDAQ/pull/1007) Add a missing error popup when adding a Function Block fails in Python GUI demo app.
+- [#1029](https://github.com/openDAQ/openDAQ/pull/1029) Fix python binding for iterators to enable list comprehensions.
 
 ## Bug fixes
 


### PR DESCRIPTION
"An Iterator in Python must provide an __iter__ method" (see https://docs.python.org/3.14/glossary.html#term-iterator). Otherwise list comprehensions like `[s.name for s in device.signals]` does not work.

Before we would see an error like:
```
TypeError: 'opendaq.opendaq.IIterator' object is not iterable
```