### PR TITLE
Python GUI: Properties and Input search UX

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -268,7 +268,6 @@ class App(tk.Tk):
         tree.bind('<<TreeviewSelect>>', self.handle_tree_select)
         tree.bind('<ButtonRelease-3>', self.handle_tree_right_button_release)
         tree.bind('<Button-3>', self.handle_tree_right_button)
-        #tree.bind('<Double-1>', lambda e: 'break')
         tree.bind('<Button-1>', self.handle_tree_click)
 
         # add a scrollbar

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -421,7 +421,6 @@ class BlockView(ttk.Frame):
                 right_widget = self.output_signals
 
             if self.properties and right_widget:
-
                 self.properties.place(
                     relx=0, rely=0, relwidth=0.55, relheight=1.0)
                 right_widget.place(

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -68,7 +68,7 @@ class BlockView(ttk.Frame):
         self.label.pack(side=tk.LEFT)
         self.edit_button = tk.Button(self.header_frame, text='Edit', image=self.edit_image, borderwidth=0, 
                                      command=lambda: AttributesDialog(self, 'Attributes', self.node, self.context).show())
-        self.edit_button.pack(side=tk.RIGHT, padx=(6, 14))
+        self.edit_button.pack(side=tk.RIGHT, padx=(6, 10))
         self.active_var = tk.IntVar(self, value=self.active)
         checkbox_state = tk.NORMAL if self.parent_active else tk.DISABLED
         self.checkbox = ttk.Checkbutton(

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -409,22 +409,30 @@ class BlockView(ttk.Frame):
         self.status_square.config(bg=color)
 
     def layout_view(self):
-        self.expanded_frame.pack(fill=tk.BOTH, expand=True)
-        self.expanded_frame.grid_columnconfigure(
-            self.cols, weight=1, minsize=int(200 * self.context.dpi_factor), uniform='column')
-        self.expanded_frame.grid_rowconfigure(self.rows, weight=1, minsize=int(350 * self.context.dpi_factor) if self.input_ports and self.output_signals or daq.IFolder.can_cast_from(self.node) and not daq.IDevice.can_cast_from(self.node) else int(600 * self.context.dpi_factor))
-        if self.properties:
-            self.properties.grid(
-                row=0, column=0, sticky=tk.NSEW)
-        if hasattr(self, '_right_container'):
-            self._right_container.grid(row=0, column=1, sticky=tk.NSEW)
-        elif self.input_ports:
-            self.input_ports.grid(row=0, column=1, sticky=tk.NSEW)
-        elif self.output_signals:
-            self.output_signals.grid(row=0, column=1, sticky=tk.NSEW)
+            self.expanded_frame.pack(fill=tk.BOTH, expand=True)
 
-        if self.recoder and not hasattr(self, 'right_stack'):
-            self.recoder.grid(row=1, column=1, sticky=tk.NSEW)
+            # Determine the right-side widget (if any)
+            right_widget = None
+            if hasattr(self, '_right_container'):
+                right_widget = self._right_container
+            elif self.input_ports:
+                right_widget = self.input_ports
+            elif self.output_signals:
+                right_widget = self.output_signals
+
+            if self.properties and right_widget:
+
+                self.properties.place(
+                    relx=0, rely=0, relwidth=0.55, relheight=1.0)
+                right_widget.place(
+                    relx=0.55, rely=0, relwidth=0.45, relheight=1.0)
+            elif self.properties:
+                self.properties.place(
+                    relx=0, rely=0, relwidth=1.0, relheight=1.0)
+
+            if self.recoder and not hasattr(self, 'right_stack'):
+                self.recoder.place(
+                    relx=0.55, rely=0, relwidth=0.45, relheight=1.0)
 
     def refresh(self, event):
         pass

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -543,6 +543,11 @@ class PropertiesTreeview(ttk.Treeview):
                     if iid in self._overlay_comboboxes:
                         x, py, w, ph = self._get_overlay_place_geometry(bbox)
                         
+                        if is_method:
+                            indent = self._tree_indent()
+                            x += indent
+                            w = max(1, w - indent)
+                        
                         if x >= visible_w or (x + w) <= 0:
                             fully_visible = False
                         else:
@@ -642,6 +647,10 @@ class PropertiesTreeview(ttk.Treeview):
         if not bbox:
             return
         x, y, width, height = self._get_overlay_place_geometry(bbox)
+        
+        indent = self._tree_indent()
+        x += indent
+        width = max(1, width - indent)
 
         def execute(_prop=prop, _iid=iid):
             result = None
@@ -677,6 +686,13 @@ class PropertiesTreeview(ttk.Treeview):
         btn = ttk.Button(self, text=prop.name, command=execute)
         btn.place(x=x, y=y, width=width, height=height)
         self._overlay_comboboxes[iid] = btn
+        
+    def _tree_indent(self):
+        try:
+            return int(str(self.tk.call(
+                "ttk::style", "lookup", "Treeview", "-indent")))
+        except Exception:
+            return 20
 
     def _place_selection_combobox(self, iid, prop):
         labels, indices = self._get_selection_options(prop.selection_values)
@@ -876,9 +892,9 @@ class PropertiesTreeview(ttk.Treeview):
         try:
             f = float(value)
             if f == int(f):
-                return str(int(f))
+                return str(int(f)).strip()
             rounded = float(f'{f:.7g}')
-            return str(rounded)
+            return str(rounded).strip()
         except Exception:
             return str(value)
 

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -452,6 +452,7 @@ class PropertiesTreeview(ttk.Treeview):
 
         default = prop_info.default_value
         component.set_property_value(path[-1], default)
+        
     def _clear_overlay_comboboxes(self):
         self._active_dropdown_cb = None
         for cb in self._overlay_comboboxes.values():

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -286,6 +286,34 @@ class PropertiesTreeview(ttk.Treeview):
         except Exception as e:
             utils.show_error('Paste error', f'Can\'t paste: {e}', parent=self)
 
+    def handle_clear_properties(self):
+        selected_item_id = utils.treeview_get_first_selection(self)
+        if selected_item_id is None:
+            return
+
+        path = utils.get_item_path(self, selected_item_id)
+        prop = utils.get_property_for_path(self.context, path, self.node)
+
+        if not prop:
+            return
+
+        try:
+            if prop.value_type == daq.CoreType.ctObject:
+                obj = daq.IPropertyObject.cast_from(prop.value)
+                self._clear_object_properties(obj)
+            elif prop.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+                self._last_method_results.pop(prop.name, None)
+            else:
+                self._clear_single_property(path)
+
+            self.refresh()
+        except Exception as e:
+            utils.show_error(
+                'Clear property values error',
+                f"Can't clear: {e}",
+                parent=self,
+            )
+
     def show_menu(self, event):
         region = self.identify_region(event.x, event.y)
         menu = tk.Menu(self, tearoff=0)
@@ -314,6 +342,8 @@ class PropertiesTreeview(ttk.Treeview):
                 menu.add_command(label='Copy', command=self.handle_copy)
             if not self.read_only and not is_readonly and not is_container:
                 menu.add_command(label='Paste', command=self.handle_paste)
+            if not self.read_only and (is_container or not is_readonly):
+                menu.add_command(label='Clear property values', command=self.handle_clear_properties)
             if not is_container:
                 menu.add_separator()
                 
@@ -382,6 +412,46 @@ class PropertiesTreeview(ttk.Treeview):
         finally:
             entry.destroy()
 
+    def _clear_object_properties(self, obj):
+        for prop_info in self.context.properties_of_component(obj):
+            if prop_info.read_only:
+                continue
+
+            if prop_info.value_type == daq.CoreType.ctObject:
+                child = obj.get_property_value(prop_info.name)
+                if daq.IPropertyObject.can_cast_from(child):
+                    self._clear_object_properties(
+                        daq.IPropertyObject.cast_from(child))
+            elif prop_info.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+                self._last_method_results.pop(prop_info.name, None)
+            else:
+                try:
+                    default = prop_info.default_value
+                    obj.set_property_value(prop_info.name, default)
+                except Exception as e:
+                    # Some properties may lack a default
+                    print(f"Skipped clearing '{prop_info.name}': {e}")
+
+    def _clear_single_property(self, path):
+        component = daq.IPropertyObject.cast_from(self.node)
+
+        for segment in path[:-1]:
+            child = component.get_property_value(segment)
+            if not daq.IPropertyObject.can_cast_from(child):
+                return
+            component = daq.IPropertyObject.cast_from(child)
+
+        prop_info = None
+        for p in self.context.properties_of_component(component):
+            if p.name == path[-1]:
+                prop_info = p
+                break
+
+        if prop_info is None:
+            return
+
+        default = prop_info.default_value
+        component.set_property_value(path[-1], default)
     def _clear_overlay_comboboxes(self):
         self._active_dropdown_cb = None
         for cb in self._overlay_comboboxes.values():

--- a/examples/applications/python/GUI Application/gui_demo/components/input_port_row_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/input_port_row_view.py
@@ -36,10 +36,7 @@ class InputPortRowView(ttk.Frame):
         self.dropdown.bind('<Return>', self.handle_dropdown_enter)
         self.dropdown.bind('<FocusOut>', self.handle_dropdown_focus_out)
         self.dropdown.bind('<Down>', self.handle_dropdown_down)
-
-        self.dropdown.bind('<MouseWheel>', lambda e: 'break')
-        self.dropdown.bind('<Button-4>', lambda e: 'break')
-        self.dropdown.bind('<Button-5>', lambda e: 'break')
+        self.dropdown.bind('<Escape>', self.handle_dropdown_escape)
 
         self.edit_icon = context.icons['settings'] if context and context.icons and 'settings' in context.icons else None
 
@@ -139,6 +136,18 @@ class InputPortRowView(ttk.Frame):
             self.selection = candidates[0]
             self.hide_suggestions()
             self.handle_connect_clicked()
+            
+    def handle_dropdown_escape(self, event):
+        self.hide_suggestions()
+        if self.input_port is not None and self.input_port.signal is not None:
+            connected_name = self._name_text_for_signal(self.input_port.signal)
+            self.input_var.set(connected_name)
+        else:
+            self.input_var.set('')
+        self.selection = ''
+        self._filtered_signals = self._all_signals
+        self.dropdown['values'] = self._all_signals
+        return 'break'
 
     def handle_dropdown_focus_out(self, event):
         self.after(50, self._hide_suggestions_if_focus_lost)
@@ -164,6 +173,14 @@ class InputPortRowView(ttk.Frame):
         except Exception:
             pass
         self.hide_suggestions()
+        if self.input_port is not None and self.input_port.signal is not None:
+            connected_name = self._name_text_for_signal(self.input_port.signal)
+            self.input_var.set(connected_name)
+        else:
+            self.input_var.set('')
+        self.selection = ''
+        self._filtered_signals = self._all_signals
+        self.dropdown['values'] = self._all_signals
 
     def show_suggestions(self, values):
         if not values:
@@ -176,15 +193,21 @@ class InputPortRowView(ttk.Frame):
             self._suggestions_popup.overrideredirect(True)
             self._suggestions_popup.transient(self.winfo_toplevel())
 
-            self._suggestions_list = tk.Listbox(self._suggestions_popup, exportselection=False)
-            self._suggestions_list.pack(fill=tk.BOTH, expand=True)
+            list_frame = ttk.Frame(self._suggestions_popup)
+            list_frame.pack(fill=tk.BOTH, expand=True)
+
+            scrollbar = ttk.Scrollbar(list_frame, orient=tk.VERTICAL)
+            self._suggestions_list = tk.Listbox(
+                list_frame, exportselection=False,
+                yscrollcommand=scrollbar.set)
+            scrollbar.config(command=self._suggestions_list.yview)
+
+            self._suggestions_list.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+            scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
             self._suggestions_list.bind('<ButtonRelease-1>', self.handle_suggestion_pick)
             self._suggestions_list.bind('<Return>', self.handle_suggestion_pick)
+            self._suggestions_list.bind('<Motion>', self._handle_suggestion_hover)
             self._suggestions_list.bind('<FocusOut>', lambda e: self.after(50, self._hide_suggestions_if_focus_lost))
-
-            self._suggestions_list.bind('<MouseWheel>', lambda e: 'break')
-            self._suggestions_list.bind('<Button-4>', lambda e: 'break')  # Linux scroll up
-            self._suggestions_list.bind('<Button-5>', lambda e: 'break')  # Linux scroll down
 
         self._suggestions_list.delete(0, tk.END)
         for item in values:
@@ -215,6 +238,13 @@ class InputPortRowView(ttk.Frame):
         self.dropdown.focus_set()
         self.dropdown.icursor(tk.END)
         self.handle_connect_clicked()
+
+    def _handle_suggestion_hover(self, event):
+        index = self._suggestions_list.nearest(event.y)
+        if index >= 0:
+            self._suggestions_list.selection_clear(0, tk.END)
+            self._suggestions_list.selection_set(index)
+            self._suggestions_list.activate(index)
 
     def handle_edit_clicked(self):
         if self.input_port is not None:

--- a/examples/applications/python/GUI Application/gui_demo/components/input_ports_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/input_ports_view.py
@@ -35,4 +35,4 @@ class InputPortsView(ttk.Frame):
                         input_port_row.pack(anchor=tk.NW, fill=tk.X)
                     return
         ttk.Label(self, text='None').pack(
-            anchor=tk.W, expand=True, padx=(10,0), pady=(5,0))
+            anchor=tk.W, expand=True, padx=(10,0), pady=(5))

--- a/examples/applications/python/GUI Application/gui_demo/components/input_ports_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/input_ports_view.py
@@ -35,4 +35,4 @@ class InputPortsView(ttk.Frame):
                         input_port_row.pack(anchor=tk.NW, fill=tk.X)
                     return
         ttk.Label(self, text='None').pack(
-            anchor=tk.W, expand=True, padx=(10,0), pady=(5))
+            anchor=tk.W, expand=True, padx=(10,0), pady=(5,0))

