### PR TITLE
Python GUI: Changed dialog text dislay and added treeview nesting for FBs and Channels

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -268,6 +268,8 @@ class App(tk.Tk):
         tree.bind('<<TreeviewSelect>>', self.handle_tree_select)
         tree.bind('<ButtonRelease-3>', self.handle_tree_right_button_release)
         tree.bind('<Button-3>', self.handle_tree_right_button)
+        #tree.bind('<Double-1>', lambda e: 'break')
+        tree.bind('<Button-1>', self.handle_tree_click)
 
         # add a scrollbar
         scroll_bar = ttk.Scrollbar(
@@ -625,6 +627,17 @@ class App(tk.Tk):
                 event.widget.selection_set(iid)
         else:
             event.widget.selection_set()
+            
+    def handle_tree_click(self, event):
+        iid = self.tree.identify_row(event.y)
+        element = self.tree.identify_element(event.x, event.y)
+
+        if element == 'indicator':
+            return
+
+        if iid and iid == utils.treeview_get_first_selection(self.tree):
+            self.tree.item(iid, open=not self.tree.item(iid, 'open'))
+            return 'break'  # prevent <<TreeviewSelect>> from refiring unnecessarily
 
     def create_property_object_menu(self, node):
         popup = tk.Menu(self.tree, tearoff=0)

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -315,7 +315,7 @@ class App(tk.Tk):
         self.set_node_active_status()
 
     def tree_traverse_components_recursive(
-            self, component, display_type=DisplayType.UNSPECIFIED):
+            self, component, display_type=DisplayType.UNSPECIFIED, tree_parent_id=None):
         if component is None:
             return
 
@@ -329,9 +329,18 @@ class App(tk.Tk):
         ) if self.context.view_hidden_components else None) if folder else []
 
         # tree view only in topology mode + parent exists
-        parent_id = '' if display_type not in (
-            DisplayType.UNSPECIFIED, DisplayType.TOPOLOGY, DisplayType.SYSTEM_OVERVIEW, DisplayType.TOPOLOGY_CUSTOM_COMPONENTS, None) or component.parent is None else component.parent.global_id
-
+        if tree_parent_id is not None:
+            parent_id = tree_parent_id
+        elif display_type not in (
+                DisplayType.UNSPECIFIED, DisplayType.TOPOLOGY, DisplayType.SYSTEM_OVERVIEW,
+                DisplayType.TOPOLOGY_CUSTOM_COMPONENTS, None) or component.parent is None:
+            parent_id = ''
+        else:
+            parent_id = component.parent.global_id
+        
+        is_fb = daq.IFunctionBlock.can_cast_from(component)
+        is_channel = daq.IChannel.can_cast_from(component)
+            
         if folder is None or items or display_type == DisplayType.TOPOLOGY_CUSTOM_COMPONENTS:
             if display_type in (DisplayType.UNSPECIFIED, DisplayType.TOPOLOGY,
                                 DisplayType.TOPOLOGY_CUSTOM_COMPONENTS, None):
@@ -350,18 +359,27 @@ class App(tk.Tk):
                 if daq.IChannel.can_cast_from(component):
                     self.tree_add_component(
                         parent_id, daq.IChannel.cast_from(component))
+                elif tree_parent_id is not None and is_fb:
+                    self.tree_add_component(parent_id, daq.IFunctionBlock.cast_from(component))
             elif display_type == DisplayType.FUNCTION_BLOCKS:
                 if daq.IFunctionBlock.can_cast_from(
                         component) and not daq.IChannel.can_cast_from(component):
                     self.tree_add_component(
                         parent_id, daq.IFunctionBlock.cast_from(component))
 
-        if folder is not None:
-            if not (daq.IFunctionBlock.can_cast_from(component)
-                    and display_type == DisplayType.FUNCTION_BLOCKS) and (self.context.view_hidden_components or folder.visible):
+        if folder is not None and (self.context.view_hidden_components or folder.visible):
+            if display_type == DisplayType.FUNCTION_BLOCKS and is_fb and not is_channel:
                 for item in items:
                     self.tree_traverse_components_recursive(
-                        item, display_type=display_type)
+                        item, display_type=display_type, tree_parent_id=component.global_id)
+            elif display_type == DisplayType.CHANNELS and (is_channel or (tree_parent_id is not None and is_fb)):
+                for item in items:
+                    self.tree_traverse_components_recursive(
+                        item, display_type=display_type, tree_parent_id=component.global_id)
+            elif not (is_fb and display_type == DisplayType.FUNCTION_BLOCKS):
+                for item in items:
+                    self.tree_traverse_components_recursive(
+                        item, display_type=display_type, tree_parent_id=tree_parent_id)
 
         if device is not None and display_type == DisplayType.TOPOLOGY:
             custom_components = device.custom_components
@@ -406,9 +424,11 @@ class App(tk.Tk):
                     status_string = 'error'
             except:
                 pass
-
+            
+            is_open = not daq.IFunctionBlock.can_cast_from(component)
+            
             self.tree.insert(parent_node_id, tk.END, iid=component_node_id, image=icon,
-                             text=self._format_tree_item_text(component_name), open=True, values=(component_node_id,), tags=(status_string,))
+                             text=self._format_tree_item_text(component_name), open=is_open, values=(component_node_id,), tags=(status_string,))
 
 
 
@@ -882,8 +902,15 @@ class App(tk.Tk):
         if node_unique_id not in self.context.nodes:
             return
         node = self.context.nodes[node_unique_id]
