### PR TITLE
Add boost::io for thrift 0.22.0 transitive dependency

### DIFF
--- a/external/boost/CMakeLists.txt
+++ b/external/boost/CMakeLists.txt
@@ -113,6 +113,7 @@ if (Boost_FETCHED)
             type_traits 
             utility 
             mp11
+            io
             uuid
         )
 


### PR DESCRIPTION
# Brief

Add boost::io for thrift 0.22.0 transitive dependency

# Description

The thrift 0.22.0 depends on boost::uuid, and boost::uuid depends on boost::io.

# Usage example

N/A

# API changes

N/A

# Required application changes

N/A

# Required module changes

N/A
