### PR TITLE
Align behaviour between the ObjectProperty and ObjectPropertyBuilder factories

### DIFF
--- a/core/coreobjects/src/property_builder_impl.cpp
+++ b/core/coreobjects/src/property_builder_impl.cpp
@@ -85,7 +85,6 @@ PropertyBuilderImpl::PropertyBuilderImpl(const StringPtr& name, IPropertyObject*
     : PropertyBuilderImpl(name, BaseObjectPtr(defaultValue))
 {
     this->valueType = ctObject;
-    this->readOnly = true;
     if (defaultValue == nullptr)
         this->defaultValue = PropertyObject().detach();
 }


### PR DESCRIPTION
# Brief

Align behaviour between the ObjectProperty and ObjectPropertyBuilder factories, tested in TestMate and had no new errors.