### PR TITLE
Reduce component config size

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -20,6 +20,7 @@
 - [#1137](https://github.com/openDAQ/openDAQ/pull/1137) Add `IInputPort::acceptsSignals` to check multiple signals at once, using a single RPC call via native protocol.
 - [#1157](https://github.com/openDAQ/openDAQ/pull/1157) Devices default to `OperationModeType::SafeOperation` when added to folder or set as root. Add virtual method to make it customizable.
 - [#1153](https://github.com/openDAQ/openDAQ/pull/1153) Enable and disable discovery for openDAQ Server via native.
+- [#1179](https://github.com/openDAQ/openDAQ/pull/1179) Reduce component config size
 
 ## Python
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -53,7 +53,6 @@
 #include <coreobjects/mutex_factory.h>
 #include <coreobjects/mutex_impl.h>
 #include <coreobjects/property_object_utils.h>
-#include <iostream>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -1102,6 +1101,12 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             return OPENDAQ_SUCCESS;
         }
 
+        StringPtr subName;
+        if (isChildProp)
+        {
+            splitOnFirstDot(propName, propName, subName);
+        }
+
         PropertyPtr prop = getUnboundProperty(propName);
         prop = checkForRefPropAndGetBoundProp(prop, objPtr);
 
@@ -1109,11 +1114,9 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOTFOUND, fmt::format(R"(Property "{}" not found.)", propName));
 
         propName = prop.getName();
+
         if (isChildProp)
         {
-            StringPtr subName;
-            splitOnFirstDot(propName, propName, subName);
-
             BaseObjectPtr childProp;
             const ErrCode err = getPropertyValueInternal(propName, &childProp);
             OPENDAQ_RETURN_IF_FAILED(err);
@@ -3387,14 +3390,7 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::DeserializeProp
     for (const auto& key : keys)
     {
         const auto propValue = propValues.readObject(key, context, factoryCallback);
-        if (propObjPtr.hasProperty(key))
-        {
-            protectedPropObjPtr.setProtectedPropertyValue(key, propValue);
-        }
-        else
-        {
-            std::cout << "Property " << key << " not found" << std::endl;
-        }
+        protectedPropObjPtr.setProtectedPropertyValue(key, propValue);
     }
 }
 

--- a/core/coreobjects/include/coreobjects/property_object_impl.h
+++ b/core/coreobjects/include/coreobjects/property_object_impl.h
@@ -53,6 +53,7 @@
 #include <coreobjects/mutex_factory.h>
 #include <coreobjects/mutex_impl.h>
 #include <coreobjects/property_object_utils.h>
+#include <iostream>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -931,7 +932,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkContain
     auto coreType = value.getCoreType();
     if (coreType == ctObject)
     {
-        auto inspect = value.asPtrOrNull<IInspectable>();
+        auto inspect = value.asPtrOrNull<IInspectable>(true);
         if (inspect.assigned() && !inspect.getInterfaceIds().empty())
         {
             return inspect.getInterfaceIds()[0] == IPropertyObject::Id;
@@ -960,18 +961,18 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkContain
         IterablePtr<IBaseObject> it;
         dict->getKeys(&it);
         if (!iterate(it, keyType))
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, "Invalid dictionary key type");
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, fmt::format(R"(Invalid dictionary key type for property "{}")", prop.getName()));
 
         dict->getValues(&it);
         if (!iterate(it, itemType))
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, "Invalid dictionary item type");
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, fmt::format(R"(Invalid dictionary item type for property "{}")", prop.getName()));
     } 
     else if (coreType == ctList)
     {
         const auto itemType = propInternal.getItemTypeNoLock();
 
         if (itemType != ctUndefined && !iterate(value, itemType))
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, "Invalid list item type");
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, fmt::format(R"(Invalid list item type for property "{}")", prop.getName()));
     }
 
     return OPENDAQ_SUCCESS;
