### PR TITLE
Python GUI: Guarding against empty e arguments and additional gui tweeks

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -96,7 +96,6 @@ class App(tk.Tk):
             context_params.discovery_servers = []
 
         self.context = AppContext(context_params)
-        self.context.on_needs_refresh = lambda: self.on_refresh_event(None)
         self.event_port = EventPort(self, event_callback=self.on_refresh_event)
 
         self.context.ui_scaling_factor = int(args.scale)
@@ -213,8 +212,12 @@ class App(tk.Tk):
         except Exception as e:
             print("Scheduler processing error:", e)
 
+        if self.context.needs_refresh:
+            self.on_refresh_event(None)
+            self.context.needs_refresh = False
+
         # Re-schedule after 50 ms
-        self.after(20, self.poll_opendaq_events)
+        self.after(50, self.poll_opendaq_events)
 
     def init_opendaq(self):
 

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -686,6 +686,26 @@ class App(tk.Tk):
             )
 
         return popup
+    
+    def create_server_menu(self, node):
+        popup = self.create_property_object_menu(node)
+
+        popup.add_command(label='Enable discovery',
+                          command=lambda: self.handle_enable_discovery(node))
+        popup.add_command(label='Disable discovery',
+                          command=lambda: self.handle_disable_discovery(node))
+
+        return popup
+
+    def handle_enable_discovery(self, node):
+        if node is None:
+            return
+        node.enable_discovery()
+
+    def handle_disable_discovery(self, node):
+        if node is None:
+            return
+        node.disable_discovery()
 
     def handle_tree_right_button_release(self, event):
         iid = utils.treeview_get_first_selection(self.tree)
@@ -700,6 +720,8 @@ class App(tk.Tk):
                 popup = self.create_function_block_menu(daq.IFunctionBlock.cast_from(node))
             elif daq.IDevice.can_cast_from(node):
                 popup = self.create_device_menu(daq.IDevice.cast_from(node))
+            elif daq.IServer.can_cast_from(node):
+                popup = self.create_server_menu(daq.IServer.cast_from(node))
 
         if popup is None:
             popup = self.create_property_object_menu(node)
@@ -718,6 +740,8 @@ class App(tk.Tk):
             return daq.IFunctionBlock.cast_from(node)
         elif daq.IDevice.can_cast_from(node):
             return daq.IDevice.cast_from(node)
+        elif daq.IServer.can_cast_from(node):
+            return daq.IServer.cast_from(node)
         elif daq.ISyncComponent.can_cast_from(node):
             return daq.ISyncComponent.cast_from(node)
         elif daq.IFolder.can_cast_from(node):
@@ -917,7 +941,8 @@ class App(tk.Tk):
         node = self.context.nodes[node_unique_id]
         if (daq.IFolder.can_cast_from(node)
                 and not daq.IDevice.can_cast_from(node)
-                and not daq.IFunctionBlock.can_cast_from(node)):
+                and not daq.IFunctionBlock.can_cast_from(node)
+                and not daq.IServer.can_cast_from(node)):
             self.tree.item(selected_iid, open=not self.tree.item(selected_iid, 'open'))
             self.tree.selection_set('')
             return

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -1082,6 +1082,8 @@ class App(tk.Tk):
 
     def _set_node_update_status_recursive(self, node):
         node_obj = utils.find_component(node, self.context.instance)
+        if node_obj is None:
+            return
         if node_obj.updating:
             self.add_tag_and_configure(node, 'selected', 'red')
         else:

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -643,6 +643,7 @@ class App(tk.Tk):
 
         popup.add_command(label='Begin update', command=self.handle_begin_update)
         popup.add_command(label='End update', command=self.handle_end_update)
+        popup.add_command(label='Clear property values', command=lambda: self.handle_tree_clear_property_values(node))
 
         return popup
 
@@ -954,6 +955,13 @@ class App(tk.Tk):
         self.context.remove_device(node)
 
         self.context.selected_node = parent
+        self.tree_update(self.context.selected_node)
+
+    def handle_tree_clear_property_values(self, node):
+        if node is None or not daq.IPropertyObject.can_cast_from(node):
+            return
+        prop_obj = daq.IPropertyObject.cast_from(node)
+        prop_obj.clear_property_values()
         self.tree_update(self.context.selected_node)
 
     # MARK: - Other

