### PR TITLE
Add support for BulkUpdate RPC

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -174,7 +174,9 @@ public:
     virtual ErrCode INTERFACE_FUNC setProtectedPropertySelectionValue(IString* propertyName, IBaseObject* value) override;
     virtual ErrCode INTERFACE_FUNC clearProtectedPropertyValue(IString* propertyName) override;
     virtual ErrCode INTERFACE_FUNC clearProtectedPropertyValues() override;
-    
+
+    virtual ErrCode INTERFACE_FUNC collectUpdatingProperties(IList** updatingProps) override;
+
     using PropertyValueEventEmitter = EventEmitter<PropertyObjectPtr, PropertyValueEventArgsPtr>;
     using EndUpdateEventEmitter = EventEmitter<PropertyObjectPtr, EndUpdateEventArgsPtr>;
 
@@ -269,6 +271,7 @@ protected:
     
     PropertyObjectPtr objPtr;
     std::atomic<bool> coreEventMuted;
+    int updateCount;
 
     bool isFrozen();
     void unfreeze();
@@ -334,7 +337,6 @@ private:
     PropertyOrderedMap localProperties;
 
     WeakRefPtr<IPropertyObject> owner;
-    int updateCount;
     UpdatingActions updatingPropsAndValues;
     WeakRefPtr<ITypeManager> manager;
     std::vector<StringPtr> customOrder;
@@ -1805,6 +1807,31 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::configureCloned
                            parameters.propValues,
                            parameters.customOrder,
                            parameters.permissionManager);
+}
+
+template <typename PropObjInterface, typename... Interfaces>
+inline ErrCode INTERFACE_FUNC GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::collectUpdatingProperties(IList** updatingProps)
+{
+    auto listOut = List<IBaseObject>();
+
+    for (const auto& [_, propValue] : propValues)
+    {
+        const auto propObj = propValue.template asPtrOrNull<IPropertyObject>(true);
+        if (!propObj.assigned())
+            continue;
+
+        auto freezable = propObj.template asPtrOrNull<IFreezable>(true);
+        if (freezable.assigned() && freezable.isFrozen())
+            continue;
+
+        auto childProps = propObj.template asPtrOrNull<IPropertyObjectInternal>(true).collectUpdatingProperties();
+
+        for (const auto& prop : childProps)
+            listOut.pushBack(prop);
+    }
+
+    *updatingProps = listOut.addRefAndReturn();
+    return OPENDAQ_SUCCESS;
 }
 
 template <typename PropObjInterface, typename... Interfaces>

--- a/core/coreobjects/include/coreobjects/property_object_internal.h
+++ b/core/coreobjects/include/coreobjects/property_object_internal.h
@@ -90,6 +90,9 @@ DECLARE_OPENDAQ_INTERFACE(IPropertyObjectInternal, IBaseObject)
      * strategy is not `OwnLock`, returns the closest ancestor with the `OwnLock` strategy.
      */
     virtual ErrCode INTERFACE_FUNC getMutexOwner(IPropertyObjectInternal** owner) = 0;
+
+    // [templateType(updatingProps, IBaseObject)]
+    virtual ErrCode INTERFACE_FUNC collectUpdatingProperties(IList** updatingProps) = 0;
 };
 
 /*!@}*/

--- a/core/opendaq/component/include/opendaq/folder_impl.h
+++ b/core/opendaq/component/include/opendaq/folder_impl.h
@@ -62,6 +62,7 @@ public:
     // IPropertyObjectInternal
     ErrCode INTERFACE_FUNC enableCoreEventTrigger() override;
     ErrCode INTERFACE_FUNC disableCoreEventTrigger() override;
+    ErrCode INTERFACE_FUNC collectUpdatingProperties(IList** updatingProps) override;
 
     static ConstCharPtr SerializeId();
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
@@ -363,6 +364,31 @@ ErrCode FolderImpl<Intf, Intfs...>::disableCoreEventTrigger()
     }
 
     return ComponentImpl<Intf, Intfs...>::disableCoreEventTrigger();
