### PR TITLE
Feature/default to safe operation

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -17,6 +17,7 @@
 - [#1088](https://github.com/openDAQ/openDAQ/pull/1088) Enable bundling of sent core events within the native configuration protocol
 - [#1097](https://github.com/openDAQ/openDAQ/pull/1097) Implement value based selection list
 - [#1124](https://github.com/openDAQ/openDAQ/pull/1124) Implement clearPropertyValues() for property objects
+- [#1157](https://github.com/openDAQ/openDAQ/pull/1157) Devices default to `OperationModeType::SafeOperation` when added to folder or set as root. Add virtual method to make it customizable.
 
 ## Python
 
@@ -52,7 +53,7 @@
 
 ## Misc
 
-- [#1125](https://github.com/openDAQ/openDAQ/pull/1125) Removing all function blocks before load 
+- [#1125](https://github.com/openDAQ/openDAQ/pull/1125) Removing all function blocks before load
 - [#1090](https://github.com/openDAQ/openDAQ/pull/1090) Reduce unnecessary RPC calls and signal updates
 - [#1049](https://github.com/openDAQ/openDAQ/pull/1049) Extract LT and OpcUa modules to remote repos
 - [#1051](https://github.com/openDAQ/openDAQ/pull/1051) Removes the FB wrapper implementation as it was never used.
@@ -83,7 +84,7 @@ The IFunctionBlockWrapper interface was removed as it was never used. Similarly,
 ### [#1125](https://github.com/openDAQ/openDAQ/pull/1125) Removing all function blocks before load
 
 On load configuration, all non-static function blocks will be removed and recreated if they are in the load config
- 
+
 ## Required module changes
 
 ### [#1037](https://github.com/openDAQ/openDAQ/pull/1037) Mandatory device types

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1140,7 +1140,7 @@ ListPtr<ILockGuard> GenericDevice<TInterface, Interfaces...>::getTreeLockGuard()
 template <typename TInterface, typename... Interfaces>
 std::set<OperationModeType> GenericDevice<TInterface, Interfaces...>::onGetAvailableOperationModes()
 {
-    return {OperationModeType::Operation};
+    return {OperationModeType::SafeOperation};
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1188,7 +1188,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationModeInternal(Op
 template <typename TInterface, typename... Interfaces>
 ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationMode(OperationModeType /* modeType */)
 {
-    return this->updateOperationModeInternal(OperationModeType::Operation);
+    return this->updateOperationModeInternal(OperationModeType::SafeOperation);
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1197,6 +1197,11 @@ ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationMode(OperationM
 {
     // TODO: Consider either ignoring calls to this or even returning error codes - the correct way to set device's
     // operation mode should be through setOperationMode
+    if (onGetAvailableOperationModes().count(modeType) == 0)
+    {
+        this->updateOperationModeInternal(onGetDefaultOperationMode());
+        return OPENDAQ_IGNORED;
+    }
     return this->updateOperationModeInternal(modeType);
 }
 

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1193,16 +1193,11 @@ ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationModeInternal(Op
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationMode(OperationModeType modeType)
+ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationMode(OperationModeType /*modeType*/)
 {
-    // TODO: Consider either ignoring calls to this or even returning error codes - the correct way to set device's
-    // operation mode should be through setOperationMode
-    if (onGetAvailableOperationModes().count(modeType) == 0)
-    {
-        this->updateOperationModeInternal(onGetDefaultOperationMode());
-        return OPENDAQ_IGNORED;
-    }
-    return this->updateOperationModeInternal(modeType);
+    // This method gets called when a device is added to the IFolder. Device ignores its parent's operation mode and
+    // enters default operation mode.
+    return this->updateOperationModeInternal(this->onGetDefaultOperationMode());
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -242,6 +242,7 @@ protected:
     virtual ListPtr<IString> onGetNetworkInterfaceNames();
 
     virtual std::set<OperationModeType> onGetAvailableOperationModes();
+    virtual OperationModeType onGetDefaultOperationMode();
 
     ListPtr<ILockGuard> getTreeLockGuard();
     ErrCode updateOperationModeNoCoreEvent(OperationModeType modeType);
@@ -266,7 +267,7 @@ private:
     void removeDeviceIfNotStatic(const StringPtr& deviceId);
 
     DeviceDomainPtr deviceDomain;
-    OperationModeType operationMode {OperationModeType::Idle};
+    OperationModeType operationMode {OperationModeType::Unknown};
     ListPtr<IInteger> availableOperationModes;
 };
 
@@ -364,7 +365,7 @@ ErrCode GenericDevice<TInterface, Interfaces...>::setAsRoot()
     auto lock = this->getRecursiveConfigLock2();
 
     this->isRootDevice = true;
-    this->updateOperationMode(OperationModeType::Unknown);
+    this->updateOperationModeInternal(this->onGetDefaultOperationMode());
     return OPENDAQ_SUCCESS;
 }
 
@@ -1144,6 +1145,12 @@ std::set<OperationModeType> GenericDevice<TInterface, Interfaces...>::onGetAvail
 }
 
 template <typename TInterface, typename... Interfaces>
+OperationModeType GenericDevice<TInterface, Interfaces...>::onGetDefaultOperationMode()
+{
+    return OperationModeType::SafeOperation;
+}
+
+template <typename TInterface, typename... Interfaces>
 ErrCode GenericDevice<TInterface, Interfaces...>::getAvailableOperationModes(IList** availableOpModes)
 {
     OPENDAQ_PARAM_NOT_NULL(availableOpModes);
@@ -1186,9 +1193,11 @@ ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationModeInternal(Op
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationMode(OperationModeType /* modeType */)
+ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationMode(OperationModeType modeType)
 {
-    return this->updateOperationModeInternal(OperationModeType::SafeOperation);
+    // TODO: Consider either ignoring calls to this or even returning error codes - the correct way to set device's
+    // operation mode should be through setOperationMode
+    return this->updateOperationModeInternal(modeType);
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -48,10 +48,10 @@ public:
 
         return deviceInfo;
     }
-        
-    std::set<daq::OperationModeType> onGetAvailableOperationModes() override 
-    { 
-        return {daq::OperationModeType::Idle, daq::OperationModeType::Operation}; 
+
+    std::set<daq::OperationModeType> onGetAvailableOperationModes() override
+    {
+        return {daq::OperationModeType::Idle, daq::OperationModeType::SafeOperation};
     }
 
     std::unordered_set<std::string> getDefaultComponents()
@@ -615,7 +615,7 @@ TEST_F(DeviceTest, DeviceSetOperationModeSanity)
     ASSERT_EQ(device.getAvailableOperationModes()[0], daq::OperationModeType::Idle);
     ASSERT_EQ(device.getAvailableOperationModes()[1], daq::OperationModeType::Operation);
     ASSERT_EQ(device.getAvailableOperationModes()[2], daq::OperationModeType::SafeOperation);
-    
+
     // check getting operation mode from the list
     daq::OperationModeType mode = device.getAvailableOperationModes()[0];
     ASSERT_EQ(mode, daq::OperationModeType::Idle);
@@ -661,7 +661,7 @@ TEST_F(DeviceTest, CheckNotSupportedOpMode)
     ASSERT_EQ(device.getAvailableOperationModes(), expectedDeviceModes);
     ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::SafeOperation);
 
-    ASSERT_EQ(device->setOperationMode(daq::OperationModeType::Operation), OPENDAQ_IGNORED);
+    ASSERT_EQ(device->setOperationMode(daq::OperationModeType::SafeOperation), OPENDAQ_IGNORED);
     ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::SafeOperation);
 }
 

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -616,8 +616,8 @@ TEST_F(DeviceTest, DeviceSetOperationModeSanity)
     auto mode2 = device.getAvailableOperationModes()[1];
     ASSERT_EQ(mode2, daq::OperationModeType::Operation);
 
-    checkDeviceOperationMode(device, daq::OperationModeType::Operation);
-    checkDeviceOperationMode(subDevice, daq::OperationModeType::Operation);
+    checkDeviceOperationMode(device, daq::OperationModeType::SafeOperation);
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::SafeOperation);
 
     ASSERT_NO_THROW(device.setOperationModeRecursive(daq::OperationModeType::Idle));
     checkDeviceOperationMode(device, daq::OperationModeType::Idle);

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -141,6 +141,11 @@ public:
         return {daq::OperationModeType::Idle, daq::OperationModeType::Operation, daq::OperationModeType::SafeOperation}; 
     }
 
+    daq::OperationModeType onGetDefaultOperationMode() override
+    {
+        return daq::OperationModeType::Idle;
+    }
+
     void onOperationModeChanged(daq::OperationModeType modeType) override
     {
         bool active = modeType != daq::OperationModeType::Idle;
@@ -593,8 +598,9 @@ TEST_F(DeviceTest, DeviceSetOperationModeSanity)
 {
     const auto device = daq::createWithImplementation<daq::IDevice, MockDevice>(daq::NullContext(), nullptr, "dev", true);
     const auto subDevice = device.getDevices()[0];
-    device.asPtr<daq::IComponentPrivate>(true).updateOperationMode(daq::OperationModeType::Unknown);
-    subDevice.asPtr<daq::IComponentPrivate>(true).updateOperationMode(daq::OperationModeType::Unknown);
+
+    checkDeviceOperationMode(device, daq::OperationModeType::Unknown);
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Unknown);
 
     auto expectedDeviceModes = daq::List<daq::IInteger>(
         static_cast<daq::Int>(daq::OperationModeType::Idle),
@@ -616,8 +622,13 @@ TEST_F(DeviceTest, DeviceSetOperationModeSanity)
     auto mode2 = device.getAvailableOperationModes()[1];
     ASSERT_EQ(mode2, daq::OperationModeType::Operation);
 
+    ASSERT_NO_THROW(device.asPtr<daq::IDevicePrivate>(true).setAsRoot());
+    checkDeviceOperationMode(device, daq::OperationModeType::Idle);
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Unknown);
+
+    ASSERT_NO_THROW(device.setOperationMode(daq::OperationModeType::SafeOperation));
     checkDeviceOperationMode(device, daq::OperationModeType::SafeOperation);
-    checkDeviceOperationMode(subDevice, daq::OperationModeType::SafeOperation);
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Unknown);
 
     ASSERT_NO_THROW(device.setOperationModeRecursive(daq::OperationModeType::Idle));
     checkDeviceOperationMode(device, daq::OperationModeType::Idle);
@@ -639,17 +650,17 @@ TEST_F(DeviceTest, DeviceSetOperationModeSanity)
 TEST_F(DeviceTest, CheckNotSupportedOpMode)
 {
     auto device = daq::createWithImplementation<daq::IDevice, TestDevice>();
-    device.asPtr<daq::IComponentPrivate>(true).updateOperationMode(daq::OperationModeType::Unknown);
+    device.asPtr<daq::IDevicePrivate>(true).setAsRoot();
 
     auto expectedDeviceModes = daq::List<daq::IInteger>(
-        static_cast<daq::Int>(daq::OperationModeType::Idle), 
-        static_cast<daq::Int>(daq::OperationModeType::Operation));
+        static_cast<daq::Int>(daq::OperationModeType::Idle),
+        static_cast<daq::Int>(daq::OperationModeType::SafeOperation));
 
     ASSERT_EQ(device.getAvailableOperationModes(), expectedDeviceModes);
-    ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::Operation);
+    ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::SafeOperation);
 
-    ASSERT_EQ(device->setOperationMode(daq::OperationModeType::SafeOperation), OPENDAQ_IGNORED);
-    ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::Operation);
+    ASSERT_EQ(device->setOperationMode(daq::OperationModeType::Operation), OPENDAQ_IGNORED);
+    ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::SafeOperation);
 }
 
 TEST_F(DeviceTest, DefaultFolderLockingStrategy)

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -599,9 +599,10 @@ TEST_F(DeviceTest, DeviceSetOperationModeSanity)
     const auto device = daq::createWithImplementation<daq::IDevice, MockDevice>(daq::NullContext(), nullptr, "dev", true);
     const auto subDevice = device.getDevices()[0];
 
-    checkDeviceOperationMode(device, daq::OperationModeType::Unknown);
-    checkDeviceOperationMode(subDevice, daq::OperationModeType::Unknown);
+    checkDeviceOperationMode(device, daq::OperationModeType::Unknown); // setAsRoot has not been called yet
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Idle); // Was added via addItem and default op mode idle
 
+    // Stateless methods checks
     auto expectedDeviceModes = daq::List<daq::IInteger>(
         static_cast<daq::Int>(daq::OperationModeType::Idle),
         static_cast<daq::Int>(daq::OperationModeType::Operation),
@@ -621,30 +622,31 @@ TEST_F(DeviceTest, DeviceSetOperationModeSanity)
 
     auto mode2 = device.getAvailableOperationModes()[1];
     ASSERT_EQ(mode2, daq::OperationModeType::Operation);
+    // end of stateless checks
 
     ASSERT_NO_THROW(device.asPtr<daq::IDevicePrivate>(true).setAsRoot());
-    checkDeviceOperationMode(device, daq::OperationModeType::Idle);
-    checkDeviceOperationMode(subDevice, daq::OperationModeType::Unknown);
+    checkDeviceOperationMode(device, daq::OperationModeType::Idle); // Set as root sets to default mode (Idle)
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Idle); // Still Idle after the initial addItem
 
     ASSERT_NO_THROW(device.setOperationMode(daq::OperationModeType::SafeOperation));
     checkDeviceOperationMode(device, daq::OperationModeType::SafeOperation);
-    checkDeviceOperationMode(subDevice, daq::OperationModeType::Unknown);
-
-    ASSERT_NO_THROW(device.setOperationModeRecursive(daq::OperationModeType::Idle));
-    checkDeviceOperationMode(device, daq::OperationModeType::Idle);
     checkDeviceOperationMode(subDevice, daq::OperationModeType::Idle);
 
-    ASSERT_NO_THROW(device.setOperationMode(daq::OperationModeType::Operation));
+    ASSERT_NO_THROW(device.setOperationModeRecursive(daq::OperationModeType::Operation));
     checkDeviceOperationMode(device, daq::OperationModeType::Operation);
-    checkDeviceOperationMode(subDevice, daq::OperationModeType::Idle);
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Operation);
+
+    ASSERT_NO_THROW(device.setOperationMode(daq::OperationModeType::Idle));
+    checkDeviceOperationMode(device, daq::OperationModeType::Idle);
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Operation);
 
     ASSERT_NO_THROW(subDevice.setOperationModeRecursive(daq::OperationModeType::SafeOperation));
-    checkDeviceOperationMode(device, daq::OperationModeType::Operation);
+    checkDeviceOperationMode(device, daq::OperationModeType::Idle);
     checkDeviceOperationMode(subDevice, daq::OperationModeType::SafeOperation);
 
-    ASSERT_NO_THROW(device.setOperationModeRecursive(daq::OperationModeType::Idle));
-    checkDeviceOperationMode(device, daq::OperationModeType::Idle);
-    checkDeviceOperationMode(subDevice, daq::OperationModeType::Idle);
+    ASSERT_NO_THROW(device.setOperationModeRecursive(daq::OperationModeType::Operation));
+    checkDeviceOperationMode(device, daq::OperationModeType::Operation);
+    checkDeviceOperationMode(subDevice, daq::OperationModeType::Operation);
 }
 
 TEST_F(DeviceTest, CheckNotSupportedOpMode)

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -112,9 +112,9 @@ public:
 class MockDevice final : public daq::Device
 {
 public:
-    MockDevice(const daq::ContextPtr& ctx, 
-               const daq::ComponentPtr& parent, 
-               const daq::StringPtr& localId, 
+    MockDevice(const daq::ContextPtr& ctx,
+               const daq::ComponentPtr& parent,
+               const daq::StringPtr& localId,
                bool addSubDevice = false)
         : daq::Device(ctx, parent, localId)
     {
@@ -136,9 +136,9 @@ public:
         }
     }
 
-    std::set<daq::OperationModeType> onGetAvailableOperationModes() override 
-    { 
-        return {daq::OperationModeType::Idle, daq::OperationModeType::Operation, daq::OperationModeType::SafeOperation}; 
+    std::set<daq::OperationModeType> onGetAvailableOperationModes() override
+    {
+        return {daq::OperationModeType::Idle, daq::OperationModeType::Operation, daq::OperationModeType::SafeOperation};
     }
 
     daq::OperationModeType onGetDefaultOperationMode() override
@@ -182,7 +182,7 @@ TEST_F(DeviceTest, DeviceInfoForwardCallbacks)
     };
 
     daq::SizeT writeCounter = 0;
-    info.getOnPropertyValueWrite("CustomChangeableField") += [&writeCounter](daq::PropertyObjectPtr& obj, daq::PropertyValueEventArgsPtr& args) 
+    info.getOnPropertyValueWrite("CustomChangeableField") += [&writeCounter](daq::PropertyObjectPtr& obj, daq::PropertyValueEventArgsPtr& args)
     {
         writeCounter++;
     };
@@ -539,7 +539,7 @@ TEST_F(DeviceTest, SerializeAndDeserializeManufacturer)
 {
     const auto context = daq::NullContext();
     const auto dev = daq::createWithImplementation<daq::IDevice, MockDevice>(context, nullptr, "dev");
-    
+
     const auto serializer = daq::JsonSerializer(daq::True);
     dev.serialize(serializer);
     const std::string str1 = serializer.getOutput();
@@ -661,7 +661,8 @@ TEST_F(DeviceTest, CheckNotSupportedOpMode)
     ASSERT_EQ(device.getAvailableOperationModes(), expectedDeviceModes);
     ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::SafeOperation);
 
-    ASSERT_EQ(device->setOperationMode(daq::OperationModeType::SafeOperation), OPENDAQ_IGNORED);
+    // Check that not supported modes are ignored
+    ASSERT_EQ(device->setOperationMode(daq::OperationModeType::Operation), OPENDAQ_IGNORED);
     ASSERT_EQ(device.getOperationMode(), daq::OperationModeType::SafeOperation);
 }
 

--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -868,7 +868,7 @@ TEST_F(CoreEventTest, DeviceAdded)
             {
                 ASSERT_EQ(args.getEventName(), "DeviceOperationModeChanged");
                 ASSERT_TRUE(args.getParameters().hasKey("OperationMode"));
-                ASSERT_EQ(args.getParameters().get("OperationMode"), static_cast<Int>(OperationModeType::Operation));
+                ASSERT_EQ(args.getParameters().get("OperationMode"), static_cast<Int>(OperationModeType::SafeOperation));
                 ASSERT_EQ(comp, instance.getDevices()[modeChangeCount + 1 ]);
                 modeChangeCount++;
             }

--- a/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
+++ b/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
@@ -53,6 +53,7 @@ protected:
     ListPtr<ILogFileInfo> onGetLogFileInfos() override;
     StringPtr onGetLog(const StringPtr& id, Int size, Int offset) override;
     std::set<OperationModeType> onGetAvailableOperationModes() override;
+    OperationModeType onGetDefaultOperationMode() override;
     void onOperationModeChanged(OperationModeType modeType) override;
 
 #ifdef DAQMODULES_REF_DEVICE_MODULE_SIMULATOR_ENABLED
@@ -95,7 +96,7 @@ private:
     std::chrono::microseconds startTimeInMs;
     std::chrono::microseconds lastCollectTime;
     std::chrono::microseconds microSecondsFromEpochToDeviceStart;
-    
+
     std::vector<ChannelPtr> channels;
     ChannelPtr canChannel;
     ChannelPtr protectedChannel;

--- a/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
+++ b/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
@@ -53,7 +53,6 @@ protected:
     ListPtr<ILogFileInfo> onGetLogFileInfos() override;
     StringPtr onGetLog(const StringPtr& id, Int size, Int offset) override;
     std::set<OperationModeType> onGetAvailableOperationModes() override;
-    OperationModeType onGetDefaultOperationMode() override;
     void onOperationModeChanged(OperationModeType modeType) override;
 
 #ifdef DAQMODULES_REF_DEVICE_MODULE_SIMULATOR_ENABLED

--- a/examples/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_impl.cpp
@@ -590,11 +590,6 @@ std::set<OperationModeType> RefDeviceImpl::onGetAvailableOperationModes()
     return {OperationModeType::Idle, OperationModeType::Operation, OperationModeType::SafeOperation};
 }
 
