### PR TITLE
Skip logging for identical component statuses

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -31,6 +31,7 @@
 - [#1081](https://github.com/openDAQ/openDAQ/pull/1081) Adds device load options to the Python GUI.
 
 ## Bug fixes
+- [#1158](https://github.com/openDAQ/openDAQ/pull/1158) Skip logging for identical component statuses.
 - [#1150](https://github.com/openDAQ/openDAQ/pull/1150) Serialize public flag for input ports
 - [#1146](https://github.com/openDAQ/openDAQ/pull/1146) Use sender addresses if device does not provide A or AAAA records
 - [#1143] (https://github.com/openDAQ/openDAQ/pull/1143) Fix uncaught exception when closing renderer window

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1417,8 +1417,8 @@ void ComponentImpl<Intf, Intfs...>::setComponentStatusWithMessage(const Componen
             "ComponentStatus has not been added to statusContainer. initComponentStatus needs to be called before setComponentStatus.");
     }
 
-    // Check if status and message are the same as before, and also Ok and empty string, and if so, return
-    if (status == oldStatus && status == ComponentStatus::Ok && message == oldMessage && message == "")
+    // Skip the update and logging if the component status is identical to old one
+    if (status == oldStatus && message == oldMessage)
         return;
 
     // Set status if initialized


### PR DESCRIPTION
# Brief

Modifies the internal `setComponentStatusWithMessage` helper to no longer log when set to the same status as before.