### PR TITLE
Simulator build: Fix VirtualBox  exclusive access to HW virtualisation

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -359,6 +359,20 @@ jobs:
           sudo apt update
           sudo apt install -y virtualbox vagrant
 
+          # VirtualBox needs exclusive access to hardware virtualization (AMD-V/VT-x).
+          # If KVM modules are loaded, VBoxManage fails with VERR_SVM_IN_USE.
+          for mod in kvm_amd kvm_intel kvm; do
+            if lsmod | grep -q "^${mod} "; then
+              if sudo modprobe -r "${mod}"; then
+                echo "Module ${mod} -- unload succeeded"
+              else
+                echo "::warning::Module ${mod} -- unload failed. VirtualBox may not start correctly."
+              fi
+            else
+              echo "Module ${mod} -- not loaded"
+            fi
+          done
+
       - name: Download package
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
# Brief

The GitHub-hosted runner image ubuntu-24.04 was updated from 20260201.15.1 to 20260209.23.1, which now loads KVM kernel modules by default. This conflicts with VirtualBox, as both require exclusive access to hardware virtualization extensions (AMD-V/VT-x). The Simulator build job fails at vagrant up with VERR_SVM_IN_USE.

# Description

Unload KVM modules (kvm_amd, kvm_intel, kvm) before running VirtualBox/Vagrant:
```bash
for mod in kvm_amd kvm_intel kvm; do
  if lsmod | grep -q "^${mod} "; then
    sudo modprobe -r "${mod}"  # unload succeeded / failed
  fi
done
```

# Usage example

N/A

# API changes

N/A

# Required application changes

N/A

# Required module changes

N/A