-OperationModeType RefDeviceImpl::onGetDefaultOperationMode()
-{
-    return OperationModeType::Operation;
-}
-
 void RefDeviceImpl::onOperationModeChanged(OperationModeType modeType)
 {
     bool active = modeType != OperationModeType::Idle;

--- a/examples/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_impl.cpp
@@ -547,7 +547,7 @@ ListPtr<ILogFileInfo> RefDeviceImpl::onGetLogFileInfos()
                                            .setEncoding("utf-8")
                                            .setLastModified(lastModified)
                                            .build();
-    
+
     return List<ILogFileInfo>(logFileInfo);
 }
 
@@ -588,6 +588,11 @@ StringPtr RefDeviceImpl::onGetLog(const StringPtr& id, Int size, Int offset)
 std::set<OperationModeType> RefDeviceImpl::onGetAvailableOperationModes()
 {
     return {OperationModeType::Idle, OperationModeType::Operation, OperationModeType::SafeOperation};
+}
+
+OperationModeType RefDeviceImpl::onGetDefaultOperationMode()
+{
+    return OperationModeType::Idle;
 }
 
 void RefDeviceImpl::onOperationModeChanged(OperationModeType modeType)

--- a/examples/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_impl.cpp
@@ -592,7 +592,7 @@ std::set<OperationModeType> RefDeviceImpl::onGetAvailableOperationModes()
 
 OperationModeType RefDeviceImpl::onGetDefaultOperationMode()
 {
-    return OperationModeType::Idle;
+    return OperationModeType::Operation;
 }
 
 void RefDeviceImpl::onOperationModeChanged(OperationModeType modeType)

