### PR TITLE
Add GCC-7 CI build using Ubuntu 20.04 container

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -122,9 +122,6 @@ runs:
         python-version: '3.14'
         architecture: ${{ inputs.enable-32bit == 'true' && 'x86' || 'x64' }}
 
-    - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
-
     - name: Install Windows dependencies
       if: runner.os == 'Windows' && inputs.additional-dependencies != ''
       shell: pwsh
@@ -134,15 +131,16 @@ runs:
       if: steps.detect-linux.outputs.pkg-manager == 'apt' && inputs.enable-32bit == 'true'
       shell: bash
       run: |
+        SUDO=""; command -v sudo &> /dev/null && SUDO="sudo"
         echo "Removing bootloader packages that conflict with i386 multi-arch"
-        if ! sudo apt-get remove -y --allow-remove-essential shim-signed grub-efi-amd64-signed grub2-common grub-efi-amd64-bin grub-common; then
+        if ! $SUDO apt-get remove -y --allow-remove-essential shim-signed grub-efi-amd64-signed grub2-common grub-efi-amd64-bin grub-common; then
           echo "::warning::Failed to remove bootloader packages"
         fi
         echo "Removing pre-installed 64-bit Python to avoid conflicts with 32-bit build"
-        if ! sudo apt-get remove -y python3 python3-pip python3-dev; then
+        if ! $SUDO apt-get remove -y python3 python3-pip python3-dev; then
           echo "::warning::Failed to remove pre-installed Python packages"
         fi
-        sudo apt-get autoremove -y
+        $SUDO apt-get autoremove -y
 
     - name: Install Linux dependencies (apt)
       if: steps.detect-linux.outputs.pkg-manager == 'apt'
@@ -150,14 +148,15 @@ runs:
       env:
         ENABLE_32BIT: ${{ inputs.enable-32bit }}
       run: |
+        SUDO=""; command -v sudo &> /dev/null && SUDO="sudo"
         if [ "$ENABLE_32BIT" == "true" ]; then
-          sudo dpkg --add-architecture i386
+          $SUDO dpkg --add-architecture i386
           PKG_FILE=".github/packages/apt-i386.txt"
         else
           PKG_FILE=".github/packages/apt.txt"
         fi
 
-        sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+        $SUDO apt-get update && $SUDO apt-get install -y --no-install-recommends \
           ${{ inputs.additional-dependencies || '' }} \
           $(cat "$PKG_FILE")
 
@@ -175,9 +174,23 @@ runs:
       run: |
         HOMEBREW_NO_AUTO_UPDATE=1 brew install mono ${{ inputs.additional-dependencies }}
 
+    - name: Format pip command
+      shell: bash
+      run: |
+        if pip install --break-system-packages --dry-run pip &> /dev/null; then
+          echo "CMD_PIP_INSTALL=pip install --break-system-packages" >> $GITHUB_ENV
+        else
+          echo "CMD_PIP_INSTALL=pip install" >> $GITHUB_ENV
+        fi
+
+    - name: Setup cmake
+      shell: bash
+      run: ${CMD_PIP_INSTALL} cmake
+
     - name: Install ninja-build
       if: inputs.cmake-generator == 'Ninja' && inputs.skip-setup-ninja != 'true'
-      uses: seanmiddleditch/gha-setup-ninja@v6
+      shell: bash
+      run: ${CMD_PIP_INSTALL} ninja
 
     - name: Setup MSYS2 MINGW64
       if: runner.os == 'Windows' && env.CXX == 'g++'

--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -226,13 +226,12 @@ runs:
 
     - name: Install Python dependencies
       if: |
-        inputs.skip-setup-python != 'true' &&
         inputs.generate-python-bindings != 'false' &&
         !(inputs.enable-32bit == 'true' && runner.os == 'Linux')
       shell: bash
       run: |
         echo "Installing numpy for Python: $(python --version)"
-        python -m pip install numpy
+        python -c "import numpy" 2>/dev/null || ${CMD_PIP_INSTALL} numpy
         echo "Done installing Python dependencies"
 
     - name: Configure

--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -177,18 +177,25 @@ runs:
     - name: Format pip command
       shell: bash
       run: |
-        if pip install --break-system-packages --dry-run pip &> /dev/null; then
-          echo "CMD_PIP_INSTALL=pip install --break-system-packages" >> $GITHUB_ENV
-        else
-          echo "CMD_PIP_INSTALL=pip install" >> $GITHUB_ENV
+        PIP_CMD=""
+        if command -v pip &> /dev/null; then
+          PIP_CMD="pip"
+        elif command -v pip3 &> /dev/null; then
+          PIP_CMD="pip3"
+        fi
+        if [ -n "$PIP_CMD" ] && $PIP_CMD install --break-system-packages --dry-run pip &> /dev/null; then
+          echo "CMD_PIP_INSTALL=$PIP_CMD install --break-system-packages" >> $GITHUB_ENV
+        elif [ -n "$PIP_CMD" ]; then
+          echo "CMD_PIP_INSTALL=$PIP_CMD install" >> $GITHUB_ENV
         fi
 
     - name: Setup cmake
