### PR TITLE
Pin Windows runner to windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build_windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     name: ${{ matrix.name }}
     if: ${{ ! github.event.pull_request.draft }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         include:
           - name: Windows VS 2022 x64 Release
-            runner: windows-latest
+            runner: windows-2022
             cmake-generator: "Visual Studio 17 2022"
             cmake-build-type: Release
             cmake-defines: -DDAQMODULES_PARQUET_RECORDER_MODULE=ON
@@ -43,7 +43,7 @@ jobs:
             generate-python-bindings: true
             generate-csharp-bindings: true
           - name: Windows VS 2022 Win32 Release
-            runner: windows-latest
+            runner: windows-2022
             cmake-generator: "Visual Studio 17 2022"
             cmake-build-type: Release
             cmake-defines:


### PR DESCRIPTION
# Brief
Pin Windows runner to windows-2022.

# Description
GitHub started rolling out windows-2025 as the new `windows-latest` image, which no longer ships the Visual Studio 17 2022 generator that our CMake configurations rely on. CI fails at the configure step with "Could not find any instance of Visual Studio".

Pin both `ci.yml` and `package.yml` to `windows-2022` explicitly until we migrate the CMake configs to the VS 17 2025 generator.

# API changes
None

# Required application changes
None

# Required module changes
None