--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -3359,9 +3359,9 @@ TEST_F(NativeDeviceModulesTest, SettingOperationMode)
 {
     auto server = CreateServerInstance();
     auto client = CreateClientInstance();
-    test_helpers::checkDeviceOperationMode(server, daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(server, daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
 
     ASSERT_EQ(server.getAvailableOperationModes(), client.getDevices()[0].getAvailableOperationModes());
     ASSERT_EQ(server.getDevices()[0].getAvailableOperationModes(), client.getDevices()[0].getDevices()[0].getAvailableOperationModes());
@@ -3372,39 +3372,39 @@ TEST_F(NativeDeviceModulesTest, SettingOperationMode)
     test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
     test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Idle, true);
 
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Idle);
 
     // setting the operation mode for server sub device
-    ASSERT_NO_THROW(server.getDevices()[0].setOperationModeRecursive(daq::OperationModeType::SafeOperation));
+    ASSERT_NO_THROW(server.getDevices()[0].setOperationModeRecursive(daq::OperationModeType::Operation));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
+    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation, true);
+
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Operation);
+
+    // setting the operation mode for client sub device
+    ASSERT_NO_THROW(client.getDevices()[0].getDevices()[0].setOperationModeRecursive(daq::OperationModeType::SafeOperation));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
     test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::SafeOperation, true);
 
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::SafeOperation);
 
