### PR TITLE
Fix paths to use openDAQ in the openDAQ-bundle project

### DIFF
--- a/bindings/dotnet/CMakeLists.txt
+++ b/bindings/dotnet/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
     return()
 endif()
 
-set(buildDir ${CMAKE_SOURCE_DIR}/build)
+set(buildDir ${OPENDAQ_SOURCE_DIR}/build)
 set(bindingsDir ${buildDir}/bindings/CSharp)
 set(bindingsSrcDir ${bindingsDir}/core)
 set(outputBinDir ${bindingsDir}/bin/${platform}/$<CONFIG>)
@@ -120,8 +120,8 @@ set(dependencyTargets ${SDK_TARGET_NAMESPACE}::coretypes
                       ${SDK_TARGET_NAMESPACE}::coreobjects
                       ${SDK_TARGET_NAMESPACE}::opendaq
 )
-add_cmake_targets(${CMAKE_SOURCE_DIR}/modules/. dependencyTargets)
-add_cmake_targets(${CMAKE_SOURCE_DIR}/examples/modules/. dependencyTargets)
+add_cmake_targets(${OPENDAQ_SOURCE_DIR}/modules/. dependencyTargets)
+add_cmake_targets(${OPENDAQ_SOURCE_DIR}/examples/modules/. dependencyTargets)
 
 message(DEBUG "Adding target dependencies: ${dependencyTargets}")
 

--- a/cmake/RTGen.cmake
+++ b/cmake/RTGen.cmake
@@ -103,7 +103,7 @@ function(_rtgen_interface LANGUAGES FILENAME OUTFILES_VAR)
             # If generating bindings set the output directory to "bindings/{LANG}"
             # Create the directory if it doesn't exist yet
             if(LOWERCASE_LANG STREQUAL "csharp")
-                set(RTGEN_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/build/bindings/${LANG}/${RTGEN_RELATIVE_PARENT_DIR}")
+                set(RTGEN_OUTPUT_DIR "${OPENDAQ_SOURCE_DIR}/build/bindings/${LANG}/${RTGEN_RELATIVE_PARENT_DIR}")
             else()
                 set(RTGEN_OUTPUT_DIR "${CURR_BINDINGS_DIR}/${LANG}")
             endif()
@@ -382,7 +382,7 @@ function(rtgen_config LIB_NAME LIB_OUTPUT_NAME MAJOR_VER MINOR_VER PATCH_VER)
             # If generating bindings set the output directory to "bindings/{LANG}"
             # Create the directory if it doesn't exist yet
             if(LOWERCASE_LANG STREQUAL "csharp")
-                set(RTGEN_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/build/bindings/${LANG}/${RTGEN_RELATIVE_PARENT_DIR}")
+                set(RTGEN_OUTPUT_DIR "${OPENDAQ_SOURCE_DIR}/build/bindings/${LANG}/${RTGEN_RELATIVE_PARENT_DIR}")
             else()
                 set(RTGEN_OUTPUT_DIR "${CURR_BINDINGS_DIR}/${LANG}")
             endif()


### PR DESCRIPTION
# Brief
This PR standardizes CMake variable references in the openDAQ build system by replacing hardcoded CMAKE_SOURCE_DIR paths with the project-specific OPENDAQ_SOURCE_DIR variable.
Enables better support for bundle/workspace scenarios where multiple CMake projects may be configured together.