### PR TITLE
Python GUI: Added a device domain view and removed dialog box overlap

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -26,7 +26,7 @@ class AppContext(object):
         self.selected_node = None
         self.include_reference_devices = False
         self.view_hidden_components = False
-        self.metadata_fields = ['unit']
+        self.metadata_fields = []
         # gui
         self.ui_scaling_factor = 1.0
         self.dpi_factor = self._detect_dpi_factor()

--- a/examples/applications/python/GUI Application/gui_demo/components/attributes_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/attributes_dialog.py
@@ -41,6 +41,28 @@ class AttributesDialog(Dialog):
 
 
             elif daq.IDevice.can_cast_from(node):
-                ttk.Label(additional_tree_frame, text='Device Info').pack(anchor=tk.W, pady=5)
-                PropertiesTreeview(additional_tree_frame, daq.IDevice.cast_from(node).info, context)
+                device = daq.IDevice.cast_from(node)
 
+                notebook = ttk.Notebook(additional_tree_frame)
+                notebook.pack(fill=tk.BOTH, expand=True)
+
+                info_frame = ttk.Frame(notebook)
+                info_frame.pack(fill=tk.BOTH, expand=True)
+                notebook.add(info_frame, text='Device Info')
+                PropertiesTreeview(info_frame, device.info, context)
+
+                domain_frame = ttk.Frame(notebook)
+                domain_frame.pack(fill=tk.BOTH, expand=True)
+                notebook.add(domain_frame, text='Device Domain')
+
+                try:
+                    device_domain = device.domain
+                except RuntimeError:
+                    device_domain = None
+
+                if device_domain is not None:
+                    DataDescriptorTreeview(domain_frame, device_domain, context)
+                else:
+                    ttk.Label(domain_frame,
+                              text='No device domain available',
+                              padding=(10, 10)).pack(anchor=tk.W)

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -11,7 +11,6 @@ from .output_signals_view import OutputSignalsView
 from .properties_view import PropertiesView
 from .recorder_view import RecorderView
 from .attributes_dialog import AttributesDialog
-from .output_signal_row import OutputSignalRow
 
 class BlockView(ttk.Frame):
 
@@ -149,7 +148,6 @@ class BlockView(ttk.Frame):
 
                 for mode in available_op_modes:
                     op_mode_menu.add_command(label=mode, command=make_select(mode))
-
 
                 self._bind_mousewheel_recursive(self.right_stack)
             

--- a/examples/applications/python/GUI Application/gui_demo/components/dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/dialog.py
@@ -13,7 +13,7 @@ class Dialog(tk.Toplevel):
         self.context = context
 
         self.configure(padx=10, pady=5)
-        self.attributes('-topmost', True)
+        self.attributes('-topmost', False)
         self.transient(parent)
         
         # Bind Escape key to close the dialog

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -178,9 +178,12 @@ class PropertiesTreeview(ttk.Treeview):
             else:
                 property_value = printed_value(
                     property_info.value_type, node.get_property_value(property_info.name))
+            
+            unit_symbol = utils.prettify_unit(property_info.unit)
+            if unit_symbol and property_value != '':
+                property_value = f'{property_value} {unit_symbol}'
 
             meta_fields = [None] * len(self._metadata_fields)
-
             try:
                 for i, field in enumerate(self._metadata_fields):
                     metadata_value = getattr(property_info, field)
@@ -199,9 +202,14 @@ class PropertiesTreeview(ttk.Treeview):
                 values=(property_value, *meta_fields))
 
             container_types = (daq.CoreType.ctObject, daq.CoreType.ctStruct, daq.CoreType.ctList, daq.CoreType.ctDict)
-            if (property_info.read_only or self.read_only) and property_info.value_type not in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+            is_single_value_selection = (
+                property_info.selection_values is not None
+                and len(property_info.selection_values) == 1
+            )
+            if property_info.value_type not in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
                 if property_info.value_type not in container_types:
-                    self.item(iid, tags=('readonly',))
+                    if property_info.read_only or self.read_only or is_single_value_selection:
+                        self.item(iid, tags=('readonly',))
 
             if property_info.value_type == daq.CoreType.ctObject:
                 hidden_children = [s.removeprefix(f"{property_info.name}.") for s in hidden if s.startswith(f"{property_info.name}.")]
@@ -430,7 +438,7 @@ class PropertiesTreeview(ttk.Treeview):
                     self._overlay_items[iid] = prop
                 elif not prop.read_only:
                     if (prop.value_type == daq.CoreType.ctBool
-                            or (prop.selection_values is not None and len(prop.selection_values) > 0)
+                            or (prop.selection_values is not None and len(prop.selection_values) > 1)
                             or prop.value_type == daq.CoreType.ctEnumeration
                             or (prop.value_type in (daq.CoreType.ctString, daq.CoreType.ctFloat, daq.CoreType.ctInt)
                                 and prop.suggested_values is not None and len(prop.suggested_values) > 0)):
@@ -611,8 +619,6 @@ class PropertiesTreeview(ttk.Treeview):
     def _place_selection_combobox(self, iid, prop):
         labels, indices = self._get_selection_options(prop.selection_values)
         if not labels:
-            return
-        if len(labels) == 1:
             return
         if prop.item_type != daq.CoreType.ctUndefined:
             current_idx = prop.value

--- a/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
@@ -3,6 +3,7 @@ from tkinter import ttk
 
 import opendaq as daq
 from .. import utils
+from datetime import timedelta
 
 from .output_signal_row import OutputSignalRow
 