--- a/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
@@ -56,7 +56,7 @@ class OutputSignalsView(ttk.Frame):
             return
 
         ttk.Label(self, text='None').pack(
-            anchor=tk.W, expand=True, padx=(10,0), pady=(5,0))
+            anchor=tk.W, expand=True, padx=(10,0), pady=(5))
         
     def _on_destroy(self, event):
         if event.widget is not self:

--- a/examples/applications/python/GUI Application/gui_demo/components/recorder_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/recorder_view.py
@@ -11,7 +11,6 @@ class RecorderView(ttk.Frame):
     def __init__(self, parent: ttk.Frame, node=None, context: AppContext = None, **kwargs):
         ttk.Frame.__init__(self, parent, **kwargs)
         self.context = context
-        self.configure(padding=(10, 5))
 
         self.node = daq.IRecorder.cast_from(node)
 
@@ -19,9 +18,10 @@ class RecorderView(ttk.Frame):
 
         utils.make_banner(header_frame, 'Recording')
         self.pb = ttk.Progressbar(header_frame, mode='indeterminate', style="Striped.Horizontal.TProgressbar",maximum=10, value=0)
-        self.pb.pack(side=tk.LEFT, anchor=tk.CENTER)
+        self.pb.pack(side=tk.LEFT, anchor=tk.CENTER, padx=(10,0), pady=(10))
+        
         self.startstop = ttk.Button(header_frame, text='Start/Stop',command=self.toggleRecording)
