### PR TITLE
Do not call begin/endUpdate on sub-components

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -19,6 +19,7 @@
 - [#1124](https://github.com/openDAQ/openDAQ/pull/1124) Implement clearPropertyValues() for property objects
 - [#1137](https://github.com/openDAQ/openDAQ/pull/1137) Add `IInputPort::acceptsSignals` to check multiple signals at once, using a single RPC call via native protocol.
 - [#1153](https://github.com/openDAQ/openDAQ/pull/1153) Enable and disable discovery for openDAQ Server via native.
+- [#1164](https://github.com/openDAQ/openDAQ/pull/1164) Remove appling begin/end update on sub components
 
 ## Python
 

--- a/core/opendaq/component/include/opendaq/folder_impl.h
+++ b/core/opendaq/component/include/opendaq/folder_impl.h
@@ -83,8 +83,6 @@ protected:
                                            const BaseObjectPtr& context,
                                            const FunctionPtr& factoryCallback);
 
-    void callBeginUpdateOnChildren() override;
-    void callEndUpdateOnChildren() override;
     void onUpdatableUpdateEnd(const BaseObjectPtr& context) override;
 
     virtual void syncComponentOperationMode(const ComponentPtr& component);
@@ -510,36 +508,6 @@ void FolderImpl<Intf, Intfs...>::deserializeCustomObjectValues(
             const auto comp = item.template asPtr<IComponent>(true);
             addItemInternal(comp);
         }
-    }
-}
-
-template <class Intf, class... Intfs>
-void FolderImpl<Intf, Intfs...>::callBeginUpdateOnChildren()
-{
-    Super::callBeginUpdateOnChildren();
-
-    for (const auto& [_, item] : items)
-    {
-        auto freezable = item.template asPtrOrNull<IFreezable>(true);
-        if (freezable.assigned() && freezable.isFrozen())
-            continue;
-
-        item.beginUpdate();
-    }
-}
-
-template <class Intf, class... Intfs>
-void FolderImpl<Intf, Intfs...>::callEndUpdateOnChildren()
-{
-    Super::callEndUpdateOnChildren();
-
-    for (const auto& [_, item] : items)
-    {
-        auto freezable = item.template asPtrOrNull<IFreezable>(true);
-        if (freezable.assigned() && freezable.isFrozen())
-            continue;
-
-        item.endUpdate();
     }
 }
 

--- a/core/opendaq/component/tests/test_folder.cpp
+++ b/core/opendaq/component/tests/test_folder.cpp
@@ -255,7 +255,7 @@ TEST_F(FolderTest, BeginUpdateEndUpdate)
     ASSERT_EQ(folder.getPropertyValue("FolderProp"), "-");
 
     component.setPropertyValue("ComponentProp", "cs");
-    ASSERT_EQ(component.getPropertyValue("ComponentProp"), "-");
+    ASSERT_EQ(component.getPropertyValue("ComponentProp"), "cs");
 
     folder.endUpdate();
 

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -362,7 +362,7 @@ TEST_F(DeviceTest, BeginUpdateEndUpdate)
     ASSERT_EQ(dev.getPropertyValue("DevProp"), "-");
 
     sig.setPropertyValue("SigProp", "cs");
-    ASSERT_EQ(sig.getPropertyValue("SigProp"), "-");
+    ASSERT_EQ(sig.getPropertyValue("SigProp"), "cs");
 
     dev.endUpdate();
 

--- a/core/opendaq/functionblock/tests/test_function_block.cpp
+++ b/core/opendaq/functionblock/tests/test_function_block.cpp
@@ -184,7 +184,7 @@ TEST_F(FunctionBlockTest, BeginUpdateEndUpdate)
     ASSERT_EQ(fb.getPropertyValue("FbProp"), "-");
 
     sig.setPropertyValue("SigProp", "cs");
-    ASSERT_EQ(sig.getPropertyValue("SigProp"), "-");
+    ASSERT_EQ(sig.getPropertyValue("SigProp"), "cs");
 
     fb.endUpdate();
 

--- a/core/opendaq/server/tests/test_server.cpp
+++ b/core/opendaq/server/tests/test_server.cpp
@@ -87,7 +87,7 @@ TEST_F(ServerTest, BeginUpdateEndUpdate)
     ASSERT_EQ(srv.getPropertyValue("SrvProp"), "-");
 
     sig.setPropertyValue("SigProp", "cs");
-    ASSERT_EQ(sig.getPropertyValue("SigProp"), "-");
+    ASSERT_EQ(sig.getPropertyValue("SigProp"), "cs");
 
     srv.endUpdate();
 

--- a/core/opendaq/signal/include/opendaq/signal_container_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_container_impl.h
@@ -125,9 +125,6 @@ protected:
     virtual FunctionBlockPtr onAddFunctionBlock(const StringPtr& typeId, const PropertyObjectPtr& config);
     virtual void onRemoveFunctionBlock(const FunctionBlockPtr& functionBlock);
 
-    void callBeginUpdateOnChildren() override;
-    void callEndUpdateOnChildren() override;
-
 private:
     template <class Component>
     void swapComponent(Component& origComponent, const Component& newComponent);
@@ -703,7 +700,7 @@ void GenericSignalContainerImpl<Intf, Intfs...>::onUpdatableUpdateEnd(const Base
 {
     for (const auto& comp : components)
     {
-        const auto updatable = comp.template asPtrOrNull<IUpdatable>();
+        const auto updatable = comp.template asPtrOrNull<IUpdatable>(true);
         if (updatable.assigned())
             updatable.updateEnded(context);
     }
@@ -744,36 +741,6 @@ void GenericSignalContainerImpl<Intf, Intfs...>::onRemoveFunctionBlock(const Fun
 
     auto lock = this->getRecursiveConfigLock2();
     this->functionBlocks.removeItem(functionBlock);
-}
-
-template <class Intf, class... Intfs>
-void GenericSignalContainerImpl<Intf, Intfs...>::callBeginUpdateOnChildren()
-{
-    Super::callBeginUpdateOnChildren();
-
-    for (const auto& comp : components)
-    {
-        auto freezable = comp.template asPtrOrNull<IFreezable>(true);
-        if (freezable.assigned() && freezable.isFrozen())
-            continue;
-
-        comp.beginUpdate();
-    }
-}
-
-template <class Intf, class... Intfs>
-void GenericSignalContainerImpl<Intf, Intfs...>::callEndUpdateOnChildren()
-{
-    for (const auto& comp : components)
-    {
-        auto freezable = comp.template asPtrOrNull<IFreezable>(true);
-        if (freezable.assigned() && freezable.isFrozen())
-            continue;
-
-        comp.endUpdate();
-    }
-
-    Super::callEndUpdateOnChildren();
 }
 
 template <class Intf, class... Intfs>

--- a/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
+++ b/shared/libraries/config_protocol/tests/test_config_protocol_integration.cpp
@@ -481,8 +481,8 @@ TEST_F(ConfigProtocolIntegrationTest, BeginEndUpdateRecursive)
 {
     clientDevice.beginUpdate();
     clientDevice.getChannels()[0].setPropertyValue("StrProp", "SomeValue");
-    ASSERT_EQ(clientDevice.getChannels()[0].getPropertyValue("StrProp"), "-");
-    ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), "-");
+    ASSERT_EQ(clientDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");
+    ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");
     clientDevice.endUpdate();
     ASSERT_EQ(clientDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");
     ASSERT_EQ(serverDevice.getChannels()[0].getPropertyValue("StrProp"), "SomeValue");

--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -752,10 +752,15 @@ TEST_F(NativeDeviceModulesTest, DiscoveringServer)
 {
     auto path = "/test/native_configuration/discovery/";
 
+    const auto deviceInfo = DeviceInfo("daq.root://default_client", "OpenDAQClient");
+    deviceInfo.setManufacturer("NativeDeviceModulesTest");
+    deviceInfo.setSerialNumber("DiscoveringServer");
+
     auto server = InstanceBuilder()
         .setModulePath("[[none]]")
         .addDiscoveryServer("mdns")
         .setDefaultRootDeviceLocalId("local")
+        .setDefaultRootDeviceInfo(deviceInfo)
         .build();
     {
         addRefDeviceModule(server);
@@ -790,7 +795,9 @@ TEST_F(NativeDeviceModulesTest, DiscoveringServer)
 
 TEST_F(NativeDeviceModulesTest, DiscoveringServerInfoMerge)
 {
-    const auto info = DeviceInfo("", "foo");
+    const auto info = DeviceInfo("daq.root://default_client", "OpenDAQClient");
+    info.setManufacturer("NativeDeviceModulesTest");
+    info.setSerialNumber("DiscoveringServerInfoMerge");
     info.setMacAddress("custom_mac");
 
     auto path = "/test/native_configuration/discovery/";
@@ -838,10 +845,15 @@ TEST_F(NativeDeviceModulesTest, DiscoveringServerInfoMerge)
 
 TEST_F(NativeDeviceModulesTest, RemoveServer)
 {
+    const auto deviceInfo = DeviceInfo("daq.root://default_client", "OpenDAQClient");
+    deviceInfo.setManufacturer("NativeDeviceModulesTest");
+    deviceInfo.setSerialNumber("RemoveServer");
+
     auto server = InstanceBuilder()
         .setModulePath("[[none]]")
         .addDiscoveryServer("mdns")
         .setDefaultRootDeviceLocalId("local")
+        .setDefaultRootDeviceInfo(deviceInfo)
         .build();
 
     addRefDeviceModule(server);
@@ -1248,9 +1260,14 @@ DevicePtr FindNativeDeviceByPath(const InstancePtr& instance, const std::string&
 
 TEST_F(NativeDeviceModulesTest, TestProtocolVersion)
 {
-    auto server = InstanceBuilder()
+    const auto deviceInfo = DeviceInfo("daq.root://default_client", "OpenDAQClient");
+    deviceInfo.setManufacturer("NativeDeviceModulesTest");
+    deviceInfo.setSerialNumber("TestProtocolVersion");
+
+    const auto server = InstanceBuilder()
         .setModulePath("[[none]]")
         .addDiscoveryServer("mdns")
+        .setDefaultRootDeviceInfo(deviceInfo)
         .build();
 
     addNativeServerModule(server);
@@ -1294,8 +1311,8 @@ TEST_F(NativeDeviceModulesTest, TestProtocolVersion)
 TEST_F(NativeDeviceModulesTest, TestDiscoveryReachabilityAfterConnect)
 {
     auto deviceInfo = DeviceInfo("testdevice://");
-    deviceInfo.setManufacturer("openDAQ");
-    deviceInfo.setSerialNumber("TestSerial");
+    deviceInfo.setManufacturer("NativeDeviceModulesTest");
+    deviceInfo.setSerialNumber("TestDiscoveryReachabilityAfterConnect");
 
     auto path = "/test/native_configurator/discovery_reachability/";
 

--- a/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -140,10 +140,15 @@ TEST_F(OpcuaDeviceModulesTest, PopulateDefaultConfigFromProvider)
 
 TEST_F(OpcuaDeviceModulesTest, DiscoveringServer)
 {
+    const auto deviceInfo = DeviceInfo("daq.root://default_client", "OpenDAQClient");
+    deviceInfo.setManufacturer("OpcuaDeviceModulesTest");
+    deviceInfo.setSerialNumber("DiscoveringServer");
+
     auto server = InstanceBuilder()
         .setModulePath("[[none]]")
         .addDiscoveryServer("mdns")
         .setDefaultRootDeviceLocalId("local")
+        .setDefaultRootDeviceInfo(deviceInfo)
         .build();
 
     addRefDeviceModule(server);
@@ -453,8 +458,13 @@ TEST_F(OpcuaDeviceModulesTest, TestProtocolVersion)
 {
     auto path = "/test/opcua/test_protocol_version/";
 
+    const auto deviceInfo = DeviceInfo("daq.root://default_client", "OpenDAQClient");
+    deviceInfo.setManufacturer("OpcuaDeviceModulesTest");
+    deviceInfo.setSerialNumber("TestProtocolVersion");
+
     auto server = InstanceBuilder()
         .setModulePath("[[none]]")
+        .setDefaultRootDeviceInfo(deviceInfo)
         .addDiscoveryServer("mdns")
         .build();
     {


### PR DESCRIPTION
# Brief

Previously, calling `beginUpdate/endUpdate` propagated down to child components. This PR changes the behaviour so that beginUpdate/endUpdate apply only to the component itself and to any nested property objects within it.

