### PR TITLE
Add support for parallel RPC calls

### DIFF
--- a/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
+++ b/modules/native_streaming_server_module/include/native_streaming_server_module/native_streaming_server_impl.h
@@ -24,6 +24,7 @@
 #include <native_streaming_protocol/native_streaming_server_handler.h>
 #include <opendaq/connection_internal.h>
 #include <tsl/ordered_map.h>
+#include <boost/asio/thread_pool.hpp>
 
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_SERVER_MODULE
 
@@ -65,6 +66,8 @@ protected:
     void componentRemoved(ComponentPtr& sender, CoreEventArgsPtr& eventArgs);
     void componentUpdated(ComponentPtr& updatedComponent);
     void coreEventCallback(ComponentPtr& sender, CoreEventArgsPtr& eventArgs);
+    void initWorkerPool();
+    std::function<void(std::function<void()>)> createBoostDispatchCallback();
 
     static void populateDefaultConfigFromProvider(const ContextPtr& context, const PropertyObjectPtr& config);
 
@@ -92,6 +95,7 @@ protected:
     size_t maxPacketReadCount;
     std::unordered_map<std::string, SizeT> registeredClientIds;
     std::unordered_map<std::string, SizeT> disconnectedClientIds;
+    std::shared_ptr<boost::asio::thread_pool> workerPool;
 };
 
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(

--- a/modules/native_streaming_server_module/tests/test_native_streaming_server_module.cpp
+++ b/modules/native_streaming_server_module/tests/test_native_streaming_server_module.cpp
@@ -164,6 +164,9 @@ TEST_F(NativeStreamingServerModuleTest, ServerConfig)
 
     ASSERT_TRUE(config.hasProperty("StreamingPacketReleaseThreshold"));
     ASSERT_EQ(config.getPropertyValue("StreamingPacketReleaseThreshold"), 10);
+
+    ASSERT_TRUE(config.hasProperty("StreamingWorkerCount"));
+    ASSERT_EQ(config.getPropertyValue("StreamingWorkerCount"), 1);
 }
 
 TEST_F(NativeStreamingServerModuleTest, CreateServer)

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_server.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_server.h
@@ -83,6 +83,7 @@ public:
 
     uint16_t getProtocolVersion() const;
     void setProtocolVersion(uint16_t protocolVersion);
+    SerializerPtr createSerializer();
 
 private:
     using DispatchFunction = std::function<BaseObjectPtr(const ParamsDictPtr&)>;
@@ -93,7 +94,6 @@ private:
     ContextPtr daqContext;
     NotificationReadyCallback notificationReadyCallback;
     DeserializerPtr deserializer;
