### PR TITLE
Fix active not set properly via native protocol if parent active is false

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -378,7 +378,17 @@ ErrCode ComponentImpl<Intf, Intfs...>::setActive(Bool active)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE);
 
         this->localActive = active;
-        if (!updateActive())
+        bool updated = updateActive();
+        if (!this->coreEventMuted && this->coreEvent.assigned())
+        {
+            const CoreEventArgsPtr args = createWithImplementation<ICoreEventArgs, CoreEventArgsImpl>(
+                CoreEventId::AttributeChanged,
+                Dict<IString, IBaseObject>({{"AttributeName", "LocalActive"}, {"LocalActive", this->localActive}}));
+
+            triggerCoreEvent(args);
+        }
+
+        if (!updated)
             return OPENDAQ_IGNORED;
     }
 

--- a/core/opendaq/opendaq/tests/test_core_events.cpp
+++ b/core/opendaq/opendaq/tests/test_core_events.cpp
@@ -1206,7 +1206,7 @@ TEST_F(CoreEventTest, ActiveChanged)
         {
             ASSERT_EQ(args.getEventId(), static_cast<int>(CoreEventId::AttributeChanged));
             ASSERT_EQ(args.getEventName(), "AttributeChanged");
-            ASSERT_TRUE(args.getParameters().hasKey("Active"));
+            ASSERT_TRUE(args.getParameters().hasKey("Active") || args.getParameters().hasKey("LocalActive"));
             changeCount++;
         };
 

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -330,6 +330,7 @@ void ConfigClientComponentBaseImpl<Impl>::attributeChanged(const CoreEventArgsPt
 
     if (attrName == "Active")
     {
+        // keep this for backwards compatibility with older protocol versions, but prefer "LocalActive" if available
         const auto parameters = args.getParameters();
         if (parameters.hasKey("LocalActive"))
         {
@@ -343,6 +344,12 @@ void ConfigClientComponentBaseImpl<Impl>::attributeChanged(const CoreEventArgsPt
             const Bool active = parameters.get("Active");
             checkErrorInfo(Impl::setActive(active));
         }
+    }
+    else if (attrName == "LocalActive")
+    {
+        const auto parameters = args.getParameters();
+        const Bool localActive = parameters.get("LocalActive");
+        checkErrorInfo(Impl::setActive(localActive));
     }
     else if (attrName == "Name")
     {

--- a/shared/libraries/config_protocol/src/config_protocol_server.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_server.cpp
@@ -699,6 +699,9 @@ CoreEventArgsPtr ConfigProtocolServer::processAttributeChangedCoreEvent(const Co
         assert(params.hasKey("Active"));
         if (protocolVersion > 21 && !params.hasKey("LocalActive"))
             return nullptr;
+
+        if (protocolVersion > 23)
+            return nullptr;
     }
 
     return processedArgs;

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -757,7 +757,7 @@ TEST_F(ConfigCoreEventTest, ComponentAttributeChanged)
                 ASSERT_EQ(args.getEventName(), "AttributeChanged");
 
                 auto attrName = args.getParameters().get("AttributeName");
-                if (attrName == "Active")
+                if (attrName == "LocalActive" || attrName == "Active")
                    activeChangeCount++;
                 else
                    otherChangeCount++;
@@ -1798,4 +1798,23 @@ TEST_F(ConfigCoreEventTest, ReconnectComponentUpdateEndDeviceInfo)
 
     ASSERT_EQ(clientDevice.getInfo().getSerialNumber(), "test");
     ASSERT_EQ(clientDevice.getInfo().getManufacturer(), "test");
+}
+
+TEST_F(ConfigCoreEventTest, ComponentSetActiveWithParentNonActive)
+{
+    serverDevice.asPtr<IComponentPrivate>().unlockAllAttributes();
+
+    const auto subDev = clientDevice.getDevices(search::Recursive(search::LocalId("mock_phys_dev")))[0];
+    const auto sig = subDev.getSignalsRecursive(search::LocalId("devicetimesig"))[0];
+
+    ASSERT_TRUE(subDev.getActive());
+    ASSERT_TRUE(sig.getActive());
+
+    sig.setActive(false);
+    subDev.setActive(false);
+
+    sig.setActive(true);
+    subDev.setActive(true);
+
+    ASSERT_TRUE(sig.getActive());
 }


### PR DESCRIPTION


# Brief

Fix a wrong state of the native client component active attribute when switching it on and off while the parent is not active



# Description

The following case will result in an out-of-sync state for the active attribute on the client.

1.) Parent component is inactive
2.) Child Component is inactive
3.) Set the child component to active 

This will set the local active to true, but the active remains false because the parent is inactive.

4.) Set the parent component to active

After this, the client child component will be inactive, while the server client component is active. It is also not possible to change the active state from the client side. After disconnecting and reconnecting, the state is in sync again.


The solution in this PR introduces a new core event attribute changed with "LocalActive" as a parameter. Only this event needs to be transported to the client. However, this must also happen when the calculated active has not changed.