### PR TITLE
Add clearing on property value read/write events for the removed property

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,7 @@
 - [#1052](https://github.com/openDAQ/openDAQ/pull/1052) Renderer FB labels take into account reference domain offset from ReferenceDomainInfo.
 - [#1054](https://github.com/openDAQ/openDAQ/pull/1054) Add validation default value items type for List And Dict Property
 - [#1059](https://github.com/openDAQ/openDAQ/pull/1059) Prevent post scaling in descriptors with vector/matrix dimensions.
+- [#1110](https://github.com/openDAQ/openDAQ/pull/1110) Add clearing on property value read/write events for the removed property
 
 ## Misc
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -2126,10 +2126,14 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::removeProper
     }
 
     localProperties.erase(propertyName);
-    if (propValues.find(propertyName) != propValues.cend())
-    {
-        propValues.erase(propertyName);
-    }
+    if (const auto it = propValues.find(propertyName); it != propValues.cend())
+        propValues.erase(it);
+
+    if (const auto it = valueReadEvents.find(propertyName); it != valueReadEvents.cend())
+        valueReadEvents.erase(it);
+
+    if (const auto it = valueWriteEvents.find(propertyName); it != valueWriteEvents.cend())
+        valueWriteEvents.erase(it);
 
     triggerCoreEventInternal(CoreEventArgsPropertyRemoved(objPtr, propertyName, path));
 

--- a/core/coreobjects/tests/test_value_changed_events.cpp
+++ b/core/coreobjects/tests/test_value_changed_events.cpp
@@ -176,6 +176,45 @@ TEST_F(PropertyValueChangedEventsTest, ObjectClear)
     ASSERT_EQ(obj1.getPropertyValue("PropClearCount"), 2);
 }
 
+TEST_F(PropertyValueChangedEventsTest, PropertyRemoveReAddClearsValueEvents)
+{
+    const auto obj = PropertyObject();
+
+    obj.addProperty(IntProperty("int", 0));
+
+    int writeCalls = 0;
+    int readCalls = 0;
+
+    obj.getOnPropertyValueWrite("int") +=
+        [&writeCalls](const PropertyObjectPtr&, const PropertyValueEventArgsPtr&)
+        {
+            writeCalls++;
+        };
+
+    obj.getOnPropertyValueRead("int") +=
+        [&readCalls](const PropertyObjectPtr&, const PropertyValueEventArgsPtr&)
+        {
+            readCalls++;
+        };
+
+    obj.setPropertyValue("int", 1);
+    obj.getPropertyValue("int");
+    ASSERT_EQ(writeCalls, 1);
+    ASSERT_EQ(readCalls, 1);
+
+    obj.removeProperty("int");
+
+    // Re-add property with the same name.
+    // Previously registered value events must not fire anymore.
+    obj.addProperty(IntProperty("int", 0));
+
+    obj.setPropertyValue("int", 2);
+    obj.getPropertyValue("int");
+
+    ASSERT_EQ(writeCalls, 1);
+    ASSERT_EQ(readCalls, 1);
+}
+
 TEST_F(PropertyValueChangedEventsTest, MultipleObjectsClear)
 {
     auto obj1 = PropertyObject(manager, "TestClass");


### PR DESCRIPTION
# Brief

While removing the property from the property object, the property object could still retain events for the removed property. This PR removes those events as well.

# API changes

None

# Required application changes

None

# Required module changes

None