-    SerializerPtr serializer;
     SerializerPtr notificationSerializer;
     std::unordered_map<std::string, DispatchFunction> rpcDispatch;
     std::mutex notificationSerializerLock;

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -75,7 +75,6 @@ ConfigProtocolServer::ConfigProtocolServer(DevicePtr rootDevice,
     , daqContext(this->rootDevice.getContext())
     , notificationReadyCallback(std::move(notificationReadyCallback))
     , deserializer(JsonDeserializer())
-    , serializer(JsonSerializer())
     , notificationSerializer(JsonSerializer())
     , componentFinder(std::make_unique<ComponentFinderRootDevice>(this->rootDevice))
     , user(user)
@@ -85,7 +84,6 @@ ConfigProtocolServer::ConfigProtocolServer(DevicePtr rootDevice,
     , streamingConsumer(this->daqContext, externalSignalsFolder)
 {
     assert(user.assigned());
-    serializer.setUser(user);
     notificationSerializer.setUser(user);
 
     buildRpcDispatchStructure();
@@ -292,6 +290,8 @@ void ConfigProtocolServer::processNoReplyPacket(const PacketBuffer& packetBuffer
 
 StringPtr ConfigProtocolServer::processRpcAndGetReply(const StringPtr& jsonStr)
 {
+    auto serializer = createSerializer();
+
     try
     {
         auto retObj = Dict<IString, IBaseObject>();
@@ -308,20 +308,19 @@ StringPtr ConfigProtocolServer::processRpcAndGetReply(const StringPtr& jsonStr)
         if (retValue.assigned())
             retObj.set("ReturnValue", retValue);
 
-        serializer.reset();
         retObj.serialize(serializer);
         return serializer.getOutput();
     }
     catch (const daq::DaqException& e)
     {
-        return prepareErrorResponse(e.getErrCode(), e.what(), this->serializer);
+        return prepareErrorResponse(e.getErrCode(), e.what(), serializer);
     }
     catch (const std::exception& e)
     {
-        return prepareErrorResponse(OPENDAQ_ERR_GENERALERROR, e.what(), this->serializer);
+        return prepareErrorResponse(OPENDAQ_ERR_GENERALERROR, e.what(), serializer);
     }
 
-    return prepareErrorResponse(OPENDAQ_ERR_GENERALERROR, "General error during serialization", this->serializer);
+    return prepareErrorResponse(OPENDAQ_ERR_GENERALERROR, "General error during serialization", serializer);
 }
 
 StringPtr ConfigProtocolServer::prepareErrorResponse(Int errorCode, const StringPtr& message, const SerializerPtr& serializer)
@@ -390,7 +389,7 @@ BaseObjectPtr ConfigProtocolServer::getSerializedRootDevice(const ParamsDictPtr&
 {
     ConfigServerAccessControl::protectObject(rootDevice, user, Permission::Read);
 
-    serializer.reset();
+    auto serializer = createSerializer();
     rootDevice.serialize(serializer);
 
     return serializer.getOutput();
@@ -571,11 +570,17 @@ void ConfigProtocolServer::setProtocolVersion(uint16_t protocolVersion)
     // downgrade serializers
     if (protocolVersion < 11)
     {
-        serializer = JsonSerializerWithVersion(2);
-        notificationSerializer = JsonSerializerWithVersion(2);
-        serializer.setUser(user);
-        notificationSerializer.setUser(user);
+        notificationSerializer = createSerializer();
     }
+}
+
+SerializerPtr ConfigProtocolServer::createSerializer()
+{
+    assert(protocolVersion > 0);
+
+    SerializerPtr serializer = (protocolVersion < 11) ? JsonSerializerWithVersion(2) : JsonSerializer();
+    serializer.setUser(user);
+    return serializer;
 }
 
 }

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
@@ -348,6 +348,14 @@ PropertyObjectPtr NativeStreamingServerHandler::createDefaultConfig()
                 .build();
         // defaultConfig.addProperty(linearCacheSizeMaxProp);
     }
+    {
+        const auto description = "Specifies the number of threads used to process native config protocol RPCs. "
+                                 "The default value is '1', which means requests are processed one at a time. "
+                                 "A value of '0' sets the number of threads to the number of available CPU cores on the system.";
+
+        const auto property = IntPropertyBuilder("StreamingWorkerCount", 1).setMinValue(0).setDescription(description).build();
+        defaultConfig.addProperty(property);
+    }
 
     return defaultConfig;
 }


### PR DESCRIPTION
# Brief

Until now, native config protocol RPC calls were processed sequentially. If RPC calls are triggered on different devices, they can be executed in parallel. To support this, a worker pool has been added to the native streaming server implementation. A new configuration setting, `StreamingWorkerCount`, has been introduced in the server configuration object. By default, this value is set to 1, which preserves the existing behaviour (sequential RPC processing) for backward compatibility. Increasing this value allows multiple RPC calls to be processed in parallel. This makes it possible to improve performance when handling RPC calls across multiple devices.

# Usage example

In C++ use:

```cpp
const InstancePtr instance = InstanceBuilder().addModulePath("").build();
auto config = instance.getAvailableServerTypes().get("OpenDAQNativeStreaming").createDefaultConfig();
config.setPropertyValue("StreamingWorkerCount", 2);
instance.addServer("OpenDAQNativeStreaming", config);
```

# API changes

none

