### PR TITLE
Add `removedNoLock()` virtual method

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -128,6 +128,7 @@ protected:
     virtual void activeChanged();
     virtual void visibleChanged();
     virtual void removed();
+    virtual void removedNoLock();
     virtual ErrCode lockAllAttributesInternal();
     ListPtr<IComponent> searchItems(const SearchFilterPtr& searchFilter, const std::vector<ComponentPtr>& items);
     void setActiveRecursive(const std::vector<ComponentPtr>& items, Bool active);
@@ -794,22 +795,25 @@ ErrCode ComponentImpl<Intf, Intfs...>::findComponent(IString* id, IComponent** o
 template<class Intf, class ... Intfs>
 ErrCode ComponentImpl<Intf, Intfs ...>::remove()
 {
-    auto lock = this->getRecursiveConfigLock2();
-
-    if (isComponentRemoved)
-        return OPENDAQ_IGNORED;
-
-    isComponentRemoved = true;
-
-    if (active)
     {
-        active = false;
-        activeChanged();
+        auto lock = this->getRecursiveConfigLock2();
+
+        if (isComponentRemoved)
+            return OPENDAQ_IGNORED;
+
+        isComponentRemoved = true;
+
+        if (active)
+        {
+            active = false;
+            activeChanged();
+        }
+
+        this->disableCoreEventTrigger();
+        removed();
     }
 
-    this->disableCoreEventTrigger();
-    removed();
-
+    removedNoLock();
     return OPENDAQ_SUCCESS;
 }
 
@@ -998,6 +1002,11 @@ void ComponentImpl<Intf, Intfs...>::visibleChanged()
 
 template <class Intf, class... Intfs>
 void ComponentImpl<Intf, Intfs...>::removed()
+{
+}
+
+template <class Intf, class ... Intfs>
+void ComponentImpl<Intf, Intfs...>::removedNoLock()
 {
 }
 


### PR DESCRIPTION
# Brief

Short refactor of input port `remove()` override to use a non-locking virtual method instead. Adds `removedNoLock()` virtual method.