+}
+
+template <class Intf, class... Intfs>
+inline ErrCode INTERFACE_FUNC FolderImpl<Intf, Intfs...>::collectUpdatingProperties(IList** updatingProps)
+{
+    ListPtr<IBaseObject> propsOut;
+    Super::collectUpdatingProperties(&propsOut);
+
+    for (const auto& [_, item] : items)
+    {
+        auto freezable = item.template asPtrOrNull<IFreezable>(true);
+        if (freezable.assigned() && freezable.isFrozen())
+            continue;
+
+        const auto childProps = item.template asPtr<IPropertyObjectInternal>().collectUpdatingProperties();
+
+        if (childProps.assigned())
+        {
+            for (const auto& prop : childProps)
+                propsOut.pushBack(prop);
+        }
+    }
+
+    *updatingProps = propsOut.detach();
+    return OPENDAQ_SUCCESS;
 }
 
 template <class Intf, class... Intfs>

--- a/core/opendaq/signal/include/opendaq/signal_container_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_container_impl.h
@@ -43,6 +43,7 @@ public:
     // IPropertyObjectInternal
     ErrCode INTERFACE_FUNC enableCoreEventTrigger() override;
     ErrCode INTERFACE_FUNC disableCoreEventTrigger() override;
+    ErrCode INTERFACE_FUNC collectUpdatingProperties(IList** updatingProps) override;
 
     // IComponentPrivate
     ErrCode INTERFACE_FUNC updateOperationMode(OperationModeType modeType) override;
@@ -201,6 +202,31 @@ ErrCode GenericSignalContainerImpl<Intf, Intfs...>::disableCoreEventTrigger()
     }
 
     return ComponentImpl<Intf, Intfs...>::disableCoreEventTrigger();
+}
+
+template <class Intf, class... Intfs>
+inline ErrCode INTERFACE_FUNC GenericSignalContainerImpl<Intf, Intfs...>::collectUpdatingProperties(IList** updatingProps)
+{
+    ListPtr<IBaseObject> propsOut;
+    Super::collectUpdatingProperties(&propsOut);
+
+    for (const auto& comp : components)
+    {
+        auto freezable = comp.template asPtrOrNull<IFreezable>(true);
+        if (freezable.assigned() && freezable.isFrozen())
+            continue;
+
+        const auto childProps = comp.asPtr<IPropertyObjectInternal>().collectUpdatingProperties();
+
+        if (childProps.assigned())
+        {
+            for (const auto& prop : childProps)
+                propsOut.pushBack(prop);
+        }
+    }
+
+    *updatingProps = propsOut.detach();
+    return OPENDAQ_SUCCESS;
 }
 
 template <class Intf, class ... Intfs>

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -80,6 +80,14 @@ ErrCode ConfigClientComponentBaseImpl<Impl>::setActive(Bool active)
     if (this->localActive == (bool) active)
         return OPENDAQ_IGNORED;
 