-    // setting the operation mode for client sub device
-    ASSERT_NO_THROW(client.getDevices()[0].getDevices()[0].setOperationModeRecursive(daq::OperationModeType::Operation));
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
-    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation, true);
-
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Operation);
-
     // setting the operation mode for client device not recursively
-    ASSERT_NO_THROW(client.getDevices()[0].setOperationMode(daq::OperationModeType::SafeOperation));
+    ASSERT_NO_THROW(client.getDevices()[0].setOperationMode(daq::OperationModeType::Operation));
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::SafeOperation, true);
-    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation, true);
+    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Operation, true);
+    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::SafeOperation, true);
 
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::SafeOperation);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::SafeOperation);
 
     // setting the operation mode for client device
     ASSERT_NO_THROW(client.setOperationModeRecursive(daq::OperationModeType::Idle));

--- a/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -1664,9 +1664,9 @@ TEST_F(OpcuaDeviceModulesTest, SettingOperationMode)
     auto server = CreateServerInstance();
     auto client = CreateClientInstance();
 
-    test_helpers::checkDeviceOperationMode(server, daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(server, daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
 
     ASSERT_EQ(server.getAvailableOperationModes(), client.getDevices()[0].getAvailableOperationModes());
     ASSERT_EQ(server.getDevices()[0].getAvailableOperationModes(), client.getDevices()[0].getDevices()[0].getAvailableOperationModes());
@@ -1676,36 +1676,36 @@ TEST_F(OpcuaDeviceModulesTest, SettingOperationMode)
     test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
     test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Idle, true);
 
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Idle);
 
     // setting the operation mode for server sub device