@@ -985,13 +986,13 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkStructT
 
     auto structPtr = value.asPtrOrNull<IStruct>();
     if (!structPtr.assigned())
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Set value is not a struct");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, fmt::format(R"(Set value is not a struct for property "{}")", prop.getName()));
 
     StructTypePtr structType = prop.asPtr<IPropertyInternal>().getStructTypeNoLock();
     StructTypePtr valueStructType = structPtr.getStructType();
 
     if (structType != valueStructType)
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Set value StructureType is different from the default.");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, fmt::format(R"(Set value StructureType is different from the default for property "{}")", prop.getName()));
 
     return OPENDAQ_SUCCESS;
 }
@@ -1006,17 +1007,17 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkEnumera
 
     auto enumerationPtr = value.asPtrOrNull<IEnumeration>();
     if (!enumerationPtr.assigned())
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Set value is not an enumeration");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, fmt::format(R"(Set value is not an enumeration for property "{}")", prop.getName()));
 
     auto propEnumerationPtr = propInternal.getDefaultValueNoLock().asPtrOrNull<IEnumeration>();
     if (!propEnumerationPtr.assigned())
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Property default value is not an enumeration");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, fmt::format(R"(Property default value is not an enumeration for property "{}")", prop.getName()));
 
     EnumerationTypePtr valueEnumerationType = enumerationPtr.getEnumerationType();
     EnumerationTypePtr propEnumerationType = propEnumerationPtr.getEnumerationType();
 
     if (propEnumerationType != valueEnumerationType)
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Set value EnumerationType is different from the default.");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, fmt::format(R"(Set value EnumerationType is different from the default for property "{}")", prop.getName()));
 
     return OPENDAQ_SUCCESS;
 }
@@ -1068,7 +1069,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkSelecti
             if (const auto dict = selectionValues.asPtrOrNull<IDict>(true); dict.assigned() && dict.hasKey(value))
                 return OPENDAQ_SUCCESS;
         }
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOTFOUND, "Value is not a key/index of selection values.");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOTFOUND, fmt::format(R"(Value is not a key/index of selection values for property "{}")", prop.getName()));
     }
 
     return OPENDAQ_SUCCESS;
@@ -1088,12 +1089,11 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
     if (frozen)
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_FROZEN);
 
+    auto propName = StringPtr::Borrow(name);
+    auto valuePtr = BaseObjectPtr::Borrow(value);
+
     const ErrCode errCode = daqTry([&]()
     {
-        auto propName = StringPtr::Borrow(name);
-        auto valuePtr = BaseObjectPtr::Borrow(value);
-        
-        StringPtr subName;
         const auto isChildProp = isChildProperty(propName);
 
         if (batch && !isChildProp)
@@ -1102,22 +1102,18 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
             return OPENDAQ_SUCCESS;
         }
 
-        if (isChildProp)
-        {
-            splitOnFirstDot(propName, propName, subName);
-        }
-
         PropertyPtr prop = getUnboundProperty(propName);
         prop = checkForRefPropAndGetBoundProp(prop, objPtr);
 
         if (!prop.assigned())
-        {
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOTFOUND, fmt::format(R"(Property "{}" not found.)", propName));
-        }
 
         propName = prop.getName();
         if (isChildProp)
         {
+            StringPtr subName;
+            splitOnFirstDot(propName, propName, subName);
+
             BaseObjectPtr childProp;
             const ErrCode err = getPropertyValueInternal(propName, &childProp);
             OPENDAQ_RETURN_IF_FAILED(err);
@@ -1142,7 +1138,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
         {
             if (propInternal.getReadOnlyNoLock() || propInternal.getValueTypeNoLock() == ctObject)
             {
-                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ACCESSDENIED);
+                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ACCESSDENIED, fmt::format(R"(Property "{}" is read only)", propName));
             }
         }
 
@@ -1197,7 +1193,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::setPropertyV
         return OPENDAQ_SUCCESS;
     });
 
-    OPENDAQ_RETURN_IF_FAILED(errCode, "Failed to set property value");
+    OPENDAQ_RETURN_IF_FAILED(errCode, fmt::format(R"(Failed to set property value "{}")", propName));
     return errCode;
 }
 
@@ -1236,7 +1232,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::checkPropert
         return OPENDAQ_SUCCESS;
     });
 
