### PR TITLE
Reduce amount of calling begin/end update while save load

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -20,7 +20,7 @@
 - [#1137](https://github.com/openDAQ/openDAQ/pull/1137) Add `IInputPort::acceptsSignals` to check multiple signals at once, using a single RPC call via native protocol.
 - [#1157](https://github.com/openDAQ/openDAQ/pull/1157) Devices default to `OperationModeType::SafeOperation` when added to folder or set as root. Add virtual method to make it customizable.
 - [#1153](https://github.com/openDAQ/openDAQ/pull/1153) Enable and disable discovery for openDAQ Server via native.
-
+- [#1178](https://github.com/openDAQ/openDAQ/pull/1178) Calling begin/end update only on the root component while save/load
 ## Python
 
 - [#980](https://github.com/openDAQ/openDAQ/pull/980) Update add device with configuration dialog in Python GUI demo app.

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -456,8 +456,8 @@ private:
                                    const SerializedObjectPtr& serialized,
                                    const ListPtr<IProperty>& props);
 
-    ErrCode beginUpdateInternal(bool deep);
-    ErrCode endUpdateInternal(bool deep);
+                                   ErrCode beginUpdateInternal(bool deep);
+                                   ErrCode endUpdateInternal(bool deep);
     ErrCode getUpdatingInternal(Bool* updating);
 
     static bool hasUserReadAccess(const BaseObjectPtr& userContext, const BaseObjectPtr& obj);
@@ -3675,9 +3675,6 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::updateObject
     if (serialized.hasKey("propValues"))
         serializedProps = serialized.readSerializedObject("propValues");
 
-    beginUpdate();
-    Finally finally([this]() { endUpdate(); });
-
     for (const auto& prop : props)
     {
         const auto propName = prop.getName();
@@ -3753,7 +3750,22 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::updateIntern
 template <class PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::update(ISerializedObject* obj, IBaseObject* /* config */)
 {
-    return updateInternal(obj, nullptr);
+    if (frozen)
+        return OPENDAQ_IGNORED;
+
+    OPENDAQ_RETURN_IF_FAILED(beginUpdate());
+
+    const ErrCode errCode = updateInternal(obj, nullptr);
+
+    const ErrCode endUpdateErrCode = endUpdate();
+    if (OPENDAQ_FAILED(endUpdateErrCode))
+    {
+        if (OPENDAQ_FAILED(errCode))
+            daqClearErrorInfo();
+        else
+            OPENDAQ_RETURN_IF_FAILED(endUpdateErrCode);
+    }
+    return errCode;
 }
 
 template <typename PropObjInterface, typename... Interfaces>

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -3619,7 +3619,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyF
             if (const auto updatable = obj.asPtrOrNull<IUpdatable>(true); updatable.assigned())
             {
                 const auto serializedNestedObj = serialized.readSerializedObject(propName);
-                return updatable->update(serializedNestedObj, typeManager);
+                return updatable->updateInternal(serializedNestedObj, typeManager);
             }
 
             propValue = serialized.readObject(propName, typeManager);

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -456,8 +456,8 @@ private:
                                    const SerializedObjectPtr& serialized,
                                    const ListPtr<IProperty>& props);
 
-                                   ErrCode beginUpdateInternal(bool deep);
-                                   ErrCode endUpdateInternal(bool deep);
+    ErrCode beginUpdateInternal(bool deep);
+    ErrCode endUpdateInternal(bool deep);
     ErrCode getUpdatingInternal(Bool* updating);
 
     static bool hasUserReadAccess(const BaseObjectPtr& userContext, const BaseObjectPtr& obj);


### PR DESCRIPTION
# Brief

Previously while save load each component was calling recursive method begin/end update. The PR moved calling this methods to the IUpdatable::update, which means that only root component is calling this method 

# API changes

None

# Required application changes

None

# Required module changes

None