-        self.startstop.pack(side=tk.RIGHT, anchor=tk.E)
+        self.startstop.pack(side=tk.RIGHT, anchor=tk.E, padx=(0,10),pady=(10))
 
 
         header_frame.pack(fill=tk.X)

--- a/examples/applications/python/GUI Application/gui_demo/utils.py
+++ b/examples/applications/python/GUI Application/gui_demo/utils.py
@@ -364,7 +364,7 @@ def make_banner(parent, text):
     _banner_bg = '#afafaf'
     _banner_fg = 'white'
     bar = tk.Frame(parent, bg=_banner_bg, bd=0, highlightthickness=0)
-    bar.pack(fill=tk.X, pady=(0, 8))
+    bar.pack(fill=tk.X, pady=(8))
     tk.Label(bar, text=text, bg=_banner_bg, fg=_banner_fg,
              font=('TkDefaultFont', 10, 'bold')).pack(
         side=tk.LEFT, padx=6, pady=2)


### PR DESCRIPTION
# Brief

Property and input search changes

# Description
## Properties
- Paste option is now disabled for read only 
- Change ratio of properties width to right-hand-side to roughly 55-45
- Constant spacing between right-hand-side rows
	- ISignals row margins on the bottom
	- Cogs in Sync
	- Horizontal indent offset on Ifunc/Iproc
- Add a right-click-option to components and object-type properties called "Clear property values" 

## Input port dropdown
 - Input port dropdown is now scrollable while editing
 - Esc now exits editing If dropdown
 - Hover-over while editing now highlights the hovered selection
 - After exiting edit, the written value is now cleared

<img width="1499" height="850" alt="slika" src="https://github.com/user-attachments/assets/491b30e5-a077-48a5-94ee-9036bb1c0333" />
<img width="1498" height="847" alt="slika" src="https://github.com/user-attachments/assets/c4bac265-0f79-4630-a5f7-ab2a6317dccf" />
<img width="496" height="237" alt="slika" src="https://github.com/user-attachments/assets/f6b8183e-d34f-483d-bf8e-b45ac8d7e4f0" />


# Usage example

```sh
py -m opendaq
```