### PR TITLE
Python gui/UI refactoring/signals preview

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -208,14 +208,14 @@ class App(tk.Tk):
         except Exception as e:
             print("Callback processing error:", e)
 
+        if self.context.needs_refresh:
+            self.on_refresh_event(None)
+            self.context.needs_refresh = False
+
         try:
             self.context.instance.context.scheduler.run_main_loop_iteration()
         except Exception as e:
             print("Scheduler processing error:", e)
-
-        if self.context.needs_refresh:
-            self.on_refresh_event(None)
-            self.context.needs_refresh = False
 
         # Re-schedule after 50 ms
         self.after(50, self.poll_opendaq_events)

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -109,6 +109,7 @@ class App(tk.Tk):
             self.context.connection_string = None
 
         self.modules_map = {}
+        self._indicator_click = False
 
         self.title('openDAQ demo')
         self.geometry('{}x{}'.format(
@@ -272,6 +273,7 @@ class App(tk.Tk):
         tree.bind('<ButtonRelease-3>', self.handle_tree_right_button_release)
         tree.bind('<Button-3>', self.handle_tree_right_button)
         tree.bind('<Button-1>', self.handle_tree_click)
+        tree.bind('<Double-1>', self._block_indicator_double_click)
 
         # add a scrollbar
         scroll_bar = ttk.Scrollbar(
@@ -630,16 +632,22 @@ class App(tk.Tk):
         else:
             event.widget.selection_set()
             
+    def _block_indicator_double_click(self, event):
+        if self.tree.identify_element(event.x, event.y) == 'indicator':
+            return 'break'
+
     def handle_tree_click(self, event):
         iid = self.tree.identify_row(event.y)
         element = self.tree.identify_element(event.x, event.y)
 
         if element == 'indicator':
-            return
+            if iid:
+                self.tree.item(iid, open=not self.tree.item(iid, 'open'))
+            return 'break'
 
         if iid and iid == utils.treeview_get_first_selection(self.tree):
             self.tree.item(iid, open=not self.tree.item(iid, 'open'))
-            return 'break'  # prevent <<TreeviewSelect>> from refiring unnecessarily
+            return 'break'
 
     def create_property_object_menu(self, node):
         popup = tk.Menu(self.tree, tearoff=0)
@@ -932,7 +940,6 @@ class App(tk.Tk):
     # MARK: - Tree view handlers
 
     def handle_tree_select(self, event):
-
         selected_iid = utils.treeview_get_first_selection(self.tree)
         if selected_iid is None:
             self.context.selected_node = None

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -656,7 +656,11 @@ class App(tk.Tk):
     def create_function_block_menu(self, node):
         popup = self.create_property_object_menu(node)
 
-        if node.available_function_block_types:
+        try:
+            has_fb_types = bool(node.available_function_block_types)
+        except RuntimeError:
+            has_fb_types = False
+        if has_fb_types:
             popup.add_command(
                 label='Add Function block',
                 command=lambda: self.add_function_block_dialog_show(node)
@@ -675,12 +679,15 @@ class App(tk.Tk):
         popup.add_command(label='Lock', command=self.handle_lock)
         popup.add_command(label='Unlock', command=self.handle_unlock)
 
-        if node.available_function_block_types:
+        try:
+            has_fb_types = bool(node.available_function_block_types)
+        except RuntimeError:
+            has_fb_types = False
+        if has_fb_types:
             popup.add_command(
                 label='Add Function block',
                 command=lambda: self.add_function_block_dialog_show(node)
             )
-
 
         if node.global_id != self.context.instance.global_id:
             popup.add_command(

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -96,6 +96,7 @@ class BlockView(ttk.Frame):
                 self.output_signals.pack(fill=tk.X)
                     
                 self.label_icon.config(image=self.device_img)
+                
                 self.cols = [0, 1]
                 self.rows = [0]
 
@@ -151,6 +152,7 @@ class BlockView(ttk.Frame):
                     op_mode_menu.add_command(label=mode, command=make_select(mode))
 
                 self._bind_mousewheel_recursive(self.right_stack)
+                self._attach_signal_preview()
             
             elif daq.IFunctionBlock.can_cast_from(self.node):
                 self._create_right_stack()
@@ -174,24 +176,12 @@ class BlockView(ttk.Frame):
                     self.recoder.pack(fill=tk.X)
                 
                 self.label_icon.config(image=self.function_block_img)
-                
-                self._signal_preview = None
-                if daq.IChannel.can_cast_from(self.node):
-                    self._signal_preview = SignalPreviewPanel(
-                        self._right_container, self.node, self.context)
-                    self._signal_preview.place(
-                        relx=0, rely=1.0, relwidth=1.0,
-                        anchor='sw')
-                    
-                self.cols = [0, 1]
-                self.rows = [0]
-                
-                self._bind_mousewheel_recursive(self.right_stack)
 
                 self.cols = [0, 1]
                 self.rows = [0]
                 
                 self._bind_mousewheel_recursive(self.right_stack)
+                self._attach_signal_preview()
                 
             elif daq.IFolder.can_cast_from(self.node):
                 self.node = daq.IFolder.cast_from(self.node)
@@ -225,6 +215,7 @@ class BlockView(ttk.Frame):
                 self.rows = [0]
 
                 self._bind_mousewheel_recursive(self.right_stack)
+                self._attach_signal_preview()
             elif daq.IComponent.can_cast_from(self.node):
                 self.node = daq.IComponent.cast_from(self.node)
                 self.properties = PropertiesView(
@@ -310,6 +301,12 @@ class BlockView(ttk.Frame):
         widget.bind('<MouseWheel>', self._on_right_mousewheel)
         for child in widget.winfo_children():
             self._bind_mousewheel_recursive(child)
+
+    def _attach_signal_preview(self):
+        self._signal_preview = SignalPreviewPanel(
+            self._right_container, self.node, self.context)
+        self._signal_preview.place(
+            relx=0, rely=1.0, relwidth=1.0, anchor='sw')
 
     def _on_destroy(self, event):
         if hasattr(self, '_signal_refresh_job') and self._signal_refresh_job is not None:
@@ -452,13 +449,6 @@ class BlockView(ttk.Frame):
         if parent_active is not None:
             self.checkbox.config(state=tk.NORMAL if parent_active else tk.DISABLED)
 
-    def handle_active_toggle(self):
-        if daq.IComponent.can_cast_from(self.node):
-            ctx = daq.IComponent.cast_from(self.node)
-            ctx.active = not ctx.active
-            self.active_var.set(ctx.active)
-            self.event_port.emit()
-    
     def handle_active_toggle(self):
         if daq.IComponent.can_cast_from(self.node):
             ctx = daq.IComponent.cast_from(self.node)

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -11,6 +11,7 @@ from .output_signals_view import OutputSignalsView
 from .properties_view import PropertiesView
 from .recorder_view import RecorderView
 from .attributes_dialog import AttributesDialog
+from .signal_preview_panel import SignalPreviewPanel
 
 class BlockView(ttk.Frame):
 
@@ -173,6 +174,19 @@ class BlockView(ttk.Frame):
                     self.recoder.pack(fill=tk.X)
                 
                 self.label_icon.config(image=self.function_block_img)
+                
+                self._signal_preview = None
+                if daq.IChannel.can_cast_from(self.node):
+                    self._signal_preview = SignalPreviewPanel(
+                        self._right_container, self.node, self.context)
+                    self._signal_preview.place(
+                        relx=0, rely=1.0, relwidth=1.0,
+                        anchor='sw')
+                    
+                self.cols = [0, 1]
+                self.rows = [0]
+                
+                self._bind_mousewheel_recursive(self.right_stack)
 
                 self.cols = [0, 1]
                 self.rows = [0]

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -196,11 +196,16 @@ class PropertiesTreeview(ttk.Treeview):
                 print(e)
 
             # Insert a treeview entry widget for the property
+            if property_info.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+                display_name = '          ' + property_info.name
+            else:
+                display_name = property_info.name
+
             iid = self.insert(
                 '' if not parent_iid else parent_iid,
                 tk.END,
                 open=True,
-                text=property_info.name,
+                text=display_name,
                 values=(property_value, *meta_fields))
 
             container_types = (daq.CoreType.ctObject, daq.CoreType.ctStruct, daq.CoreType.ctList, daq.CoreType.ctDict)

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -70,8 +70,8 @@ class PropertiesTreeview(ttk.Treeview):
 
         # bind double-click to editing (if not read_only)
         if not self.read_only:
-            self.bind('<Double-1>', lambda event: self.edit_value())
-        self.bind('<Button-3>', lambda event: self.show_menu(event))
+            self.bind('<Double-1>', lambda event=None: self.edit_value())
+        self.bind('<Button-3>', lambda event=None: self.show_menu(event))
         self.bind('<MouseWheel>', lambda e=None: self.after_idle(self._sync_overlays))
         self.bind('<ButtonRelease-1>', lambda e=None: self.after(10, self._sync_overlays), add='+')
         self.bind('<Configure>', self._on_configure)

--- a/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 
 from .output_signal_row import OutputSignalRow
 
-
 class OutputSignalsView(ttk.Frame):
     def __init__(self, parent, node=None, context=None, **kwargs):
         ttk.Frame.__init__(self, parent, **kwargs)
@@ -31,7 +30,9 @@ class OutputSignalsView(ttk.Frame):
             node = daq.ISignal.cast_from(self.node)
             self.make_output_signal_section([node], 'Signal info')
             self.make_output_signal_section([node.domain_signal], 'Domain signal')
-            self.make_output_signal_section(node.related_signals, 'Related signals')
+            related = node.related_signals
+            self.make_output_signal_section(
+                related if related is not None else [], 'Related signals')
         elif daq.IDevice.can_cast_from(self.node):
             node = daq.IDevice.cast_from(self.node)
             signals = node.get_signals(daq.AnySearchFilter() if self.context.view_hidden_components else None)
@@ -93,11 +94,15 @@ class OutputSignalsView(ttk.Frame):
         value_label.pack(side=tk.RIGHT, padx=(4, 0))
 
         res = device_domain.tick_resolution
-        origin = device_domain.origin
         origin_dt = None
 
-        if res is not None and origin is not None and str(origin) != '':
-            origin_str = str(origin)
+        try:
+            origin = device_domain.origin
+            origin_str = str(origin) if origin is not None else ''
+        except RuntimeError:
+            origin_str = ''
+
+        if res is not None and origin_str.strip():
             origin_dt = utils.parse_origin(origin_str)
 
         res_num = res.numerator if res is not None else None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -3,6 +3,7 @@ import time
 import tkinter as tk
 from tkinter import ttk
 from collections import deque
+import numpy as np
 
 import opendaq as daq
 
@@ -152,17 +153,15 @@ class SignalPreviewPanel(ttk.Frame):
 
             display = name
             if display in self._eligible:
-                try:
-                    local_id = signal.local_id
-                except (RuntimeError, AttributeError):
-                    local_id = signal.global_id
+                local_id = getattr(signal, 'local_id', signal.global_id)
                 display = f'{name} ({local_id})'
 
                 first_signal = self._eligible.pop(name)
-                try:
+                if first_signal.local_id is not None:
                     first_local = first_signal.local_id
-                except (RuntimeError, AttributeError):
+                else:
                     first_local = first_signal.global_id
+                    
                 self._eligible[f'{name} ({first_local})'] = first_signal
 
             self._eligible[display] = signal
@@ -176,57 +175,44 @@ class SignalPreviewPanel(ttk.Frame):
 
     @staticmethod
     def _is_chartable(signal):
-        try:
-            desc = signal.descriptor
-            if desc is None:
-                return False
-
-            # Must be a numeric sample type (float or integer variant)
-            st_name = (desc.sample_type.name
-                       if hasattr(desc.sample_type, 'name')
-                       else str(desc.sample_type))
-            numeric_prefixes = ('Float', 'Int', 'UInt', 'float', 'int', 'uint')
-            if not any(st_name.startswith(p) for p in numeric_prefixes):
-                return False
-
-            # Scalar only -- dimensions list must be empty
-            try:
-                dims = desc.dimensions
-                if dims is not None and len(dims) > 0:
-                    return False
-            except RuntimeError:
-                pass
-
-            # No struct fields -- rejects CAN frames, complex structs
-            try:
-                fields = desc.struct_fields
-                if fields is not None and len(fields) > 0:
-                    return False
-            except RuntimeError:
-                pass
-
-            domain_sig = signal.domain_signal
-            if domain_sig is None:
-                return False
-            domain_desc = domain_sig.descriptor
-            if domain_desc is None:
-                return False
-
-            # Domain unit symbol must be "s" (time domain)
-            unit = domain_desc.unit
-            if unit is None:
-                return False
-            symbol = unit.symbol if hasattr(unit, 'symbol') else None
-            if symbol is None or str(symbol) != 's':
-                return False
-
-            # Domain must have tick_resolution for tick-to-seconds conversion
-            if domain_desc.tick_resolution is None:
-                return False
-
-            return True
-        except (RuntimeError, AttributeError):
+        desc = getattr(signal, 'descriptor', None)
+        if desc is None:
             return False
+
+        sample_type = getattr(desc, 'sample_type', None)
+        if not sample_type:
+            return False
+
+        st_name = getattr(sample_type, 'name', str(sample_type))
+        numeric_prefixes = ('Float', 'Int', 'UInt', 'float', 'int', 'uint')
+        if not any(st_name.startswith(p) for p in numeric_prefixes):
+            return False
+
+        dims = getattr(desc, 'dimensions', None)
+        if dims and len(dims) > 0:
+            return False
+
+        fields = getattr(desc, 'struct_fields', None)
+        if fields and len(fields) > 0:
+            return False
+
+        domain_sig = getattr(signal, 'domain_signal', None)
+        if domain_sig is None:
+            return False
+
+        domain_desc = getattr(domain_sig, 'descriptor', None)
+        if domain_desc is None:
+            return False
+
+        unit = getattr(domain_desc, 'unit', None)
+        symbol = getattr(unit, 'symbol', None)
+        if str(symbol) != 's':
+            return False
+
+        if getattr(domain_desc, 'tick_resolution', None) is None:
+            return False
+
+        return True
 
     # MARK: Signal selection
 
@@ -243,12 +229,10 @@ class SignalPreviewPanel(ttk.Frame):
         self._needs_redraw = True
 
         self._unit_str = ''
-        try:
+        if signal.descriptor.unit is not None:
             unit = signal.descriptor.unit
             if unit is not None and unit.symbol is not None:
                 self._unit_str = str(unit.symbol)
-        except RuntimeError:
-            pass
 
         # Cache tick resolution for tick -> seconds conversion.
         domain_desc = signal.domain_signal.descriptor
@@ -262,20 +246,16 @@ class SignalPreviewPanel(ttk.Frame):
         else:
             self._origin_epoch = None
 
-        try:
-            self._reader = daq.StreamReader(signal)
-            self._last_data_time = time.monotonic()
-        except RuntimeError as e:
-            print(f'[SignalPreview] Failed to create StreamReader: {e}')
-            self._reader = None
+        self._reader = daq.StreamReader(signal)
+        self._last_data_time = time.monotonic()
 
     # MARK: Polling
 
     def _on_duration_selected(self, _event=None):
         raw = self._duration_var.get().rstrip('s')
-        try:
+        if float(raw) is not None:
             seconds = float(raw)
-        except ValueError:
+        else:
             return
         if seconds <= 0:
             return
@@ -291,20 +271,23 @@ class SignalPreviewPanel(ttk.Frame):
             return
         if not self._is_chartable(self._selected_signal):
             return
-        try:
-            domain_desc = self._selected_signal.domain_signal.descriptor
-            res = domain_desc.tick_resolution
-            self._tick_res_num = res.numerator
-            self._tick_res_den = res.denominator
 
-            self._reader = daq.StreamReader(self._selected_signal)
-            self._first_tick = None
-            self._data.clear()
-            self._last_data_time = time.monotonic()
-            self._needs_redraw = True
-        except RuntimeError as e:
-            print(f'[SignalPreview] Recreate failed: {e}')
-            self._reader = None
+        domain_desc = getattr(
+            getattr(self._selected_signal, 'domain_signal', None),
+            'descriptor', None)
+        if domain_desc is None:
+            return
+        res = getattr(domain_desc, 'tick_resolution', None)
+        if res is None:
+            return
+
+        self._tick_res_num = res.numerator
+        self._tick_res_den = res.denominator
+        self._reader = daq.StreamReader(self._selected_signal)
+        self._first_tick = None
+        self._data.clear()
+        self._last_data_time = time.monotonic()
+        self._needs_redraw = True
 
     def _on_log_toggled(self):
         self._needs_redraw = True
@@ -351,12 +334,8 @@ class SignalPreviewPanel(ttk.Frame):
         base = self._first_tick
         buf = self._data
 
-        try:
-            import numpy as np
-            t_arr = (domain_ticks.astype(np.float64) - base) * ratio
-            v_arr = values.astype(np.float64)
-        except (ImportError, AttributeError):
-            t_arr = None
+        t_arr = (domain_ticks.astype(np.float64) - base) * ratio
+        v_arr = values.astype(np.float64)
 
         if t_arr is not None:
             target = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
@@ -729,19 +708,15 @@ class SignalPreviewPanel(ttk.Frame):
     def _on_destroy(self, event):
         if event.widget is not self:
             return
+
         for job_attr in ('_poll_job', '_draw_job'):
-            job = getattr(self, job_attr, None)
-            if job is not None:
-                try:
-                    self.after_cancel(job)
-                except Exception:
-                    pass
+            job_id = getattr(self, job_attr, None)
+            if job_id:
+                self.after_cancel(job_id)
                 setattr(self, job_attr, None)
 
-        try:
+        if self._chart.winfo_exists():
             self._chart.delete('all')
-        except tk.TclError:
-            pass
-        self._chart_ready = False
 
+        self._chart_ready = False
         self._reader = None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -1,0 +1,541 @@
+import tkinter as tk
+from tkinter import ttk
+from collections import deque
+
+import opendaq as daq
+
+from .. import utils
+
+
+class SignalPreviewPanel(ttk.Frame):
+    WINDOW_SECONDS = 5.0
+    MAX_BUFFER_SIZE = 10_000
+    POLL_MS = 33          # drain the reader this often
+    DRAW_MS = 66         # repaint the chart this often
+    CANVAS_HEIGHT = 160
+
+    _BG      = '#1e1e2e'
+    _LINE    = '#89b4fa'
+    _GRID    = '#313244'
+    _TEXT    = '#cdd6f4'
+    _AXIS    = '#585b70'
+    _FILL    = '#252942'
+
+    _AXIS_FONT = ('TkFixedFont', 7)
+    _VAL_FONT  = ('TkFixedFont', 10, 'bold')
+
+    def __init__(self, parent, node, context=None, **kwargs):
+        super().__init__(parent, **kwargs)
+        self.node = node
+        self.context = context
+
+        self._collapsed = True
+        self._reader = None
+        self._selected_signal = None
+        self._poll_job = None
+        self._draw_job = None
+
+        # Buffer of (elapsed_seconds, value) pairs.
+        self._data = deque(maxlen=self.MAX_BUFFER_SIZE)
+
+        self._tick_res_num = None
+        self._tick_res_den = None
+        self._origin_epoch = None   # datetime | None
+        self._first_tick = None
+
+        # name -> ISignal for chartable signals
+        self._eligible = {}
+        self._needs_redraw = True
+        self._chart_ready = False
+
+        # Build widgets
+        self._build_toggle_bar()
+        self._build_content()
+        self._populate_dropdown()
+
+        self._schedule_poll()
+        self._schedule_draw()
+        self.bind('<Destroy>', self._on_destroy)
+        self._update_placement()
+
+    def _build_toggle_bar(self):
+        self._toggle_frame = utils.make_banner(self, '\u25B2 Signal Preview')
+        self._toggle_frame.configure(cursor='hand2')
+
+        self._arrow_label = self._toggle_frame.winfo_children()[0]
+        self._arrow_label.configure(cursor='hand2')
+
+        for w in (self._toggle_frame, self._arrow_label):
+            w.bind('<Button-1>', lambda _e: self._toggle())
+
+    def _build_content(self):
+        self._content_frame = ttk.Frame(self)
+        dd_row = ttk.Frame(self._content_frame)
+        dd_row.pack(fill=tk.X, padx=4, pady=(4, 2))
+
+        ttk.Label(dd_row, text='Signal:').pack(side=tk.LEFT, padx=(0, 4))
+
+        self._signal_var = tk.StringVar()
+        self._dropdown = ttk.Combobox(
+            dd_row, textvariable=self._signal_var, state='readonly')
+        self._dropdown.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        self._dropdown.bind('<<ComboboxSelected>>', self._on_signal_selected)
+
+        # Duration selector
+        self._duration_presets = [1, 2, 5, 10, 30, 60]
+        self._duration_var = tk.StringVar(value='5s')
+        dur_cb = ttk.Combobox(
+            dd_row, textvariable=self._duration_var, state='readonly',
+            values=[f'{d}s' for d in self._duration_presets], width=5)
+        dur_cb.pack(side=tk.LEFT, padx=(4, 0))
+        dur_cb.bind('<<ComboboxSelected>>', self._on_duration_selected)
+
+        # Chart canvas
+        self._chart = tk.Canvas(
+            self._content_frame, bg=self._BG,
+            height=self.CANVAS_HEIGHT, highlightthickness=0)
+        self._chart.pack(fill=tk.BOTH, expand=True, padx=4, pady=(2, 4))
+
+        self._chart.bind('<Configure>', lambda _e: self._invalidate_chart())
+        self._block_mousewheel_recursive(self)
+
+    def _block_mousewheel_recursive(self, widget):
+        for event in ('<MouseWheel>', '<Button-4>', '<Button-5>'):
+            widget.bind(event, lambda _e: 'break')
+        for child in widget.winfo_children():
+            self._block_mousewheel_recursive(child)
+
+    # MARK: Dropdown
+    def _populate_dropdown(self):
+        self._eligible.clear()
+
+        if self.node is None:
+            return
+
+        signals = []
+        if daq.IFunctionBlock.can_cast_from(self.node):
+            fb = daq.IFunctionBlock.cast_from(self.node)
+            search_filter = (
+                daq.AnySearchFilter()
+                if self.context and self.context.view_hidden_components
+                else None)
+            signals = fb.get_signals(search_filter)
+
+        for sig in signals:
+            if sig is None or not daq.ISignal.can_cast_from(sig):
+                continue
+            signal = daq.ISignal.cast_from(sig)
+            if not self._is_chartable(signal):
+                continue
+
+            name = signal.name if signal.name else signal.global_id
+            display = name
+            counter = 1
+            while display in self._eligible:
+                counter += 1
+                display = f'{name} ({counter})'
+            self._eligible[display] = signal
+
+        names = list(self._eligible.keys())
+        self._dropdown['values'] = names
+
+        if len(names) == 1:
+            self._signal_var.set(names[0])
+            self._on_signal_selected()
+
+    @staticmethod
+    def _is_chartable(signal):
+        try:
+            desc = signal.descriptor
+            if desc is None:
+                return False
+
+            st_name = desc.sample_type.name if hasattr(desc.sample_type, 'name') else str(desc.sample_type)
+            numeric_prefixes = ('Float', 'Int', 'UInt', 'float', 'int', 'uint')
+            if not any(st_name.startswith(p) for p in numeric_prefixes):
+                return False
+
+            domain_sig = signal.domain_signal
+            if domain_sig is None:
+                return False
+            domain_desc = domain_sig.descriptor
+            if domain_desc is None:
+                return False
+
+            unit = domain_desc.unit
+            if unit is None or unit.quantity is None:
+                return False
+            if unit.quantity.casefold() != 'time':
+                return False
+
+            if domain_desc.tick_resolution is None:
+                return False
+
+            return True
+        except (RuntimeError, AttributeError):
+            return False
+
+    # MARK: Signal selection
+
+    def _on_signal_selected(self, _event=None):
+        name = self._signal_var.get()
+        signal = self._eligible.get(name)
+        if signal is None:
+            return
+
+        self._reader = None
+        self._selected_signal = signal
+        self._data.clear()
+        self._first_tick = None
+        self._needs_redraw = True
+
+        # Cache tick resolution for tick -> seconds conversion.
+        domain_desc = signal.domain_signal.descriptor
+        res = domain_desc.tick_resolution
+        self._tick_res_num = res.numerator
+        self._tick_res_den = res.denominator
+
+        origin_str = str(domain_desc.origin) if hasattr(domain_desc, 'origin') else ''
+        if origin_str.strip():
+            self._origin_epoch = utils.parse_origin(origin_str)
+        else:
+            self._origin_epoch = None
+
+        try:
+            self._reader = daq.StreamReader(signal)
+        except RuntimeError as e:
+            print(f'[SignalPreview] Failed to create StreamReader: {e}')
+            self._reader = None
+
+    # MARK: Polling
+
+    def _on_duration_selected(self, _event=None):
+        raw = self._duration_var.get().rstrip('s')
+        try:
+            seconds = float(raw)
+        except ValueError:
+            return
+        if seconds <= 0:
+            return
+        self.WINDOW_SECONDS = seconds
+        self._needs_redraw = True
+
+        # Vertical grid lines are created once for the initial WINDOW_SECONDS.
+        self._chart_ready = False
+
+    def _schedule_poll(self):
+        self._poll_job = self.after(self.POLL_MS, self._poll_tick)
+
+    def _poll_tick(self):
+        self._poll_job = None
+        if not self.winfo_exists():
+            return
+
+        if self._reader is not None:
+            try:
+                available = self._reader.available_count
+                if available > 0:
+                    # Cap each read so the UI thread isn't blocked for too long
+                    # on very high sample-rate signals.
+                    count = min(available, 8000)
+                    values, domain_ticks = self._reader.read_with_domain(count)
+                    self._ingest(values, domain_ticks)
+            except RuntimeError as e:
+                # The reader can become invalid when the signal is disconnected
+                # or its descriptor changes.
+                print(f'[SignalPreview] Read error (reader invalidated): {e}')
+                self._reader = None
+
+        self._poll_job = self.after(self.POLL_MS, self._poll_tick)
+
+    def _ingest(self, values, domain_ticks):
+        if values is None or domain_ticks is None:
+            return
+
+        n = len(values)
+        if n == 0:
+            return
+
+        ratio = self._tick_res_num / self._tick_res_den
+        if self._first_tick is None:
+            self._first_tick = int(domain_ticks[0])
+
+        base = self._first_tick
+        buf = self._data
+
+        for i in range(n):
+            elapsed = (int(domain_ticks[i]) - base) * ratio
+            buf.append((elapsed, float(values[i])))
+
+        self._needs_redraw = True
+
+    # MARK: Drawing
+
+    def _invalidate_chart(self):
+        self._chart_ready = False
+        self._needs_redraw = True
+
+    def _ensure_chart_items(self):
+        c = self._chart
+        c.delete('all')
+
+        # Z-order: fill -> grid -> axes -> line -> labels
+
+        self._fill_id = c.create_polygon(
+            0, 0, 0, 0, 0, 0, fill=self._FILL, outline='', state='hidden')
+
+        # Horizontal grid
+        self._hgrid_ids = []
+        self._hgrid_label_ids = []
+        for _ in range(5):
+            gid = c.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
+            lid = c.create_text(
+                0, 0, text='', fill=self._TEXT, anchor=tk.E, font=self._AXIS_FONT)
+            self._hgrid_ids.append(gid)
+            self._hgrid_label_ids.append(lid)
+
+        # Vertical grid (1-second intervals inside the window)
+        n_vsecs = max(int(self.WINDOW_SECONDS) - 1, 0)
+        self._vgrid_ids = []
+        self._vgrid_label_ids = []
+        for _ in range(n_vsecs):
+            vid = c.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
+            vlid = c.create_text(
+                0, 0, text='', fill=self._TEXT, anchor=tk.N, font=self._AXIS_FONT)
+            self._vgrid_ids.append(vid)
+            self._vgrid_label_ids.append(vlid)
+
+        self._yaxis_id = c.create_line(0, 0, 0, 0, fill=self._AXIS)
+        self._xaxis_id = c.create_line(0, 0, 0, 0, fill=self._AXIS)
+
+        # Grid numbers
+        self._xlabel_l = c.create_text(
+            0, 0, text='', fill=self._TEXT, anchor=tk.SW, font=self._AXIS_FONT)
+        self._xlabel_r = c.create_text(
+            0, 0, text='', fill=self._TEXT, anchor=tk.SE, font=self._AXIS_FONT)
+
+        self._line_id = c.create_line(
+            0, 0, 0, 0, fill=self._LINE, width=1, smooth=False)
+
+        self._badge_id = c.create_text(
+            0, 0, text='', fill=self._LINE, anchor=tk.NE, font=self._VAL_FONT)
+
+        self._nodata_id = c.create_text(
+            0, 0, text='', fill=self._TEXT, font=('TkDefaultFont', 10),
+            state='hidden')
+
+        self._chart_ready = True
+
+    def _schedule_draw(self):
+        self._draw_job = self.after(self.DRAW_MS, self._draw_tick)
+
+    def _draw_tick(self):
+        self._draw_job = None
+        if not self.winfo_exists():
+            return
+
+        if not self._collapsed and self._needs_redraw:
+            self._draw_chart()
+            self._needs_redraw = False
+
+        self._draw_job = self.after(self.DRAW_MS, self._draw_tick)
+        
+    def _draw_chart(self):
+        if not self._chart_ready:
+            self._ensure_chart_items()
+
+        c = self._chart
+        w = c.winfo_width()
+        h = c.winfo_height()
+        if w < 20 or h < 20:
+            return
+
+        ml, mr, mt, mb = 55, 12, 10, 22
+        pw = w - ml - mr
+        ph = h - mt - mb
+        if pw < 10 or ph < 10:
+            return
+
+        buf = self._data
+        has_data = len(buf) > 0
+
+        if not has_data:
+            c.coords(self._nodata_id, w // 2, h // 2)
+            c.itemconfig(self._nodata_id, text='No data', state='normal')
+            c.itemconfig(self._line_id, state='hidden')
+            c.itemconfig(self._fill_id, state='hidden')
+            c.itemconfig(self._badge_id, state='hidden')
+            return
+
+        c.itemconfig(self._nodata_id, state='hidden')
+
+        # Visible window
+        t_latest = buf[-1][0]
+        t_earliest = t_latest - self.WINDOW_SECONDS
+
+        visible = [(t, v) for t, v in buf if t >= t_earliest]
+        
+        if len(visible) == 0:
+            c.coords(self._nodata_id, w // 2, h // 2)
+            c.itemconfig(self._nodata_id, text='Waiting...', state='normal')
+            c.itemconfig(self._line_id, state='hidden')
+            c.itemconfig(self._fill_id, state='hidden')
+            c.itemconfig(self._badge_id, state='hidden')
+            return
+
+        # Y range with breathing room
+        vals = [v for _, v in visible]
+        v_lo, v_hi = min(vals), max(vals)
+        if v_lo == v_hi:
+            v_lo -= 1.0
+            v_hi += 1.0
+        else:
+            pad = (v_hi - v_lo) * 0.08
+            v_lo -= pad
+            v_hi += pad
+
+        t_span = self.WINDOW_SECONDS
+        v_span = v_hi - v_lo
+        
+        def xpx(t):
+            return ml + (t - t_earliest) / t_span * pw
+
+        def ypx(v):
+            return mt + (1.0 - (v - v_lo) / v_span) * ph
+
+        # Horizontal grid + Y labels
+        for i in range(5):
+            gy = mt + ph * i / 4
+            c.coords(self._hgrid_ids[i], ml, gy, ml + pw, gy)
+            gv = v_hi - v_span * i / 4
+            c.coords(self._hgrid_label_ids[i], ml - 4, gy)
+            c.itemconfig(self._hgrid_label_ids[i], text=self._fmt(gv))
+
+        # Vertical grid at 1-second marks
+        for i, vid in enumerate(self._vgrid_ids):
+            # i=0 -> -4s, i=1 -> -3s, ... i=3 -> -1s  (for 5s window)
+            secs_ago = int(self.WINDOW_SECONDS) - 1 - i
+            t_mark = t_latest - secs_ago
+            vx = xpx(t_mark)
+            c.coords(vid, vx, mt, vx, mt + ph)
+            c.coords(self._vgrid_label_ids[i], vx, mt + ph + 3)
+            c.itemconfig(self._vgrid_label_ids[i], text=f'-{secs_ago}s')
+
+        # Axes
+        c.coords(self._yaxis_id, ml, mt, ml, mt + ph)
+        c.coords(self._xaxis_id, ml, mt + ph, ml + pw, mt + ph)
+
+        c.coords(self._xlabel_l, ml, h - 2)
+        c.itemconfig(self._xlabel_l, text=f'-{self.WINDOW_SECONDS:.0f}s')
+        c.coords(self._xlabel_r, ml + pw, h - 2)
+        c.itemconfig(self._xlabel_r, text='now')
+
+        # Min/max envelope downsampl
+        if len(visible) > pw * 3:
+            n_buckets = max(pw, 4)
+            bucket_w = t_span / n_buckets
+            envelope = []
+            bi = 0
+            b_edge = t_earliest + bucket_w
+            b_min = b_max = None
+
+            for t, v in visible:
+                while t >= b_edge and bi < n_buckets - 1:
+                    if b_min is not None:
+                        if b_min[0] <= b_max[0]:
+                            envelope.append(b_min)
+                            if b_max != b_min:
+                                envelope.append(b_max)
+                        else:
+                            envelope.append(b_max)
+                            if b_min != b_max:
+                                envelope.append(b_min)
+                    b_min = b_max = None
+                    bi += 1
+                    b_edge = t_earliest + (bi + 1) * bucket_w
+
+                if b_min is None or v < b_min[1]:
+                    b_min = (t, v)
+                if b_max is None or v > b_max[1]:
+                    b_max = (t, v)
+
+            if b_min is not None:
+                if b_min[0] <= b_max[0]:
+                    envelope.append(b_min)
+                    if b_max != b_min:
+                        envelope.append(b_max)
+                else:
+                    envelope.append(b_max)
+                    if b_min != b_max:
+                        envelope.append(b_min)
+            visible = envelope
+
+        # Filled area under curve
+        bottom_y = mt + ph
+        if len(visible) >= 2:
+            fill_coords = [xpx(visible[0][0]), bottom_y]
+            for t, v in visible:
+                fill_coords.extend([xpx(t), ypx(v)])
+            fill_coords.extend([xpx(visible[-1][0]), bottom_y])
+            c.coords(self._fill_id, *fill_coords)
+            c.itemconfig(self._fill_id, state='normal')
+        else:
+            c.itemconfig(self._fill_id, state='hidden')
+
+        # Data line (1 px, no smoothing)
+        if len(visible) >= 2:
+            line_coords = []
+            for t, v in visible:
+                line_coords.extend([xpx(t), ypx(v)])
+            c.coords(self._line_id, *line_coords)
+            c.itemconfig(self._line_id, state='normal')
+        elif len(visible) == 1:
+            px, py = xpx(visible[0][0]), ypx(visible[0][1])
+            c.coords(self._line_id, px, py, px + 1, py)
+            c.itemconfig(self._line_id, state='normal')
+
+        # Current value badge
+        c.coords(self._badge_id, ml + pw - 4, mt + 4)
+        c.itemconfig(
+            self._badge_id, text=self._fmt(visible[-1][1]), state='normal')
+
+    @staticmethod
+    def _fmt(v):
+        if v != 0 and abs(v) < 0.001:
+            return f'{v:.3e}'
+        if abs(v) >= 100_000:
+            return f'{v:.1f}'
+        if v == int(v):
+            return str(int(v))
+        return f'{v:.4g}'
+
+    def _toggle(self):
+        self._collapsed = not self._collapsed
+        if self._collapsed:
+            self._content_frame.pack_forget()
+            self._arrow_label.config(text='\u25B2 Signal Preview')
+        else:
+            self._content_frame.pack(
+                fill=tk.BOTH, expand=True, after=self._toggle_frame)
+            self._arrow_label.config(text='\u25BC Signal Preview')
+            self._needs_redraw = True
+
+        self.update_idletasks()
+        self._update_placement()
+
+    def _update_placement(self):
+        self.update_idletasks()
+        self.place_configure(height=self.winfo_reqheight())
+
+    def _on_destroy(self, event):
+        if event.widget is not self:
+            return
+        for job_attr in ('_poll_job', '_draw_job'):
+            job = getattr(self, job_attr, None)
+            if job is not None:
+                try:
+                    self.after_cancel(job)
+                except Exception:
+                    pass
+                setattr(self, job_attr, None)
+        self._reader = None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -1,3 +1,5 @@
+import math
+import time
 import tkinter as tk
 from tkinter import ttk
 from collections import deque
@@ -9,17 +11,18 @@ from .. import utils
 
 class SignalPreviewPanel(ttk.Frame):
     WINDOW_SECONDS = 5.0
-    MAX_BUFFER_SIZE = 10_000
+    MAX_BUFFER_SIZE = 100_000
     POLL_MS = 33          # drain the reader this often
+    _TARGET_PPS = 2000
     DRAW_MS = 66         # repaint the chart this often
     CANVAS_HEIGHT = 160
 
-    _BG      = '#1e1e2e'
-    _LINE    = '#89b4fa'
-    _GRID    = '#313244'
-    _TEXT    = '#cdd6f4'
-    _AXIS    = '#585b70'
-    _FILL    = '#252942'
+    _BG      = '#ffffff'
+    _LINE    = '#1a6dcc'
+    _GRID    = '#e4e4e4'
+    _TEXT    = '#444444'
+    _AXIS    = '#999999'
+    _FILL    = '#dceafa'
 
     _AXIS_FONT = ('TkFixedFont', 7)
     _VAL_FONT  = ('TkFixedFont', 10, 'bold')
@@ -29,7 +32,7 @@ class SignalPreviewPanel(ttk.Frame):
         self.node = node
         self.context = context
 
-        self._collapsed = True
+        self._collapsed = False
         self._reader = None
         self._selected_signal = None
         self._poll_job = None
@@ -45,21 +48,26 @@ class SignalPreviewPanel(ttk.Frame):
 
         # name -> ISignal for chartable signals
         self._eligible = {}
+        self._unit_str = ''
+        self._last_data_time = None
+        self._STALE_TIMEOUT = 2.0
         self._needs_redraw = True
         self._chart_ready = False
+        self._px_ml = 65
 
         # Build widgets
         self._build_toggle_bar()
         self._build_content()
+        self._content_frame.pack(
+            fill=tk.BOTH, expand=True, after=self._toggle_frame)
         self._populate_dropdown()
 
         self._schedule_poll()
         self._schedule_draw()
         self.bind('<Destroy>', self._on_destroy)
-        self._update_placement()
 
     def _build_toggle_bar(self):
-        self._toggle_frame = utils.make_banner(self, '\u25B2 Signal Preview')
+        self._toggle_frame = utils.make_banner(self, '\u25BC Signal Preview')
         self._toggle_frame.configure(cursor='hand2')
 
         self._arrow_label = self._toggle_frame.winfo_children()[0]
@@ -90,6 +98,12 @@ class SignalPreviewPanel(ttk.Frame):
         dur_cb.pack(side=tk.LEFT, padx=(4, 0))
         dur_cb.bind('<<ComboboxSelected>>', self._on_duration_selected)
 
+        self._log_var = tk.BooleanVar(value=False)
+        log_cb = ttk.Checkbutton(
+            dd_row, text='Log', variable=self._log_var,
+            command=self._on_log_toggled)
+        log_cb.pack(side=tk.LEFT, padx=(4, 0))
+
         # Chart canvas
         self._chart = tk.Canvas(
             self._content_frame, bg=self._BG,
@@ -101,7 +115,7 @@ class SignalPreviewPanel(ttk.Frame):
 
     def _block_mousewheel_recursive(self, widget):
         for event in ('<MouseWheel>', '<Button-4>', '<Button-5>'):
-            widget.bind(event, lambda _e: 'break')
+            widget.bind(event, lambda _e=None: 'break')
         for child in widget.winfo_children():
             self._block_mousewheel_recursive(child)
 
@@ -113,12 +127,18 @@ class SignalPreviewPanel(ttk.Frame):
             return
 
         signals = []
-        if daq.IFunctionBlock.can_cast_from(self.node):
+        search_filter = (
+            daq.AnySearchFilter()
+            if self.context and self.context.view_hidden_components
+            else None)
+
+        if daq.ISignal.can_cast_from(self.node):
+            signals = [daq.ISignal.cast_from(self.node)]
+        elif daq.IDevice.can_cast_from(self.node):
+            device = daq.IDevice.cast_from(self.node)
+            signals = device.get_signals(search_filter)
+        elif daq.IFunctionBlock.can_cast_from(self.node):
             fb = daq.IFunctionBlock.cast_from(self.node)
-            search_filter = (
-                daq.AnySearchFilter()
-                if self.context and self.context.view_hidden_components
-                else None)
             signals = fb.get_signals(search_filter)
 
         for sig in signals:
@@ -129,11 +149,22 @@ class SignalPreviewPanel(ttk.Frame):
                 continue
 
             name = signal.name if signal.name else signal.global_id
+
             display = name
-            counter = 1
-            while display in self._eligible:
-                counter += 1
-                display = f'{name} ({counter})'
+            if display in self._eligible:
+                try:
+                    local_id = signal.local_id
+                except (RuntimeError, AttributeError):
+                    local_id = signal.global_id
+                display = f'{name} ({local_id})'
+
+                first_signal = self._eligible.pop(name)
+                try:
+                    first_local = first_signal.local_id
+                except (RuntimeError, AttributeError):
+                    first_local = first_signal.global_id
+                self._eligible[f'{name} ({first_local})'] = first_signal
+
             self._eligible[display] = signal
 
         names = list(self._eligible.keys())
@@ -150,10 +181,29 @@ class SignalPreviewPanel(ttk.Frame):
             if desc is None:
                 return False
 
-            st_name = desc.sample_type.name if hasattr(desc.sample_type, 'name') else str(desc.sample_type)
+            # Must be a numeric sample type (float or integer variant)
+            st_name = (desc.sample_type.name
+                       if hasattr(desc.sample_type, 'name')
+                       else str(desc.sample_type))
             numeric_prefixes = ('Float', 'Int', 'UInt', 'float', 'int', 'uint')
             if not any(st_name.startswith(p) for p in numeric_prefixes):
                 return False
+
+            # Scalar only -- dimensions list must be empty
+            try:
+                dims = desc.dimensions
+                if dims is not None and len(dims) > 0:
+                    return False
+            except RuntimeError:
+                pass
+
+            # No struct fields -- rejects CAN frames, complex structs
+            try:
+                fields = desc.struct_fields
+                if fields is not None and len(fields) > 0:
+                    return False
+            except RuntimeError:
+                pass
 
             domain_sig = signal.domain_signal
             if domain_sig is None:
@@ -162,12 +212,15 @@ class SignalPreviewPanel(ttk.Frame):
             if domain_desc is None:
                 return False
 
+            # Domain unit symbol must be "s" (time domain)
             unit = domain_desc.unit
-            if unit is None or unit.quantity is None:
+            if unit is None:
                 return False
-            if unit.quantity.casefold() != 'time':
+            symbol = unit.symbol if hasattr(unit, 'symbol') else None
+            if symbol is None or str(symbol) != 's':
                 return False
 
+            # Domain must have tick_resolution for tick-to-seconds conversion
             if domain_desc.tick_resolution is None:
                 return False
 
@@ -189,6 +242,14 @@ class SignalPreviewPanel(ttk.Frame):
         self._first_tick = None
         self._needs_redraw = True
 
+        self._unit_str = ''
+        try:
+            unit = signal.descriptor.unit
+            if unit is not None and unit.symbol is not None:
+                self._unit_str = str(unit.symbol)
+        except RuntimeError:
+            pass
+
         # Cache tick resolution for tick -> seconds conversion.
         domain_desc = signal.domain_signal.descriptor
         res = domain_desc.tick_resolution
@@ -203,6 +264,7 @@ class SignalPreviewPanel(ttk.Frame):
 
         try:
             self._reader = daq.StreamReader(signal)
+            self._last_data_time = time.monotonic()
         except RuntimeError as e:
             print(f'[SignalPreview] Failed to create StreamReader: {e}')
             self._reader = None
@@ -223,6 +285,30 @@ class SignalPreviewPanel(ttk.Frame):
         # Vertical grid lines are created once for the initial WINDOW_SECONDS.
         self._chart_ready = False
 
+    def _recreate_reader(self):
+        self._reader = None
+        if self._selected_signal is None:
+            return
+        if not self._is_chartable(self._selected_signal):
+            return
+        try:
+            domain_desc = self._selected_signal.domain_signal.descriptor
+            res = domain_desc.tick_resolution
+            self._tick_res_num = res.numerator
+            self._tick_res_den = res.denominator
+
+            self._reader = daq.StreamReader(self._selected_signal)
+            self._first_tick = None
+            self._data.clear()
+            self._last_data_time = time.monotonic()
+            self._needs_redraw = True
+        except RuntimeError as e:
+            print(f'[SignalPreview] Recreate failed: {e}')
+            self._reader = None
+
+    def _on_log_toggled(self):
+        self._needs_redraw = True
+
     def _schedule_poll(self):
         self._poll_job = self.after(self.POLL_MS, self._poll_tick)
 
@@ -235,16 +321,18 @@ class SignalPreviewPanel(ttk.Frame):
             try:
                 available = self._reader.available_count
                 if available > 0:
-                    # Cap each read so the UI thread isn't blocked for too long
-                    # on very high sample-rate signals.
-                    count = min(available, 8000)
-                    values, domain_ticks = self._reader.read_with_domain(count)
+                    values, domain_ticks = self._reader.read_with_domain(available)
                     self._ingest(values, domain_ticks)
+                    self._last_data_time = time.monotonic()
             except RuntimeError as e:
-                # The reader can become invalid when the signal is disconnected
-                # or its descriptor changes.
-                print(f'[SignalPreview] Read error (reader invalidated): {e}')
-                self._reader = None
+                print(f'[SignalPreview] Reader invalidated, recreating: {e}')
+                self._recreate_reader()
+
+        if (self._reader is not None
+                and self._last_data_time is not None
+                and time.monotonic() - self._last_data_time > self._STALE_TIMEOUT):
+            print('[SignalPreview] Reader stale, recreating')
+            self._recreate_reader()
 
         self._poll_job = self.after(self.POLL_MS, self._poll_tick)
 
@@ -263,9 +351,64 @@ class SignalPreviewPanel(ttk.Frame):
         base = self._first_tick
         buf = self._data
 
-        for i in range(n):
-            elapsed = (int(domain_ticks[i]) - base) * ratio
-            buf.append((elapsed, float(values[i])))
+        try:
+            import numpy as np
+            t_arr = (domain_ticks.astype(np.float64) - base) * ratio
+            v_arr = values.astype(np.float64)
+        except (ImportError, AttributeError):
+            t_arr = None
+
+        if t_arr is not None:
+            target = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
+
+            stride = 1
+            if n > 2:
+                dt = t_arr[-1] - t_arr[0]
+                if dt > 0:
+                    actual_rate = n / dt
+                    if actual_rate > target:
+                        stride = max(1, int(actual_rate / target))
+
+            if stride <= 1:
+                # Fast path: extend buffer with all points
+                for i in range(n):
+                    buf.append((t_arr[i], v_arr[i]))
+            else:
+                usable = (n // stride) * stride
+                if usable > 0:
+                    t_chunk = t_arr[:usable].reshape(-1, stride)
+                    v_chunk = v_arr[:usable].reshape(-1, stride)
+
+                    mn_idx = v_chunk.argmin(axis=1)
+                    mx_idx = v_chunk.argmax(axis=1)
+
+                    for ci in range(len(v_chunk)):
+                        mni = mn_idx[ci]
+                        mxi = mx_idx[ci]
+                        if mni == mxi:
+                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+                        elif mni < mxi:
+                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+                            buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
+                        else:
+                            buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
+                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+
+                # Handle leftover samples after the last full chunk
+                for i in range(usable, n):
+                    buf.append((t_arr[i], v_arr[i]))
+        else:
+            stride = 1
+            if n > 2:
+                dt = (int(domain_ticks[-1]) - int(domain_ticks[0])) * ratio
+                if dt > 0:
+                    actual_rate = n / dt
+                    target_fb = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
+                    if actual_rate > target_fb:
+                        stride = max(1, int(actual_rate / target_fb))
+            for i in range(0, n, stride):
+                elapsed = (int(domain_ticks[i]) - base) * ratio
+                buf.append((elapsed, float(values[i])))
 
         self._needs_redraw = True
 
@@ -294,11 +437,9 @@ class SignalPreviewPanel(ttk.Frame):
             self._hgrid_ids.append(gid)
             self._hgrid_label_ids.append(lid)
 
-        # Vertical grid (1-second intervals inside the window)
-        n_vsecs = max(int(self.WINDOW_SECONDS) - 1, 0)
         self._vgrid_ids = []
         self._vgrid_label_ids = []
-        for _ in range(n_vsecs):
+        for _ in range(10):
             vid = c.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
             vlid = c.create_text(
                 0, 0, text='', fill=self._TEXT, anchor=tk.N, font=self._AXIS_FONT)
@@ -317,8 +458,11 @@ class SignalPreviewPanel(ttk.Frame):
         self._line_id = c.create_line(
             0, 0, 0, 0, fill=self._LINE, width=1, smooth=False)
 
+        self._badge_bg_id = c.create_rectangle(
+            0, 0, 0, 0, fill=self._BG, outline=self._GRID, width=1,
+            state='hidden')
         self._badge_id = c.create_text(
-            0, 0, text='', fill=self._LINE, anchor=tk.NE, font=self._VAL_FONT)
+            0, 0, text='', fill='#111111', anchor=tk.NE, font=self._VAL_FONT)
 
         self._nodata_id = c.create_text(
             0, 0, text='', fill=self._TEXT, font=('TkDefaultFont', 10),
@@ -350,7 +494,7 @@ class SignalPreviewPanel(ttk.Frame):
         if w < 20 or h < 20:
             return
 
-        ml, mr, mt, mb = 55, 12, 10, 22
+        ml, mr, mt, mb = 65, 12, 10, 22
         pw = w - ml - mr
         ph = h - mt - mb
         if pw < 10 or ph < 10:
@@ -365,6 +509,7 @@ class SignalPreviewPanel(ttk.Frame):
             c.itemconfig(self._line_id, state='hidden')
             c.itemconfig(self._fill_id, state='hidden')
             c.itemconfig(self._badge_id, state='hidden')
+            c.itemconfig(self._badge_bg_id, state='hidden')
             return
 
         c.itemconfig(self._nodata_id, state='hidden')
@@ -381,18 +526,41 @@ class SignalPreviewPanel(ttk.Frame):
             c.itemconfig(self._line_id, state='hidden')
             c.itemconfig(self._fill_id, state='hidden')
             c.itemconfig(self._badge_id, state='hidden')
+            c.itemconfig(self._badge_bg_id, state='hidden')
             return
 
         # Y range with breathing room
         vals = [v for _, v in visible]
         v_lo, v_hi = min(vals), max(vals)
-        if v_lo == v_hi:
-            v_lo -= 1.0
-            v_hi += 1.0
+
+        use_log = self._log_var.get()
+
+        if use_log:
+            abs_max = max(abs(v) for v in vals)
+            symlog_thresh = max(abs_max * 0.01, 1e-10)
+
+            def symlog(v):
+                return math.copysign(math.log10(1.0 + abs(v) / symlog_thresh), v)
+
+            symlog_vals = [symlog(v) for v in vals]
+            sl_lo = min(symlog_vals)
+            sl_hi = max(symlog_vals)
+            if sl_lo == sl_hi:
+                sl_lo -= 1.0
+                sl_hi += 1.0
+            else:
+                pad = (sl_hi - sl_lo) * 0.05
+                sl_lo -= pad
+                sl_hi += pad
+            sl_span = sl_hi - sl_lo
         else:
-            pad = (v_hi - v_lo) * 0.08
-            v_lo -= pad
-            v_hi += pad
+            if v_lo == v_hi:
+                v_lo -= 1.0
+                v_hi += 1.0
+            else:
+                pad = (v_hi - v_lo) * 0.08
+                v_lo -= pad
+                v_hi += pad
 
         t_span = self.WINDOW_SECONDS
         v_span = v_hi - v_lo
@@ -400,26 +568,56 @@ class SignalPreviewPanel(ttk.Frame):
         def xpx(t):
             return ml + (t - t_earliest) / t_span * pw
 
-        def ypx(v):
-            return mt + (1.0 - (v - v_lo) / v_span) * ph
+        if use_log:
+            def ypx(v):
+                return mt + (1.0 - (symlog(v) - sl_lo) / sl_span) * ph
+        else:
+            def ypx(v):
+                return mt + (1.0 - (v - v_lo) / v_span) * ph
 
         # Horizontal grid + Y labels
+        unit_suffix = f' {self._unit_str}' if self._unit_str else ''
         for i in range(5):
             gy = mt + ph * i / 4
             c.coords(self._hgrid_ids[i], ml, gy, ml + pw, gy)
-            gv = v_hi - v_span * i / 4
+            if use_log:
+                sl_val = sl_hi - (sl_hi - sl_lo) * i / 4
+                gv = math.copysign(
+                    symlog_thresh * (10.0 ** abs(sl_val) - 1.0), sl_val)
+            else:
+                gv = v_hi - v_span * i / 4
             c.coords(self._hgrid_label_ids[i], ml - 4, gy)
-            c.itemconfig(self._hgrid_label_ids[i], text=self._fmt(gv))
+            c.itemconfig(self._hgrid_label_ids[i],
+                         text=self._fmt(gv) + unit_suffix)
 
-        # Vertical grid at 1-second marks
-        for i, vid in enumerate(self._vgrid_ids):
-            # i=0 -> -4s, i=1 -> -3s, ... i=3 -> -1s  (for 5s window)
-            secs_ago = int(self.WINDOW_SECONDS) - 1 - i
-            t_mark = t_latest - secs_ago
+        _nice = [0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 30, 60]
+        grid_interval = _nice[-1]
+        for ni in _nice:
+            if self.WINDOW_SECONDS / ni <= 7:
+                grid_interval = ni
+                break
+
+        first_mark = math.ceil(t_earliest / grid_interval) * grid_interval
+        slot = 0
+        t_mark = first_mark
+        
+        while t_mark < t_latest and slot < len(self._vgrid_ids):
             vx = xpx(t_mark)
-            c.coords(vid, vx, mt, vx, mt + ph)
-            c.coords(self._vgrid_label_ids[i], vx, mt + ph + 3)
-            c.itemconfig(self._vgrid_label_ids[i], text=f'-{secs_ago}s')
+            c.coords(self._vgrid_ids[slot], vx, mt, vx, mt + ph)
+            secs_ago = t_latest - t_mark
+            if grid_interval >= 1:
+                label = f'-{secs_ago:.0f}s'
+            else:
+                label = f'-{secs_ago:.1f}s'
+            c.coords(self._vgrid_label_ids[slot], vx, mt + ph + 3)
+            c.itemconfig(self._vgrid_label_ids[slot], text=label, state='normal')
+            slot += 1
+            t_mark += grid_interval
+
+        # Hide unused grid slots
+        for i in range(slot, len(self._vgrid_ids)):
+            c.itemconfig(self._vgrid_ids[i], state='hidden')
+            c.itemconfig(self._vgrid_label_ids[i], state='hidden')
 
         # Axes
         c.coords(self._yaxis_id, ml, mt, ml, mt + ph)
@@ -494,10 +692,18 @@ class SignalPreviewPanel(ttk.Frame):
             c.coords(self._line_id, px, py, px + 1, py)
             c.itemconfig(self._line_id, state='normal')
 
-        # Current value badge
-        c.coords(self._badge_id, ml + pw - 4, mt + 4)
-        c.itemconfig(
-            self._badge_id, text=self._fmt(visible[-1][1]), state='normal')
+        badge_text = self._fmt(visible[-1][1])
+        if self._unit_str:
+            badge_text += f' {self._unit_str}'
+        bx = ml + pw - 4
+        by = mt + 4
+        c.coords(self._badge_id, bx, by)
+        c.itemconfig(self._badge_id, text=badge_text, state='normal')
+        c.update_idletasks()
+        bb = c.bbox(self._badge_id)
+        if bb:
+            c.coords(self._badge_bg_id, bb[0] - 3, bb[1] - 1, bb[2] + 3, bb[3] + 1)
+            c.itemconfig(self._badge_bg_id, state='normal')
 
     @staticmethod
     def _fmt(v):
@@ -519,14 +725,7 @@ class SignalPreviewPanel(ttk.Frame):
                 fill=tk.BOTH, expand=True, after=self._toggle_frame)
             self._arrow_label.config(text='\u25BC Signal Preview')
             self._needs_redraw = True
-
-        self.update_idletasks()
-        self._update_placement()
-
-    def _update_placement(self):
-        self.update_idletasks()
-        self.place_configure(height=self.winfo_reqheight())
-
+            
     def _on_destroy(self, event):
         if event.widget is not self:
             return
@@ -538,4 +737,11 @@ class SignalPreviewPanel(ttk.Frame):
                 except Exception:
                     pass
                 setattr(self, job_attr, None)
+
+        try:
+            self._chart.delete('all')
+        except tk.TclError:
+            pass
+        self._chart_ready = False
+
         self._reader = None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -1,5 +1,4 @@
 import math
-import time
 import tkinter as tk
 from tkinter import ttk
 from collections import deque
@@ -50,8 +49,12 @@ class SignalPreviewPanel(ttk.Frame):
         # name -> ISignal for chartable signals
         self._eligible = {}
         self._unit_str = ''
-        self._last_data_time = None
-        self._STALE_TIMEOUT = 2.0
+        self._last_descriptor_hash = None
+        self._signal_event_handler = None
+        self._signal_event_component = None
+        self._parent_event_handler = None
+        self._parent_event_component = None
+        self._reader_dirty = False
         self._needs_redraw = True
         self._chart_ready = False
         self._px_ml = 65
@@ -101,7 +104,7 @@ class SignalPreviewPanel(ttk.Frame):
 
         self._log_var = tk.BooleanVar(value=False)
         log_cb = ttk.Checkbutton(
-            dd_row, text='Log', variable=self._log_var,
+            dd_row, text='Logarithm', variable=self._log_var,
             command=self._on_log_toggled)
         log_cb.pack(side=tk.LEFT, padx=(4, 0))
 
@@ -247,9 +250,48 @@ class SignalPreviewPanel(ttk.Frame):
             self._origin_epoch = None
 
         self._reader = daq.StreamReader(signal)
-        self._last_data_time = time.monotonic()
+        self._last_descriptor_hash = self._descriptor_fingerprint(signal)
+
+        self._unsubscribe_core_events()
+
+        if daq.IComponent.can_cast_from(signal):
+            self._signal_event_component = signal
+            self._signal_event_handler = daq.QueuedEventHandler(self._on_core_event)
+            comp = daq.IComponent.cast_from(signal)
+            comp.on_component_core_event + self._signal_event_handler
+
+        ancestor = getattr(signal, 'parent', None)
+        while ancestor is not None:
+            if (daq.IFunctionBlock.can_cast_from(ancestor)
+                    or daq.IDevice.can_cast_from(ancestor)):
+                break
+            ancestor = getattr(ancestor, 'parent', None)
+
+        if ancestor is not None and daq.IComponent.can_cast_from(ancestor):
+            self._parent_event_component = ancestor
+            self._parent_event_handler = daq.QueuedEventHandler(self._on_core_event)
+            comp = daq.IComponent.cast_from(ancestor)
+            comp.on_component_core_event + self._parent_event_handler
 
     # MARK: Polling
+
+    def _unsubscribe_core_events(self):
+        for handler_attr, comp_attr in (
+            ('_signal_event_handler', '_signal_event_component'),
+            ('_parent_event_handler', '_parent_event_component'),
+        ):
+            handler = getattr(self, handler_attr, None)
+            comp = getattr(self, comp_attr, None)
+            if handler is not None and comp is not None:
+                if daq.IComponent.can_cast_from(comp):
+                    component = daq.IComponent.cast_from(comp)
+                    component.on_component_core_event - handler
+            setattr(self, handler_attr, None)
+            setattr(self, comp_attr, None)
+
+    def _on_core_event(self, sender, args):
+        if args.event_name in ('DescriptorChanged', 'PropertyValueChanged', 'ComponentUpdateEnd'):
+            self._reader_dirty = True
 
     def _on_duration_selected(self, _event=None):
         raw = self._duration_var.get().rstrip('s')
@@ -286,8 +328,33 @@ class SignalPreviewPanel(ttk.Frame):
         self._reader = daq.StreamReader(self._selected_signal)
         self._first_tick = None
         self._data.clear()
-        self._last_data_time = time.monotonic()
+        self._last_descriptor_hash = self._descriptor_fingerprint(self._selected_signal)
         self._needs_redraw = True
+
+    @staticmethod
+    def _descriptor_fingerprint(signal):
+        desc = getattr(signal, 'descriptor', None)
+        if desc is None:
+            return None
+        d_desc = getattr(getattr(signal, 'domain_signal', None), 'descriptor', None)
+
+        st = getattr(getattr(desc, 'sample_type', None), 'name', None)
+        rule = getattr(getattr(desc, 'data_rule', None), 'type', None)
+        rule_name = getattr(rule, 'name', str(rule)) if rule else None
+
+        d_rule = getattr(getattr(d_desc, 'data_rule', None), 'type', None) if d_desc else None
+        d_rule_name = getattr(d_rule, 'name', str(d_rule)) if d_rule else None
+
+        # For linear domain rules, the delta parameter encodes the sample rate.
+        # A change here means the rate changed even if everything else looks the same.
+        d_rule_params = None
+        if d_desc is not None:
+            dr = getattr(d_desc, 'data_rule', None)
+            if dr is not None:
+                params = getattr(dr, 'parameters', None)
+                d_rule_params = str(params) if params is not None else None
+
+        return (st, rule_name, d_rule_name, d_rule_params)
 
     def _on_log_toggled(self):
         self._needs_redraw = True
@@ -306,15 +373,20 @@ class SignalPreviewPanel(ttk.Frame):
                 if available > 0:
                     values, domain_ticks = self._reader.read_with_domain(available)
                     self._ingest(values, domain_ticks)
-                    self._last_data_time = time.monotonic()
             except RuntimeError as e:
                 print(f'[SignalPreview] Reader invalidated, recreating: {e}')
                 self._recreate_reader()
 
-        if (self._reader is not None
-                and self._last_data_time is not None
-                and time.monotonic() - self._last_data_time > self._STALE_TIMEOUT):
-            print('[SignalPreview] Reader stale, recreating')
+        if self._reader is not None and self._selected_signal is not None:
+            current = self._descriptor_fingerprint(self._selected_signal)
+            if current != self._last_descriptor_hash:
+                print('[SignalPreview] Descriptor changed, recreating reader')
+                self._recreate_reader()
+                self._last_descriptor_hash = current
+
+        if self._reader_dirty:
+            self._reader_dirty = False
+            print('[SignalPreview] Property changed, recreating reader')
             self._recreate_reader()
 
         self._poll_job = self.after(self.POLL_MS, self._poll_tick)
@@ -719,4 +791,5 @@ class SignalPreviewPanel(ttk.Frame):
             self._chart.delete('all')
 
         self._chart_ready = False
+        self._unsubscribe_core_events()
         self._reader = None

--- a/examples/applications/python/GUI Application/gui_demo/utils.py
+++ b/examples/applications/python/GUI Application/gui_demo/utils.py
@@ -267,7 +267,7 @@ def value_to_coretype(value, coretype: daq.CoreType):
 def get_item_path(tree, item_id):
     path = []
     while item_id:
-        item_text = tree.item(item_id, 'text')
+        item_text = tree.item(item_id, 'text').strip()
         path.insert(0, item_text)
         item_id = tree.parent(item_id)
     return path


### PR DESCRIPTION
# Brief
Add real-time Signal Preview panel to the Python GUI demo with live charting, fix tree view expand/collapse, fix GIL crash on device disconnect, and fix several minor UI bugs.

# Description
- Add `SignalPreviewPanel` component: real-time scrolling line chart for numeric time-domain signals with duration selector, symlog toggle, adaptive grid, min/max envelope downsampling, numpy-accelerated ingest, and retained-mode flicker-free rendering
- Integrate Signal Preview into Device, FunctionBlock, Channel, and Signal views via `BlockView._attach_signal_preview()`
- Fix tree view +/- indicator requiring double-click to expand/collapse folders
- Add core event subscriptions on signal and owning component for instant reader recreation on property/descriptor changes
- Fix `PyEval_RestoreThread` GIL crash on device disconnect by reordering `poll_opendaq_events` to refresh before `run_main_loop_iteration()`
- Fix right-click on disconnected device crashing due to unguarded `available_function_block_types`
- Fix `PropertiesTreeview` lambda missing event parameter on Python 3.14
- Fix method button text peeking through overlay in properties treeview

# Usage example
In terminal use:
```shell
python -m opendaq
```

<img width="1497" height="851" alt="slika" src="https://github.com/user-attachments/assets/6e2112ba-6c6b-494f-8af4-fb903a27b627" />

<img width="1499" height="851" alt="slika" src="https://github.com/user-attachments/assets/66f661a7-ae03-46e2-abd0-8e960f7b30ae" />

<img width="1498" height="848" alt="slika" src="https://github.com/user-attachments/assets/adb20b2f-5949-4fc8-9e41-d451a23805ad" />

Select any Channel, Device, FunctionBlock, or Signal node in the tree. The Signal Preview panel appears at the bottom of the right-side view with a dropdown of eligible signals, a duration selector (1s-60s), and an optional Log scale toggle.

# API changes
None

# Required application changes

**New file: `gui_demo/components/signal_preview_panel.py`**

Drop the new file into the components directory.

**`gui_demo/components/block_view.py`** -- add import and attach call in all four node branches:

Add import:
```diff
+ from .signal_preview_panel import SignalPreviewPanel
```

Add helper and calls:
```diff
+ def _attach_signal_preview(self):
+     self._signal_preview = SignalPreviewPanel(
+         self._right_container, self.node, self.context)
+     self._signal_preview.place(
+         relx=0, rely=1.0, relwidth=1.0, anchor='sw')
```
Call `self._attach_signal_preview()` after `self._bind_mousewheel_recursive(self.right_stack)` in the IDevice, IFunctionBlock, and ISignal branches.

**`gui_demo.py`** -- five changes:

1. Reorder `poll_opendaq_events`:
```diff
  daq.event_queue.process_events()
+ if self.context.needs_refresh:
+     self.on_refresh_event(None)
+     self.context.needs_refresh = False
  self.context.instance.context.scheduler.run_main_loop_iteration()
- if self.context.needs_refresh:
-     self.on_refresh_event(None)
-     self.context.needs_refresh = False
```

2. Fix tree indicator click:
```diff
  def handle_tree_click(self, event):
      ...
      if element == 'indicator':
-         self._indicator_click = True
-         return
+         if iid:
+             self.tree.item(iid, open=not self.tree.item(iid, 'open'))
+         return 'break'
```

3. Block double-click on indicator:
```diff
+ tree.bind('<Double-1>', self._block_indicator_double_click)

+ def _block_indicator_double_click(self, event):
+     if self.tree.identify_element(event.x, event.y) == 'indicator':
+         return 'break'
```

4. Guard disconnected device right-click menu:
```diff
- if node.available_function_block_types:
+ try:
+     has_fb_types = bool(node.available_function_block_types)
+ except RuntimeError:
+     has_fb_types = False
+ if has_fb_types:
```
Apply in both `create_function_block_menu` and `create_device_menu`.

**`gui_demo/components/generic_properties_treeview.py`** -- two changes:

1. Fix lambda missing event arg:
```diff
- self.bind('<Double-1>', lambda event: self.edit_value())
- self.bind('<Button-3>', lambda event: self.show_menu(event))
+ self.bind('<Double-1>', lambda event=None: self.edit_value())
+ self.bind('<Button-3>', lambda event=None: self.show_menu(event))
```

2. Pad method row text to hide behind button:
```diff
+ if property_info.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+     display_name = '          ' + property_info.name
+ else:
+     display_name = property_info.name
  iid = self.insert(
-     ... text=property_info.name, ...)
+     ... text=display_name, ...)
```

**`gui_demo/utils.py`** -- strip whitespace in path resolution:
```diff
  def get_item_path(tree, item_id):
      ...
-     item_text = tree.item(item_id, 'text')
+     item_text = tree.item(item_id, 'text').strip()
```

**`gui_demo/components/output_signals_view.py`** -- fix None origin display:
```diff
- origin = device_domain.origin
- if res is not None and origin is not None and str(origin) != '':
-     origin_str = str(origin)
+ try:
+     origin = device_domain.origin
+     origin_str = str(origin) if origin is not None else ''
+ except RuntimeError:
+     origin_str = ''
+ if res is not None and origin_str.strip():
      origin_dt = utils.parse_origin(origin_str)
```

Signal Preview now subscribes to `on_component_core_event` on both the signal itself
(for DescriptorChanged) and the owning channel/function block/device (for PropertyValueChanged).
The owning component is found by walking up from signal.parent past the "Sig" folder until
an IFunctionBlock or IDevice is reached. Both subscriptions are cleaned up in _on_destroy.

# Required module changes
None