-    ASSERT_NO_THROW(server.getDevices()[0].setOperationModeRecursive(daq::OperationModeType::SafeOperation));
+    ASSERT_NO_THROW(server.getDevices()[0].setOperationModeRecursive(daq::OperationModeType::Operation));
+    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
+    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation, true);
+
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Operation);
+
+    // setting the operation mode for client sub device
+    ASSERT_NO_THROW(client.getDevices()[0].getDevices()[0].setOperationModeRecursive(daq::OperationModeType::SafeOperation));
     test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
     test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::SafeOperation, true);
 
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
     test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::SafeOperation);
 
-    // setting the operation mode for client sub device
-    ASSERT_NO_THROW(client.getDevices()[0].getDevices()[0].setOperationModeRecursive(daq::OperationModeType::Operation));
-    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Idle, true);
-    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation, true);
-
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Idle);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Operation);
-
     // setting the operation mode for client device not recursively
-    ASSERT_NO_THROW(client.getDevices()[0].setOperationMode(daq::OperationModeType::SafeOperation));
-    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::SafeOperation, true);
-    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::Operation, true);
+    ASSERT_NO_THROW(client.getDevices()[0].setOperationMode(daq::OperationModeType::Operation));
+    test_helpers::checkDeviceOperationMode(server.getRootDevice(), daq::OperationModeType::Operation, true);
+    test_helpers::checkDeviceOperationMode(server.getDevices()[0], daq::OperationModeType::SafeOperation, true);
 