+    if (this->updateCount > 0 && this->clientComm->isBulkUpdateSupported())
+    {
+        auto action = Dict<IString, IBaseObject>();
+        action.set("Value", active);
+        this->clientUpdatingActions.push_back({"SetActive", action});
+        return OPENDAQ_SUCCESS;
+    }
+
     const ErrCode errCode = daqTry([this, &active]
     {
         this->clientComm->setAttributeValue(this->remoteGlobalId, "Active", active); 

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -33,6 +33,12 @@
 namespace daq::config_protocol
 {
 
+struct ClientUpdatingAction
+{
+    std::string type;
+    DictPtr<IString, IBaseObject> params;
+};
+
 template <typename Impl>
 class ConfigClientPropertyObjectBaseImpl;
 
@@ -76,19 +82,21 @@ public:
     ErrCode INTERFACE_FUNC remoteUpdate(ISerializedObject* serialized) override;
     ErrCode INTERFACE_FUNC setRemoteUpdating(Bool remoteUpdating) override;
 
+    ErrCode INTERFACE_FUNC collectUpdatingProperties(IList** updatingProps) override;
+
 protected:
     bool deserializationComplete;
+
 
     virtual void handleRemoteCoreObjectInternal(const ComponentPtr& sender, const CoreEventArgsPtr& args);
     virtual void onRemoteUpdate(const SerializedObjectPtr& serialized);
     PropertyObjectPtr cloneChildPropertyObject(const PropertyPtr& prop) override;
 
-/*
     void beginApplyUpdate() override;
     void endApplyUpdate() override;
-    */
 
     bool remoteUpdating;
+    std::vector<ClientUpdatingAction> clientUpdatingActions;
 
 private:
     BaseObjectPtr getValueFromServer(const StringPtr& propName, bool& setValue);
@@ -181,11 +189,19 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::setPropertyValue(IString* prop
 {
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
-//    if (this->updateCount > 0)
-//        return Impl::setPropertyValue(propertyName, value);
-
     const auto propertyNamePtr = StringPtr::Borrow(propertyName);
     const auto valuePtr = BaseObjectPtr::Borrow(value);
+
+    if (this->updateCount > 0 && this->clientComm->isBulkUpdateSupported())
+    {
+        auto action = Dict<IString, IBaseObject>();
+        action.set("Name", propertyNamePtr);
+        action.set("Value", valuePtr);
+        action.set("Path", this->getPath());
+        clientUpdatingActions.push_back({"SetPropertyValue", action});
+        return OPENDAQ_SUCCESS;
+    }
+
     const ErrCode errCode = daqTry([this, &propertyNamePtr, &valuePtr]()
     {
         checkCanSetPropertyValue(propertyNamePtr);
@@ -285,6 +301,16 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::clearPropertyValue(IString* pr
     OPENDAQ_PARAM_NOT_NULL(propertyName);
 
     const auto propertyNamePtr = StringPtr::Borrow(propertyName);
+
+    if (this->updateCount > 0 && this->clientComm->isBulkUpdateSupported())
+    {
+        auto action = Dict<IString, IBaseObject>();
+        action.set("Name", propertyNamePtr);
+        action.set("Path", this->getPath());
+        clientUpdatingActions.push_back({"ClearPropertyValue", action});
+        return OPENDAQ_SUCCESS;
+    }
+
     const ErrCode errCode = daqTry([this, &propertyNamePtr]()
     {
         clientComm->clearPropertyValue(remoteGlobalId, propertyNamePtr);
@@ -379,29 +405,63 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::clearProtectedPropertyValues()
 template <class Impl>
 ErrCode INTERFACE_FUNC ConfigClientPropertyObjectBaseImpl<Impl>::beginUpdate()
 {
-    const ErrCode errCode = daqTry([this]()
+    if (clientComm->isBulkUpdateSupported())
     {
-        std::string path{};
-        if (this->getPath().assigned())
-            path = this->getPath().toStdString();
-        clientComm->beginUpdate(remoteGlobalId, path);
-    });
-    OPENDAQ_RETURN_IF_FAILED(errCode);
-    return errCode;
+        return Impl::beginUpdate();
+    }
+    else
+    {
+        const ErrCode errCode = daqTry(
+            [this]()
+            {
+                std::string path{};
+                if (this->getPath().assigned())
+                    path = this->getPath().toStdString();
+                clientComm->beginUpdate(remoteGlobalId, path);
+            });
+        OPENDAQ_RETURN_IF_FAILED(errCode);
+        return errCode;
+    }
 }
 
 template <class Impl>
 ErrCode INTERFACE_FUNC ConfigClientPropertyObjectBaseImpl<Impl>::endUpdate()
 {
-    const ErrCode errCode = daqTry([this]()
+    if (clientComm->isBulkUpdateSupported())
     {
-        std::string path{};
-        if (this->getPath().assigned())
-            path = this->getPath().toStdString();
-        clientComm->endUpdate(remoteGlobalId, path);
-    });
-    OPENDAQ_RETURN_IF_FAILED(errCode);
-    return errCode;
+        if (this->updateCount > 1)
+            return Impl::endUpdate();
+
+        return daqTry(
+            [this]()
+            {
+                ListPtr<IBaseObject> updateList;
+                ConfigClientPropertyObjectBaseImpl::collectUpdatingProperties(&updateList);
+
+                ErrCode status = Impl::endUpdate();
+
+                if (OPENDAQ_FAILED(status))
+                    return status;
+
+                if (updateList.getCount() > 0)
+                    status = clientComm->tryBulkUpdate(remoteGlobalId, updateList);
+
+                return status;
+            });
+    }
+    else
+    {
+        const ErrCode errCode = daqTry(
+            [this]()
+            {
+                std::string path{};
+                if (this->getPath().assigned())
+                    path = this->getPath().toStdString();
+                clientComm->endUpdate(remoteGlobalId, path);
+            });
+        OPENDAQ_RETURN_IF_FAILED(errCode);
+        return errCode;
+    }
 }
 
 template <class Impl>
@@ -535,6 +595,29 @@ ErrCode ConfigClientPropertyObjectBaseImpl<Impl>::setRemoteUpdating(Bool remoteU
     OPENDAQ_RETURN_IF_FAILED(errCode);
 
     this->remoteUpdating = remoteUpdating;
+    return OPENDAQ_SUCCESS;
+}
+
+template <class Impl>
+inline ErrCode INTERFACE_FUNC ConfigClientPropertyObjectBaseImpl<Impl>::collectUpdatingProperties(IList** updatingProps)
+{
+    ListPtr<IBaseObject> childProps;
+    Impl::collectUpdatingProperties(&childProps);
+
+    auto propsOut = List<IBaseObject>();
+
+    for (const auto& action : clientUpdatingActions)
+    {
+        propsOut.pushBack(List<IBaseObject>(action.type, remoteGlobalId, action.params));
+    }
+
+    for (const auto& prop : childProps)
+    {
+        propsOut.pushBack(prop);
+    }
+
+    clientUpdatingActions.clear();
+    *updatingProps = propsOut.addRefAndReturn();
     return OPENDAQ_SUCCESS;
 }
 
@@ -752,47 +835,22 @@ PropertyObjectPtr ConfigClientPropertyObjectBaseImpl<Impl>::cloneChildPropertyOb
     return nullptr;
 }
 
-/*
 template <class Impl>
 void ConfigClientPropertyObjectBaseImpl<Impl>::beginApplyUpdate()
 {
-    if (remoteUpdating)
-        return Impl::beginApplyUpdate();
+    if (this->clientComm->isBulkUpdateSupported())
+        this->clientUpdatingActions.clear();
 
-    clientComm->beginUpdate(remoteGlobalId, getPathInternal());
+    return Impl::beginApplyUpdate();
 }
 
 template <class Impl>
 void ConfigClientPropertyObjectBaseImpl<Impl>::endApplyUpdate()
 {
-    if (remoteUpdating)
-        return Impl::endApplyUpdate();
-
-    ListPtr<IDict> propsAndValuesEx;
-
-    if (clientComm->getProtocolVersion() >= 1)
-    {
-        propsAndValuesEx = List<IDict>();
-
-        auto ignoredProps = List<IString>();
-        for (auto& item : this->updatingPropsAndValues)
-        {
-            auto itemEx = Dict<IString, IBaseObject>();
-            itemEx.set("Name", String(item.first));
-            itemEx.set("SetValue", Boolean(item.second.setValue));
-            itemEx.set("ProtectedAccess", Boolean(item.second.protectedAccess));
-            itemEx.set("Value", item.second.value);
-            propsAndValuesEx.pushBack(itemEx);
-        }
-    }
-    else
-        applyUpdatingPropsAndValuesProtocolVer0();
-
-    this->updatingPropsAndValues.clear();
-
-    clientComm->endUpdate(remoteGlobalId, getPathInternal(), propsAndValuesEx);
+    return Impl::endApplyUpdate();
 }
 
+/*
 template <class Impl>
 void ConfigClientPropertyObjectBaseImpl<Impl>::applyUpdatingPropsAndValuesProtocolVer0()
 {

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol.h
@@ -180,7 +180,7 @@ public:
 
 inline constexpr uint16_t GetLatestConfigProtocolVersion()
 {
-    return 22;
+    return 23;
 }
 
 inline std::set<uint16_t> GetSupportedConfigProtocolVersions()

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -89,6 +89,9 @@ public:
     void beginUpdate(const std::string& globalId, const std::string& path = "");
     void endUpdate(const std::string& globalId, const std::string& path = "", const ListPtr<IDict>& props = nullptr);
     void clearPropertyValues(const std::string& globalId, const std::string& path = "");
+    bool isBulkUpdateSupported();
+    void bulkUpdate(const std::string& globalId, const ListPtr<IBaseObject>& updateList);
+    ErrCode tryBulkUpdate(const std::string& globalId, const ListPtr<IBaseObject>& updateList);
 
     DictPtr<IString, IFunctionBlockType> getAvailableFunctionBlockTypes(const std::string& globalId, bool isFb = false);
     ComponentHolderPtr addFunctionBlock(const std::string& globalId,

--- a/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_server_component.h
@@ -51,6 +51,7 @@ public:
     static BaseObjectPtr addFunctionBlock(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr removeFunctionBlock(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
     static BaseObjectPtr getComponentConfig(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
+    static BaseObjectPtr bulkUpdate(const RpcContext& context, const ComponentPtr& component, const ParamsDictPtr& params);
 
 private:
     static void applyProps(uint16_t protocolVersion, const PropertyObjectPtr& obj, const ListPtr<IDict>& props);
@@ -470,6 +471,75 @@ inline BaseObjectPtr ConfigServerComponent::getComponentConfig(const RpcContext&
 
     if (const auto & componentPrivate = component.asPtrOrNull<IComponentPrivate>(true); componentPrivate.assigned())
         return componentPrivate.getComponentConfig();
+    return nullptr;
+}
+
+inline BaseObjectPtr ConfigServerComponent::bulkUpdate(const RpcContext& context,
+                                                       const ComponentPtr& component,
+                                                       const ParamsDictPtr& params)
+{
+    static const auto getRelativeGlobalId = [](std::string str, const std::string& prefixToStrip)
+    {
+        if (str.rfind(prefixToStrip, 0) == 0)
+            str = str.substr(prefixToStrip.length());
+
+        if (!str.empty() && str[0] == '/')
+            str = str.substr(1);
+
+        return str;
+    };
+
+    // bulkUpdate
+
+    ListPtr<IBaseObject> updateList = params.get("UpdateList");
+    if (!updateList.assigned() || updateList.getCount() == 0)
+        return nullptr;
+
+    const auto globalId = params.get("ComponentGlobalId");
+
+    component.beginUpdate();
+
+    for (const ListPtr<IBaseObject>& action : updateList)
+    {
+        const auto actionType = action[0];
+        const auto remoteId = String(action[1]);
+        const auto relativeGlobalId = getRelativeGlobalId(remoteId, globalId);
+        const DictPtr<IString, IBaseObject> actionParams = action[2];
+
+        PropertyObjectPtr obj = component;
+        if (!relativeGlobalId.empty())
+            obj = component.findComponent(relativeGlobalId);
+
+        if (actionType == "SetPropertyValue")
+        {
+            const auto name = String(actionParams.get("Name"));
+            const auto value = actionParams.get("Value");
+            const auto path = String(actionParams.get("Path"));
+
+            if (path.getLength() > 0)
+                obj = obj.getPropertyValue(path);
+
+            obj.setPropertyValue(name, value);
+        }
+        if (actionType == "ClearPropertyValue")
+        {
+            const auto name = String(actionParams.get("Name"));
+            const auto path = String(actionParams.get("Path"));
+
+            if (path.getLength() > 0)
+                obj = obj.getPropertyValue(path);
+
+            obj.clearPropertyValue(name);
+        }
+        else if (actionType == "SetActive")
+        {
+            const Bool active = actionParams.get("Value");
+            obj.asPtr<IComponent>().setActive(active);
+        }
+    }
+
+    component.endUpdate();
+
     return nullptr;
 }
 

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -244,6 +244,40 @@ void ConfigProtocolClientComm::clearPropertyValues(const std::string& globalId, 
     sendComponentCommand(globalId, ClientCommand("ClearPropertyValues", 22), params);    
 }
 
+bool ConfigProtocolClientComm::isBulkUpdateSupported()
+{
+    return protocolVersion >= 23;
+}
+
+void ConfigProtocolClientComm::bulkUpdate(const std::string& globalId, const ListPtr<IBaseObject>& updateList)
+{
+    requireMinServerVersion(ClientCommand("BulkUpdate", 23));
+
+    auto dict = Dict<IString, IBaseObject>();
+    dict.set("ComponentGlobalId", String(globalId));
+    dict.set("UpdateList", updateList);
+
+    auto buffer = createRpcRequestPacketBuffer(generateId(), "BulkUpdate", dict);
+    const auto reply = sendRequestCallback(buffer);
+
+    parseRpcOrRejectReply(reply.parseRpcRequestOrReply());
+}
+
+ErrCode ConfigProtocolClientComm::tryBulkUpdate(const std::string& globalId, const ListPtr<IBaseObject>& updateList)
+{
+    try
+    {
+        bulkUpdate(globalId, updateList);
+    }
+    catch (const DaqException& e)
+    {
+        LOG_E("BulkUpdate operation failed: {}", e.what());
+        return errorFromException(e);
+    }
+
+    return OPENDAQ_SUCCESS;
+}
+
 DictPtr<IString, IFunctionBlockType> ConfigProtocolClientComm::getAvailableFunctionBlockTypes(const std::string& globalId, bool isFb)
 {
     auto command = isFb ? ClientCommand("GetAvailableFunctionBlockTypes", 9) : ClientCommand("GetAvailableFunctionBlockTypes");

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -86,7 +86,7 @@ ConfigProtocolServer::ConfigProtocolServer(DevicePtr rootDevice,
     , user(user)
     , connectionType(connectionType)
     , protocolVersion(0)
-    , supportedServerVersions(std::set<uint16_t>({17, 18, 19, 20, 21, 22}))
+    , supportedServerVersions(std::set<uint16_t>({17, 18, 19, 20, 21, 22, 23}))
     , streamingConsumer(this->daqContext, externalSignalsFolder)
     , packedCoreEvents(List<IBaseObject>())
 {
@@ -150,7 +150,8 @@ void ConfigProtocolServer::buildRpcDispatchStructure()
     addHandler<ComponentPtr>("SetAttributeValue", &ConfigServerComponent::setAttributeValue);
     addHandler<ComponentPtr>("Update", &ConfigServerComponent::update);
     addHandler<ComponentPtr>("ClearPropertyValues", &ConfigServerComponent::clearPropertyValues);
-    
+    addHandler<ComponentPtr>("BulkUpdate", &ConfigServerComponent::bulkUpdate);
+
     addHandler<ComponentPtr>("GetAvailableFunctionBlockTypes", &ConfigServerComponent::getAvailableFunctionBlockTypes);
     addHandler<ComponentPtr>("AddFunctionBlock", &ConfigServerComponent::addFunctionBlock);
     addHandler<ComponentPtr>("RemoveFunctionBlock", &ConfigServerComponent::removeFunctionBlock);


### PR DESCRIPTION
# Brief

Add support for `BulkUpdate` RPC to enable client side begin / end update functionality.


# Description

Client will start batching actions on the client side when `beginUpdate()` is called. When `endUpdate()` is called, the client will send a single large `BulkUpdate` RPC request containing all the changes. This significantly improves performance, as it reduces the number of requests sent to the server.
The client will check whether the `BulkUpdate` RPC is supported by the server. If the server does not support this RPC, the client will revert to the original begin / end update logic.

# Usage example

Interface stays the same.

# API changes

A new type of RPC is added to the server device.

# Required application changes

To enable this functionality both, server and client version must be updated.
