### PR TITLE
MDNS discovery ratelimiting

### DIFF
--- a/bindings/c/include/copendaq/modulemanager/discovery_server.h
+++ b/bindings/c/include/copendaq/modulemanager/discovery_server.h
@@ -40,6 +40,7 @@ extern "C"
     typedef struct daqDeviceInfo daqDeviceInfo;
     typedef struct daqDevice daqDevice;
     typedef struct daqLogger daqLogger;
+    typedef struct daqDict daqDict;
 
     EXPORTED extern const daqIntfID DAQ_DISCOVERY_SERVER_INTF_ID;
     void EXPORTED daqDiscoveryServer_getInterfaceId(daqIntfID* intfId);
@@ -47,7 +48,7 @@ extern "C"
     daqErrCode EXPORTED daqDiscoveryServer_registerService(daqDiscoveryServer* self, daqString* id, daqPropertyObject* config, daqDeviceInfo* deviceInfo);
     daqErrCode EXPORTED daqDiscoveryServer_unregisterService(daqDiscoveryServer* self, daqString* id);
     daqErrCode EXPORTED daqDiscoveryServer_setRootDevice(daqDiscoveryServer* self, daqDevice* device);
-    daqErrCode EXPORTED daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger);
+    daqErrCode EXPORTED daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger, daqDict* options);
 
 #ifdef __cplusplus
 }

--- a/bindings/c/include/copendaq/modulemanager/discovery_server.h
+++ b/bindings/c/include/copendaq/modulemanager/discovery_server.h
@@ -48,7 +48,8 @@ extern "C"
     daqErrCode EXPORTED daqDiscoveryServer_registerService(daqDiscoveryServer* self, daqString* id, daqPropertyObject* config, daqDeviceInfo* deviceInfo);
     daqErrCode EXPORTED daqDiscoveryServer_unregisterService(daqDiscoveryServer* self, daqString* id);
     daqErrCode EXPORTED daqDiscoveryServer_setRootDevice(daqDiscoveryServer* self, daqDevice* device);
-    daqErrCode EXPORTED daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger, daqDict* options);
+    daqErrCode EXPORTED daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger);
+    daqErrCode EXPORTED daqDiscoveryServer_createMdnsDiscoveryServerWithOptions(daqDiscoveryServer** obj, daqLogger* logger, daqDict* options);
 
 #ifdef __cplusplus
 }

--- a/bindings/c/src/copendaq/modulemanager/discovery_server.cpp
+++ b/bindings/c/src/copendaq/modulemanager/discovery_server.cpp
@@ -37,10 +37,18 @@ daqErrCode daqDiscoveryServer_setRootDevice(daqDiscoveryServer* self, daqDevice*
     return reinterpret_cast<daq::IDiscoveryServer*>(self)->setRootDevice(reinterpret_cast<daq::IDevice*>(device));
 }
 
-daqErrCode daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger, daqDict* options)
+daqErrCode daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger)
 {
     daq::IDiscoveryServer* ptr = nullptr;
-    daqErrCode err = daq::createMdnsDiscoveryServer(&ptr, reinterpret_cast<daq::ILogger*>(logger), reinterpret_cast<daq::IDict*>(options));
+    daqErrCode err = daq::createMdnsDiscoveryServer(&ptr, reinterpret_cast<daq::ILogger*>(logger));
+    *obj = reinterpret_cast<daqDiscoveryServer*>(ptr);
+    return err;
+}
+
+daqErrCode daqDiscoveryServer_createMdnsDiscoveryServerWithOptions(daqDiscoveryServer** obj, daqLogger* logger, daqDict* options)
+{
+    daq::IDiscoveryServer* ptr = nullptr;
+    daqErrCode err = daq::createMdnsDiscoveryServerWithOptions(&ptr, reinterpret_cast<daq::ILogger*>(logger), reinterpret_cast<daq::IDict*>(options));
     *obj = reinterpret_cast<daqDiscoveryServer*>(ptr);
     return err;
 }

--- a/bindings/c/src/copendaq/modulemanager/discovery_server.cpp
+++ b/bindings/c/src/copendaq/modulemanager/discovery_server.cpp
@@ -37,10 +37,10 @@ daqErrCode daqDiscoveryServer_setRootDevice(daqDiscoveryServer* self, daqDevice*
     return reinterpret_cast<daq::IDiscoveryServer*>(self)->setRootDevice(reinterpret_cast<daq::IDevice*>(device));
 }
 
-daqErrCode daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger)
+daqErrCode daqDiscoveryServer_createMdnsDiscoveryServer(daqDiscoveryServer** obj, daqLogger* logger, daqDict* options)
 {
     daq::IDiscoveryServer* ptr = nullptr;
-    daqErrCode err = daq::createMdnsDiscoveryServer(&ptr, reinterpret_cast<daq::ILogger*>(logger));
+    daqErrCode err = daq::createMdnsDiscoveryServer(&ptr, reinterpret_cast<daq::ILogger*>(logger), reinterpret_cast<daq::IDict*>(options));
     *obj = reinterpret_cast<daqDiscoveryServer*>(ptr);
     return err;
 }