-    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::Operation);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::SafeOperation);
-    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getRootDevice(), daq::OperationModeType::SafeOperation);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0], daq::OperationModeType::Operation);
+    test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::SafeOperation);
 
     // setting the operation mode for client device
     ASSERT_NO_THROW(client.setOperationModeRecursive(daq::OperationModeType::Idle));


### PR DESCRIPTION
# Brief

Change default for `OperationModeType` provided in the base device class to `SafeOperation`. Add `GenericDevice::onGetDefaultOperationMode` protected getter for device implementers to override (defaults to `SafeOperation`). When added to a folder, device will enter its default operation mode.

# Description

- Default set of available operation modes now includes only `OperationModeType::SafeOperation` (can be overriden)
- Add method `GenericDevice::onGetDefaultOperationMode` with default return value `OperationModeType::SafeOperation` (can be overriden)
- `GenericDevice::setAsRoot` now uses the `onGetDefaultOperationMode` method to change operation mode of the root device
- `GenericDevice` now starts in `OperationModeType::Unknown` during constructor. It is up to the derived classes/users to change it to a valid value.
- When added to a folder, device will enter its default operation mode (`updateOperationMode` now uses the return value of `onGetDefaultOperationMode` instead of hardcoded value).

# API changes

None

# Required application changes

None

# Required module changes

To restore previous behavior of not overriden functions implement:
```c++
DeviceDerivedClass::onGetDefaultOperationMode() override
{
  return OperationModeType::Operation;
}

DeviceDerivedClass::onGetAvailableOperationModes() override
{
  return {OperationModeType::Operation};
}
```
Or use a custom set of values that describe your device.