+      if: env.CMD_PIP_INSTALL != ''
       shell: bash
       run: ${CMD_PIP_INSTALL} cmake
 
     - name: Install ninja-build
-      if: inputs.cmake-generator == 'Ninja' && inputs.skip-setup-ninja != 'true'
+      if: env.CMD_PIP_INSTALL != '' && inputs.cmake-generator == 'Ninja' && inputs.skip-setup-ninja != 'true'
       shell: bash
       run: ${CMD_PIP_INSTALL} ninja
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,6 @@ jobs:
             cmake-defines: >-
               -DDAQMODULES_REF_FB_MODULE_ENABLE_RENDERER=OFF 
               -DDAQMODULES_BASIC_CSV_RECORDER_MODULE=OFF
-              -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF 
-              -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
           - name: Ubuntu Latest x86_64 gcc-14 Release
             cc: gcc-14
             cxx: g++-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,14 @@ jobs:
           path: ${{ steps.build-and-test.outputs.gtest-xml-path }}
 
   build_linux:
-    runs-on: ubuntu-latest
-    name: ${{ matrix.name }}
     if: ${{ ! github.event.pull_request.draft }}
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    container:
+      image: ${{ matrix.image }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        TZ: Etc/UTC
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.name }}
@@ -120,35 +125,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu Latest gcc-9 Release
-            cc: gcc-9
-            cxx: g++-9
-            additional-packages: g++-9
+          - name: Ubuntu 20.04 armv8 gcc-7 Release
+            image: ubuntu:20.04
+            runner: ubuntu-24.04-arm
+            cc: gcc-7
+            cxx: g++-7
+            additional-packages: gcc-7 g++-7 python3-pip python3-dev
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines:
-          - name: Ubuntu Latest gcc-14 Release
+            cmake-defines: -DDAQMODULES_REF_FB_MODULE_ENABLE_RENDERER=OFF -DDAQMODULES_BASIC_CSV_RECORDER_MODULE=OFF
+          - name: Ubuntu Latest x86_64 gcc-14 Release
             cc: gcc-14
             cxx: g++-14
             additional-packages: g++-14
             cmake-generator: Ninja
             cmake-build-type: Release
             cmake-defines:
-          - name: Ubuntu Latest clang-14 Release
+          - name: Ubuntu Latest x86_64 clang-14 Release
             cc: clang-14
             cxx: clang++-14
             additional-packages: clang-14
             cmake-generator: Ninja
             cmake-build-type: Release
             cmake-defines:
-          - name: Ubuntu Latest clang-16 Release
+          - name: Ubuntu Latest x86_64 clang-16 Release
             cc: clang-16
             cxx: clang++-16
             additional-packages: clang-16
             cmake-generator: Ninja
             cmake-build-type: Release
             cmake-defines:
-          - name: Ubuntu Latest gcc x86_32 Release
+          - name: Ubuntu Latest x86 gcc x86 Release
             cc: gcc
             cxx: g++
             additional-packages:
@@ -189,6 +196,12 @@ jobs:
           #   cmake-defines:
 
     steps:
+      - name: Container bootstrap
+        if: matrix.image != ''
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git ca-certificates
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -204,6 +217,7 @@ jobs:
           enable-32bit: ${{ matrix.enable-32bit == true }}
           enable-tests: true
           ctest-preset: ${{ env.ctest_preset }}
+          skip-setup-python: ${{ matrix.image != '' }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,11 @@ jobs:
             additional-packages: gcc-7 g++-7 python3-pip python3-dev
             cmake-generator: Ninja
             cmake-build-type: Release
-            cmake-defines: -DDAQMODULES_REF_FB_MODULE_ENABLE_RENDERER=OFF -DDAQMODULES_BASIC_CSV_RECORDER_MODULE=OFF
+            cmake-defines: >-
+              -DDAQMODULES_REF_FB_MODULE_ENABLE_RENDERER=OFF 
+              -DDAQMODULES_BASIC_CSV_RECORDER_MODULE=OFF
+              -DOPENDAQ_GENERATE_PYTHON_BINDINGS=OFF 
+              -DOPENDAQ_GENERATE_CSHARP_BINDINGS=OFF
           - name: Ubuntu Latest x86_64 gcc-14 Release
             cc: gcc-14
             cxx: g++-14
@@ -155,7 +159,7 @@ jobs:
             cmake-generator: Ninja
             cmake-build-type: Release
             cmake-defines:
-          - name: Ubuntu Latest x86 gcc x86 Release
+          - name: Ubuntu Latest x86 gcc Release
             cc: gcc
             cxx: g++
             additional-packages:


### PR DESCRIPTION
# Brief

Replace GCC-9 CI job with GCC-7 running in an Ubuntu 20.04 container on ARM runner

# Description

- Replace GCC-9 build matrix entry with GCC-7 in Ubuntu 20.04 container
- Add container bootstrap step to install git and ca-certificates
- Install python3-pip via additional-packages for cmake/ninja pip installation
- Install cmake and ninja via pip instead of external GitHub Actions
