### PR TITLE
Update minimum GCC version to 8.4 and add Intel icx compiler docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -50,6 +50,6 @@ See also: https://github.com/oneapi-src/oneapi-ci for official CI integration ex
 **Building**
 
 ```shell
-cmake -B build -G Ninja -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icx
+cmake -B build -G Ninja -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx
 cmake --build build
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -28,3 +28,28 @@ Build boost steps:
 - Create user-config.jam file in home directory. In the file write: `using gcc : aarch64 : aarch64-linux-gnu-g++`
 - Configure with `./bootstrap.sh --prefix=<path>boost_1_69_0-Linux --with-libraries=regex,date_time,filesystem,system`
 - Build with `./b2 install -j 2  cxxflags=-fPIC cflags=-fPIC toolset=gcc-aarch64`
+
+## Intel oneAPI DPC++/C++ (icx) notes
+
+Requires Intel oneAPI Base Toolkit with the `intel.oneapi.win.cpp-dpcpp-common` component.
+
+See also: https://github.com/oneapi-src/oneapi-ci for official CI integration examples.
+
+### Windows
+
+**Installation**
+
+1. Download Intel oneAPI Base Toolkit from https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html
+2. Run the installer and select at least the **DPC++/C++ Compiler** component (`intel.oneapi.win.cpp-dpcpp-common`)
+3. Set up the environment before configuring:
+   ```shell
+   "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat"
+   "C:\Program Files (x86)\Intel\oneAPI\compiler\latest\env\vars.bat"
+   ```
+
+**Building**
+
+```shell
+cmake -B build -G Ninja -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icx
+cmake --build build
+```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ documentation can be built with Antora by following the guide found in [docs/Ant
   <tr>
    <td><strong>OS</strong></td>
    <td><strong>Platform</strong></td>
-   <td><strong>GCC 7.3.1+</strong></td>
+   <td><strong>GCC 8.4+</strong></td>
    <td><strong>Clang 5+</strong></td>
    <td><strong>VC++ (v14.1+)</strong></td>
+   <td><strong>Intel DPC++/C++ (icx) 2025.3</strong></td>
   </tr>
   <tr>
    <td rowspan="2">Windows <br>(Visual Studio)</td>
@@ -55,17 +56,21 @@ documentation can be built with Antora by following the guide found in [docs/Ant
    <td rowspan="2">/</td>
    <td>✅</td>
    <td>✅</td>
+   <td>✅</td>
   </tr>
   <tr>
    <td>arm64</td>
    <td>⚠️🛠️</td>
    <td>⚠️🛠️</td>
+   <td>/</td>
   </tr>
   <tr>
    <td rowspan="1">Windows <br>(MinGW)</td>
    <td>x86, x64</td>
    <td>☑️</td>
    <td>☑️</td>
+   <td rowspan="10">/
+   </td>
    <td rowspan="10">/
    </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ documentation can be built with Antora by following the guide found in [docs/Ant
    <td><strong>OS</strong></td>
    <td><strong>Platform</strong></td>
    <td><strong>GCC 8.4+</strong></td>
-   <td><strong>Clang 5+</strong></td>
-   <td><strong>VC++ (v14.1+)</strong></td>
+   <td><strong>Clang 6+</strong></td>
+   <td><strong>VC++ (v14.3+)</strong></td>
    <td><strong>Intel DPC++/C++ (icx) 2025.3</strong></td>
   </tr>
   <tr>


### PR DESCRIPTION
# Brief

TaskFlow 3.11.0 (bumped in #1001) requires GCC >= 8.4, update the documented minimum accordingly.

Closes #1082

# Description

- Update minimum GCC version from 7.3.1 to 8.4 in README.md to match TaskFlow 3.11.0 requirement (bumped in #1001)
- Add Intel DPC++/C++ (icx) 2025.3 to the supported compilers table
- Add Intel oneAPI build instructions to BUILD.md

# Usage example

N/A

# API changes

N/A

# Required application changes

N/A

# Required module changes

N/A
