### PR TITLE
Fix open load module window on mac os gui

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -596,6 +596,8 @@ class App(tk.Tk):
     def handle_load_modules_button_clicked(self):
         if platform.system() == 'Windows':
             extension = '.module.dll'
+        elif platform.system() == 'Darwin':
+            extension = '.dylib'
         else:
             extension = '.module.so'
 

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -902,10 +902,10 @@ class App(tk.Tk):
 
         info_fields = [("ID", ctype.id)]
         if type_kind == "device" and daq.IDeviceType.can_cast_from(comp_type):
-            prefix = getattr(daq.IDeviceType.cast_from(comp_type), 'prefix', None)
+            prefix = daq.IDeviceType.cast_from(comp_type).connection_string_prefix
             info_fields.append(("Prefix", prefix))  # the label row already handles None -> "N/A"
         elif type_kind == "streaming" and daq.IStreamingType.can_cast_from(comp_type):
-            prefix = getattr(daq.IStreamingType.cast_from(comp_type), 'prefix', None)
+            prefix = daq.IStreamingType.cast_from(comp_type).connection_string_prefix
             info_fields.append(("Prefix", prefix))
 
         for label, value in info_fields:


### PR DESCRIPTION
# Brief

This PR fixes that GUI issues: 
- The button `load module` didn’t open the window because the extension filter wasn’t properly set on macOS. 
- Module prefix was showing N/A