--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -39,9 +39,9 @@ class AppContext(object):
         try:
             daq.OPENDAQ_MODULES_DIR
         except:
-            builder.add_module_path('.')
+            builder.module_path = '.'
         else:
-            builder.add_module_path(daq.OPENDAQ_MODULES_DIR)
+            builder.module_path = daq.OPENDAQ_MODULES_DIR
 
         if params.module_path != None:
             builder.add_module_path(params.module_path)

--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -53,7 +53,7 @@ class AppContext(object):
         self.instance.context.on_core_event + daq.QueuedEventHandler(self.on_core_event)
         self.connection_string = ''
         self.signals = {}
-        self.on_needs_refresh: Optional[Callable[[], None]] = None
+        self.needs_refresh = False
 
     def _detect_dpi_factor(self) -> float:
         """Detect system DPI scaling factor (1.0 = 96 DPI). Used to scale UI elements on high-DPI displays."""
@@ -188,12 +188,12 @@ class AppContext(object):
             return []
 
     def on_core_event(self, sender: Optional[daq.IComponent], args: daq.IEventArgs):
-        if sender is None or self.on_needs_refresh is None:
+        if sender is None or args is None:
             return
         if daq.IDevice.can_cast_from(sender) and args.event_name == "StatusChanged":
             core_event_args: daq.ICoreEventArgs = daq.ICoreEventArgs.cast_from(args)
             if "ConnectionStatus" in core_event_args.parameters.keys():
-                self.on_needs_refresh()
+                self.needs_refresh = True
             return
         if args.event_name in ("ComponentAdded", "ComponentRemoved"):
-            self.on_needs_refresh()
+            self.needs_refresh = True

--- a/examples/applications/python/GUI Application/gui_demo/components/add_function_block_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_function_block_dialog.py
@@ -18,7 +18,7 @@ class AddFunctionBlockDialog(Dialog):
         self.parent_component = selected_component
 
         self.geometry('{}x{}'.format(
-            int(900 * self.context.ui_scaling_factor * self.context.dpi_factor),
+            int(1400 * self.context.ui_scaling_factor * self.context.dpi_factor),
             int(400 * self.context.ui_scaling_factor * self.context.dpi_factor)))
 
         # parent
@@ -63,7 +63,7 @@ class AddFunctionBlockDialog(Dialog):
         dpi = self.context.dpi_factor
         tree.column('name', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
                     self.context.ui_scaling_factor * dpi), stretch=tk.NO)
-        tree.column('description', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+        tree.column('description', anchor=tk.W, minwidth=int(400 * dpi), width=int(300 *
                     self.context.ui_scaling_factor * dpi))
         tree.column('id', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
                     self.context.ui_scaling_factor * dpi))
@@ -118,14 +118,14 @@ class AddFunctionBlockDialog(Dialog):
 
             if daq.IDevice.can_cast_from(component):
                 device = daq.IDevice.cast_from(component)
-                tree.insert(parent_id, tk.END, text=device.description,
+                tree.insert(parent_id, tk.END, text=device.name,
                             iid=device.global_id, open=tk.TRUE)
                 parent_id = device.global_id
 
             if daq.IFunctionBlock.can_cast_from(component):
                 function_block = daq.IFunctionBlock.cast_from(component)
                 if function_block.available_function_block_types:
-                    tree.insert(parent_id, tk.END, text=function_block.description,
+                    tree.insert(parent_id, tk.END, text=function_block.name,
                                 iid=function_block.global_id, open=tk.TRUE)
                     parent_id = function_block.global_id
 

--- a/examples/applications/python/GUI Application/gui_demo/components/add_function_block_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_function_block_dialog.py
@@ -46,23 +46,26 @@ class AddFunctionBlockDialog(Dialog):
         # child
 
         tree_frame = ttk.Frame(self)
-        tree = ttk.Treeview(tree_frame, columns=('id', 'name'), displaycolumns=(
-            'id', 'name'), show='tree headings', selectmode=tk.BROWSE)
+        tree = ttk.Treeview(tree_frame, columns=('name', 'description', 'id'), displaycolumns=(
+            'name', 'description', 'id'), show='tree headings', selectmode=tk.BROWSE)
         scroll_bar = ttk.Scrollbar(
             tree_frame, orient=tk.VERTICAL, command=tree.yview)
         tree.configure(yscrollcommand=scroll_bar.set)
         scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
 
         # define headings
-        tree.heading('id', text='Name', anchor=tk.W)
-        tree.heading('name', text='Description', anchor=tk.W)
+        tree.heading('name', text='Name', anchor=tk.W)
+        tree.heading('description', text='Description', anchor=tk.W)
+        tree.heading('id', text='Id', anchor=tk.W)
 
         # layout
         tree.column('#0', width=0, stretch=tk.NO)
         dpi = self.context.dpi_factor
-        tree.column('id', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
-                    self.context.ui_scaling_factor * dpi), stretch=tk.NO)
         tree.column('name', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+                    self.context.ui_scaling_factor * dpi), stretch=tk.NO)