@@ -35,6 +36,7 @@ class OutputSignalsView(ttk.Frame):
             node = daq.IDevice.cast_from(self.node)
             signals = node.get_signals(daq.AnySearchFilter() if self.context.view_hidden_components else None)
             self.make_output_signal_section(signals, 'Output signals')
+            self.make_device_domain_section(node)
         elif daq.IFunctionBlock.can_cast_from(self.node):
             node = daq.IFunctionBlock.cast_from(self.node)
             signals = node.get_signals(daq.AnySearchFilter() if self.context.view_hidden_components else None)
@@ -67,3 +69,47 @@ class OutputSignalsView(ttk.Frame):
             except Exception:
                 pass
             self._refresh_job = None
+
+
+    def make_device_domain_section(self, device_node):
+        if not hasattr(device_node, 'domain') or device_node.domain is None:
+            return
+
+        device_domain = device_node.domain
+        utils.make_banner(self, 'Device domain')
+
+        row = ttk.Frame(self, padding=(10, 5))
+        row.pack(fill=tk.X)
+        ttk.Label(row, text='Last value:').pack(side=tk.LEFT)
+        value_label = ttk.Label(row, text='N/A')
+        value_label.pack(side=tk.RIGHT, padx=(4, 0))
+
+        # Resolve static domain metadata once; _refresh only reads the tick count.
+        res = device_domain.tick_resolution
+        origin = device_domain.origin
+        origin_dt = None
+
+        if res is not None and origin is not None and str(origin) != '':
+            origin_str = str(origin)
+            origin_dt = utils.parse_origin(origin_str)
+
+        res_num = res.numerator if res is not None else None
+        res_den = res.denominator if res is not None else None
+
+        def _refresh():
+            if not hasattr(device_node, 'ticks_since_origin'):
+                return
+            ticks = device_node.ticks_since_origin
+            if ticks is None:
+                return
+            if origin_dt is not None and res_num is not None and res_den is not None:
+                seconds = ticks * res_num / res_den
+                ts = origin_dt + timedelta(seconds=seconds)
+                value_label.config(
+                    text=ts.strftime('%Y-%m-%d %H:%M:%S.%f')
+                    .rstrip('0').rstrip('.'))
+            else:
+                value_label.config(text=f'Ticks: {ticks}')
+
+        row.refresh = _refresh
+        self._rows.append(row)

--- a/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
@@ -80,11 +80,18 @@ class OutputSignalsView(ttk.Frame):
 
         row = ttk.Frame(self, padding=(10, 5))
         row.pack(fill=tk.X)
-        ttk.Label(row, text='Last value:').pack(side=tk.LEFT)
+        
+        unit = device_domain.unit
+        if unit and unit.quantity:
+            label_text = unit.quantity.capitalize()
+        else:
+            label_text = f"{device_node.name} Domain"
+            
+        ttk.Label(row, text=label_text).pack(side=tk.LEFT)
+        
         value_label = ttk.Label(row, text='N/A')
         value_label.pack(side=tk.RIGHT, padx=(4, 0))
 
-        # Resolve static domain metadata once; _refresh only reads the tick count.
         res = device_domain.tick_resolution
         origin = device_domain.origin
         origin_dt = None

--- a/examples/applications/python/GUI Application/gui_demo/utils.py
+++ b/examples/applications/python/GUI Application/gui_demo/utils.py
@@ -200,10 +200,15 @@ def get_last_value_for_signal(output_signal):
             if origin_str is not None:
                 try:
                     origin = datetime.fromisoformat(origin_str)
-                except ValueError as e:
+                except ValueError:
                     origin = parse_iso_string(origin_str)
                 if last_value is not None:
-                    last_value_in_seconds = int(last_value) * desc.tick_resolution.numerator / desc.tick_resolution.denominator
+                    tick_value = int(last_value)
+                    last_value_in_seconds = (
+                        tick_value
+                        * desc.tick_resolution.numerator
+                        / desc.tick_resolution.denominator
+                    )
                     last_value = origin + timedelta(seconds=last_value_in_seconds)
 
             if isinstance(last_value, float):
@@ -393,3 +398,20 @@ def poll_signal_rows(widget, rows, interval_ms=200, _job_attr='_signal_refresh_j
         setattr(widget, _job_attr, widget.after(interval_ms, _tick))
 
     setattr(widget, _job_attr, widget.after(interval_ms, _tick))
+    
+def parse_origin(origin_str):
+    """Try fromisoformat first, fall back to strptime for the trailing Z format.
+    Returns None if the string can't be parsed at all."""
+    if not origin_str:
+        return None
+    dt = None
+    try:
+        dt = datetime.fromisoformat(origin_str)
+    except ValueError:
+        pass
+    if dt is None:
+        try:
+            dt = datetime.strptime(origin_str, '%Y-%m-%dT%H:%M:%S%z')
+        except ValueError:
+            pass
+    return dt


### PR DESCRIPTION
# Brief

Added a device domain outout with some ui tweeks

# Description

## Device domain
- is now nolonger collapsable
- shows only the last value in the row, other info is in the attributes dialog
- use signal output view for it
- uses the name of the domain signal

## Property treeview tweeks
- Now mark selection properties with only a single selectable value as read only (they should be grayed out) 
- Now hides the "Unit" column by default in properties view and show it as a suffix of the displayed Value. This is done for all types of properties, including selection.

## Dialog overlap
- the dialog box nolonger overlaps on all other windows on desktop

# Usage example

```sh
py -m opendaq
```

<img width="1501" height="849" alt="slika" src="https://github.com/user-attachments/assets/e3b90bf4-4c4e-45cd-b59e-f2bb672c1a0a" />

