### PR TITLE
CI workflow: add 32-bit build support on Linux

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -54,6 +54,7 @@ runs:
         fi
 
     - name: Set up Python
+      if: ${{ !(inputs.enable-32bit == 'true' && runner.os == 'Linux') }}
       uses: actions/setup-python@v5
       with:
         python-version: '3.14'
@@ -67,14 +68,46 @@ runs:
       shell: pwsh
       run: choco install ${{ inputs.additional-dependencies }} -y --no-progress
 
+    - name: Remove conflicting packages (for 32-bit build)
+      if: runner.os == 'Linux' && inputs.enable-32bit == 'true'
+      shell: bash
+      run: |
+        echo "Removing bootloader packages that conflict with i386 multi-arch"
+        if ! sudo apt-get remove -y --allow-remove-essential shim-signed grub-efi-amd64-signed grub2-common grub-efi-amd64-bin grub-common; then
+          echo "::warning::Failed to remove bootloader packages"
+        fi
+        echo "Removing pre-installed 64-bit Python to avoid conflicts with 32-bit build"
+        if ! sudo apt-get remove -y python3 python3-pip python3-dev; then
+          echo "::warning::Failed to remove pre-installed Python packages"
+        fi
+        sudo apt-get autoremove -y
+
     - name: Install Linux dependencies
       if: runner.os == 'Linux'
       shell: bash
+      env:
+        ENABLE_32BIT: ${{ inputs.enable-32bit }}
       run: |
+        DEV_PACKAGES=(
+          libx11-dev
+          libxi-dev
+          libxcursor-dev
+          libxrandr-dev
+          libgl-dev
+          libudev-dev
+          libfreetype6-dev
+        )
+
+        if [ "$ENABLE_32BIT" == "true" ]; then
+          sudo dpkg --add-architecture i386
+          DEV_PACKAGES=("${DEV_PACKAGES[@]/%/:i386}" python3:i386 python3-dev:i386 gcc-multilib g++-multilib \
+            libx11-6:i386 libxrandr2:i386 libxcursor1:i386 libxi6:i386 libgl1:i386)
+        fi
+
         sudo apt-get update && sudo apt-get install -y --no-install-recommends \
           ${{ inputs.additional-dependencies || '' }} \
           lld mono-runtime libmono-system-json-microsoft4.0-cil libmono-system-data4.0-cil \
-          libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev
+          "${DEV_PACKAGES[@]}"
 
     - name: Install macOS dependencies
       if: runner.os == 'macOS'
@@ -112,9 +145,10 @@ runs:
       uses: ./.github/actions/setup-compiler-icx
 
     - name: Install Python dependencies
+      if: ${{ !(inputs.enable-32bit == 'true' && runner.os == 'Linux') }}
       shell: bash
       run: |
-        echo "Installing numpy for Python versions: $(python --version)"
+        echo "Installing numpy for Python: $(python --version)"
         python -m pip install numpy
         echo "Done installing Python dependencies"
 
@@ -125,6 +159,7 @@ runs:
         CMAKE_BUILD_TYPE: ${{ inputs.cmake-build-type }}
         CMAKE_GENERATOR: ${{ inputs.cmake-generator }}
         CI_GIT_BRANCH: ${{ github.head_ref }}
+        ENABLE_32BIT: ${{ inputs.enable-32bit }}
       run: |
         CMAKE_BUILD_PATH="build"
         mkdir -p "$CMAKE_BUILD_PATH"
@@ -136,9 +171,24 @@ runs:
           CMAKE_ARGS="--preset ${{ inputs.cmake-config-preset }}"
         fi
 
-        # Visual Studio specific options
+        # Detect Visual Studio generator
+        IS_VISUAL_STUDIO=false
         if [[ "$CMAKE_GENERATOR" == "Visual Studio"* ]]; then
+          IS_VISUAL_STUDIO=true
+        fi
+
+        # Visual Studio specific options
+        if [ "$IS_VISUAL_STUDIO" == "true" ]; then
           CMAKE_ARGS="$CMAKE_ARGS -DOPENDAQ_MSVC_SINGLE_PROCESS_BUILD=ON"