-    OPENDAQ_RETURN_IF_FAILED(errCode, "Value type is different than Property type and conversion failed");
+    OPENDAQ_RETURN_IF_FAILED(errCode, fmt::format(R"(Value type is different than Property type and conversion failed for property "{}")", prop.getName()));
     return errCode;
 }
 
@@ -1461,13 +1457,13 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::readLocalVal
         {
             if (it->second.getCoreType() != ctList)
             {
-                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDPARAMETER, "Could not access the index as the value is not a list.");
+                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDPARAMETER, fmt::format(R"(Could not access the index as the value is not a list for property "{}")", name));
             }
 
             ListPtr<IBaseObject> list = it->second;
             if (info.index >= (int) list.getCount())
             {
-                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_OUTOFRANGE, "The index parameter is out of bounds of the list.");
+                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_OUTOFRANGE, fmt::format(R"(The index parameter is out of bounds of the list for property "{}")", name));
             }
             value = list[std::size_t(info.index)];
         }
@@ -1620,7 +1616,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyA
             ListPtr<IBaseObject> list = value;
             if (index >= static_cast<int>(list.getCount()))
             {
-                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_OUTOFRANGE, "The index parameter is out of bounds of the list.");
+                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_OUTOFRANGE, fmt::format(R"(The index parameter is out of bounds of the list for property "{}")", propName));
             }
             value = list[std::size_t(index)];
         }
@@ -2061,7 +2057,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::clearPropert
         {
             if (propInternal.getReadOnlyNoLock() && !isChildProp)
             {
-                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ACCESSDENIED);
+                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ACCESSDENIED, fmt::format(R"(Property "{}" is read only)", propName));
             }
         }
 
@@ -2177,9 +2173,10 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
     OPENDAQ_PARAM_NOT_NULL(propertyName);
     OPENDAQ_PARAM_NOT_NULL(value);
 
+    const auto propName = StringPtr::Borrow(propertyName);
+
     const ErrCode errCode = daqTry([&]()
     {
-        const auto propName = StringPtr::Borrow(propertyName);
         BaseObjectPtr valuePtr;
         PropertyPtr prop;
 
@@ -2220,7 +2217,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
         else if (propType == PropertyType::Selection)
         {
             if (propInternal.getValueTypeNoLock() != valuePtr.getCoreType())
-                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, "Selection item type mismatch");
+                return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, fmt::format(R"(Selection item type mismatch for property "{}")", propName));
 
             *value = valuePtr.detach();
             return OPENDAQ_SUCCESS;
@@ -2232,12 +2229,12 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getPropertyS
         }
 
         if (propInternal.getItemTypeNoLock() != valuePtr.getCoreType())
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, "List item type mismatch");
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDTYPE, fmt::format(R"(List item type mismatch for property "{}")", propName));
 
         *value = valuePtr.detach();
         return OPENDAQ_SUCCESS;
     });
-    OPENDAQ_RETURN_IF_FAILED(errCode, "Failed to get property selection value");
+    OPENDAQ_RETURN_IF_FAILED(errCode, fmt::format(R"(Failed to get property selection value for property "{}")", propName));
     return errCode;
 }
 
@@ -2270,10 +2267,9 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getProperty(
             prop = prop.asPtr<IPropertyInternal>().cloneWithOwner(objPtr);
         }
 
-        auto freezable = prop.template asPtrOrNull<IFreezable>();
-        if (freezable.assigned())
+        if (const auto freezable = prop.template asPtrOrNull<IFreezable>(true); freezable.assigned())
         {
-            freezable.freeze();
+            OPENDAQ_RETURN_IF_FAILED(freezable->freeze());
         }
 
         *property = prop.detach();
@@ -2295,17 +2291,17 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::addProperty(
         const PropertyPtr propPtr = property;
         StringPtr propName = propPtr.getName();
         if (!propName.assigned())
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDVALUE, "Property does not have an assigned name.");
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDVALUE, fmt::format(R"(Property "{}" does not have an assigned name.)", propName));
 
         if (hasDuplicateReferences(propPtr, objPtr))
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDVALUE,
-                                       "Reference property references a property that is already referenced by another.");
+                                       fmt::format(R"(Reference property "{}" references a property that is already referenced by another.)", propName));
 
         propPtr.asPtr<IOwnable>().setOwner(objPtr);
 
         const auto res = localProperties.insert(std::make_pair(propName, propPtr));
         if (!res.second)
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ALREADYEXISTS, fmt::format(R"(Property with name {} already exists.)", propName));
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_ALREADYEXISTS, fmt::format(R"(Property "{}" already exists.)", propName));
 
         auto readEvent = propPtr.asPtr<IPropertyInternal>().getClassOnPropertyValueRead();
         if (readEvent.getListenerCount())
