### PR TITLE
Ignore unsubscribe completed on removed mirrored signal objects

### DIFF
--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -166,12 +166,12 @@ void InstanceImpl::stopAndRemoveServers() const
     if (rootDevice.isRemoved())
         return;
 
-    for (const auto& server : rootDevice.getServers())
-    {
+    auto servers = rootDevice.getServers();
+    for (const auto& server : servers)
         server.stop();
-        // Manually remove servers from the root device to clean-up circular references to root device held by servers
+
+    for (const auto& server : servers)
         rootDevice.removeServer(server);
-    }
 }
 
 ErrCode InstanceImpl::getContext(IContext** context)

--- a/core/opendaq/streaming/include/opendaq/mirrored_signal_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_signal_impl.h
@@ -373,6 +373,9 @@ ErrCode MirroredSignalBase<Interfaces...>::unsubscribeCompletedInternal(IString*
 {
     OPENDAQ_PARAM_NOT_NULL(streamingConnectionString);
 
+    if (this->isComponentRemoved)
+        return OPENDAQ_IGNORED;
+
     const auto streamingConnectionStringPtr = StringPtr::Borrow(streamingConnectionString);
     auto thisPtr = this->template borrowPtr<MirroredSignalConfigPtr>();
 

--- a/external_modules/CMakeLists.txt
+++ b/external_modules/CMakeLists.txt
@@ -21,7 +21,7 @@ if (OPENDAQ_ENABLE_WEBSOCKET_STREAMING AND (DAQMODULES_OPENDAQ_CLIENT_MODULE OR 
         FetchContent_Declare(
             LtStreamingModulesLegacy
             GIT_REPOSITORY https://github.com/openDAQ/LTStreamingModulesLegacy.git
-            GIT_TAG        04d8fdf7fac03ae43773e4e97943c66f02a7f6ca
+            GIT_TAG        74f978a0e1dfaefd100c9eb78fb08ceeb38de148
             GIT_PROGRESS   ON
             GIT_SHALLOW    OFF
             SOURCE_SUBDIR  "INVALID"

--- a/tests/integration/test_opendaq_device_modules/test_streaming.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_streaming.cpp
@@ -223,6 +223,9 @@ TEST_P(StreamingTest, LastValue)
     std::future<StringPtr> subscribeCompleteFuture;
     test_helpers::setupSubscribeAckHandler(subscribeCompletePromise, subscribeCompleteFuture, mirroredSignalPtr);
 
+    std::promise<StringPtr> unsubscribeCompletePromise;
+    std::future<StringPtr> unsubscribeCompleteFuture;
+
     // before any packet send
     ASSERT_FALSE(serverSignal.getLastValue().assigned());
     ASSERT_FALSE(mirroredSignalPtr.getLastValue().assigned());
@@ -241,8 +244,11 @@ TEST_P(StreamingTest, LastValue)
         ASSERT_TRUE(mirroredSignalPtr.getLastValue().assigned());
         // generated packets are sent and read, signal is still subscribed via streaming - mirrored signal gets last value from streaming
         EXPECT_EQ(serverSignal.getLastValue(), mirroredSignalPtr.getLastValue());
+        
+        test_helpers::setupUnsubscribeAckHandler(unsubscribeCompletePromise, unsubscribeCompleteFuture, mirroredSignalPtr);
     }
-
+    
+    ASSERT_TRUE(test_helpers::waitForAcknowledgement(unsubscribeCompleteFuture));
     ASSERT_TRUE(serverSignal.getLastValue().assigned());
     ASSERT_TRUE(mirroredSignalPtr.getLastValue().assigned());
     // signal is not subscribed via streaming anymore - mirrored signal gets last value from config but it hasn't changed yet


### PR DESCRIPTION
# Brief

Ignore unsubscribe completed on removed mirrored signal objects.