### PR TITLE
fix macroses should use daq namespace for used variables 

### DIFF
--- a/core/coretypes/include/coretypes/ctutils.h
+++ b/core/coretypes/include/coretypes/ctutils.h
@@ -422,7 +422,7 @@ ErrCode makeErrorInfo(ErrCode errCode, IBaseObject* source, const std::string& m
 #define OPENDAQ_RETURN_IF_FAILED_EXCEPT(errCode, expectedErrCode, ...)                  \
     do                                                                                  \
     {                                                                                   \
-        const ErrCode errCode_ = (errCode);                                             \
+        const daq::ErrCode errCode_ = (errCode);                                        \
         if ((errCode_) == (expectedErrCode))                                            \
             daqClearErrorInfo();                                                        \
         else if (OPENDAQ_FAILED(errCode_))                                              \
@@ -432,7 +432,7 @@ ErrCode makeErrorInfo(ErrCode errCode, IBaseObject* source, const std::string& m
 #define OPENDAQ_RETURN_IF_FAILED(errCode, ...)                                          \
     do                                                                                  \
     {                                                                                   \
-        const ErrCode errCode_ = (errCode);                                             \
+        const daq::ErrCode errCode_ = (errCode);                                        \
         if (OPENDAQ_FAILED(errCode_))                                                   \
             return DAQ_EXTEND_ERROR_INFO(errCode_, ##__VA_ARGS__);                      \
     } while (0)


### PR DESCRIPTION
# Brief

macroses `OPENDAQ_RETURN_IF_FAILED_EXCEPT` and `OPENDAQ_RETURN_IF_FAILED` were using `ErrCode` variable without `daq` namespace which makes impossible to use them without `using namespace daw`

# API changes

None

# Required module changes

None