@@ -2543,7 +2539,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getOnPropert
 
     PropertyInternalPtr prop = getUnboundProperty(name);
     if (prop.getReferencedPropertyUnresolved().assigned())
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALID_OPERATION, "getOnPropertyValueWrite is not allowed for the reference properties");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALID_OPERATION, fmt::format(R"(getOnPropertyValueWrite is not allowed for the reference properties "{}")", name));
 
     auto [it, _] = valueWriteEvents.try_emplace(name);
     *event = it->second.addRefAndReturn();
@@ -2584,7 +2580,7 @@ ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::getOnPropert
 
     PropertyInternalPtr prop = getUnboundProperty(name);
     if (prop.getReferencedPropertyUnresolved().assigned())
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALID_OPERATION, "getOnPropertyValueRead is not allowed for the reference properties");
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALID_OPERATION, fmt::format(R"(getOnPropertyValueRead is not allowed for the reference properties "{}")", name));
 
     auto [it, _] = valueReadEvents.try_emplace(name);
     *event = it->second.addRefAndReturn();
@@ -2679,7 +2675,7 @@ template <typename PropObjInterface, typename... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::endUpdateInternal(bool deep)
 {
     if (updateCount == 0)
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE);
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "The object is not in updating state");
 
     const auto newUpdateCount = --updateCount;
 
@@ -3148,32 +3144,30 @@ template <class PropObjInterface, class... Interfaces>
 ErrCode GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::serializePropertyValue(const StringPtr& name,
                                                                                            const ObjectPtr<IBaseObject>& value,
                                                                                            ISerializer* serializer,
-                                                                                           bool /*forUpdate*/)
+                                                                                           bool forUpdate)
 {
     if (value.assigned())
     {
-        ISerializable* serializableValue;
-        ErrCode errCode = value->borrowInterface(ISerializable::Id, reinterpret_cast<void**>(&serializableValue));
-        if (OPENDAQ_FAILED(errCode))
+        if (forUpdate)
         {
-            if (errCode == OPENDAQ_ERR_NOINTERFACE)
+            if (const auto updatable = value.asPtrOrNull<IUpdatable>(true); updatable.assigned())
+            {
+                OPENDAQ_RETURN_IF_FAILED(serializer->keyStr(name));
+                OPENDAQ_RETURN_IF_FAILED(updatable->serializeForUpdate(serializer));
                 return OPENDAQ_SUCCESS;
-            return DAQ_EXTEND_ERROR_INFO(errCode);
+            }
         }
 
-        errCode = serializer->keyStr(name);
-        OPENDAQ_RETURN_IF_FAILED(errCode);
-
-        errCode = serializableValue->serialize(serializer);
-        OPENDAQ_RETURN_IF_FAILED(errCode);
+        if (const auto serializable = value.asPtrOrNull<ISerializable>(true); serializable.assigned())
+        {
+            OPENDAQ_RETURN_IF_FAILED(serializer->keyStr(name));
+            OPENDAQ_RETURN_IF_FAILED(serializable->serialize(serializer));
+        }
     }
     else
     {
-        ErrCode errCode = serializer->keyStr(name);
-        OPENDAQ_RETURN_IF_FAILED(errCode);
-
-        errCode = serializer->writeNull();
-        OPENDAQ_RETURN_IF_FAILED(errCode);
+        OPENDAQ_RETURN_IF_FAILED(serializer->keyStr(name));
+        OPENDAQ_RETURN_IF_FAILED(serializer->writeNull());
     }
 
     return OPENDAQ_SUCCESS;
@@ -3393,7 +3387,14 @@ void GenericPropertyObjectImpl<PropObjInterface, Interfaces...>::DeserializeProp
     for (const auto& key : keys)
     {
         const auto propValue = propValues.readObject(key, context, factoryCallback);
-        protectedPropObjPtr.setProtectedPropertyValue(key, propValue);
+        if (propObjPtr.hasProperty(key))
+        {
+            protectedPropObjPtr.setProtectedPropertyValue(key, propValue);
+        }
+        else
+        {
+            std::cout << "Property " << key << " not found" << std::endl;
+        }
     }
 }
 

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -1262,7 +1262,8 @@ void ComponentImpl<Intf, Intfs...>::serializeCustomObjectValues(const Serializer
         tags.serialize(serializer);
     }
 
