### PR TITLE
Changing the default value of cmake option OPENDAQ_RTGEN_ON_CMAKE_CONFIG to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ option(OPENDAQ_MIMALLOC_SUPPORT "Enable MiMalloc-based packet allocator" OFF)
 option(OPENDAQ_ENABLE_NATIVE_STREAMING "Enable ${SDK_NAME} native streaming" OFF)
 option(OPENDAQ_ALWAYS_FETCH_DEPENDENCIES "Ignore any installed libraries and always build all dependencies from source" ON)
 option(OPENDAQ_ENABLE_ACCESS_CONTROL "Enable object-level access control" ON)
-option(OPENDAQ_RTGEN_ON_CMAKE_CONFIG "Run RT gen as part of the CMake configuration process to make sure the files exist during development" ON)
+option(OPENDAQ_RTGEN_ON_CMAKE_CONFIG "Run RT gen as part of the CMake configuration process to make sure the files exist during development" OFF)
 
 option(OPENDAQ_ENABLE_OPCUA "Enable OpcUa" OFF)
 cmake_dependent_option(OPCUA_ENABLE_ENCRYPTION "Enable OpcUa encryption" OFF "OPENDAQ_ENABLE_OPCUA" OFF)


### PR DESCRIPTION
# Brief

The PR https://github.com/openDAQ/openDAQ/pull/1043 implemented running rtget on cmake configuration step if cmake option `OPENDAQ_RTGEN_ON_CMAKE_CONFIG` is enabled. The default state was set to `ON` As well which changed the default behavior of the project building. Current pr is reverting the option default state to `OFF`

# API changes

None

# Required application changes

None

# Required module changes

None
