### PR TITLE
Rename package files to Conan-style triplet convention

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,13 +194,13 @@ jobs:
 
           # SDK packages
           aws s3 rm "${DST_URI}/${SDK_DIR}/" --recursive --exclude '*' \
-            --include 'opendaq-*_win_*.exe' \
-            --include 'opendaq-*_win_*.zip' \
-            --include 'opendaq-*_linux_*.deb' \
-            --include 'opendaq-*_linux_*.zip' \
+            --include 'opendaq-*-windows-*.exe' \
+            --include 'opendaq-*-windows-*.zip' \
+            --include 'opendaq-*-linux-*.deb' \
+            --include 'opendaq-*-linux-*.zip' \
             --include 'opendaq-*-examples.zip'
-          for f in "${SRC}"/opendaq-*_win_*/*.exe \
-                   "${SRC}"/opendaq-*_linux_*/*.deb \
+          for f in "${SRC}"/opendaq-*-windows-*/*.exe \
+                   "${SRC}"/opendaq-*-linux-*/*.deb \
                    "${SRC}"/opendaq-*-examples*.zip; do
             aws s3 cp "$f" "${DST_URI}/${SDK_DIR}/"
           done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -198,9 +198,11 @@ jobs:
             --include 'opendaq-*-windows-*.zip' \
             --include 'opendaq-*-linux-*.deb' \
             --include 'opendaq-*-linux-*.zip' \
+            --include 'opendaq-*-macos-*.pkg' \
             --include 'opendaq-*-examples.zip'
           for f in "${SRC}"/opendaq-*-windows-*/*.exe \
                    "${SRC}"/opendaq-*-linux-*/*.deb \