-    if(!forUpdate) {
+    if (!forUpdate)
+    {
         if (statusContainer.getStatuses().getCount() > 0)
         {
             serializer.key("statuses");
@@ -1273,7 +1274,10 @@ void ComponentImpl<Intf, Intfs...>::serializeCustomObjectValues(const Serializer
     if (componentConfig.assigned())
     {
         serializer.key("ComponentConfig");
-        componentConfig.serialize(serializer);
+        if (forUpdate)
+            componentConfig.template asPtr<IUpdatable>(true).serializeForUpdate(serializer);
+        else
+            componentConfig.serialize(serializer);
     }
 }
 

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -2119,14 +2119,15 @@ void GenericDevice<TInterface, Interfaces...>::updateDevice(const std::string& d
             }
         }
         
-        PropertyObjectPtr deviceConfig;
-        DeviceInfoPtr discoveredDeviceInfo;
-
+        PropertyObjectPtr deviceConfig = onCreateDefaultAddDeviceConfig();
+        const auto updatetableDeviceConfig = deviceConfig.template asPtr<IUpdatable>(true);
+        
         if (serializedDevice.hasKey("deviceConfig"))
-            deviceConfig = serializedDevice.readObject("deviceConfig");
+            updatetableDeviceConfig.updateInternal(serializedDevice.readObject("deviceConfig"), context);
         else if (serializedDevice.hasKey("ComponentConfig"))
-            deviceConfig = serializedDevice.readObject("ComponentConfig");
-                
+            updatetableDeviceConfig.updateInternal(serializedDevice.readObject("ComponentConfig"), context);
+
+        DeviceInfoPtr discoveredDeviceInfo;
         StringPtr manufacturer;
         StringPtr serialNumber;
         StringPtr connectionString;

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -2123,9 +2123,9 @@ void GenericDevice<TInterface, Interfaces...>::updateDevice(const std::string& d
         const auto updatetableDeviceConfig = deviceConfig.template asPtr<IUpdatable>(true);
         
         if (serializedDevice.hasKey("deviceConfig"))
-            updatetableDeviceConfig.updateInternal(serializedDevice.readObject("deviceConfig"), context);
+            updatetableDeviceConfig.updateInternal(serializedDevice.readSerializedObject("deviceConfig"), context);
         else if (serializedDevice.hasKey("ComponentConfig"))
-            updatetableDeviceConfig.updateInternal(serializedDevice.readObject("ComponentConfig"), context);
+            updatetableDeviceConfig.updateInternal(serializedDevice.readSerializedObject("ComponentConfig"), context);
 
         DeviceInfoPtr discoveredDeviceInfo;
         StringPtr manufacturer;

--- a/core/opendaq/signal/include/opendaq/signal_container_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_container_impl.h
@@ -840,18 +840,20 @@ void GenericSignalContainerImpl<Intf, Intfs...>::updateFunctionBlock(const std::
         return;
     }
 
-    PropertyObjectPtr config;
+    PropertyObjectPtr functionConfig = availableTypes.get(typeId).createDefaultConfig();
+
     if (serializedFunctionBlock.hasKey("ComponentConfig"))
-        config = serializedFunctionBlock.readObject("ComponentConfig");
-    else
-        config = PropertyObject();
+    {
+        const auto updatetableFunctionConfig = functionConfig.template asPtr<IUpdatable>(true);
+        updatetableFunctionConfig.updateInternal(serializedFunctionBlock.readObject("ComponentConfig"), context);
+    }
 
-    if (!config.hasProperty("LocalId"))
-        config.addProperty(StringProperty("LocalId", fbId));
+    if (!functionConfig.hasProperty("LocalId"))
+        functionConfig.addProperty(StringProperty("LocalId", fbId));
     else
-        config.setPropertyValue("LocalId", fbId);
+        functionConfig.setPropertyValue("LocalId", fbId);
 
-    auto fb = onAddFunctionBlock(typeId, config);
+    auto fb = onAddFunctionBlock(typeId, functionConfig);
 
     const UpdatablePtr updatableFb = fb.template asPtr<IUpdatable>(true);
     updatableFb.updateInternal(serializedFunctionBlock, context);    

--- a/core/opendaq/signal/include/opendaq/signal_container_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_container_impl.h
@@ -845,7 +845,7 @@ void GenericSignalContainerImpl<Intf, Intfs...>::updateFunctionBlock(const std::
     if (serializedFunctionBlock.hasKey("ComponentConfig"))
     {
         const auto updatetableFunctionConfig = functionConfig.template asPtr<IUpdatable>(true);
-        updatetableFunctionConfig.updateInternal(serializedFunctionBlock.readObject("ComponentConfig"), context);
+        updatetableFunctionConfig.updateInternal(serializedFunctionBlock.readSerializedObject("ComponentConfig"), context);
     }
 
     if (!functionConfig.hasProperty("LocalId"))

--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -3320,7 +3320,7 @@ TEST_F(NativeDeviceModulesTest, SaveLoadDeviceConfig)
         addRefDeviceModule(client);
 
         auto deviceConfig = client.createDefaultAddDeviceConfig();
-        deviceConfig.addProperty(StringProperty("TestKey", "TestValue"));
+        deviceConfig.setPropertyValue("Device.daqref.NumberOfChannels", 1);
         client.getDevices()[0].addDevice("daqref://device1", deviceConfig);
         config = client.saveConfiguration();
     }
@@ -3335,9 +3335,7 @@ TEST_F(NativeDeviceModulesTest, SaveLoadDeviceConfig)
     ASSERT_EQ(devices.getCount(), 1u);
 
     auto deviceConfig = devices[0].asPtr<IComponentPrivate>(true).getComponentConfig();
-    ASSERT_TRUE(deviceConfig.assigned());
-    ASSERT_TRUE(deviceConfig.hasProperty("TestKey"));
-    ASSERT_EQ(deviceConfig.getPropertyValue("TestKey"), "TestValue");
+    ASSERT_EQ(deviceConfig.getPropertyValue("Device.daqref.NumberOfChannels"), 1);
 }
 
 TEST_F(NativeDeviceModulesTest, SaveLoadFunctionBlockConfig)
@@ -3349,7 +3347,8 @@ TEST_F(NativeDeviceModulesTest, SaveLoadFunctionBlockConfig)
         auto clientRoot = client.getDevices()[0];
 
         auto fbConfig = PropertyObject();
-        fbConfig.addProperty(BoolProperty("UseMultiThreadedScheduler", false));
+        fbConfig.addProperty(BoolProperty("UseMultiThreadedScheduler", true));
+        fbConfig.setPropertyValue("UseMultiThreadedScheduler", false);
 
         auto fb = clientRoot.addFunctionBlock("RefFBModuleStatistics", fbConfig);
         config = client.saveConfiguration();


### PR DESCRIPTION
# Brief

Reduce component config size



# Description

This change optimizes component configuration serialization by using update-specific serialization paths instead of full serialization where possible.
- Property objects now call serializeForUpdate for nested property objects, avoiding full serialization of unchanged nested configuration data.
- Components also use serializeForUpdate when serializing component configuration for updates. During loading, the component is initialised with its default configuration first, and then the serialized update configuration is applied on top of it.

This reduces the size of serialized configuration payloads while preserving the ability to restore the intended component state through default initialization followed by configuration update.


# Usage example

the same tree was serialised before and after applying optimisation:
- before 761 kb
- after 69 kb

# API changes

None

# Required application changes

None

# Required module changes

None