-        self.context.selected_node = node
+        if (daq.IFolder.can_cast_from(node)
+                and not daq.IDevice.can_cast_from(node)
+                and not daq.IFunctionBlock.can_cast_from(node)):
+            self.tree.item(selected_iid, open=not self.tree.item(selected_iid, 'open'))
+            self.tree.selection_set('')
+            return
 
+        self.context.selected_node = node
+        
         self.right_side_panel_clear()
         self.right_side_panel_draw_node(node)
 

--- a/examples/applications/python/GUI Application/gui_demo/components/add_device_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_device_dialog.py
@@ -50,8 +50,8 @@ class AddDeviceDialog(Dialog):
 
         right_side_frame = ttk.Frame(self)
         device_tree_frame = ttk.Frame(right_side_frame)
-        device_tree = ttk.Treeview(device_tree_frame, columns=('name', 'conn'), displaycolumns=(
-            'name', 'conn'), show='tree headings', selectmode=tk.BROWSE)
+        device_tree = ttk.Treeview(device_tree_frame, columns=('name', 'loc', 'conn'), displaycolumns=(
+            'name', 'loc', 'conn'), show='tree headings', selectmode=tk.BROWSE)
 
         device_scroll_bar = ttk.Scrollbar(
             device_tree_frame, orient=tk.VERTICAL, command=device_tree.yview)
@@ -62,10 +62,12 @@ class AddDeviceDialog(Dialog):
         self.parent_device_tree = parent_device_tree
 
         device_tree.heading('name', text='Name', anchor=tk.W)
+        device_tree.heading('loc', text=' Location', anchor=tk.W)
         device_tree.heading('conn', text='Connection string', anchor=tk.W)
 
         device_tree.column('#0', width=0, stretch=False)
         device_tree.column('name', anchor=tk.W, minwidth=int(200 * self.context.dpi_factor))
+        device_tree.column('loc',  anchor=tk.W, minwidth=int(100 * self.context.dpi_factor))
         device_tree.column('conn', anchor=tk.W, minwidth=int(300 * self.context.dpi_factor))
 
         device_tree.bind('<Double-1>', self.handle_device_tree_double_click)
@@ -139,7 +141,7 @@ class AddDeviceDialog(Dialog):
         # Fill the textbox with connection string from the device
         connection_string = self.device_tree.item(selected_item_iid, 'values')
         self.conn_string_entry.delete(0, tk.END)
-        self.conn_string_entry.insert(0, connection_string[1])
+        self.conn_string_entry.insert(0, connection_string[2])
 
     def handle_device_tree_double_click(self, event):
         self.process_add_device(False)
@@ -298,6 +300,7 @@ class AddDeviceDialog(Dialog):
             try:
                 devices = [
                     (daq.IDeviceInfo.cast_from(d).name,
+                     daq.IDeviceInfo.cast_from(d).location,
                      daq.IDeviceInfo.cast_from(d).connection_string)
                     for d in parent_device.available_devices
                 ]
@@ -313,8 +316,8 @@ class AddDeviceDialog(Dialog):
         try:
             tree.delete(*tree.get_children())
             tree.configure(cursor='')
-            for name, conn in devices:
-                tree.insert('', tk.END, iid=conn, values=(name, conn))
+            for name, loc, conn in devices:
+                tree.insert('', tk.END, iid=conn, values=(name, loc, conn))
         except tk.TclError:
             pass  # dialog was closed before results arrived
 

--- a/examples/applications/python/GUI Application/gui_demo/components/add_function_block_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_function_block_dialog.py
@@ -54,8 +54,8 @@ class AddFunctionBlockDialog(Dialog):
         scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
 
         # define headings
-        tree.heading('id', text='TypeId', anchor=tk.W)
-        tree.heading('name', text='Name', anchor=tk.W)
+        tree.heading('id', text='Name', anchor=tk.W)
+        tree.heading('name', text='Description', anchor=tk.W)
 
         # layout
         tree.column('#0', width=0, stretch=tk.NO)

--- a/examples/applications/python/GUI Application/gui_demo/components/add_server_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_server_dialog.py
@@ -32,14 +32,14 @@ class AddServerDialog(Dialog):
         scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
 
         # define headings
-        tree.heading('id', text='TypeId', anchor=tk.W)
-        tree.heading('name', text='Name', anchor=tk.W)
+        tree.heading('id', text='Name', anchor=tk.W)
+        tree.heading('name', text='Description', anchor=tk.W)
 
         tree.column('#0', width=0, stretch=tk.NO)
         dpi = self.context.dpi_factor
-        tree.column('id', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+        tree.column('id', anchor=tk.W, minwidth=int(300 * dpi), width=int(400 *
                     self.context.ui_scaling_factor * dpi), stretch=tk.NO)
-        tree.column('name', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+        tree.column('name', anchor=tk.W, minwidth=int(300 * dpi), width=int(400 *
                     self.context.ui_scaling_factor * dpi))
 
         # bind double-click and right-click


### PR DESCRIPTION
# Brief

Updated some dialog display text and updated the tree view drawout.

# Description

## Dialogs
- Add function block dialog columns should be Name, Description instead of TypeID and Name. 
- Add device dialog columns should be Name, Location, Connection String
- Add server dialog columns should be Name, Description 

## Treeview

- Default folders should not be clickable; Clicking on them expands or collapses them 
- Channel view 
	- Should show nested FBs 
	- Should be collapsed by default 
- Function blocks view
	- Does not show nested FBs 
	- Should show them as expandable
	- Should be collapsed by default 

# Usage example
In terminal use:
```sh
py -m opendaq
```