--- a/bindings/python/opendaq/generated/modulemanager/py_discovery_server.cpp
+++ b/bindings/python/opendaq/generated/modulemanager/py_discovery_server.cpp
@@ -40,8 +40,9 @@ void defineIDiscoveryServer(pybind11::module_ m, PyDaqIntf<daq::IDiscoveryServer
 {
     cls.doc() = "";
 
-    m.def("MdnsDiscoveryServer", [](daq::ILogger* logger, std::variant<daq::IDict*, py::dict>& options){
-        return daq::MdnsDiscoveryServer_Create(logger, getVariantValue<daq::IDict*>(options));
+    m.def("MdnsDiscoveryServer", &daq::MdnsDiscoveryServer_Create);
+    m.def("MdnsDiscoveryServerWithOptions", [](daq::ILogger* logger, std::variant<daq::IDict*, py::dict>& options){
+        return daq::MdnsDiscoveryServerWithOptions_Create(logger, getVariantValue<daq::IDict*>(options));
     }, py::arg("logger"), py::arg("options"));
 
 

--- a/bindings/python/opendaq/generated/modulemanager/py_discovery_server.cpp
+++ b/bindings/python/opendaq/generated/modulemanager/py_discovery_server.cpp
@@ -40,7 +40,10 @@ void defineIDiscoveryServer(pybind11::module_ m, PyDaqIntf<daq::IDiscoveryServer
 {
     cls.doc() = "";
 
-    m.def("MdnsDiscoveryServer", &daq::MdnsDiscoveryServer_Create);
+    m.def("MdnsDiscoveryServer", [](daq::ILogger* logger, std::variant<daq::IDict*, py::dict>& options){
+        return daq::MdnsDiscoveryServer_Create(logger, getVariantValue<daq::IDict*>(options));
+    }, py::arg("logger"), py::arg("options"));
+
 
     cls.def("register_service",
         [](daq::IDiscoveryServer *object, std::variant<daq::IString*, py::str, daq::IEvalValue*>& id, daq::IPropertyObject* config, daq::IDeviceInfo* deviceInfo)

--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -64,6 +64,7 @@
 
 ## Misc
 
+- [#1171](https://github.com/openDAQ/openDAQ/pull/1171) MDNS discovery ratelimiting
 - [#1125](https://github.com/openDAQ/openDAQ/pull/1125) Removing all function blocks before load 
 - [#1109](https://github.com/openDAQ/openDAQ/pull/1109) New check version dependencies mechanism for modules
 - [#1090](https://github.com/openDAQ/openDAQ/pull/1090) Reduce unnecessary RPC calls and signal updates

--- a/core/opendaq/modulemanager/include/opendaq/discovery_server.h
+++ b/core/opendaq/modulemanager/include/opendaq/discovery_server.h
@@ -44,6 +44,7 @@ DECLARE_OPENDAQ_INTERFACE(IDiscoveryServer, IBaseObject)
 
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(LIBRARY_FACTORY, 
     MdnsDiscoveryServer, IDiscoveryServer,
-    ILogger*, logger)
+    ILogger*, logger,
+    IDict*, options)
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/modulemanager/include/opendaq/discovery_server.h
+++ b/core/opendaq/modulemanager/include/opendaq/discovery_server.h
@@ -42,8 +42,12 @@ DECLARE_OPENDAQ_INTERFACE(IDiscoveryServer, IBaseObject)
 };
 /*!@}*/
 
-OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(LIBRARY_FACTORY, 
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(LIBRARY_FACTORY,
     MdnsDiscoveryServer, IDiscoveryServer,
+    ILogger*, logger)
+
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(LIBRARY_FACTORY,
+    MdnsDiscoveryServerWithOptions, IDiscoveryServer,
     ILogger*, logger,
     IDict*, options)
 

--- a/core/opendaq/modulemanager/include/opendaq/discovery_server_factory.h
+++ b/core/opendaq/modulemanager/include/opendaq/discovery_server_factory.h
@@ -30,9 +30,20 @@ BEGIN_NAMESPACE_OPENDAQ
  * @brief Creates an MDNS-based Discovery Server.
  * @param logger The logger the Discovery Server has access to.
  */
-inline DiscoveryServerPtr MdnsDiscoveryServer(const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& options)
+inline DiscoveryServerPtr MdnsDiscoveryServer(const LoggerPtr& logger)
 {
-    DiscoveryServerPtr obj(MdnsDiscoveryServer_Create(logger, options));
+    DiscoveryServerPtr obj(MdnsDiscoveryServer_Create(logger));
+    return obj;
+}
+
+/*!
+ * @brief Creates an MDNS-based Discovery Server with options specified via instance config provider.
+ * @param logger The logger the Discovery Server has access to.
+ * @param options The options dictionary.
+ */
+inline DiscoveryServerPtr MdnsDiscoveryServerWithOptions(const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& options)
+{
+    DiscoveryServerPtr obj(MdnsDiscoveryServerWithOptions_Create(logger, options));
     return obj;
 }
 /*!@}*/

--- a/core/opendaq/modulemanager/include/opendaq/discovery_server_factory.h
+++ b/core/opendaq/modulemanager/include/opendaq/discovery_server_factory.h
@@ -30,9 +30,9 @@ BEGIN_NAMESPACE_OPENDAQ
  * @brief Creates an MDNS-based Discovery Server.
  * @param logger The logger the Discovery Server has access to.
  */
-inline DiscoveryServerPtr MdnsDiscoveryServer(const LoggerPtr& logger)
+inline DiscoveryServerPtr MdnsDiscoveryServer(const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& options)
 {
-    DiscoveryServerPtr obj(MdnsDiscoveryServer_Create(logger));
+    DiscoveryServerPtr obj(MdnsDiscoveryServer_Create(logger, options));
     return obj;
 }
 /*!@}*/

--- a/core/opendaq/modulemanager/include/opendaq/mdns_discovery_server_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/mdns_discovery_server_impl.h
@@ -26,6 +26,7 @@ BEGIN_NAMESPACE_OPENDAQ
 class MdnsDiscoveryServerImpl : public ImplementationOf<IDiscoveryServer>
 {
 public:
+    MdnsDiscoveryServerImpl(const LoggerPtr& logger);
     MdnsDiscoveryServerImpl(const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& options);
 
     ErrCode INTERFACE_FUNC registerService(IString* id, IPropertyObject* config, IDeviceInfo* deviceInfo) override;

--- a/core/opendaq/modulemanager/include/opendaq/mdns_discovery_server_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/mdns_discovery_server_impl.h
@@ -26,7 +26,7 @@ BEGIN_NAMESPACE_OPENDAQ
 class MdnsDiscoveryServerImpl : public ImplementationOf<IDiscoveryServer>
 {
 public:
-    MdnsDiscoveryServerImpl(const LoggerPtr& logger);
+    MdnsDiscoveryServerImpl(const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& options);
 
     ErrCode INTERFACE_FUNC registerService(IString* id, IPropertyObject* config, IDeviceInfo* deviceInfo) override;
     ErrCode INTERFACE_FUNC unregisterService(IString* id) override;

--- a/core/opendaq/modulemanager/src/mdns_discovery_server_impl.cpp
+++ b/core/opendaq/modulemanager/src/mdns_discovery_server_impl.cpp
@@ -23,6 +23,11 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
+MdnsDiscoveryServerImpl::MdnsDiscoveryServerImpl(const LoggerPtr& logger)
+    : MdnsDiscoveryServerImpl(logger, Dict<IString, IBaseObject>())
+{
+}
+
 MdnsDiscoveryServerImpl::MdnsDiscoveryServerImpl(const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& options)
     : discoveryServer(options)
     , loggerComponent(logger.getOrAddComponent("MdnsDiscoveryServerImpl"))
@@ -242,7 +247,12 @@ void MdnsDiscoveryServerImpl::registerIpModificationService(const DevicePtr& roo
 
 #if !defined(BUILDING_STATIC_LIBRARY)
 
-extern "C" ErrCode PUBLIC_EXPORT createMdnsDiscoveryServer(IDiscoveryServer** objTmp, ILogger* logger, IDict* options)
+extern "C" ErrCode PUBLIC_EXPORT createMdnsDiscoveryServer(IDiscoveryServer** objTmp, ILogger* logger)
+{
+    return daq::createObject<IDiscoveryServer, MdnsDiscoveryServerImpl>(objTmp, logger);
+}
+
+extern "C" ErrCode PUBLIC_EXPORT createMdnsDiscoveryServerWithOptions(IDiscoveryServer** objTmp, ILogger* logger, IDict* options)
 {
     return daq::createObject<IDiscoveryServer, MdnsDiscoveryServerImpl>(objTmp, logger, options);
 }

--- a/core/opendaq/modulemanager/src/mdns_discovery_server_impl.cpp
+++ b/core/opendaq/modulemanager/src/mdns_discovery_server_impl.cpp
@@ -23,8 +23,9 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-MdnsDiscoveryServerImpl::MdnsDiscoveryServerImpl(const LoggerPtr& logger)
-    : loggerComponent(logger.getOrAddComponent("MdnsDiscoveryServerImpl"))
+MdnsDiscoveryServerImpl::MdnsDiscoveryServerImpl(const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& options)
+    : discoveryServer(options)
+    , loggerComponent(logger.getOrAddComponent("MdnsDiscoveryServerImpl"))
 {
 }
 
@@ -241,9 +242,9 @@ void MdnsDiscoveryServerImpl::registerIpModificationService(const DevicePtr& roo
 
 #if !defined(BUILDING_STATIC_LIBRARY)
 
-extern "C" ErrCode PUBLIC_EXPORT createMdnsDiscoveryServer(IDiscoveryServer** objTmp, ILogger* logger)
+extern "C" ErrCode PUBLIC_EXPORT createMdnsDiscoveryServer(IDiscoveryServer** objTmp, ILogger* logger, IDict* options)
 {
-    return daq::createObject<IDiscoveryServer, MdnsDiscoveryServerImpl>(objTmp, logger);
+    return daq::createObject<IDiscoveryServer, MdnsDiscoveryServerImpl>(objTmp, logger, options);
 }
 
 #endif

--- a/core/opendaq/opendaq/src/instance_builder_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_builder_impl.cpp
@@ -35,7 +35,14 @@ DictPtr<IString, IBaseObject> InstanceBuilderImpl::GetDefaultOptions()
             {"SerializePrettyPrint", False}
         })},
         {"Modules", Dict<IString, IBaseObject>(
-        )}
+        )},
+        {"MdnsDiscoveryServer", Dict<IString, IBaseObject>(
+        {
+            {"SingleQuerierRateLimitPerSecond", 25},
+            {"MaxActiveQueriers", 150},
+            {"MaxQueryCountPerSecond", 75},
+            {"EnableDiscoveryRateLimit", True}
+        })},
     });
 }
 

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -90,10 +90,10 @@ static DiscoveryServerPtr createDiscoveryServer(const StringPtr& serviceName, co
 {
     if (serviceName == "mdns")
     {
-        DictPtr<IString, IBaseObject> mdnsOptions = Dict<IString, IBaseObject>();
         if (instanceOptions.hasKey("MdnsDiscoveryServer"))
-            mdnsOptions = instanceOptions.get("MdnsDiscoveryServer");
-        return MdnsDiscoveryServer(logger, mdnsOptions);
+            return MdnsDiscoveryServerWithOptions(logger, instanceOptions.get("MdnsDiscoveryServer"));
+        else
+            return MdnsDiscoveryServer(logger);
     }
     return nullptr;
 }

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -86,10 +86,15 @@ static StringPtr DefineLocalId(const StringPtr& localId)
     return "openDAQDevice";
 }
 
-static DiscoveryServerPtr createDiscoveryServer(const StringPtr& serviceName, const LoggerPtr& logger)
+static DiscoveryServerPtr createDiscoveryServer(const StringPtr& serviceName, const LoggerPtr& logger, const DictPtr<IString, IBaseObject>& instanceOptions)
 {
     if (serviceName == "mdns")
-        return MdnsDiscoveryServer(logger);
+    {
+        DictPtr<IString, IBaseObject> mdnsOptions = Dict<IString, IBaseObject>();
+        if (instanceOptions.hasKey("MdnsDiscoveryServer"))
+            mdnsOptions = instanceOptions.get("MdnsDiscoveryServer");
+        return MdnsDiscoveryServer(logger, mdnsOptions);
+    }
     return nullptr;
 }
 
@@ -153,7 +158,7 @@ static ContextPtr ContextFromInstanceBuilder(IInstanceBuilder* instanceBuilder)
     auto discoveryServers = Dict<IString, IDiscoveryServer>();
     for (const auto& serverName : builderPtr.getDiscoveryServers())
     {
-        auto server = createDiscoveryServer(serverName, logger);
+        auto server = createDiscoveryServer(serverName, logger, options);
         if (server.assigned())
             discoveryServers.set(serverName, server);
     }

--- a/examples/applications/python/Discovery/discovery_server_ratelimiting.py
+++ b/examples/applications/python/Discovery/discovery_server_ratelimiting.py
@@ -1,0 +1,86 @@
+##
+# Creates a temporary json file to be used as a Json config provider for creating the openDAQ
+# instance. The file contains reference configuration parameters for mDNS server ratelimiting.
+#
+# Starts an openDAQ simulator. The simulator uses the reference device as its root and
+# starts up the OPC UA and Native servers with "mdns" discovery enabled. The serial number
+# and local ID of the reference device are overridden to "sim01" and "RefDevSimulator"
+# respectively.
+#
+# IMPORTANT: Only 1 simulator should be active at any given time to avoid serial number
+# clashes during discovery and connection! openDAQ devices should generally have a globally
+# unique combination of manufacturer + serial number, and a globally unique local ID.
+##
+
+import json
+from pathlib import Path
+import opendaq
+
+CONFIG_FILE = Path("mdns-discovery-ratelimiting.json")
+
+config = opendaq.PropertyObject()
+config.add_property(opendaq.StringProperty(opendaq.String(
+    'Name'), opendaq.String('Reference device simulator'), opendaq.Boolean(True)))
+config.add_property(opendaq.StringProperty(opendaq.String(
+    'LocalId'), opendaq.String('RefDevSimulator'), opendaq.Boolean(True)))
+config.add_property(opendaq.StringProperty(opendaq.String(
+    'SerialNumber'), opendaq.String('sim01'), opendaq.Boolean(True)))
+
+# Create a new openDAQ(TM) Json config provider file
+# Fail immediately if file exists
+if CONFIG_FILE.exists():
+    print(f"Error: file already exists: {CONFIG_FILE}")
+    exit(1)
+
+try:
+    with CONFIG_FILE.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "MdnsDiscoveryServer":
+                {
+                    "EnableDiscoveryRateLimit": True,
+                    "SingleQuerierRateLimitPerSecond": 30,
+                    "MaxActiveQueriers": 200,
+                    "MaxQueryCountPerSecond": 80
+                }
+            },
+            f,
+            indent=2
+        )
+
+except Exception as e:
+    print(f"Error: failed to create config file: {e}")
+    exit(1)
+
+# Read from file and create config provider
+config_provider = opendaq.JsonConfigProvider(opendaq.String(str(CONFIG_FILE)))
+
+# Create a new openDAQ(TM) instance builder
+instance_builder = opendaq.InstanceBuilder()
+
+# Add Mdns discovery service available for servers
+instance_builder.add_discovery_server("mdns")
+
+# Set config provider
+instance_builder.add_config_provider(config_provider)
+
+# Set reference device as a root
+instance_builder.set_root_device('daqref://device0', config)
+
+# until instance builder factory gets updated
+instance_builder.module_path = opendaq.OPENDAQ_MODULES_DIR
+
+# Creating a new instance from builder
+instance = instance_builder.build()
+
+# cleanup created file
+CONFIG_FILE.unlink()
+
+# Start an openDAQ OpcUa and native streaming servers
+servers = instance.add_standard_servers()
+
+# Enable discovery for all servers
+for server in servers:
+    server.enable_discovery()
+
+input('Press "Enter" to exit the application ...')

--- a/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
+++ b/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
@@ -478,6 +478,9 @@ inline void MDNSDiscoveryClient::encodeNonDiscoveryRequest(const std::string& re
 
 inline void MDNSDiscoveryClient::setupDiscoveryQuery()
 {
+    // TODO according to the RFC  https://www.rfc-editor.org/rfc/rfc6763.html#section-12
+    // device does not mandatory respond with all additional records to PTR query
+    // we expect that it does but we need to check if the device actually replied with SRV, A, AAAA, TXT records and if didn't then query for missing records explicitely
     std::vector<mdns_record_type> types {MDNS_RECORDTYPE_PTR};
     discoveryQueries.resize(serviceNames.size() * types.size());
     for (size_t nameIdx = 0; nameIdx < serviceNames.size(); nameIdx++)
@@ -837,6 +840,7 @@ inline std::string MDNSDiscoveryClient::getIpv6NetworkInterfaceFromIndex(unsigne
     return "";
 }
 
+// as some devices do not reply with A nor AAAA records we additionally cache the sender address as a workaround to get the device address
 inline void MDNSDiscoveryClient::cacheFromAddress(int sock, const sockaddr* from, const std::string& serviceInstance)
 {
     if (from->sa_family == AF_INET)

--- a/shared/libraries/discovery_common/src/daq_discovery_common.cpp
+++ b/shared/libraries/discovery_common/src/daq_discovery_common.cpp
@@ -1,5 +1,6 @@
 #include <discovery_common/daq_discovery_common.h>
 #include <cctype>
+#include <iostream>
 #include <map>
 #include <set>
 #include <algorithm>
@@ -125,14 +126,36 @@ TxtProperties DiscoveryUtils::connectedClientsInfoToTxt(const PropertyObjectPtr&
 {
     TxtProperties result;
 
+    PropertyObjectPtr connectedClientsInfoClone;
+    if (const auto propertyObjectInternalPtr = connectedClientsInfo.asPtrOrNull<IPropertyObjectInternal>(); propertyObjectInternalPtr.assigned())
+    {
+        try
+        {
+            connectedClientsInfoClone = propertyObjectInternalPtr.clone();
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "DiscoveryUtils::connectedClientsInfoToTxt: clone failed: " << e.what() << "\n";
+        }
+        catch (...)
+        {
+            std::cerr << "DiscoveryUtils::connectedClientsInfoToTxt: clone failed (unknown error)\n";
+        }
+    }
+
+    if (!connectedClientsInfoClone.assigned() || connectedClientsInfoClone.getAllProperties().getCount() == 0)
+    {
+        return result;
+    }
+
     const auto zeroPadNumber =
-        [width = std::to_string(connectedClientsInfo.getAllProperties().getCount() - 1).size()](size_t index)
+        [width = std::to_string(connectedClientsInfoClone.getAllProperties().getCount() - 1).size()](size_t index)
         {
             return std::string(width - std::to_string(index).size(), '0') + std::to_string(index);
         };
 
     size_t index = 0;
-    for (const auto& clientInfoProperty : connectedClientsInfo.getAllProperties())
+    for (const auto& clientInfoProperty : connectedClientsInfoClone.getAllProperties())
     {
         const PropertyObjectPtr connectedClientPropObject = clientInfoProperty.getValue();
 

--- a/shared/libraries/discovery_common/src/daq_discovery_common.cpp
+++ b/shared/libraries/discovery_common/src/daq_discovery_common.cpp
@@ -131,6 +131,7 @@ TxtProperties DiscoveryUtils::connectedClientsInfoToTxt(const PropertyObjectPtr&
     {
         try
         {
+            auto lock = propertyObjectInternalPtr.getRecursiveLockGuard();
             connectedClientsInfoClone = propertyObjectInternalPtr.clone();
         }
         catch (const std::exception& e)

--- a/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
+++ b/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
@@ -86,46 +86,21 @@ struct AdapterInfo
 struct UniqueQuerier
 {
     struct sockaddr_storage addr;
-    int sock;
 
     bool operator==(const UniqueQuerier& other) const noexcept;
 };
 
-struct AtomicSteadyTimePoint
-{
-    using Clock = std::chrono::steady_clock;
-    using TimePointType = Clock::time_point;
-    using Rep = TimePointType::rep;
-
-public:
-    AtomicSteadyTimePoint() = delete;
-    AtomicSteadyTimePoint(const AtomicSteadyTimePoint&) = delete;
-    AtomicSteadyTimePoint& operator=(const AtomicSteadyTimePoint&) = delete;
-
-    AtomicSteadyTimePoint(TimePointType tp);
-    AtomicSteadyTimePoint& operator=(TimePointType tp);
-    operator TimePointType() const;
-
-private:
-    void store(TimePointType tp);
-    TimePointType load() const;
-    static Rep toRep(TimePointType tp);
-    static Clock::time_point fromRep(Rep v);
-
-    std::atomic<Rep> value;
-};
-
 struct QuerierBucket
 {
-    QuerierBucket(const UniqueQuerier& querier, uint32_t hashFingerprint, size_t maxBurst, size_t refillRate, AtomicSteadyTimePoint::TimePointType lastQueried);
+    QuerierBucket(const UniqueQuerier& querier, uint32_t hashFingerprint, size_t maxBurst, size_t refillRate, std::chrono::steady_clock::time_point lastQueried);
 
     const UniqueQuerier primaryQuerier;
     const uint32_t primaryQuerierHash;
 
-    std::atomic_size_t tokens;          // current available capacity
+    size_t tokens;                                  // current available capacity
     const size_t maxBurst;
-    const size_t refillRate;            // tokens per second
-    AtomicSteadyTimePoint lastQueried;
+    const size_t refillRate;                        // tokens per second
+    std::chrono::steady_clock::time_point lastQueried;
 };
 
 using ModifyIpConfigCallback = std::function<discovery_common::TxtProperties(const std::string& ifaceName, const discovery_common::TxtProperties& properties)>;
@@ -191,9 +166,9 @@ private:
                               const std::string& uuid);
 
     bool allowQuery(int sock, const sockaddr* from);
-    bool isStaleBucket(const QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now) const;
-    void refillTokens(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now);
-    bool tryConsumeToken(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now);
+    bool isStaleBucket(const QuerierBucket& bucket, std::chrono::steady_clock::time_point now) const;
+    void refillTokens(QuerierBucket& bucket, std::chrono::steady_clock::time_point now);
+    bool tryConsumeToken(QuerierBucket& bucket, std::chrono::steady_clock::time_point now);
 
     std::string hostName;
 
@@ -216,6 +191,7 @@ private:
     const uint32_t maxQueriers;
     const size_t maxBurst;
     std::vector<std::optional<QuerierBucket>> querierBucketsTable;
+    std::mutex rateLimitingSync;
 };
 
 END_NAMESPACE_DISCOVERY_SERVICE

--- a/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
+++ b/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
@@ -187,9 +187,10 @@ private:
 
     DictPtr<IString, IBaseObject> options;
 
-    const size_t perQuerierBucketLimit;
-    const uint32_t maxQueriers;
-    const size_t maxBurst;
+    const bool discoveryRatelimitEnabled;
+    const size_t singleQuerierRateLimitPerSecond;
+    const uint32_t maxActiveQueriers;
+    const size_t maxQueryCountPerSecond;
     std::vector<std::optional<QuerierBucket>> querierBucketsTable;
     std::mutex rateLimitingSync;
 };

--- a/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
+++ b/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
@@ -29,6 +29,7 @@
 #include <functional>
 #include <mdns.h>
 #include <unordered_set>
+#include <optional>
 
 #ifdef _WIN32
     #include <winsock2.h>

--- a/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
+++ b/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
@@ -82,13 +82,58 @@ struct AdapterInfo
     std::string name;
 };
 
+struct UniqueQuerier
+{
+    struct sockaddr_storage addr;
+    int sock;
+
+    bool operator==(const UniqueQuerier& other) const noexcept;
+};
+
+struct AtomicSteadyTimePoint
+{
+    using Clock = std::chrono::steady_clock;
+    using TimePointType = Clock::time_point;
+    using Rep = TimePointType::rep;
+
+public:
+    AtomicSteadyTimePoint() = delete;
+    AtomicSteadyTimePoint(const AtomicSteadyTimePoint&) = delete;
+    AtomicSteadyTimePoint& operator=(const AtomicSteadyTimePoint&) = delete;
+
+    AtomicSteadyTimePoint(TimePointType tp);
+    AtomicSteadyTimePoint& operator=(TimePointType tp);
+    operator TimePointType() const;
+
+private:
+    void store(TimePointType tp);
+    TimePointType load() const;
+    static Rep toRep(TimePointType tp);
+    static Clock::time_point fromRep(Rep v);
+
+    std::atomic<Rep> value;
+};
+
+struct QuerierBucket
+{
+    QuerierBucket(const UniqueQuerier& querier, uint32_t hashFingerprint, size_t maxBurst, size_t refillRate, AtomicSteadyTimePoint::TimePointType lastQueried);
+
+    const UniqueQuerier primaryQuerier;
+    const uint32_t primaryQuerierHash;
+
+    std::atomic_size_t tokens;          // current available capacity
+    const size_t maxBurst;
+    const size_t refillRate;            // tokens per second
+    AtomicSteadyTimePoint lastQueried;
+};
+
 using ModifyIpConfigCallback = std::function<discovery_common::TxtProperties(const std::string& ifaceName, const discovery_common::TxtProperties& properties)>;
 using RetrieveIpConfigCallback = std::function<discovery_common::TxtProperties(const std::string& ifaceName)>;
 
 class MDNSDiscoveryServer
 {
 public:
-	explicit MDNSDiscoveryServer();
+    explicit MDNSDiscoveryServer(const DictPtr<IString, IBaseObject>& options);
     ~MDNSDiscoveryServer();
 
     void announceService(const MdnsDiscoveredService& service, bool goodbye) const;
@@ -144,6 +189,11 @@ private:
                               bool unicast,
                               const std::string& uuid);
 
+    bool allowQuery(int sock, const sockaddr* from);
+    bool isStaleBucket(const QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now) const;
+    void refillTokens(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now);
+    bool tryConsumeToken(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now);
+
     std::string hostName;
 
     std::mutex mx;
@@ -158,6 +208,13 @@ private:
     ModifyIpConfigCallback modifyIpConfigCallback{nullptr};
     RetrieveIpConfigCallback retrieveIpConfigCallback{nullptr};
     std::unordered_set<std::string> processedIpConfigReqIds;
+
+    DictPtr<IString, IBaseObject> options;
+
+    const size_t perQuerierBucketLimit;
+    const uint32_t maxQueriers;
+    const size_t maxBurst;
+    std::vector<std::optional<QuerierBucket>> querierBucketsTable;
 };
 
 END_NAMESPACE_DISCOVERY_SERVICE

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -68,10 +68,7 @@ size_t MdnsDiscoveredService::updateConnectedClientsAndGetPropsCount() const
     using namespace discovery_common;
 
     const PropertyObjectPtr connectedClientsInfo = deviceInfo.getPropertyValue("activeClientConnections");
-    if (connectedClientsInfo.getAllProperties().getCount() != 0)
-        connectedClientsProperties = DiscoveryUtils::connectedClientsInfoToTxt(connectedClientsInfo);
-    else
-        connectedClientsProperties = TxtProperties();
+    connectedClientsProperties = DiscoveryUtils::connectedClientsInfoToTxt(connectedClientsInfo);
 
     return properties.size() + dynamicProperties.size() + connectedClientsProperties.size();
 }

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -181,9 +181,9 @@ std::string MDNSDiscoveryServer::getHostname()
 MDNSDiscoveryServer::MDNSDiscoveryServer(const DictPtr<IString, IBaseObject>& options)
     : options(options)
     , discoveryRatelimitEnabled(options.hasKey("EnableDiscoveryRateLimit") ? static_cast<bool>(options.get("EnableDiscoveryRateLimit")) : true)
-    , singleQuerierRateLimitPerSecond(options.hasKey("SingleQuerierRateLimitPerSecond") ? static_cast<size_t>(options.get("SingleQuerierRateLimitPerSecond")) : 10)
-    , maxActiveQueriers(options.hasKey("MaxActiveQueriers") ? static_cast<uint32_t>(options.get("MaxActiveQueriers")) : 100)
-    , maxQueryCountPerSecond(std::max(options.hasKey("MaxQueryCountPerSecond") ? static_cast<size_t>(options.get("MaxQueryCountPerSecond")) : 50, singleQuerierRateLimitPerSecond))
+    , singleQuerierRateLimitPerSecond(options.hasKey("SingleQuerierRateLimitPerSecond") ? static_cast<size_t>(options.get("SingleQuerierRateLimitPerSecond")) : 25)
+    , maxActiveQueriers(options.hasKey("MaxActiveQueriers") ? static_cast<uint32_t>(options.get("MaxActiveQueriers")) : 150)
+    , maxQueryCountPerSecond(std::max(options.hasKey("MaxQueryCountPerSecond") ? static_cast<size_t>(options.get("MaxQueryCountPerSecond")) : 75, singleQuerierRateLimitPerSecond))
     , querierBucketsTable(maxActiveQueriers)
 {
     fmt::print("MDNSDiscoveryServer ratelimiting ({}) params singleQuerierRateLimitPerSecond {}, maxActiveQueriers {}, maxQueryCountPerSecond {}", discoveryRatelimitEnabled, singleQuerierRateLimitPerSecond, maxActiveQueriers, maxQueryCountPerSecond);

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -26,6 +26,55 @@
 #include <arpa/inet.h>
 #endif
 
+template <>
+struct fmt::formatter<daq::discovery_server::UniqueQuerier> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(const daq::discovery_server::UniqueQuerier& q, FormatContext& ctx) const
+    {
+        char host[NI_MAXHOST] = {};
+        char service[NI_MAXSERV] = {};
+
+        std::string result;
+
+        if (q.addr.ss_family == AF_INET)
+        {
+            const auto* addr = reinterpret_cast<const sockaddr_in*>(&q.addr);
+
+            if (getnameinfo(reinterpret_cast<const sockaddr*>(addr),
+                            sizeof(sockaddr_in),
+                            host,
+                            sizeof(host),
+                            service,
+                            sizeof(service),
+                            NI_NUMERICHOST | NI_NUMERICSERV) == 0)
+            {
+                result = fmt::format("{}:{} (sock={})", host, ntohs(addr->sin_port), q.sock);
+            }
+        }
+        else if (q.addr.ss_family == AF_INET6)
+        {
+            const auto* addr = reinterpret_cast<const sockaddr_in6*>(&q.addr);
+
+            if (getnameinfo(reinterpret_cast<const sockaddr*>(addr),
+                            sizeof(sockaddr_in6),
+                            host,
+                            sizeof(host),
+                            service,
+                            sizeof(service),
+                            NI_NUMERICHOST | NI_NUMERICSERV) == 0)
+            {
+                result = fmt::format("[{}]:{} (sock={})", host, ntohs(addr->sin6_port), q.sock);
+            }
+        }
+
+        if (result.empty())
+            result = "<unknown>";
+
+        return fmt::formatter<std::string_view>::format(result, ctx);
+    }
+};
+
 BEGIN_NAMESPACE_DISCOVERY_SERVICE
 
 MdnsDiscoveredService::MdnsDiscoveredService(const std::string& serviceName,
@@ -111,6 +160,12 @@ void MdnsDiscoveredService::populateRecords(std::vector<mdns_record_t>& records)
     }
 }
 
+static size_t toMs(const AtomicSteadyTimePoint::TimePointType& point)
+{
+    static auto baseTp = AtomicSteadyTimePoint::Clock::now();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(point - baseTp).count();
+}
+
 std::string MDNSDiscoveryServer::getHostname() 
 {
     char hostname_buffer[256];
@@ -132,7 +187,12 @@ std::string MDNSDiscoveryServer::getHostname()
     return hostname;
 }
     
-MDNSDiscoveryServer::MDNSDiscoveryServer(void)
+MDNSDiscoveryServer::MDNSDiscoveryServer(const DictPtr<IString, IBaseObject>& options)
+    : options(options)
+    , perQuerierBucketLimit(options.hasKey("RateLimitPerQuerier") ? static_cast<size_t>(options.get("RateLimitPerQuerier")) : 10)
+    , maxQueriers(options.hasKey("MaxQueriersLimit") ? static_cast<uint32_t>(options.get("MaxQueriersLimit")) : 100)
+    , maxBurst(std::max(options.hasKey("MaxBurst") ? static_cast<size_t>(options.get("MaxBurst")) : 50, perQuerierBucketLimit))
+    , querierBucketsTable(maxQueriers)
 {
 #ifdef _WIN32
     WORD versionWanted = MAKEWORD(1, 1);
@@ -891,8 +951,185 @@ void MDNSDiscoveryServer::sendIpConfigResponse(int sock,
     populateTxtRecords(recordName, resProps, txtRecords);
 
     std::vector<char>sendBuffer(2048);
-    // TODO: Add interface index
-    non_mdns_query_send(sock, sendBuffer.data(), sendBuffer.size(), query_id, opcode, 0x1, 0, 0, txtRecords.data(), txtRecords.size(), 0, 0, 0, 0, unicast ? 0x1 : 0x0, to, addrlen, 0);
+
+    unsigned int if_index = 0;
+    AdapterInfo adapter;
+    if (getAdapter(sock, adapter))
+        if_index = adapter.ipv6ifindex;
+    non_mdns_query_send(sock, sendBuffer.data(), sendBuffer.size(), query_id, opcode, 0x1, 0, 0, txtRecords.data(), txtRecords.size(), 0, 0, 0, 0, unicast ? 0x1 : 0x0, to, addrlen, if_index);
+}
+
+static uint32_t xxHash32(const UniqueQuerier& querier)
+{
+    XXH32_state_t* state = XXH32_createState();
+    XXH32_reset(state, 123456789);
+
+    XXH32_update(state, &querier.sock, sizeof(querier.sock));
+    XXH32_update(state, &querier.addr.ss_family, sizeof(querier.addr.ss_family));
+
+    if (querier.addr.ss_family == AF_INET)
+    {
+        auto* addr = reinterpret_cast<const sockaddr_in*>(&querier.addr);
+        XXH32_update(state, &addr->sin_addr, sizeof(addr->sin_addr));
+        XXH32_update(state, &addr->sin_port, sizeof(addr->sin_port));
+    }
+    else if (querier.addr.ss_family == AF_INET6)
+    {
+        auto* addr = reinterpret_cast<const sockaddr_in6*>(&querier.addr);
+        XXH32_update(state, &addr->sin6_addr, sizeof(addr->sin6_addr));
+        XXH32_update(state, &addr->sin6_port, sizeof(addr->sin6_port));
+    }
+
+    uint32_t result = XXH32_digest(state);
+    XXH32_freeState(state);
+    return result;
+}
+
+static inline uint32_t mulHigh32(uint32_t a, uint32_t b)
+{
+    uint32_t a_hi = a >> 16;
+    uint32_t a_lo = a & 0xFFFF;
+    uint32_t b_hi = b >> 16;
+    uint32_t b_lo = b & 0xFFFF;
+
+    uint32_t p0 = a_lo * b_lo;
+    uint32_t p1 = a_lo * b_hi;
+    uint32_t p2 = a_hi * b_lo;
+    uint32_t p3 = a_hi * b_hi;
+
+    uint32_t carry = (p0 >> 16) + (p1 & 0xFFFF) + (p2 & 0xFFFF);
+
+    return p3 + (p1 >> 16) + (p2 >> 16) + (carry >> 16);
+}
+
+static inline uint32_t hashToIndex(uint32_t hash, uint32_t indexLimit)
+{
+    uint32_t x = hash;
+
+    x ^= x >> 16;
+    x *= 0x7feb352d;
+    x ^= x >> 15;
+    x *= 0x846ca68b;
+    x ^= x >> 16;
+
+    return mulHigh32(x, indexLimit);
+}
+
+bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
+{
+    sockaddr_storage storage{};
+    if (from->sa_family == AF_INET)
+        std::memcpy(&storage, from, sizeof(sockaddr_in));
+    else
+        std::memcpy(&storage, from, sizeof(sockaddr_in6));
+
+    UniqueQuerier querier{storage, sock};
+    const auto now = AtomicSteadyTimePoint::Clock::now();
+
+    const uint32_t hash = xxHash32(querier);
+
+    const uint32_t bucketIndex = hashToIndex(hash, maxQueriers);
+    auto& bucketSlot = querierBucketsTable[bucketIndex];
+
+    // Empty slot
+    if (!bucketSlot.has_value())
+    {
+        bucketSlot.emplace(
+            querier,
+            hash,
+            maxBurst,
+            perQuerierBucketLimit,
+            now);
+
+        //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
+        //fmt::print("...allowed as completely new querier, tokens {}\n", bucketSlot->tokens.load(std::memory_order_relaxed));
+        return true;
+    }
+
+    auto& bucket = *bucketSlot;
+    AtomicSteadyTimePoint::TimePointType lastQueried = bucket.lastQueried;
+
+    // Different querier mapped to same slot
+    if (!(bucket.primaryQuerierHash == hash && bucket.primaryQuerier == querier))
+    {
+        // Replace stale bucket
+        if (isStaleBucket(bucket, now))
+        {
+            fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
+            fmt::print("...allowed as replacement querier for {} last queried at {}; hash {}, slot index {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex);
+            bucketSlot.emplace(
+                querier,
+                hash,
+                maxBurst,
+                perQuerierBucketLimit,
+                now);
+
+            return true;
+        }
+
+        // Share bucket
+        fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
+        fmt::print("...will share bucket with {} last queried at {}; hash {}, slot index {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex);
+        bucketSlot.emplace(
+            querier,
+            hash,
+            maxBurst,
+            perQuerierBucketLimit,
+            now);
+    }
+
+    refillTokens(bucket, now);
+
+    bool result = tryConsumeToken(bucket, now);
+    if (result)
+    {
+        //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
+        //fmt::print("...allowed bcs tokens available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.querier, toMs(lastQueried), bucket.hashFingerprint, bucketIndex, bucket.tokens.load(std::memory_order_relaxed));
+    }
+    else
+    {
+        fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
+        fmt::print("...rejected bcs tokens are not available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex, bucket.tokens.load(std::memory_order_relaxed));
+    }
+    return result;
+}
+
+void MDNSDiscoveryServer::refillTokens(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now)
+{
+    const AtomicSteadyTimePoint::TimePointType lastQueried = bucket.lastQueried;
+    const auto elapsed = now - lastQueried;
+    const auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+
+    if (elapsedSeconds == 0)
+        return;
+
+    const size_t refillAmount = elapsedSeconds * perQuerierBucketLimit;
+    const size_t currentTokens = bucket.tokens.load(std::memory_order_relaxed);
+    const size_t newTokenCount = std::min(currentTokens + refillAmount, maxBurst);
+
+    bucket.tokens.store(newTokenCount, std::memory_order_relaxed);
+    bucket.lastQueried = now;
+}
+
+bool MDNSDiscoveryServer::tryConsumeToken(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now)
+{
+    auto currentTokens = bucket.tokens.load(std::memory_order_relaxed);
+
+    if (currentTokens == 0)
+        return false;
+
+    bucket.tokens.store(currentTokens - 1, std::memory_order_relaxed);
+    bucket.lastQueried = now;
+
+    return true;
+}
+
+bool MDNSDiscoveryServer::isStaleBucket(const QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now) const
+{
+    constexpr auto bucketTimeout = std::chrono::seconds(10);
+    AtomicSteadyTimePoint::TimePointType lastQueried = bucket.lastQueried;
+    const auto inactiveDuration = now - lastQueried;
+    return inactiveDuration > bucketTimeout;
 }
 
 int MDNSDiscoveryServer::nonDiscoveryCallback(
@@ -969,6 +1206,9 @@ int MDNSDiscoveryServer::discoveryCallback(
     size_t size, size_t name_offset, size_t name_length, size_t rdata_offset,
     size_t rdata_length, void* user_data)
 {
+    if (!allowQuery(sock, from))
+        return 0;
+
     if (entry != MDNS_ENTRYTYPE_QUESTION)
         return 0;
 
@@ -1080,5 +1320,78 @@ int MDNSDiscoveryServer::discoveryCallback(
     return 0;
 }
 
+bool UniqueQuerier::operator==(const UniqueQuerier& other) const noexcept
+{
+    if (sock != other.sock)
+        return false;
+
+    if (addr.ss_family != other.addr.ss_family)
+        return false;
+
+    if (addr.ss_family == AF_INET)
+    {
+        auto* aIpV4 = reinterpret_cast<const sockaddr_in*>(&addr);
+        auto* bIpV4 = reinterpret_cast<const sockaddr_in*>(&other.addr);
+
+        return aIpV4->sin_port == bIpV4->sin_port &&
+               aIpV4->sin_addr.s_addr == bIpV4->sin_addr.s_addr;
+    }
+
+    if (addr.ss_family == AF_INET6)
+    {
+        auto* aIpV6 = reinterpret_cast<const sockaddr_in6*>(&addr);
+        auto* bIpV6 = reinterpret_cast<const sockaddr_in6*>(&other.addr);
+
+        return aIpV6->sin6_port == bIpV6->sin6_port &&
+               std::memcmp(&aIpV6->sin6_addr, &bIpV6->sin6_addr, sizeof(in6_addr)) == 0;
+    }
+
+    return false;
+}
+
+AtomicSteadyTimePoint::AtomicSteadyTimePoint(TimePointType tp)
+    : value(toRep(tp))
+{}
+
+AtomicSteadyTimePoint::operator TimePointType() const
+{
+    return fromRep(value.load(std::memory_order_relaxed));
+}
+
+AtomicSteadyTimePoint& AtomicSteadyTimePoint::operator=(TimePointType tp)
+{
+    value.store(toRep(tp), std::memory_order_relaxed);
+    return *this;
+}
+
+AtomicSteadyTimePoint::TimePointType AtomicSteadyTimePoint::fromRep(Rep v)
+{
+    return TimePointType(Clock::duration(v));
+}
+
+AtomicSteadyTimePoint::Rep AtomicSteadyTimePoint::toRep(AtomicSteadyTimePoint::TimePointType tp)
+{
+    return tp.time_since_epoch().count();
+}
+
+void AtomicSteadyTimePoint::store(AtomicSteadyTimePoint::TimePointType tp)
+{
+    value.store(toRep(tp), std::memory_order_relaxed);
+}
+
+AtomicSteadyTimePoint::TimePointType AtomicSteadyTimePoint::load() const
+{
+    return fromRep(value.load(std::memory_order_relaxed));
+}
+
+QuerierBucket::QuerierBucket(const UniqueQuerier& querier, uint32_t hashFingerprint, size_t maxBurst, size_t refillRate, AtomicSteadyTimePoint::TimePointType lastQueried)
+    : primaryQuerier(querier)
+    , primaryQuerierHash(hashFingerprint)
+    , tokens(maxBurst)
+    , maxBurst(maxBurst)
+    , refillRate(refillRate)
+    , lastQueried(lastQueried)
+{
+}
 
 END_NAMESPACE_DISCOVERY_SERVICE

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -153,7 +153,7 @@ void MdnsDiscoveredService::populateRecords(std::vector<mdns_record_t>& records)
 
 static size_t toMs(const std::chrono::steady_clock::time_point& point)
 {
-    static auto baseTp = std::chrono::steady_clock::now();
+    static auto baseTp = point;
     return std::chrono::duration_cast<std::chrono::milliseconds>(point - baseTp).count();
 }
 
@@ -180,10 +180,10 @@ std::string MDNSDiscoveryServer::getHostname()
     
 MDNSDiscoveryServer::MDNSDiscoveryServer(const DictPtr<IString, IBaseObject>& options)
     : options(options)
-    , discoveryRatelimitEnabled(options.hasKey("EnableDiscoveryRateLimit") ? static_cast<bool>(options.get("EnableDiscoveryRateLimit")) : true)
-    , singleQuerierRateLimitPerSecond(options.hasKey("SingleQuerierRateLimitPerSecond") ? static_cast<size_t>(options.get("SingleQuerierRateLimitPerSecond")) : 25)
-    , maxActiveQueriers(options.hasKey("MaxActiveQueriers") ? static_cast<uint32_t>(options.get("MaxActiveQueriers")) : 150)
-    , maxQueryCountPerSecond(std::max(options.hasKey("MaxQueryCountPerSecond") ? static_cast<size_t>(options.get("MaxQueryCountPerSecond")) : 75, singleQuerierRateLimitPerSecond))
+    , discoveryRatelimitEnabled(static_cast<bool>(options.getOrDefault("EnableDiscoveryRateLimit", true)))
+    , singleQuerierRateLimitPerSecond(static_cast<size_t>(options.getOrDefault("SingleQuerierRateLimitPerSecond", 25)))
+    , maxActiveQueriers(static_cast<uint32_t>(options.getOrDefault("MaxActiveQueriers", 150)))
+    , maxQueryCountPerSecond(std::max(static_cast<size_t>(options.getOrDefault("MaxQueryCountPerSecond", 75)), singleQuerierRateLimitPerSecond))
     , querierBucketsTable(maxActiveQueriers)
 {
     fmt::print("MDNSDiscoveryServer ratelimiting ({}) params singleQuerierRateLimitPerSecond {}, maxActiveQueriers {}, maxQueryCountPerSecond {}", discoveryRatelimitEnabled, singleQuerierRateLimitPerSecond, maxActiveQueriers, maxQueryCountPerSecond);
@@ -1071,12 +1071,6 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
         // Share bucket
         fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
         fmt::print("...will share bucket with {} last queried at {}; hash {}, slot index {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex);
-        bucketSlot.emplace(
-            querier,
-            hash,
-            maxQueryCountPerSecond,
-            singleQuerierRateLimitPerSecond,
-            now);
     }
 
     refillTokens(bucket, now);
@@ -1085,7 +1079,7 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
     if (result)
     {
         //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        //fmt::print("...allowed bcs tokens available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.querier, toMs(lastQueried), bucket.hashFingerprint, bucketIndex, bucket.tokens);
+        //fmt::print("...allowed bcs tokens available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex, bucket.tokens);
     }
     else
     {

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -180,12 +180,13 @@ std::string MDNSDiscoveryServer::getHostname()
     
 MDNSDiscoveryServer::MDNSDiscoveryServer(const DictPtr<IString, IBaseObject>& options)
     : options(options)
-    , perQuerierBucketLimit(options.hasKey("RateLimitPerQuerier") ? static_cast<size_t>(options.get("RateLimitPerQuerier")) : 10)
-    , maxQueriers(options.hasKey("MaxQueriersLimit") ? static_cast<uint32_t>(options.get("MaxQueriersLimit")) : 100)
-    , maxBurst(std::max(options.hasKey("MaxBurst") ? static_cast<size_t>(options.get("MaxBurst")) : 50, perQuerierBucketLimit))
-    , querierBucketsTable(maxQueriers)
+    , discoveryRatelimitEnabled(options.hasKey("EnableDiscoveryRateLimit") ? static_cast<bool>(options.get("EnableDiscoveryRateLimit")) : true)
+    , singleQuerierRateLimitPerSecond(options.hasKey("SingleQuerierRateLimitPerSecond") ? static_cast<size_t>(options.get("SingleQuerierRateLimitPerSecond")) : 10)
+    , maxActiveQueriers(options.hasKey("MaxActiveQueriers") ? static_cast<uint32_t>(options.get("MaxActiveQueriers")) : 100)
+    , maxQueryCountPerSecond(std::max(options.hasKey("MaxQueryCountPerSecond") ? static_cast<size_t>(options.get("MaxQueryCountPerSecond")) : 50, singleQuerierRateLimitPerSecond))
+    , querierBucketsTable(maxActiveQueriers)
 {
-    fmt::print("MDNSDiscoveryServer ratelimiting params perQuerierBucketLimit {}, maxQueriers {}, maxBurst {}", perQuerierBucketLimit, maxQueriers, maxBurst);
+    fmt::print("MDNSDiscoveryServer ratelimiting ({}) params singleQuerierRateLimitPerSecond {}, maxActiveQueriers {}, maxQueryCountPerSecond {}", discoveryRatelimitEnabled, singleQuerierRateLimitPerSecond, maxActiveQueriers, maxQueryCountPerSecond);
 #ifdef _WIN32
     WORD versionWanted = MAKEWORD(1, 1);
     WSADATA wsaData;
@@ -1026,7 +1027,7 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
     const auto now = std::chrono::steady_clock::now();
 
     const uint32_t hash = xxHash32(querier);
-    const uint32_t bucketIndex = hashToIndex(hash, maxQueriers);
+    const uint32_t bucketIndex = hashToIndex(hash, maxActiveQueriers);
 
     auto lock = std::lock_guard(rateLimitingSync);
     auto& bucketSlot = querierBucketsTable[bucketIndex];
@@ -1037,8 +1038,8 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
         bucketSlot.emplace(
             querier,
             hash,
-            maxBurst,
-            perQuerierBucketLimit,
+            maxQueryCountPerSecond,
+            singleQuerierRateLimitPerSecond,
             now);
 
         //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
@@ -1060,8 +1061,8 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
             bucketSlot.emplace(
                 querier,
                 hash,
-                maxBurst,
-                perQuerierBucketLimit,
+                maxQueryCountPerSecond,
+                singleQuerierRateLimitPerSecond,
                 now);
 
             return true;
@@ -1073,8 +1074,8 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
         bucketSlot.emplace(
             querier,
             hash,
-            maxBurst,
-            perQuerierBucketLimit,
+            maxQueryCountPerSecond,
+            singleQuerierRateLimitPerSecond,
             now);
     }
 
@@ -1103,9 +1104,9 @@ void MDNSDiscoveryServer::refillTokens(QuerierBucket& bucket, std::chrono::stead
     if (elapsedSeconds == 0)
         return;
 
-    const size_t refillAmount = elapsedSeconds * perQuerierBucketLimit;
+    const size_t refillAmount = elapsedSeconds * singleQuerierRateLimitPerSecond;
     const size_t currentTokens = bucket.tokens;
-    const size_t newTokenCount = std::min(currentTokens + refillAmount, maxBurst);
+    const size_t newTokenCount = std::min(currentTokens + refillAmount, maxQueryCountPerSecond);
 
     bucket.tokens = newTokenCount;
     bucket.lastQueried = now;
@@ -1206,7 +1207,7 @@ int MDNSDiscoveryServer::discoveryCallback(
     size_t size, size_t name_offset, size_t name_length, size_t rdata_offset,
     size_t rdata_length, void* user_data)
 {
-    if (!allowQuery(sock, from))
+    if (discoveryRatelimitEnabled && !allowQuery(sock, from))
         return 0;
 
     if (entry != MDNS_ENTRYTYPE_QUESTION)

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -27,49 +27,40 @@
 #endif
 
 template <>
-struct fmt::formatter<daq::discovery_server::UniqueQuerier> : fmt::formatter<std::string_view>
+struct fmt::formatter<daq::discovery_server::UniqueQuerier>
+    : fmt::formatter<std::string_view>
 {
     template <typename FormatContext>
-    auto format(const daq::discovery_server::UniqueQuerier& q, FormatContext& ctx) const
+    auto format(const daq::discovery_server::UniqueQuerier& q,
+                FormatContext& ctx) const
     {
-        char host[NI_MAXHOST] = {};
-        char service[NI_MAXSERV] = {};
-
+        char host[INET6_ADDRSTRLEN] = {};
         std::string result;
 
         if (q.addr.ss_family == AF_INET)
         {
             const auto* addr = reinterpret_cast<const sockaddr_in*>(&q.addr);
 
-            if (getnameinfo(reinterpret_cast<const sockaddr*>(addr),
-                            sizeof(sockaddr_in),
-                            host,
-                            sizeof(host),
-                            service,
-                            sizeof(service),
-                            NI_NUMERICHOST | NI_NUMERICSERV) == 0)
-            {
-                result = fmt::format("{}:{} (sock={})", host, ntohs(addr->sin_port), q.sock);
-            }
+            inet_ntop(AF_INET, &addr->sin_addr, host, sizeof(host));
+
+            result = fmt::format("address: {}; port: {}",
+                                 host,
+                                 ntohs(addr->sin_port));
         }
         else if (q.addr.ss_family == AF_INET6)
         {
             const auto* addr = reinterpret_cast<const sockaddr_in6*>(&q.addr);
 
-            if (getnameinfo(reinterpret_cast<const sockaddr*>(addr),
-                            sizeof(sockaddr_in6),
-                            host,
-                            sizeof(host),
-                            service,
-                            sizeof(service),
-                            NI_NUMERICHOST | NI_NUMERICSERV) == 0)
-            {
-                result = fmt::format("[{}]:{} (sock={})", host, ntohs(addr->sin6_port), q.sock);
-            }
-        }
+            inet_ntop(AF_INET6, &addr->sin6_addr, host, sizeof(host));
 
-        if (result.empty())
+            result = fmt::format("address: {}; port: {}",
+                                 host,
+                                 ntohs(addr->sin6_port));
+        }
+        else
+        {
             result = "<unknown>";
+        }
 
         return fmt::formatter<std::string_view>::format(result, ctx);
     }
@@ -160,9 +151,9 @@ void MdnsDiscoveredService::populateRecords(std::vector<mdns_record_t>& records)
     }
 }
 
-static size_t toMs(const AtomicSteadyTimePoint::TimePointType& point)
+static size_t toMs(const std::chrono::steady_clock::time_point& point)
 {
-    static auto baseTp = AtomicSteadyTimePoint::Clock::now();
+    static auto baseTp = std::chrono::steady_clock::now();
     return std::chrono::duration_cast<std::chrono::milliseconds>(point - baseTp).count();
 }
 
@@ -194,6 +185,7 @@ MDNSDiscoveryServer::MDNSDiscoveryServer(const DictPtr<IString, IBaseObject>& op
     , maxBurst(std::max(options.hasKey("MaxBurst") ? static_cast<size_t>(options.get("MaxBurst")) : 50, perQuerierBucketLimit))
     , querierBucketsTable(maxQueriers)
 {
+    fmt::print("MDNSDiscoveryServer ratelimiting params perQuerierBucketLimit {}, maxQueriers {}, maxBurst {}", perQuerierBucketLimit, maxQueriers, maxBurst);
 #ifdef _WIN32
     WORD versionWanted = MAKEWORD(1, 1);
     WSADATA wsaData;
@@ -959,30 +951,36 @@ void MDNSDiscoveryServer::sendIpConfigResponse(int sock,
     non_mdns_query_send(sock, sendBuffer.data(), sendBuffer.size(), query_id, opcode, 0x1, 0, 0, txtRecords.data(), txtRecords.size(), 0, 0, 0, 0, unicast ? 0x1 : 0x0, to, addrlen, if_index);
 }
 
-static uint32_t xxHash32(const UniqueQuerier& querier)
+static uint32_t xxHash32(const UniqueQuerier& q)
 {
-    XXH32_state_t* state = XXH32_createState();
-    XXH32_reset(state, 123456789);
+    uint8_t buf[sizeof(q.addr.ss_family) + sizeof(sockaddr_in6)];
+    size_t nBytes = 0;
 
-    XXH32_update(state, &querier.sock, sizeof(querier.sock));
-    XXH32_update(state, &querier.addr.ss_family, sizeof(querier.addr.ss_family));
+    memcpy(buf + nBytes, &q.addr.ss_family, sizeof(q.addr.ss_family));
+    nBytes += sizeof(q.addr.ss_family);
 
-    if (querier.addr.ss_family == AF_INET)
+    if (q.addr.ss_family == AF_INET)
     {
-        auto* addr = reinterpret_cast<const sockaddr_in*>(&querier.addr);
-        XXH32_update(state, &addr->sin_addr, sizeof(addr->sin_addr));
-        XXH32_update(state, &addr->sin_port, sizeof(addr->sin_port));
+        auto* addr = reinterpret_cast<const sockaddr_in*>(&q.addr);
+
+        memcpy(buf + nBytes, &addr->sin_addr, sizeof(addr->sin_addr));
+        nBytes += sizeof(addr->sin_addr);
+
+        memcpy(buf + nBytes, &addr->sin_port, sizeof(addr->sin_port));
+        nBytes += sizeof(addr->sin_port);
     }
-    else if (querier.addr.ss_family == AF_INET6)
+    else if (q.addr.ss_family == AF_INET6)
     {
-        auto* addr = reinterpret_cast<const sockaddr_in6*>(&querier.addr);
-        XXH32_update(state, &addr->sin6_addr, sizeof(addr->sin6_addr));
-        XXH32_update(state, &addr->sin6_port, sizeof(addr->sin6_port));
+        auto* addr = reinterpret_cast<const sockaddr_in6*>(&q.addr);
+
+        memcpy(buf + nBytes, &addr->sin6_addr, sizeof(addr->sin6_addr));
+        nBytes += sizeof(addr->sin6_addr);
+
+        memcpy(buf + nBytes, &addr->sin6_port, sizeof(addr->sin6_port));
+        nBytes += sizeof(addr->sin6_port);
     }
 
-    uint32_t result = XXH32_digest(state);
-    XXH32_freeState(state);
-    return result;
+    return XXH32(buf, nBytes, 123456789);
 }
 
 static inline uint32_t mulHigh32(uint32_t a, uint32_t b)
@@ -1006,6 +1004,7 @@ static inline uint32_t hashToIndex(uint32_t hash, uint32_t indexLimit)
 {
     uint32_t x = hash;
 
+    // extra bit mixing before index reduction
     x ^= x >> 16;
     x *= 0x7feb352d;
     x ^= x >> 15;
@@ -1023,12 +1022,13 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
     else
         std::memcpy(&storage, from, sizeof(sockaddr_in6));
 
-    UniqueQuerier querier{storage, sock};
-    const auto now = AtomicSteadyTimePoint::Clock::now();
+    UniqueQuerier querier{storage};
+    const auto now = std::chrono::steady_clock::now();
 
     const uint32_t hash = xxHash32(querier);
-
     const uint32_t bucketIndex = hashToIndex(hash, maxQueriers);
+
+    auto lock = std::lock_guard(rateLimitingSync);
     auto& bucketSlot = querierBucketsTable[bucketIndex];
 
     // Empty slot
@@ -1042,12 +1042,12 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
             now);
 
         //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        //fmt::print("...allowed as completely new querier, tokens {}\n", bucketSlot->tokens.load(std::memory_order_relaxed));
+        //fmt::print("...allowed as completely new querier, tokens {}\n", bucketSlot->tokens);
         return true;
     }
 
     auto& bucket = *bucketSlot;
-    AtomicSteadyTimePoint::TimePointType lastQueried = bucket.lastQueried;
+    std::chrono::steady_clock::time_point lastQueried = bucket.lastQueried;
 
     // Different querier mapped to same slot
     if (!(bucket.primaryQuerierHash == hash && bucket.primaryQuerier == querier))
@@ -1084,19 +1084,19 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
     if (result)
     {
         //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        //fmt::print("...allowed bcs tokens available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.querier, toMs(lastQueried), bucket.hashFingerprint, bucketIndex, bucket.tokens.load(std::memory_order_relaxed));
+        //fmt::print("...allowed bcs tokens available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.querier, toMs(lastQueried), bucket.hashFingerprint, bucketIndex, bucket.tokens);
     }
     else
     {
         fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        fmt::print("...rejected bcs tokens are not available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex, bucket.tokens.load(std::memory_order_relaxed));
+        fmt::print("...rejected bcs tokens are not available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex, bucket.tokens);
     }
     return result;
 }
 
-void MDNSDiscoveryServer::refillTokens(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now)
+void MDNSDiscoveryServer::refillTokens(QuerierBucket& bucket, std::chrono::steady_clock::time_point now)
 {
-    const AtomicSteadyTimePoint::TimePointType lastQueried = bucket.lastQueried;
+    const std::chrono::steady_clock::time_point lastQueried = bucket.lastQueried;
     const auto elapsed = now - lastQueried;
     const auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
 
@@ -1104,30 +1104,30 @@ void MDNSDiscoveryServer::refillTokens(QuerierBucket& bucket, AtomicSteadyTimePo
         return;
 
     const size_t refillAmount = elapsedSeconds * perQuerierBucketLimit;
-    const size_t currentTokens = bucket.tokens.load(std::memory_order_relaxed);
+    const size_t currentTokens = bucket.tokens;
     const size_t newTokenCount = std::min(currentTokens + refillAmount, maxBurst);
 
-    bucket.tokens.store(newTokenCount, std::memory_order_relaxed);
+    bucket.tokens = newTokenCount;
     bucket.lastQueried = now;
 }
 
-bool MDNSDiscoveryServer::tryConsumeToken(QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now)
+bool MDNSDiscoveryServer::tryConsumeToken(QuerierBucket& bucket, std::chrono::steady_clock::time_point now)
 {
-    auto currentTokens = bucket.tokens.load(std::memory_order_relaxed);
+    auto currentTokens = bucket.tokens;
 
     if (currentTokens == 0)
         return false;
 
-    bucket.tokens.store(currentTokens - 1, std::memory_order_relaxed);
+    bucket.tokens = currentTokens - 1;
     bucket.lastQueried = now;
 
     return true;
 }
 
-bool MDNSDiscoveryServer::isStaleBucket(const QuerierBucket& bucket, AtomicSteadyTimePoint::TimePointType now) const
+bool MDNSDiscoveryServer::isStaleBucket(const QuerierBucket& bucket, std::chrono::steady_clock::time_point now) const
 {
     constexpr auto bucketTimeout = std::chrono::seconds(10);
-    AtomicSteadyTimePoint::TimePointType lastQueried = bucket.lastQueried;
+    std::chrono::steady_clock::time_point lastQueried = bucket.lastQueried;
     const auto inactiveDuration = now - lastQueried;
     return inactiveDuration > bucketTimeout;
 }
@@ -1322,9 +1322,6 @@ int MDNSDiscoveryServer::discoveryCallback(
 
 bool UniqueQuerier::operator==(const UniqueQuerier& other) const noexcept
 {
-    if (sock != other.sock)
-        return false;
-
     if (addr.ss_family != other.addr.ss_family)
         return false;
 
@@ -1349,42 +1346,7 @@ bool UniqueQuerier::operator==(const UniqueQuerier& other) const noexcept
     return false;
 }
 
-AtomicSteadyTimePoint::AtomicSteadyTimePoint(TimePointType tp)
-    : value(toRep(tp))
-{}
-
-AtomicSteadyTimePoint::operator TimePointType() const
-{
-    return fromRep(value.load(std::memory_order_relaxed));
-}
-
-AtomicSteadyTimePoint& AtomicSteadyTimePoint::operator=(TimePointType tp)
-{
-    value.store(toRep(tp), std::memory_order_relaxed);
-    return *this;
-}
-
-AtomicSteadyTimePoint::TimePointType AtomicSteadyTimePoint::fromRep(Rep v)
-{
-    return TimePointType(Clock::duration(v));
-}
-
-AtomicSteadyTimePoint::Rep AtomicSteadyTimePoint::toRep(AtomicSteadyTimePoint::TimePointType tp)
-{
-    return tp.time_since_epoch().count();
-}
-
-void AtomicSteadyTimePoint::store(AtomicSteadyTimePoint::TimePointType tp)
-{
-    value.store(toRep(tp), std::memory_order_relaxed);
-}
-
-AtomicSteadyTimePoint::TimePointType AtomicSteadyTimePoint::load() const
-{
-    return fromRep(value.load(std::memory_order_relaxed));
-}
-
-QuerierBucket::QuerierBucket(const UniqueQuerier& querier, uint32_t hashFingerprint, size_t maxBurst, size_t refillRate, AtomicSteadyTimePoint::TimePointType lastQueried)
+QuerierBucket::QuerierBucket(const UniqueQuerier& querier, uint32_t hashFingerprint, size_t maxBurst, size_t refillRate, std::chrono::steady_clock::time_point lastQueried)
     : primaryQuerier(querier)
     , primaryQuerierHash(hashFingerprint)
     , tokens(maxBurst)

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -26,46 +26,6 @@
 #include <arpa/inet.h>
 #endif
 
-template <>
-struct fmt::formatter<daq::discovery_server::UniqueQuerier>
-    : fmt::formatter<std::string_view>
-{
-    template <typename FormatContext>
-    auto format(const daq::discovery_server::UniqueQuerier& q,
-                FormatContext& ctx) const
-    {
-        char host[INET6_ADDRSTRLEN] = {};
-        std::string result;
-
-        if (q.addr.ss_family == AF_INET)
-        {
-            const auto* addr = reinterpret_cast<const sockaddr_in*>(&q.addr);
-
-            inet_ntop(AF_INET, &addr->sin_addr, host, sizeof(host));
-
-            result = fmt::format("address: {}; port: {}",
-                                 host,
-                                 ntohs(addr->sin_port));
-        }
-        else if (q.addr.ss_family == AF_INET6)
-        {
-            const auto* addr = reinterpret_cast<const sockaddr_in6*>(&q.addr);
-
-            inet_ntop(AF_INET6, &addr->sin6_addr, host, sizeof(host));
-
-            result = fmt::format("address: {}; port: {}",
-                                 host,
-                                 ntohs(addr->sin6_port));
-        }
-        else
-        {
-            result = "<unknown>";
-        }
-
-        return fmt::formatter<std::string_view>::format(result, ctx);
-    }
-};
-
 BEGIN_NAMESPACE_DISCOVERY_SERVICE
 
 MdnsDiscoveredService::MdnsDiscoveredService(const std::string& serviceName,
@@ -151,12 +111,6 @@ void MdnsDiscoveredService::populateRecords(std::vector<mdns_record_t>& records)
     }
 }
 
-static size_t toMs(const std::chrono::steady_clock::time_point& point)
-{
-    static auto baseTp = point;
-    return std::chrono::duration_cast<std::chrono::milliseconds>(point - baseTp).count();
-}
-
 std::string MDNSDiscoveryServer::getHostname() 
 {
     char hostname_buffer[256];
@@ -186,7 +140,6 @@ MDNSDiscoveryServer::MDNSDiscoveryServer(const DictPtr<IString, IBaseObject>& op
     , maxQueryCountPerSecond(std::max(static_cast<size_t>(options.getOrDefault("MaxQueryCountPerSecond", 75)), singleQuerierRateLimitPerSecond))
     , querierBucketsTable(maxActiveQueriers)
 {
-    fmt::print("MDNSDiscoveryServer ratelimiting ({}) params singleQuerierRateLimitPerSecond {}, maxActiveQueriers {}, maxQueryCountPerSecond {}", discoveryRatelimitEnabled, singleQuerierRateLimitPerSecond, maxActiveQueriers, maxQueryCountPerSecond);
 #ifdef _WIN32
     WORD versionWanted = MAKEWORD(1, 1);
     WSADATA wsaData;
@@ -1041,23 +994,16 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
             maxQueryCountPerSecond,
             singleQuerierRateLimitPerSecond,
             now);
-
-        //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        //fmt::print("...allowed as completely new querier, tokens {}\n", bucketSlot->tokens);
         return true;
     }
 
     auto& bucket = *bucketSlot;
-    std::chrono::steady_clock::time_point lastQueried = bucket.lastQueried;
-
-    // Different querier mapped to same slot
+    // Different querier mapped to same slot: replace stale bucket or share bucket
     if (!(bucket.primaryQuerierHash == hash && bucket.primaryQuerier == querier))
     {
-        // Replace stale bucket
+        // replace stale bucket
         if (isStaleBucket(bucket, now))
         {
-            fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-            fmt::print("...allowed as replacement querier for {} last queried at {}; hash {}, slot index {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex);
             bucketSlot.emplace(
                 querier,
                 hash,
@@ -1067,26 +1013,10 @@ bool MDNSDiscoveryServer::allowQuery(int sock, const sockaddr* from)
 
             return true;
         }
-
-        // Share bucket
-        fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        fmt::print("...will share bucket with {} last queried at {}; hash {}, slot index {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex);
     }
 
     refillTokens(bucket, now);
-
-    bool result = tryConsumeToken(bucket, now);
-    if (result)
-    {
-        //fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        //fmt::print("...allowed bcs tokens available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex, bucket.tokens);
-    }
-    else
-    {
-        fmt::print("Arrived query from: {} at {}; hash {}, slot index {}", querier, toMs(now), hash, bucketIndex);
-        fmt::print("...rejected bcs tokens are not available for {} last queried at {}; hash {}, slot index {}, tokens {}\n", bucket.primaryQuerier, toMs(lastQueried), bucket.primaryQuerierHash, bucketIndex, bucket.tokens);
-    }
-    return result;
+    return tryConsumeToken(bucket, now);
 }
 
 void MDNSDiscoveryServer::refillTokens(QuerierBucket& bucket, std::chrono::steady_clock::time_point now)


### PR DESCRIPTION
# Brief

Introduces a token-bucket-based rate limiting mechanism for openDAQ mDNS server to mitigate excessive incoming query traffic and reduce the impact of abusive or malfunctioning queriers. 
Improves thread safety of connected-client list retrieval by operating on a cloned nested property object instead of the original instance.

# Description

Incoming queries are grouped into fixed-capacity "querier buckets" table-like container.
Each bucket represents a unique querier identified by:
- source IP address
- source port
- address family

Each querier is mapped into a bucket table using a 32-bit xxHash-based fingerprint and a 32-bit-computation-friendly hash-to-index transformation.

Every bucket maintains:
- current token count
- maximum burst capacity
- token refill rate
- last query timestamp

For every incoming query:
1. The querier identity is hashed.
2. The hash is transformed into a bucket table index.
3. If the bucket at the index belongs to the same querier:
    * tokens are refilled according to elapsed time
    * one token is consumed
    * the query is allowed only if tokens are available
4. If the bucket belongs to another querier:
    * stale buckets may be replaced
    * otherwise the querier shares the existing bucket limits

The design allows bucket sharing under hash collisions in order to maintain predictable limited memory usage. Increasing the configured maximum number of querier buckets reduces the probability of hash collisions and therefore improves fairness of rate-limit distribution between independent queriers. 

# Usage example

The mechanism is configurable through the introduced new group of instance config provider parameters under the key `"MdnsDiscoveryServer"`:
- `"EnableDiscoveryRateLimit"` - boolean - enables or disables rate limiting - default value is `true`
- `"SingleQuerierRateLimitPerSecond"` - integer number - per-querier refill rate - tokens per second - default  value is `25`,
- `"MaxActiveQueriers"` - integer (32bit) number - maximum tracked queriers - the number of querier buckets in the table - default value is `150`,
- `"MaxQueryCountPerSecond"` - integer number - maximum burst size - allows short-term spikes of mDNS queries from a querier - default value is `75`.