+        fi
+
+        # 32-bit build configuration
+        if [ "$ENABLE_32BIT" == "true" ]; then
+          if [ "$IS_VISUAL_STUDIO" == "true" ]; then
+            CMAKE_ARGS="$CMAKE_ARGS -A Win32"
+          else
+            CMAKE_ARGS="$CMAKE_ARGS -DOPENDAQ_FORCE_COMPILE_32BIT=ON"
+          fi
         fi
 
         if [ -n "$CMAKE_BUILD_TYPE" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             enable-tests: true
           - name: Windows VS 2022 Win32 Release
             cmake-build-type: Release
-            cmake-defines: -A Win32
+            cmake-defines:
             cmake-generator: "Visual Studio 17 2022"
             enable-32bit: true
             enable-tests: true
@@ -148,6 +148,16 @@ jobs:
             cmake-generator: Ninja
             cmake-build-type: Release
             cmake-defines:
+          - name: Ubuntu Latest gcc x86_32 Release
+            cc: gcc
+            cxx: g++
+            additional-packages:
+            cmake-generator: Ninja
+            cmake-build-type: Release
+            cmake-defines: >-
+              -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF 
+              -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
+            enable-32bit: true
           # The Debug configurations are disabled until the problem with test_py_opendaq is resolved.
           # - name: Ubuntu Latest gcc-9 Debug
           #   cc: gcc-9
@@ -191,6 +201,7 @@ jobs:
           cmake-config-preset: ${{ env.cmake_preset }}
           cmake-config-args: ${{ matrix.cmake-defines }}
           cmake-generator: ${{ matrix.cmake-generator }}
+          enable-32bit: ${{ matrix.enable-32bit == true }}
           enable-tests: true
           ctest-preset: ${{ env.ctest_preset }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,24 @@ if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "In-source build is not supported! Please choose a separate build directory e.g.: /build/x64/msvc")
 endif()
 
+# 32-bit Linux cross-compilation setup (must be before project())
+if(OPENDAQ_FORCE_COMPILE_32BIT AND CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+    set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -m32" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -m32" CACHE STRING "" FORCE)
+    set(CMAKE_ASM_FLAGS_INIT "${CMAKE_ASM_FLAGS_INIT} -m32" CACHE STRING "" FORCE)
+
+    # Help CMake find 32-bit libraries
+    list(APPEND CMAKE_LIBRARY_PATH /usr/lib/i386-linux-gnu)
+
+    if(NOT CMAKE_SYSTEM_NAME)
+        set(CMAKE_SYSTEM_NAME Linux CACHE STRING "" FORCE)
+    endif()
+    
+    if(NOT CMAKE_SYSTEM_PROCESSOR)
+        set(CMAKE_SYSTEM_PROCESSOR i386 CACHE STRING "" FORCE)
+    endif()
+endif()
+
 project(${SDK_NAME}
     LANGUAGES CXX
     VERSION ${OPENDAQ_PACKAGE_VERSION}
@@ -371,7 +389,14 @@ if ((CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX) AND NOT MSVC)
     if(OPENDAQ_FORCE_COMPILE_32BIT)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -m32")
         set(BUILD_64Bit OFF)
+
+        # Linux GCC 32-bit specific flags
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCXX)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -ffloat-store")
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+        endif()
     endif()
 
     # The flag -fuse-ld=lld is needed on MinGW where the default linker is hardly usable.

--- a/examples/modules/audio_device_module/src/CMakeLists.txt
+++ b/examples/modules/audio_device_module/src/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(${LIB_NAME}
 # Should link only what you need $<BUILD_INTERFACE:Boost::locale>
 target_link_libraries(${LIB_NAME} PRIVATE $<BUILD_INTERFACE:Boost::locale>)
 
-if (CMAKE_COMPILER_IS_GNUCXX AND MINGW)
+if (CMAKE_COMPILER_IS_GNUCXX AND (MINGW OR OPENDAQ_FORCE_COMPILE_32BIT))
     target_compile_options(${LIB_NAME} PRIVATE -Wno-error)
 endif()
 

--- a/external/bcrypt/src/crypt_blowfish.c
+++ b/external/bcrypt/src/crypt_blowfish.c
@@ -58,7 +58,7 @@
 #endif
 
 #ifdef __i386__
-#define BF_ASM				1
+#define BF_ASM				0
 #define BF_SCALE			1
 #elif defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_ASM				0

--- a/shared/libraries/opcua/opcuashared/src/bcrypt/crypt_blowfish.c
+++ b/shared/libraries/opcua/opcuashared/src/bcrypt/crypt_blowfish.c
@@ -54,7 +54,7 @@
 #include <opcuashared/bcrypt/crypt_blowfish.h>
 
 #ifdef __i386__
-#define BF_ASM				1
+#define BF_ASM				0
 #define BF_SCALE			1
 #elif defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_ASM				0


### PR DESCRIPTION
# Brief

Enable 32-bit Linux build support in CI

# Description

- Extend `build-sdk` action for 32-bit Linux (i386 multi-arch)
- Add Ubuntu gcc x86_32 Release CI configuration
- Add 32-bit specific CMake flags (-m32, -fPIC, -ffloat-store)
- Disable bcrypt ASM for 32-bit Linux
- Disable Python/C# bindings for 32-bit (Python i386 not available via setup-python)
- Fix `stringop-overflow` warning in audio_device_module

# Usage example

N/A

# API changes

N/A

# Required application changes

N/A

# Required module changes

N/A