+                   "${SRC}"/opendaq-*-macos-*/*.pkg \
                    "${SRC}"/opendaq-*-examples*.zip; do
             aws s3 cp "$f" "${DST_URI}/${SDK_DIR}/"
           done

--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -95,57 +95,71 @@ endif()
 ##
 ## Package filename customization
 ##
+## Format: opendaq-<version>[-<sha>]-<arch>-<os>-<compiler>-<compiler-version>-<build-type>
+## Field ordering follows GNU triplet convention (<arch>-<os>-…), values follow
+## Conan settings vocabulary (arch, os, compiler). SHA is appended to the
+## version for non-release builds to disambiguate dev/rc commits.
+##
 
-# OS name
+# OS name (Conan settings.os, lowercase)
 string(TOLOWER "${CMAKE_SYSTEM_NAME}" _PACKING_OS_NAME)
 if(_PACKING_OS_NAME STREQUAL "darwin")
     set(_PACKING_OS_NAME "macos")
-elseif(_PACKING_OS_NAME STREQUAL "windows")
-    set(_PACKING_OS_NAME "win")
 endif()
 
-# Architecture
+# Architecture (Conan settings.arch)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
-        set(_PACKING_ARCH_NAME "ARM_64")
+        set(_PACKING_ARCH_NAME "armv8")
     else()
         set(_PACKING_ARCH_NAME "x86_64")
     endif()
 else()
-    set(_PACKING_ARCH_NAME "x86_32")
-endif()
-
-# Compiler
-if(MSVC AND CMAKE_VS_VERSION_BUILD_NUMBER)
-    set(_PACKING_COMPILER_VER "${CMAKE_VS_VERSION_BUILD_NUMBER}")
-    set(_PACKING_COMPILER_ID "msvc")
-else()
-    set(_PACKING_COMPILER_VER "${CMAKE_CXX_COMPILER_VERSION}")
-    string(TOLOWER "${CMAKE_CXX_COMPILER_ID}" _PACKING_COMPILER_ID)
-    # Rename GNU to gcc
-    if(_PACKING_COMPILER_ID STREQUAL "gnu")
-        set(_PACKING_COMPILER_ID "gcc")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM")
+        set(_PACKING_ARCH_NAME "armv7")
+    else()
+        set(_PACKING_ARCH_NAME "x86")
     endif()
 endif()
 
-# Assemble version string with optional tweak (4th component)
-set(_PACKING_VERSION "${OPENDAQ_PACKAGE_VERSION}")
-string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+\\.([0-9]+)" _PACKING_TWEAK_MATCH "${package_version}")
-if(_PACKING_TWEAK_MATCH)
-    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" _PACKING_TWEAK "${package_version}")
-    string(APPEND _PACKING_VERSION ".${_PACKING_TWEAK}")
+# Compiler (Conan settings.compiler) and major version
+if(MSVC)
+    set(_PACKING_COMPILER_ID "msvc")
+    set(_PACKING_COMPILER_VER "${MSVC_TOOLSET_VERSION}")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(_PACKING_COMPILER_ID "gcc")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set(_PACKING_COMPILER_ID "apple-clang")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(_PACKING_COMPILER_ID "clang")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel" OR CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    set(_PACKING_COMPILER_ID "intel-cc")
+else()
+    string(TOLOWER "${CMAKE_CXX_COMPILER_ID}" _PACKING_COMPILER_ID)
+endif()
+if(NOT MSVC)
+    string(REGEX REPLACE "^([0-9]+).*" "\\1" _PACKING_COMPILER_VER "${CMAKE_CXX_COMPILER_VERSION}")
 endif()
 
-# Assemble filename: opendaq-VERSION[-SHA]_OS_ARCH_COMPILER
-# Add SHA only for dev versions (version ends with "dev")
-set(_PACKING_FILENAME "opendaq-${_PACKING_VERSION}")
-if(package_version MATCHES "dev$" AND OPENDAQ_WC_REVISION_HASH)
+# Build type (lowercase). Empty on multi-config generators when CMAKE_BUILD_TYPE
+# is not set at configure time; fall back to "release".
+if(CMAKE_BUILD_TYPE)
+    string(TOLOWER "${CMAKE_BUILD_TYPE}" _PACKING_BUILD_TYPE)
+else()
+    set(_PACKING_BUILD_TYPE "release")
+endif()
+
+# Version comes from opendaq_version as-is (keeps dev/rc suffix). SHA is
+# appended for non-release builds to disambiguate commits of the same version.
+set(_PACKING_VERSION "${package_version}")
+if(NOT OPENDAQ_IS_RELEASE_VERSION AND OPENDAQ_WC_REVISION_HASH)
     string(SUBSTRING "${OPENDAQ_WC_REVISION_HASH}" 0 7 _PACKING_SHORT_SHA)
-    string(APPEND _PACKING_FILENAME "-${_PACKING_SHORT_SHA}")
+    string(APPEND _PACKING_VERSION "-${_PACKING_SHORT_SHA}")
 endif()
-string(APPEND _PACKING_FILENAME "_${_PACKING_OS_NAME}_${_PACKING_ARCH_NAME}_${_PACKING_COMPILER_ID}${_PACKING_COMPILER_VER}")
 
-set(CPACK_PACKAGE_FILE_NAME "${_PACKING_FILENAME}")
+set(CPACK_PACKAGE_FILE_NAME
+    "opendaq-${_PACKING_VERSION}-${_PACKING_ARCH_NAME}-${_PACKING_OS_NAME}-${_PACKING_COMPILER_ID}-${_PACKING_COMPILER_VER}-${_PACKING_BUILD_TYPE}"
+)
 
 ##
 ## Finally ...

--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -141,17 +141,19 @@ if(NOT MSVC)
     string(REGEX REPLACE "^([0-9]+).*" "\\1" _PACKING_COMPILER_VER "${CMAKE_CXX_COMPILER_VERSION}")
 endif()
 
-# Build type (lowercase). Empty on multi-config generators when CMAKE_BUILD_TYPE
-# is not set at configure time; fall back to "release".
+# Build type (lowercase). If not set (multi-config generators) fall back to "release".
 if(CMAKE_BUILD_TYPE)
     string(TOLOWER "${CMAKE_BUILD_TYPE}" _PACKING_BUILD_TYPE)
 else()
     set(_PACKING_BUILD_TYPE "release")
 endif()
 
-# Version comes from opendaq_version as-is (keeps dev/rc suffix). SHA is
-# appended for non-release builds to disambiguate commits of the same version.
-set(_PACKING_VERSION "${package_version}")
+# Version is the clean major.minor.patch, extended with an optional 4th tweak component.
+# For non-release builds, a short SHA is appended to disambiguate commits.
+set(_PACKING_VERSION "${OPENDAQ_PACKAGE_VERSION}")
+if(package_version MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+\\.([0-9]+)")
+    string(APPEND _PACKING_VERSION ".${CMAKE_MATCH_1}")
+endif()
 if(NOT OPENDAQ_IS_RELEASE_VERSION AND OPENDAQ_WC_REVISION_HASH)
     string(SUBSTRING "${OPENDAQ_WC_REVISION_HASH}" 0 7 _PACKING_SHORT_SHA)
     string(APPEND _PACKING_VERSION "-${_PACKING_SHORT_SHA}")


### PR DESCRIPTION
# Brief

Package filename follows GNU/Conan format triplets:

```
opendaq-<version>[-<sha>]-<arch>-<os>-<compiler>-<compiler-version>-<build-type>
```

Current filenames use a custom set of platform aliases (`win`, `ARM_64`, `x86_32`) that require a lookup to decode. Aligning with Conan's settings vocabulary makes package names immediately recognizable to anyone familiar with Conan profiles.

# Description

- Field separator `_` -> `-`
- Order follows GNU triplet: arch before os
- Arch/os/compiler values follow Conan settings vocabulary:
  - `<arch>` -> armv7, armv8, x86, x86_64
  - `<os>` -> windows, linux, macos
  - `<compiler>` -> msvc, gcc, clang, apple-clang, intel-cc
  - `<compiler-version>` -> major part of compiler version, or toolset version for msvc
  - `<build-type>` -> debug, release
- `<sha>` is appended for non-release builds to disambiguate commits of the same base version
- S3 upload globs in `deploy.yml` updated to match the new os field naming

# Examples

```
opendaq-3.40.0-x86_64-linux-gcc-14-release.deb
opendaq-3.40.0-x86_64-windows-msvc-143-release.exe
opendaq-3.31.0dev-abc1234-armv8-macos-apple-clang-21-release.pkg
```
