### PR TITLE
Bugfix: Client should reflect the remote device's operation mode on connect

### DIFF
--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -72,6 +72,7 @@ public:
     ErrCode INTERFACE_FUNC getOperationMode(OperationModeType* modeType) override;
 
     ErrCode INTERFACE_FUNC setParentActive(Bool parentActive) override;
+    ErrCode INTERFACE_FUNC setAsRoot() override;
 
     template <class Implementation>
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
@@ -390,6 +391,18 @@ inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::setParentActive(Bool 
     if (this->isRootDevice)
         return OPENDAQ_IGNORED;
     return Super::setParentActive(parentActive);
+}
+
+template <class TDeviceBase>
+ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::setAsRoot()
+{
+    if (this->isComponentRemoved)
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_COMPONENT_REMOVED);
+
+    auto lock = this->getRecursiveConfigLock2();
+
+    this->isRootDevice = true;
+    return OPENDAQ_SUCCESS;
 }
 
 template <class TDeviceBase>

--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -4695,3 +4695,13 @@ TEST_F(NativeDeviceModulesTest, ComponentActiveChangedRecursiveGateway)
     for (const auto& comp : clientLeafDevice.getItems(search::Recursive(search::Any())))
         ASSERT_TRUE(comp.getActive()) << "Leaf component should be active: " << comp.getGlobalId();
 }
+
+TEST_F(NativeDeviceModulesTest, NonDefaultOpMode)
+{
+    auto server = CreateServerSimulator("NonDefaultOpMode");
+    server.setOperationMode(OperationModeType::Idle);
+    auto client = CreateClientConnectedToSimulator("NonDefaultOpMode");
+
+    ASSERT_EQ(server.getOperationMode(), OperationModeType::Idle);
+    ASSERT_EQ(client.getDevices()[0].getOperationMode(), OperationModeType::Idle);
+}


### PR DESCRIPTION
# Brief

Client side mirrored device should not enter default mode when connected to the remote device (add missing override). Add a test for ti.



# Description

- Add missing override that doesn't switch client side device to default op mode.
- Add test