+        tree.column('description', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+                    self.context.ui_scaling_factor * dpi))
+        tree.column('id', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
                     self.context.ui_scaling_factor * dpi))
 
         # bind double-click and right-click
@@ -115,14 +118,14 @@ class AddFunctionBlockDialog(Dialog):
 
             if daq.IDevice.can_cast_from(component):
                 device = daq.IDevice.cast_from(component)
-                tree.insert(parent_id, tk.END, text=device.name,
+                tree.insert(parent_id, tk.END, text=device.description,
                             iid=device.global_id, open=tk.TRUE)
                 parent_id = device.global_id
 
             if daq.IFunctionBlock.can_cast_from(component):
                 function_block = daq.IFunctionBlock.cast_from(component)
                 if function_block.available_function_block_types:
-                    tree.insert(parent_id, tk.END, text=function_block.name,
+                    tree.insert(parent_id, tk.END, text=function_block.description,
                                 iid=function_block.global_id, open=tk.TRUE)
                     parent_id = function_block.global_id
 
@@ -138,9 +141,9 @@ class AddFunctionBlockDialog(Dialog):
 
         available_function_block_types = self.parent_component.available_function_block_types
         for function_block_id in available_function_block_types:
+            fb_type = daq.IFunctionBlockType.cast_from(available_function_block_types[function_block_id])
             self.fb_tree.insert('', tk.END, iid=function_block_id, values=(
-                function_block_id,
-                daq.IFunctionBlockType.cast_from(available_function_block_types[function_block_id]).name))
+                fb_type.name, fb_type.description, function_block_id))
 
     def handle_parent_device_selected(self, event):
         selected_item = utils.treeview_get_first_selection(
@@ -161,7 +164,7 @@ class AddFunctionBlockDialog(Dialog):
         selected = utils.treeview_get_first_selection(self.fb_tree)
         if selected and self.parent_component:
             try:
-                fb_id = self.fb_tree.item(selected)['values'][0]
+                fb_id = self.fb_tree.item(selected)['values'][2]
                 fb_type = self.parent_component.available_function_block_types[fb_id]
                 cfg = daq.IComponentType.cast_from(fb_type).create_default_config()
                 can_config = len(cfg.all_properties) > 0
@@ -176,7 +179,7 @@ class AddFunctionBlockDialog(Dialog):
         selected = utils.treeview_get_first_selection(self.fb_tree)
         if selected and self.parent_component:
             try:
-                fb_id = self.fb_tree.item(selected)['values'][0]
+                fb_id = self.fb_tree.item(selected)['values'][2]
                 fb_type = self.parent_component.available_function_block_types[fb_id]
                 cfg = daq.IComponentType.cast_from(fb_type).create_default_config()
                 can_config = len(cfg.all_properties) > 0
@@ -218,7 +221,7 @@ class AddFunctionBlockDialog(Dialog):
             return
 
         item = self.fb_tree.item(selected_item)
-        function_block_id = item['values'][0]
+        function_block_id = item['values'][2]
 
         if not open_config_dialog:
             self.execute_add_fb(function_block_id)

--- a/examples/applications/python/GUI Application/gui_demo/components/add_server_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_server_dialog.py
@@ -38,9 +38,9 @@ class AddServerDialog(Dialog):
 
         tree.column('#0', width=0, stretch=tk.NO)
         dpi = self.context.dpi_factor
-        tree.column('name', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+        tree.column('name', anchor=tk.W, minwidth=int(150 * dpi), width=int(200 *
                     self.context.ui_scaling_factor * dpi), stretch=tk.NO)
-        tree.column('description', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+        tree.column('description', anchor=tk.W, minwidth=int(400 * dpi), width=int(350 *
                     self.context.ui_scaling_factor * dpi))
         tree.column('id', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
                     self.context.ui_scaling_factor * dpi), stretch=tk.NO)

--- a/examples/applications/python/GUI Application/gui_demo/components/add_server_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_server_dialog.py
@@ -24,23 +24,26 @@ class AddServerDialog(Dialog):
         # child
 
         tree_frame = ttk.Frame(self)
-        tree = ttk.Treeview(tree_frame, columns=('id', 'name'), displaycolumns=(
-            'id', 'name'), show='tree headings', selectmode=tk.BROWSE)
+        tree = ttk.Treeview(tree_frame, columns=('name', 'description','id'), displaycolumns=(
+            'name', 'description','id'), show='tree headings', selectmode=tk.BROWSE)
         scroll_bar = ttk.Scrollbar(
             tree_frame, orient=tk.VERTICAL, command=tree.yview)
         tree.configure(yscrollcommand=scroll_bar.set)
         scroll_bar.pack(side=tk.RIGHT, fill=tk.Y)
 
         # define headings
-        tree.heading('id', text='Name', anchor=tk.W)
-        tree.heading('name', text='Description', anchor=tk.W)
+        tree.heading('name', text='Name', anchor=tk.W)
+        tree.heading('description', text='Description', anchor=tk.W)
+        tree.heading('id', text='Id', anchor=tk.W)
 
         tree.column('#0', width=0, stretch=tk.NO)
         dpi = self.context.dpi_factor
-        tree.column('id', anchor=tk.W, minwidth=int(300 * dpi), width=int(400 *
+        tree.column('name', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
                     self.context.ui_scaling_factor * dpi), stretch=tk.NO)
-        tree.column('name', anchor=tk.W, minwidth=int(300 * dpi), width=int(400 *
+        tree.column('description', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
                     self.context.ui_scaling_factor * dpi))
+        tree.column('id', anchor=tk.W, minwidth=int(200 * dpi), width=int(300 *
+                    self.context.ui_scaling_factor * dpi), stretch=tk.NO)
 
         # bind double-click and right-click
         tree.bind('<Double-1>', self.handle_server_tree_double_click)
@@ -78,15 +81,16 @@ class AddServerDialog(Dialog):
 
             available_server_types = self.context.instance.available_server_types
             for server_type_id in available_server_types:
-                self.server_tree.insert('', tk.END, iid=server_type_id, 
-                                        values=(server_type_id, daq.IServerType.cast_from(available_server_types[server_type_id]).name))
+                server_type = daq.IServerType.cast_from(available_server_types[server_type_id])
+                self.server_tree.insert('', tk.END, iid=server_type_id,
+                                        values=(server_type.name, server_type.description, server_type_id))
 
     def handle_server_type_selected(self, e=None):
         can_config = False
         selected = utils.treeview_get_first_selection(self.server_tree)
 
         if selected:
-            server_id = self.server_tree.item(selected)['values'][0]
+            server_id = self.server_tree.item(selected)['values'][2]
             can_config = self._is_server_configurable(server_id)
 
         self._server_config_btn.configure(state=tk.NORMAL if can_config else tk.DISABLED)
@@ -97,7 +101,7 @@ class AddServerDialog(Dialog):
         can_config = False
         selected = utils.treeview_get_first_selection(self.server_tree)
         if selected:
-            server_id = self.server_tree.item(selected)['values'][0]
+            server_id = self.server_tree.item(selected)['values'][2]
             can_config = self._is_server_configurable(server_id)
 
         menu = tk.Menu(self, tearoff=0)
@@ -149,7 +153,7 @@ class AddServerDialog(Dialog):
             return
 
         item = self.server_tree.item(selected_item)
-        server_type_id = item['values'][0]
+        server_type_id = item['values'][2]
 
         if not open_config_dialog:
             self.execute_add_server(server_type_id)

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -445,3 +445,24 @@ class BlockView(ttk.Frame):
             self.active_var.set(ctx.active)
             self.event_port.emit()
     
+    def handle_active_toggle(self):
+        if daq.IComponent.can_cast_from(self.node):
+            ctx = daq.IComponent.cast_from(self.node)
+            ctx.active = not ctx.active
+            self.active_var.set(ctx.active)
+            self.event_port.emit()
+
+    def _handle_enable_discovery(self):
+        try:
+            self.node.enable_discovery()
+        except Exception as e:
+            print(f'Enable discovery failed: {e}')
+            utils.show_error('Enable discovery failed', str(e), self)
+
+    def _handle_disable_discovery(self):
+        try:
+            self.node.disable_discovery()
+        except Exception as e:
+            print(f'Disable discovery failed: {e}')
+            utils.show_error('Disable discovery failed', str(e), self)
+    

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -211,7 +211,6 @@ class BlockView(ttk.Frame):
                 self.rows = [0]
 
                 self._bind_mousewheel_recursive(self.right_stack)
-
             elif daq.IComponent.can_cast_from(self.node):
                 self.node = daq.IComponent.cast_from(self.node)
                 self.properties = PropertiesView(

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -72,11 +72,13 @@ class PropertiesTreeview(ttk.Treeview):
         if not self.read_only:
             self.bind('<Double-1>', lambda event: self.edit_value())
         self.bind('<Button-3>', lambda event: self.show_menu(event))
-        self.bind('<MouseWheel>', lambda e: self.after_idle(self._sync_overlays))
-        self.bind('<ButtonRelease-1>', lambda e: self.after(10, self._sync_overlays), add='+')
+        self.bind('<MouseWheel>', lambda e=None: self.after_idle(self._sync_overlays))
+        self.bind('<ButtonRelease-1>', lambda e=None: self.after(10, self._sync_overlays), add='+')
         self.bind('<Configure>', self._on_configure)
-        self.bind('<Map>', lambda e: self.after_idle(self._sync_overlays) if e.widget is self else None)
-        self.winfo_toplevel().bind('<<DialogReady>>', lambda e: self._sync_overlays(), add='+')
+        self.bind('<Map>', lambda e=None: self.after_idle(self._sync_overlays) if e.widget is self else None)
+        self._toplevel_bind_id = self.winfo_toplevel().bind(
+            '<<DialogReady>>', lambda e=None: self._sync_overlays(), add='+')
+        self.bind('<Destroy>', self._on_destroy)
 
         self.refresh()
 
@@ -877,6 +879,13 @@ class PropertiesTreeview(ttk.Treeview):
             if prop.suggested_values is not None and len(prop.suggested_values) > 0:
                 return  # handled by overlay combobox
             self.edit_simple_property(selected_item_id, prop.value, path)
+
+    def _on_destroy(self, event):
+        if event.widget is self:
+            try:
+                self.winfo_toplevel().unbind('<<DialogReady>>', self._toplevel_bind_id)
+            except Exception:
+                pass
 
     @staticmethod
     def _format_value(value):

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -705,6 +705,9 @@ class PropertiesTreeview(ttk.Treeview):
 
     def _place_selection_combobox(self, iid, prop):
         labels, indices = self._get_selection_options(prop.selection_values)
+        unit_symbol = utils.prettify_unit(prop.unit)
+        if unit_symbol:
+            labels = [f'{l} {unit_symbol}' for l in labels]
         if not labels:
             return
         if prop.item_type != daq.CoreType.ctUndefined:
@@ -767,16 +770,21 @@ class PropertiesTreeview(ttk.Treeview):
         if not suggestions:
             return
 
-        cb = self._make_combobox(iid, suggestions, self._format_value(prop.value), editable=True)
+        unit_symbol = utils.prettify_unit(prop.unit)
+        current_display = self._format_value(prop.value)
+        if unit_symbol:
+            suggestions = [f'{s} {unit_symbol}' for s in suggestions]
+            current_display = f'{current_display} {unit_symbol}'
+
+        cb = self._make_combobox(iid, suggestions, current_display, editable=True)
         if cb is None:
             return
 
-        def save(_cb=cb, _prop=prop):
-            try:
-                _prop.value = utils.value_to_coretype(_cb.get(), _prop.value_type)
-            except Exception as e:
-                print("Failed to set suggested value:", e)
-                return
+        def save(_cb=cb, _prop=prop, _unit=unit_symbol):
+            raw = _cb.get()
+            if _unit:
+                raw = raw.removesuffix(f' {_unit}').strip()
+            _prop.value = utils.value_to_coretype(raw, _prop.value_type)
             self.refresh()
 
         cb.bind('<Return>', lambda e: save())

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -294,33 +294,48 @@ class PropertiesTreeview(ttk.Treeview):
         except Exception as e:
             utils.show_error('Paste error', f'Can\'t paste: {e}', parent=self)
 
-    def handle_clear_properties(self):
+    def handle_clear_property_value(self):
+        selected_item_id = utils.treeview_get_first_selection(self)
+        if selected_item_id is None:
+            return
+
+        path = utils.get_item_path(self, selected_item_id)
+        if not path or not daq.IPropertyObject.can_cast_from(self.node):
+            return
+
+        component = daq.IPropertyObject.cast_from(self.node)
+        for segment in path[:-1]:
+            child = component.get_property_value(segment)
+            if not daq.IPropertyObject.can_cast_from(child):
+                return
+            component = daq.IPropertyObject.cast_from(child)
+
+        component.clear_property_value(path[-1])
+        self.refresh()
+
+    def handle_clear_property_values(self):
         selected_item_id = utils.treeview_get_first_selection(self)
         if selected_item_id is None:
             return
 
         path = utils.get_item_path(self, selected_item_id)
         prop = utils.get_property_for_path(self.context, path, self.node)
-
-        if not prop:
+        if prop is None:
             return
 
-        try:
-            if prop.value_type == daq.CoreType.ctObject:
-                obj = daq.IPropertyObject.cast_from(prop.value)
-                self._clear_object_properties(obj)
-            elif prop.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
-                self._last_method_results.pop(prop.name, None)
-            else:
-                self._clear_single_property(path)
+        if prop.value_type == daq.CoreType.ctObject and daq.IPropertyObject.can_cast_from(prop.value):
+            obj = daq.IPropertyObject.cast_from(prop.value)
+            obj.clear_property_values()
+        elif daq.IPropertyObject.can_cast_from(self.node):
+            component = daq.IPropertyObject.cast_from(self.node)
+            for segment in path[:-1]:
+                child = component.get_property_value(segment)
+                if not daq.IPropertyObject.can_cast_from(child):
+                    return
+                component = daq.IPropertyObject.cast_from(child)
+            component.clear_property_value(path[-1])
 
-            self.refresh()
-        except Exception as e:
-            utils.show_error(
-                'Clear property values error',
-                f"Can't clear: {e}",
-                parent=self,
-            )
+        self.refresh()
 
     def show_menu(self, event):
         region = self.identify_region(event.x, event.y)
@@ -350,8 +365,10 @@ class PropertiesTreeview(ttk.Treeview):
                 menu.add_command(label='Copy', command=self.handle_copy)
             if not self.read_only and not is_readonly and not is_container:
                 menu.add_command(label='Paste', command=self.handle_paste)
-            if not self.read_only and (is_container or not is_readonly):
-                menu.add_command(label='Clear property values', command=self.handle_clear_properties)
+            if not self.read_only and not is_container and not is_readonly:
+                menu.add_command(label='Clear property value', command=self.handle_clear_property_value)
+            if not self.read_only and is_container:
+                menu.add_command(label='Clear property values', command=self.handle_clear_property_values)
             if not is_container:
                 menu.add_separator()
                 
@@ -419,47 +436,6 @@ class PropertiesTreeview(ttk.Treeview):
             print("Failed to set value:", e)
         finally:
             entry.destroy()
-
-    def _clear_object_properties(self, obj):
-        for prop_info in self.context.properties_of_component(obj):
-            if prop_info.read_only:
-                continue
-
-            if prop_info.value_type == daq.CoreType.ctObject:
-                child = obj.get_property_value(prop_info.name)
-                if daq.IPropertyObject.can_cast_from(child):
-                    self._clear_object_properties(
-                        daq.IPropertyObject.cast_from(child))
-            elif prop_info.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
-                self._last_method_results.pop(prop_info.name, None)
-            else:
-                try:
-                    default = prop_info.default_value
-                    obj.set_property_value(prop_info.name, default)
-                except Exception as e:
-                    # Some properties may lack a default
-                    print(f"Skipped clearing '{prop_info.name}': {e}")
-
-    def _clear_single_property(self, path):
-        component = daq.IPropertyObject.cast_from(self.node)
-
-        for segment in path[:-1]:
-            child = component.get_property_value(segment)
-            if not daq.IPropertyObject.can_cast_from(child):
-                return
-            component = daq.IPropertyObject.cast_from(child)
-
-        prop_info = None
-        for p in self.context.properties_of_component(component):
-            if p.name == path[-1]:
-                prop_info = p
-                break
-
-        if prop_info is None:
-            return
-
-        default = prop_info.default_value
-        component.set_property_value(path[-1], default)
         
     def _clear_overlay_comboboxes(self):
         self._active_dropdown_cb = None

--- a/examples/applications/python/GUI Application/gui_demo/components/load_instance_config_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/load_instance_config_dialog.py
@@ -83,7 +83,9 @@ class LoadInstanceConfigDialog(Dialog):
         self.tree.bind('<MouseWheel>', lambda e: self.tree.after_idle(self._sync_overlays))
         self.tree.bind('<ButtonRelease-1>', lambda e: self.tree.after(10, self._sync_overlays), add='+')
         self.tree.bind('<Configure>', lambda e: self.tree.after_idle(self._sync_overlays))
-        self.tree.winfo_toplevel().bind('<<DialogReady>>', lambda e: self._sync_overlays(), add='+')
+        self._toplevel_bind_id = self.winfo_toplevel().bind(
+            '<<DialogReady>>', lambda e=None: self._sync_overlays(), add='+')
+        self.bind('<Destroy>', self._on_destroy)
 
         self.on_refresh_event(None)
 
@@ -102,6 +104,13 @@ class LoadInstanceConfigDialog(Dialog):
         if value is None:
             return ''
         return str(value)
+
+    def _on_destroy(self, event):
+        if event.widget is self:
+            try:
+                self.winfo_toplevel().unbind('<<DialogReady>>', self._toplevel_bind_id)
+            except Exception:
+                pass
 
     def _place_bool_checkbox(self, iid, prop, meta):
         bbox = self.tree.bbox(iid, meta['editable_column'])


### PR DESCRIPTION
# Brief

Add server support, refactor tree columns, improve property clear actions, fix Py callback crashes

# Description

- Refactored `add_server_dialog.py` columns to define all three (`name`, `description`, `id`), populate values in that order, and read the id back from `values[2]` instead of `values[0]`
- Applied the same column refactor to `add_function_block_dialog.py`
- Added `clear_property_values` to the tree right-click context menu, calling the native SDK `clear_property_values()` on the selected node
- Split the properties panel context menu clear action into two: "Clear property value" (singular, for normal properties via SDK `clear_property_value(name)`) and "Clear property values" (plural, for containers via SDK `clear_property_values()`)
- Removed the manual `_clear_object_properties` and `_clear_single_property` helpers, replaced by native SDK calls
- Added server support to the tree: `IServer` added to `find_fb_device_folder`, excluded from the folder-toggle logic in `handle_tree_select`, and given its own right-click context menu with "Enable discovery"
- Added unit suffixes to selection and suggested combobox overlays in the properties panel, with strip-on-save for editable suggested values
- Fixed orphaned `<<DialogReady>>` toplevel bindings that persisted after widget destruction, causing `lambda() missing 1 required positional argument: 'e'` errors when operation modes changed.
- Made event lambda parameters optional (`e=None`) as a defensive measure against Python 3.14 Tkinter callback dispatch calling handlers with zero arguments.
- Added `<Destroy>` cleanup handlers that unbind toplevel-level event subscriptions when `PropertiesTreeview` or `LoadInstanceConfigDialog` instances are destroyed.
- Guarded `_set_node_update_status_recursive` against `None` components to prevent the cascading `'NoneType' object has no attribute 'updating'` error during tree refresh after operation mode changes.

# Usage example

## In terminal use

```sh
py -m opendaq
```

<img width="1127" height="746" alt="slika" src="https://github.com/user-attachments/assets/faeb4235-38a7-47a7-b5c5-29ef3aa7eb5f" />


<img width="901" height="429" alt="slika" src="https://github.com/user-attachments/assets/59efd168-dc27-4624-b4a1-a37b352fbcb5" />

<img width="898" height="430" alt="slika" src="https://github.com/user-attachments/assets/ad720875-2c02-4759-9c57-137b10b21f99" />


<img width="354" height="124" alt="slika" src="https://github.com/user-attachments/assets/be5c67ee-d7f9-4484-b78d-ea99f83565a2" />

