### PR TITLE
Backport: Signal preview

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -109,6 +109,7 @@ class App(tk.Tk):
             self.context.connection_string = None
 
         self.modules_map = {}
+        self._indicator_click = False
 
         self.title('openDAQ demo')
         self.geometry('{}x{}'.format(
@@ -207,14 +208,14 @@ class App(tk.Tk):
         except Exception as e:
             print("Callback processing error:", e)
 
+        if self.context.needs_refresh:
+            self.on_refresh_event(None)
+            self.context.needs_refresh = False
+
         try:
             self.context.instance.context.scheduler.run_main_loop_iteration()
         except Exception as e:
             print("Scheduler processing error:", e)
-
-        if self.context.needs_refresh:
-            self.on_refresh_event(None)
-            self.context.needs_refresh = False
 
         # Re-schedule after 50 ms
         self.after(50, self.poll_opendaq_events)
@@ -272,6 +273,7 @@ class App(tk.Tk):
         tree.bind('<ButtonRelease-3>', self.handle_tree_right_button_release)
         tree.bind('<Button-3>', self.handle_tree_right_button)
         tree.bind('<Button-1>', self.handle_tree_click)
+        tree.bind('<Double-1>', self._block_indicator_double_click)
 
         # add a scrollbar
         scroll_bar = ttk.Scrollbar(
@@ -630,16 +632,22 @@ class App(tk.Tk):
         else:
             event.widget.selection_set()
             
+    def _block_indicator_double_click(self, event):
+        if self.tree.identify_element(event.x, event.y) == 'indicator':
+            return 'break'
+
     def handle_tree_click(self, event):
         iid = self.tree.identify_row(event.y)
         element = self.tree.identify_element(event.x, event.y)
 
         if element == 'indicator':
-            return
+            if iid:
+                self.tree.item(iid, open=not self.tree.item(iid, 'open'))
+            return 'break'
 
         if iid and iid == utils.treeview_get_first_selection(self.tree):
             self.tree.item(iid, open=not self.tree.item(iid, 'open'))
-            return 'break'  # prevent <<TreeviewSelect>> from refiring unnecessarily
+            return 'break'
 
     def create_property_object_menu(self, node):
         popup = tk.Menu(self.tree, tearoff=0)
@@ -656,7 +664,11 @@ class App(tk.Tk):
     def create_function_block_menu(self, node):
         popup = self.create_property_object_menu(node)
 
-        if node.available_function_block_types:
+        try:
+            has_fb_types = bool(node.available_function_block_types)
+        except RuntimeError:
+            has_fb_types = False
+        if has_fb_types:
             popup.add_command(
                 label='Add Function block',
                 command=lambda: self.add_function_block_dialog_show(node)
@@ -675,12 +687,15 @@ class App(tk.Tk):
         popup.add_command(label='Lock', command=self.handle_lock)
         popup.add_command(label='Unlock', command=self.handle_unlock)
 
-        if node.available_function_block_types:
+        try:
+            has_fb_types = bool(node.available_function_block_types)
+        except RuntimeError:
+            has_fb_types = False
+        if has_fb_types:
             popup.add_command(
                 label='Add Function block',
                 command=lambda: self.add_function_block_dialog_show(node)
             )
-
 
         if node.global_id != self.context.instance.global_id:
             popup.add_command(
@@ -925,7 +940,6 @@ class App(tk.Tk):
     # MARK: - Tree view handlers
 
     def handle_tree_select(self, event):
-
         selected_iid = utils.treeview_get_first_selection(self.tree)
         if selected_iid is None:
             self.context.selected_node = None

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -247,13 +247,21 @@ class App(tk.Tk):
 
         view_menu = tk.Menu(menu_bar, tearoff=0)
         menu_bar.add_cascade(label='View', menu=view_menu)
-        view_menu.add_checkbutton(
-            label='Show hidden components', command=self.handle_view_show_hidden_components)
+        view_menu.add_checkbutton(label='Show hidden components',command=self.handle_view_show_hidden_components)
+
+        self._signal_preview_var = tk.BooleanVar(value=self.context.view_signal_preview)
+        view_menu.add_checkbutton(label='Signal preview',variable=self._signal_preview_var,command=self.handle_view_signal_preview_toggled)
 
     def handle_view_show_hidden_components(self):
         self.context.view_hidden_components = not self.context.view_hidden_components
         self.tree_update()
 
+    def handle_view_signal_preview_toggled(self):
+        self.context.view_signal_preview = self._signal_preview_var.get()
+        if self.context.selected_node is not None:
+            self.right_side_panel_clear()
+            self.right_side_panel_draw_node(self.context.selected_node)
+            
     # MARK: - Tree view
     def tree_widget_create(self, parent_frame):
         frame = ttk.Frame(parent_frame)

--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -26,6 +26,7 @@ class AppContext(object):
         self.selected_node = None
         self.include_reference_devices = False
         self.view_hidden_components = False
+        self.view_signal_preview = True
         self.metadata_fields = []
         # gui
         self.ui_scaling_factor = 1.0

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -11,6 +11,7 @@ from .output_signals_view import OutputSignalsView
 from .properties_view import PropertiesView
 from .recorder_view import RecorderView
 from .attributes_dialog import AttributesDialog
+from .signal_preview_panel import SignalPreviewPanel
 
 class BlockView(ttk.Frame):
 
@@ -95,6 +96,7 @@ class BlockView(ttk.Frame):
                 self.output_signals.pack(fill=tk.X)
                     
                 self.label_icon.config(image=self.device_img)
+                
                 self.cols = [0, 1]
                 self.rows = [0]
 
@@ -150,6 +152,7 @@ class BlockView(ttk.Frame):
                     op_mode_menu.add_command(label=mode, command=make_select(mode))
 
                 self._bind_mousewheel_recursive(self.right_stack)
+                self._attach_signal_preview()
             
             elif daq.IFunctionBlock.can_cast_from(self.node):
                 self._create_right_stack()
@@ -178,6 +181,7 @@ class BlockView(ttk.Frame):
                 self.rows = [0]
                 
                 self._bind_mousewheel_recursive(self.right_stack)
+                self._attach_signal_preview()
                 
             elif daq.IFolder.can_cast_from(self.node):
                 self.node = daq.IFolder.cast_from(self.node)
@@ -211,6 +215,7 @@ class BlockView(ttk.Frame):
                 self.rows = [0]
 
                 self._bind_mousewheel_recursive(self.right_stack)
+                self._attach_signal_preview()
             elif daq.IComponent.can_cast_from(self.node):
                 self.node = daq.IComponent.cast_from(self.node)
                 self.properties = PropertiesView(
@@ -296,6 +301,12 @@ class BlockView(ttk.Frame):
         widget.bind('<MouseWheel>', self._on_right_mousewheel)
         for child in widget.winfo_children():
             self._bind_mousewheel_recursive(child)
+
+    def _attach_signal_preview(self):
+        self._signal_preview = SignalPreviewPanel(
+            self._right_container, self.node, self.context)
+        self._signal_preview.place(
+            relx=0, rely=1.0, relwidth=1.0, anchor='sw')
 
     def _on_destroy(self, event):
         if hasattr(self, '_signal_refresh_job') and self._signal_refresh_job is not None:
@@ -438,13 +449,6 @@ class BlockView(ttk.Frame):
         if parent_active is not None:
             self.checkbox.config(state=tk.NORMAL if parent_active else tk.DISABLED)
 
-    def handle_active_toggle(self):
-        if daq.IComponent.can_cast_from(self.node):
-            ctx = daq.IComponent.cast_from(self.node)
-            ctx.active = not ctx.active
-            self.active_var.set(ctx.active)
-            self.event_port.emit()
-    
     def handle_active_toggle(self):
         if daq.IComponent.can_cast_from(self.node):
             ctx = daq.IComponent.cast_from(self.node)

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -91,7 +91,6 @@ class BlockView(ttk.Frame):
 
                 self._create_right_stack()
                 
-                signals = self.node.get_signals(daq.AnySearchFilter() if self.context.view_hidden_components else None)
                 self.output_signals = OutputSignalsView(self.right_stack, self.node, self.context)
                 self.output_signals.pack(fill=tk.X)
                     
@@ -152,7 +151,10 @@ class BlockView(ttk.Frame):
                     op_mode_menu.add_command(label=mode, command=make_select(mode))
 
                 self._bind_mousewheel_recursive(self.right_stack)
-                self._attach_signal_preview()
+                
+                signals = self.node.get_signals(daq.AnySearchFilter() if self.context.view_hidden_components else None)
+                if signals:
+                    self._attach_signal_preview()
             
             elif daq.IFunctionBlock.can_cast_from(self.node):
                 self._create_right_stack()
@@ -166,8 +168,10 @@ class BlockView(ttk.Frame):
                 self.properties = PropertiesView(
                     self.expanded_frame, self.node, self.context)
 
-                self.input_ports = InputPortsView(self.right_stack, self.node, self.context)
-                self.input_ports.pack(fill=tk.BOTH, expand=True)
+                inputs = self.node.get_input_ports()
+                if inputs:
+                    self.input_ports = InputPortsView(self.right_stack, self.node, self.context)
+                    self.input_ports.pack(fill=tk.BOTH, expand=True)
 
                 self.output_signals = OutputSignalsView(self.right_stack, self.node, self.context)
                 self.output_signals.pack(fill=tk.BOTH, expand=True)
@@ -181,7 +185,10 @@ class BlockView(ttk.Frame):
                 self.rows = [0]
                 
                 self._bind_mousewheel_recursive(self.right_stack)
-                self._attach_signal_preview()
+                
+                signals = self.node.get_signals(daq.AnySearchFilter() if self.context.view_hidden_components else None)
+                if signals:
+                    self._attach_signal_preview()
                 
             elif daq.IFolder.can_cast_from(self.node):
                 self.node = daq.IFolder.cast_from(self.node)

--- a/examples/applications/python/GUI Application/gui_demo/components/block_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/block_view.py
@@ -310,6 +310,9 @@ class BlockView(ttk.Frame):
             self._bind_mousewheel_recursive(child)
 
     def _attach_signal_preview(self):
+        if not self.context.view_signal_preview:
+            return
+
         self._signal_preview = SignalPreviewPanel(
             self._right_container, self.node, self.context)
         self._signal_preview.place(

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -70,8 +70,8 @@ class PropertiesTreeview(ttk.Treeview):
 
         # bind double-click to editing (if not read_only)
         if not self.read_only:
-            self.bind('<Double-1>', lambda event: self.edit_value())
-        self.bind('<Button-3>', lambda event: self.show_menu(event))
+            self.bind('<Double-1>', lambda event=None: self.edit_value())
+        self.bind('<Button-3>', lambda event=None: self.show_menu(event))
         self.bind('<MouseWheel>', lambda e=None: self.after_idle(self._sync_overlays))
         self.bind('<ButtonRelease-1>', lambda e=None: self.after(10, self._sync_overlays), add='+')
         self.bind('<Configure>', self._on_configure)
@@ -196,11 +196,16 @@ class PropertiesTreeview(ttk.Treeview):
                 print(e)
 
             # Insert a treeview entry widget for the property
+            if property_info.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+                display_name = '          ' + property_info.name
+            else:
+                display_name = property_info.name
+
             iid = self.insert(
                 '' if not parent_iid else parent_iid,
                 tk.END,
                 open=True,
-                text=property_info.name,
+                text=display_name,
                 values=(property_value, *meta_fields))
 
             container_types = (daq.CoreType.ctObject, daq.CoreType.ctStruct, daq.CoreType.ctList, daq.CoreType.ctDict)

--- a/examples/applications/python/GUI Application/gui_demo/components/output_signal_row.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/output_signal_row.py
@@ -85,7 +85,12 @@ class OutputSignalRow(ttk.Frame):
         return text
 
     def _read_values(self):
-        last_value = utils.get_last_value_for_signal(self.output_signal)
+        # Both reads can raise RuntimeError when the device can not handle 200ms pings for last value
+        try:
+            last_value = utils.get_last_value_for_signal(self.output_signal)
+        except RuntimeError:
+            last_value = None
+
         raw_value = None
         try:
             if self.output_signal is not None and daq.ISignal.can_cast_from(self.output_signal):

--- a/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/output_signals_view.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 
 from .output_signal_row import OutputSignalRow
 
-
 class OutputSignalsView(ttk.Frame):
     def __init__(self, parent, node=None, context=None, **kwargs):
         ttk.Frame.__init__(self, parent, **kwargs)
@@ -31,7 +30,9 @@ class OutputSignalsView(ttk.Frame):
             node = daq.ISignal.cast_from(self.node)
             self.make_output_signal_section([node], 'Signal info')
             self.make_output_signal_section([node.domain_signal], 'Domain signal')
-            self.make_output_signal_section(node.related_signals, 'Related signals')
+            related = node.related_signals
+            self.make_output_signal_section(
+                related if related is not None else [], 'Related signals')
         elif daq.IDevice.can_cast_from(self.node):
             node = daq.IDevice.cast_from(self.node)
             signals = node.get_signals(daq.AnySearchFilter() if self.context.view_hidden_components else None)
@@ -93,11 +94,15 @@ class OutputSignalsView(ttk.Frame):
         value_label.pack(side=tk.RIGHT, padx=(4, 0))
 
         res = device_domain.tick_resolution
-        origin = device_domain.origin
         origin_dt = None
 
-        if res is not None and origin is not None and str(origin) != '':
-            origin_str = str(origin)
+        try:
+            origin = device_domain.origin
+            origin_str = str(origin) if origin is not None else ''
+        except RuntimeError:
+            origin_str = ''
+
+        if res is not None and origin_str.strip():
             origin_dt = utils.parse_origin(origin_str)
 
         res_num = res.numerator if res is not None else None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -1,0 +1,795 @@
+import math
+import tkinter as tk
+from tkinter import ttk
+from collections import deque
+import numpy as np
+
+import opendaq as daq
+
+from .. import utils
+
+
+class SignalPreviewPanel(ttk.Frame):
+    WINDOW_SECONDS = 5.0
+    MAX_BUFFER_SIZE = 100_000
+    POLL_MS = 33          # drain the reader this often
+    _TARGET_PPS = 2000
+    DRAW_MS = 66         # repaint the chart this often
+    CANVAS_HEIGHT = 160
+
+    _BG      = '#ffffff'
+    _LINE    = '#1a6dcc'
+    _GRID    = '#e4e4e4'
+    _TEXT    = '#444444'
+    _AXIS    = '#999999'
+    _FILL    = '#dceafa'
+
+    _AXIS_FONT = ('TkFixedFont', 7)
+    _VAL_FONT  = ('TkFixedFont', 10, 'bold')
+
+    def __init__(self, parent, node, context=None, **kwargs):
+        super().__init__(parent, **kwargs)
+        self.node = node
+        self.context = context
+
+        self._collapsed = False
+        self._reader = None
+        self._selected_signal = None
+        self._poll_job = None
+        self._draw_job = None
+
+        # Buffer of (elapsed_seconds, value) pairs.
+        self._data = deque(maxlen=self.MAX_BUFFER_SIZE)
+
+        self._tick_res_num = None
+        self._tick_res_den = None
+        self._origin_epoch = None   # datetime | None
+        self._first_tick = None
+
+        # name -> ISignal for chartable signals
+        self._eligible = {}
+        self._unit_str = ''
+        self._last_descriptor_hash = None
+        self._signal_event_handler = None
+        self._signal_event_component = None
+        self._parent_event_handler = None
+        self._parent_event_component = None
+        self._reader_dirty = False
+        self._needs_redraw = True
+        self._chart_ready = False
+        self._px_ml = 65
+
+        # Build widgets
+        self._build_toggle_bar()
+        self._build_content()
+        self._content_frame.pack(
+            fill=tk.BOTH, expand=True, after=self._toggle_frame)
+        self._populate_dropdown()
+
+        self._schedule_poll()
+        self._schedule_draw()
+        self.bind('<Destroy>', self._on_destroy)
+
+    def _build_toggle_bar(self):
+        self._toggle_frame = utils.make_banner(self, '\u25BC Signal Preview')
+        self._toggle_frame.configure(cursor='hand2')
+
+        self._arrow_label = self._toggle_frame.winfo_children()[0]
+        self._arrow_label.configure(cursor='hand2')
+
+        for w in (self._toggle_frame, self._arrow_label):
+            w.bind('<Button-1>', lambda _e: self._toggle())
+
+    def _build_content(self):
+        self._content_frame = ttk.Frame(self)
+        dd_row = ttk.Frame(self._content_frame)
+        dd_row.pack(fill=tk.X, padx=4, pady=(4, 2))
+
+        ttk.Label(dd_row, text='Signal:').pack(side=tk.LEFT, padx=(0, 4))
+
+        self._signal_var = tk.StringVar()
+        self._dropdown = ttk.Combobox(
+            dd_row, textvariable=self._signal_var, state='readonly')
+        self._dropdown.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        self._dropdown.bind('<<ComboboxSelected>>', self._on_signal_selected)
+
+        # Duration selector
+        self._duration_presets = [1, 2, 5, 10, 30, 60]
+        self._duration_var = tk.StringVar(value='5s')
+        dur_cb = ttk.Combobox(
+            dd_row, textvariable=self._duration_var, state='readonly',
+            values=[f'{d}s' for d in self._duration_presets], width=5)
+        dur_cb.pack(side=tk.LEFT, padx=(4, 0))
+        dur_cb.bind('<<ComboboxSelected>>', self._on_duration_selected)
+
+        self._log_var = tk.BooleanVar(value=False)
+        log_cb = ttk.Checkbutton(
+            dd_row, text='Logarithm', variable=self._log_var,
+            command=self._on_log_toggled)
+        log_cb.pack(side=tk.LEFT, padx=(4, 0))
+
+        # Chart canvas
+        self._chart = tk.Canvas(
+            self._content_frame, bg=self._BG,
+            height=self.CANVAS_HEIGHT, highlightthickness=0)
+        self._chart.pack(fill=tk.BOTH, expand=True, padx=4, pady=(2, 4))
+
+        self._chart.bind('<Configure>', lambda _e: self._invalidate_chart())
+        self._block_mousewheel_recursive(self)
+
+    def _block_mousewheel_recursive(self, widget):
+        for event in ('<MouseWheel>', '<Button-4>', '<Button-5>'):
+            widget.bind(event, lambda _e=None: 'break')
+        for child in widget.winfo_children():
+            self._block_mousewheel_recursive(child)
+
+    # MARK: Dropdown
+    def _populate_dropdown(self):
+        self._eligible.clear()
+
+        if self.node is None:
+            return
+
+        signals = []
+        search_filter = (
+            daq.AnySearchFilter()
+            if self.context and self.context.view_hidden_components
+            else None)
+
+        if daq.ISignal.can_cast_from(self.node):
+            signals = [daq.ISignal.cast_from(self.node)]
+        elif daq.IDevice.can_cast_from(self.node):
+            device = daq.IDevice.cast_from(self.node)
+            signals = device.get_signals(search_filter)
+        elif daq.IFunctionBlock.can_cast_from(self.node):
+            fb = daq.IFunctionBlock.cast_from(self.node)
+            signals = fb.get_signals(search_filter)
+
+        for sig in signals:
+            if sig is None or not daq.ISignal.can_cast_from(sig):
+                continue
+            signal = daq.ISignal.cast_from(sig)
+            if not self._is_chartable(signal):
+                continue
+
+            name = signal.name if signal.name else signal.global_id
+
+            display = name
+            if display in self._eligible:
+                local_id = getattr(signal, 'local_id', signal.global_id)
+                display = f'{name} ({local_id})'
+
+                first_signal = self._eligible.pop(name)
+                if first_signal.local_id is not None:
+                    first_local = first_signal.local_id
+                else:
+                    first_local = first_signal.global_id
+                    
+                self._eligible[f'{name} ({first_local})'] = first_signal
+
+            self._eligible[display] = signal
+
+        names = list(self._eligible.keys())
+        self._dropdown['values'] = names
+
+        if len(names) == 1:
+            self._signal_var.set(names[0])
+            self._on_signal_selected()
+
+    @staticmethod
+    def _is_chartable(signal):
+        desc = getattr(signal, 'descriptor', None)
+        if desc is None:
+            return False
+
+        sample_type = getattr(desc, 'sample_type', None)
+        if not sample_type:
+            return False
+
+        st_name = getattr(sample_type, 'name', str(sample_type))
+        numeric_prefixes = ('Float', 'Int', 'UInt', 'float', 'int', 'uint')
+        if not any(st_name.startswith(p) for p in numeric_prefixes):
+            return False
+
+        dims = getattr(desc, 'dimensions', None)
+        if dims and len(dims) > 0:
+            return False
+
+        fields = getattr(desc, 'struct_fields', None)
+        if fields and len(fields) > 0:
+            return False
+
+        domain_sig = getattr(signal, 'domain_signal', None)
+        if domain_sig is None:
+            return False
+
+        domain_desc = getattr(domain_sig, 'descriptor', None)
+        if domain_desc is None:
+            return False
+
+        unit = getattr(domain_desc, 'unit', None)
+        symbol = getattr(unit, 'symbol', None)
+        if str(symbol) != 's':
+            return False
+
+        if getattr(domain_desc, 'tick_resolution', None) is None:
+            return False
+
+        return True
+
+    # MARK: Signal selection
+
+    def _on_signal_selected(self, _event=None):
+        name = self._signal_var.get()
+        signal = self._eligible.get(name)
+        if signal is None:
+            return
+
+        self._reader = None
+        self._selected_signal = signal
+        self._data.clear()
+        self._first_tick = None
+        self._needs_redraw = True
+
+        self._unit_str = ''
+        if signal.descriptor.unit is not None:
+            unit = signal.descriptor.unit
+            if unit is not None and unit.symbol is not None:
+                self._unit_str = str(unit.symbol)
+
+        # Cache tick resolution for tick -> seconds conversion.
+        domain_desc = signal.domain_signal.descriptor
+        res = domain_desc.tick_resolution
+        self._tick_res_num = res.numerator
+        self._tick_res_den = res.denominator
+
+        origin_str = str(domain_desc.origin) if hasattr(domain_desc, 'origin') else ''
+        if origin_str.strip():
+            self._origin_epoch = utils.parse_origin(origin_str)
+        else:
+            self._origin_epoch = None
+
+        self._reader = daq.StreamReader(signal)
+        self._last_descriptor_hash = self._descriptor_fingerprint(signal)
+
+        self._unsubscribe_core_events()
+
+        if daq.IComponent.can_cast_from(signal):
+            self._signal_event_component = signal
+            self._signal_event_handler = daq.QueuedEventHandler(self._on_core_event)
+            comp = daq.IComponent.cast_from(signal)
+            comp.on_component_core_event + self._signal_event_handler
+
+        ancestor = getattr(signal, 'parent', None)
+        while ancestor is not None:
+            if (daq.IFunctionBlock.can_cast_from(ancestor)
+                    or daq.IDevice.can_cast_from(ancestor)):
+                break
+            ancestor = getattr(ancestor, 'parent', None)
+
+        if ancestor is not None and daq.IComponent.can_cast_from(ancestor):
+            self._parent_event_component = ancestor
+            self._parent_event_handler = daq.QueuedEventHandler(self._on_core_event)
+            comp = daq.IComponent.cast_from(ancestor)
+            comp.on_component_core_event + self._parent_event_handler
+
+    # MARK: Polling
+
+    def _unsubscribe_core_events(self):
+        for handler_attr, comp_attr in (
+            ('_signal_event_handler', '_signal_event_component'),
+            ('_parent_event_handler', '_parent_event_component'),
+        ):
+            handler = getattr(self, handler_attr, None)
+            comp = getattr(self, comp_attr, None)
+            if handler is not None and comp is not None:
+                if daq.IComponent.can_cast_from(comp):
+                    component = daq.IComponent.cast_from(comp)
+                    component.on_component_core_event - handler
+            setattr(self, handler_attr, None)
+            setattr(self, comp_attr, None)
+
+    def _on_core_event(self, sender, args):
+        if args.event_name in ('DescriptorChanged', 'PropertyValueChanged', 'ComponentUpdateEnd'):
+            self._reader_dirty = True
+
+    def _on_duration_selected(self, _event=None):
+        raw = self._duration_var.get().rstrip('s')
+        if float(raw) is not None:
+            seconds = float(raw)
+        else:
+            return
+        if seconds <= 0:
+            return
+        self.WINDOW_SECONDS = seconds
+        self._needs_redraw = True
+
+        # Vertical grid lines are created once for the initial WINDOW_SECONDS.
+        self._chart_ready = False
+
+    def _recreate_reader(self):
+        self._reader = None
+        if self._selected_signal is None:
+            return
+        if not self._is_chartable(self._selected_signal):
+            return
+
+        domain_desc = getattr(
+            getattr(self._selected_signal, 'domain_signal', None),
+            'descriptor', None)
+        if domain_desc is None:
+            return
+        res = getattr(domain_desc, 'tick_resolution', None)
+        if res is None:
+            return
+
+        self._tick_res_num = res.numerator
+        self._tick_res_den = res.denominator
+        self._reader = daq.StreamReader(self._selected_signal)
+        self._first_tick = None
+        self._data.clear()
+        self._last_descriptor_hash = self._descriptor_fingerprint(self._selected_signal)
+        self._needs_redraw = True
+
+    @staticmethod
+    def _descriptor_fingerprint(signal):
+        desc = getattr(signal, 'descriptor', None)
+        if desc is None:
+            return None
+        d_desc = getattr(getattr(signal, 'domain_signal', None), 'descriptor', None)
+
+        st = getattr(getattr(desc, 'sample_type', None), 'name', None)
+        rule = getattr(getattr(desc, 'data_rule', None), 'type', None)
+        rule_name = getattr(rule, 'name', str(rule)) if rule else None
+
+        d_rule = getattr(getattr(d_desc, 'data_rule', None), 'type', None) if d_desc else None
+        d_rule_name = getattr(d_rule, 'name', str(d_rule)) if d_rule else None
+
+        # For linear domain rules, the delta parameter encodes the sample rate.
+        # A change here means the rate changed even if everything else looks the same.
+        d_rule_params = None
+        if d_desc is not None:
+            dr = getattr(d_desc, 'data_rule', None)
+            if dr is not None:
+                params = getattr(dr, 'parameters', None)
+                d_rule_params = str(params) if params is not None else None
+
+        return (st, rule_name, d_rule_name, d_rule_params)
+
+    def _on_log_toggled(self):
+        self._needs_redraw = True
+
+    def _schedule_poll(self):
+        self._poll_job = self.after(self.POLL_MS, self._poll_tick)
+
+    def _poll_tick(self):
+        self._poll_job = None
+        if not self.winfo_exists():
+            return
+
+        if self._reader is not None:
+            try:
+                available = self._reader.available_count
+                if available > 0:
+                    values, domain_ticks = self._reader.read_with_domain(available)
+                    self._ingest(values, domain_ticks)
+            except RuntimeError as e:
+                print(f'[SignalPreview] Reader invalidated, recreating: {e}')
+                self._recreate_reader()
+
+        if self._reader is not None and self._selected_signal is not None:
+            current = self._descriptor_fingerprint(self._selected_signal)
+            if current != self._last_descriptor_hash:
+                print('[SignalPreview] Descriptor changed, recreating reader')
+                self._recreate_reader()
+                self._last_descriptor_hash = current
+
+        if self._reader_dirty:
+            self._reader_dirty = False
+            print('[SignalPreview] Property changed, recreating reader')
+            self._recreate_reader()
+
+        self._poll_job = self.after(self.POLL_MS, self._poll_tick)
+
+    def _ingest(self, values, domain_ticks):
+        if values is None or domain_ticks is None:
+            return
+
+        n = len(values)
+        if n == 0:
+            return
+
+        ratio = self._tick_res_num / self._tick_res_den
+        if self._first_tick is None:
+            self._first_tick = int(domain_ticks[0])
+
+        base = self._first_tick
+        buf = self._data
+
+        t_arr = (domain_ticks.astype(np.float64) - base) * ratio
+        v_arr = values.astype(np.float64)
+
+        if t_arr is not None:
+            target = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
+
+            stride = 1
+            if n > 2:
+                dt = t_arr[-1] - t_arr[0]
+                if dt > 0:
+                    actual_rate = n / dt
+                    if actual_rate > target:
+                        stride = max(1, int(actual_rate / target))
+
+            if stride <= 1:
+                # Fast path: extend buffer with all points
+                for i in range(n):
+                    buf.append((t_arr[i], v_arr[i]))
+            else:
+                usable = (n // stride) * stride
+                if usable > 0:
+                    t_chunk = t_arr[:usable].reshape(-1, stride)
+                    v_chunk = v_arr[:usable].reshape(-1, stride)
+
+                    mn_idx = v_chunk.argmin(axis=1)
+                    mx_idx = v_chunk.argmax(axis=1)
+
+                    for ci in range(len(v_chunk)):
+                        mni = mn_idx[ci]
+                        mxi = mx_idx[ci]
+                        if mni == mxi:
+                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+                        elif mni < mxi:
+                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+                            buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
+                        else:
+                            buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
+                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+
+                # Handle leftover samples after the last full chunk
+                for i in range(usable, n):
+                    buf.append((t_arr[i], v_arr[i]))
+        else:
+            stride = 1
+            if n > 2:
+                dt = (int(domain_ticks[-1]) - int(domain_ticks[0])) * ratio
+                if dt > 0:
+                    actual_rate = n / dt
+                    target_fb = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
+                    if actual_rate > target_fb:
+                        stride = max(1, int(actual_rate / target_fb))
+            for i in range(0, n, stride):
+                elapsed = (int(domain_ticks[i]) - base) * ratio
+                buf.append((elapsed, float(values[i])))
+
+        self._needs_redraw = True
+
+    # MARK: Drawing
+
+    def _invalidate_chart(self):
+        self._chart_ready = False
+        self._needs_redraw = True
+
+    def _ensure_chart_items(self):
+        c = self._chart
+        c.delete('all')
+
+        # Z-order: fill -> grid -> axes -> line -> labels
+
+        self._fill_id = c.create_polygon(
+            0, 0, 0, 0, 0, 0, fill=self._FILL, outline='', state='hidden')
+
+        # Horizontal grid
+        self._hgrid_ids = []
+        self._hgrid_label_ids = []
+        for _ in range(5):
+            gid = c.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
+            lid = c.create_text(
+                0, 0, text='', fill=self._TEXT, anchor=tk.E, font=self._AXIS_FONT)
+            self._hgrid_ids.append(gid)
+            self._hgrid_label_ids.append(lid)
+
+        self._vgrid_ids = []
+        self._vgrid_label_ids = []
+        for _ in range(10):
+            vid = c.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
+            vlid = c.create_text(
+                0, 0, text='', fill=self._TEXT, anchor=tk.N, font=self._AXIS_FONT)
+            self._vgrid_ids.append(vid)
+            self._vgrid_label_ids.append(vlid)
+
+        self._yaxis_id = c.create_line(0, 0, 0, 0, fill=self._AXIS)
+        self._xaxis_id = c.create_line(0, 0, 0, 0, fill=self._AXIS)
+
+        # Grid numbers
+        self._xlabel_l = c.create_text(
+            0, 0, text='', fill=self._TEXT, anchor=tk.SW, font=self._AXIS_FONT)
+        self._xlabel_r = c.create_text(
+            0, 0, text='', fill=self._TEXT, anchor=tk.SE, font=self._AXIS_FONT)
+
+        self._line_id = c.create_line(
+            0, 0, 0, 0, fill=self._LINE, width=1, smooth=False)
+
+        self._badge_bg_id = c.create_rectangle(
+            0, 0, 0, 0, fill=self._BG, outline=self._GRID, width=1,
+            state='hidden')
+        self._badge_id = c.create_text(
+            0, 0, text='', fill='#111111', anchor=tk.NE, font=self._VAL_FONT)
+
+        self._nodata_id = c.create_text(
+            0, 0, text='', fill=self._TEXT, font=('TkDefaultFont', 10),
+            state='hidden')
+
+        self._chart_ready = True
+
+    def _schedule_draw(self):
+        self._draw_job = self.after(self.DRAW_MS, self._draw_tick)
+
+    def _draw_tick(self):
+        self._draw_job = None
+        if not self.winfo_exists():
+            return
+
+        if not self._collapsed and self._needs_redraw:
+            self._draw_chart()
+            self._needs_redraw = False
+
+        self._draw_job = self.after(self.DRAW_MS, self._draw_tick)
+        
+    def _draw_chart(self):
+        if not self._chart_ready:
+            self._ensure_chart_items()
+
+        c = self._chart
+        w = c.winfo_width()
+        h = c.winfo_height()
+        if w < 20 or h < 20:
+            return
+
+        ml, mr, mt, mb = 65, 12, 10, 22
+        pw = w - ml - mr
+        ph = h - mt - mb
+        if pw < 10 or ph < 10:
+            return
+
+        buf = self._data
+        has_data = len(buf) > 0
+
+        if not has_data:
+            c.coords(self._nodata_id, w // 2, h // 2)
+            c.itemconfig(self._nodata_id, text='No data', state='normal')
+            c.itemconfig(self._line_id, state='hidden')
+            c.itemconfig(self._fill_id, state='hidden')
+            c.itemconfig(self._badge_id, state='hidden')
+            c.itemconfig(self._badge_bg_id, state='hidden')
+            return
+
+        c.itemconfig(self._nodata_id, state='hidden')
+
+        # Visible window
+        t_latest = buf[-1][0]
+        t_earliest = t_latest - self.WINDOW_SECONDS
+
+        visible = [(t, v) for t, v in buf if t >= t_earliest]
+        
+        if len(visible) == 0:
+            c.coords(self._nodata_id, w // 2, h // 2)
+            c.itemconfig(self._nodata_id, text='Waiting...', state='normal')
+            c.itemconfig(self._line_id, state='hidden')
+            c.itemconfig(self._fill_id, state='hidden')
+            c.itemconfig(self._badge_id, state='hidden')
+            c.itemconfig(self._badge_bg_id, state='hidden')
+            return
+
+        # Y range with breathing room
+        vals = [v for _, v in visible]
+        v_lo, v_hi = min(vals), max(vals)
+
+        use_log = self._log_var.get()
+
+        if use_log:
+            abs_max = max(abs(v) for v in vals)
+            symlog_thresh = max(abs_max * 0.01, 1e-10)
+
+            def symlog(v):
+                return math.copysign(math.log10(1.0 + abs(v) / symlog_thresh), v)
+
+            symlog_vals = [symlog(v) for v in vals]
+            sl_lo = min(symlog_vals)
+            sl_hi = max(symlog_vals)
+            if sl_lo == sl_hi:
+                sl_lo -= 1.0
+                sl_hi += 1.0
+            else:
+                pad = (sl_hi - sl_lo) * 0.05
+                sl_lo -= pad
+                sl_hi += pad
+            sl_span = sl_hi - sl_lo
+        else:
+            if v_lo == v_hi:
+                v_lo -= 1.0
+                v_hi += 1.0
+            else:
+                pad = (v_hi - v_lo) * 0.08
+                v_lo -= pad
+                v_hi += pad
+
+        t_span = self.WINDOW_SECONDS
+        v_span = v_hi - v_lo
+        
+        def xpx(t):
+            return ml + (t - t_earliest) / t_span * pw
+
+        if use_log:
+            def ypx(v):
+                return mt + (1.0 - (symlog(v) - sl_lo) / sl_span) * ph
+        else:
+            def ypx(v):
+                return mt + (1.0 - (v - v_lo) / v_span) * ph
+
+        # Horizontal grid + Y labels
+        unit_suffix = f' {self._unit_str}' if self._unit_str else ''
+        for i in range(5):
+            gy = mt + ph * i / 4
+            c.coords(self._hgrid_ids[i], ml, gy, ml + pw, gy)
+            if use_log:
+                sl_val = sl_hi - (sl_hi - sl_lo) * i / 4
+                gv = math.copysign(
+                    symlog_thresh * (10.0 ** abs(sl_val) - 1.0), sl_val)
+            else:
+                gv = v_hi - v_span * i / 4
+            c.coords(self._hgrid_label_ids[i], ml - 4, gy)
+            c.itemconfig(self._hgrid_label_ids[i],
+                         text=self._fmt(gv) + unit_suffix)
+
+        _nice = [0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 30, 60]
+        grid_interval = _nice[-1]
+        for ni in _nice:
+            if self.WINDOW_SECONDS / ni <= 7:
+                grid_interval = ni
+                break
+
+        first_mark = math.ceil(t_earliest / grid_interval) * grid_interval
+        slot = 0
+        t_mark = first_mark
+        
+        while t_mark < t_latest and slot < len(self._vgrid_ids):
+            vx = xpx(t_mark)
+            c.coords(self._vgrid_ids[slot], vx, mt, vx, mt + ph)
+            secs_ago = t_latest - t_mark
+            if grid_interval >= 1:
+                label = f'-{secs_ago:.0f}s'
+            else:
+                label = f'-{secs_ago:.1f}s'
+            c.coords(self._vgrid_label_ids[slot], vx, mt + ph + 3)
+            c.itemconfig(self._vgrid_label_ids[slot], text=label, state='normal')
+            slot += 1
+            t_mark += grid_interval
+
+        # Hide unused grid slots
+        for i in range(slot, len(self._vgrid_ids)):
+            c.itemconfig(self._vgrid_ids[i], state='hidden')
+            c.itemconfig(self._vgrid_label_ids[i], state='hidden')
+
+        # Axes
+        c.coords(self._yaxis_id, ml, mt, ml, mt + ph)
+        c.coords(self._xaxis_id, ml, mt + ph, ml + pw, mt + ph)
+
+        c.coords(self._xlabel_l, ml, h - 2)
+        c.itemconfig(self._xlabel_l, text=f'-{self.WINDOW_SECONDS:.0f}s')
+        c.coords(self._xlabel_r, ml + pw, h - 2)
+        c.itemconfig(self._xlabel_r, text='now')
+
+        # Min/max envelope downsampl
+        if len(visible) > pw * 3:
+            n_buckets = max(pw, 4)
+            bucket_w = t_span / n_buckets
+            envelope = []
+            bi = 0
+            b_edge = t_earliest + bucket_w
+            b_min = b_max = None
+
+            for t, v in visible:
+                while t >= b_edge and bi < n_buckets - 1:
+                    if b_min is not None:
+                        if b_min[0] <= b_max[0]:
+                            envelope.append(b_min)
+                            if b_max != b_min:
+                                envelope.append(b_max)
+                        else:
+                            envelope.append(b_max)
+                            if b_min != b_max:
+                                envelope.append(b_min)
+                    b_min = b_max = None
+                    bi += 1
+                    b_edge = t_earliest + (bi + 1) * bucket_w
+
+                if b_min is None or v < b_min[1]:
+                    b_min = (t, v)
+                if b_max is None or v > b_max[1]:
+                    b_max = (t, v)
+
+            if b_min is not None:
+                if b_min[0] <= b_max[0]:
+                    envelope.append(b_min)
+                    if b_max != b_min:
+                        envelope.append(b_max)
+                else:
+                    envelope.append(b_max)
+                    if b_min != b_max:
+                        envelope.append(b_min)
+            visible = envelope
+
+        # Filled area under curve
+        bottom_y = mt + ph
+        if len(visible) >= 2:
+            fill_coords = [xpx(visible[0][0]), bottom_y]
+            for t, v in visible:
+                fill_coords.extend([xpx(t), ypx(v)])
+            fill_coords.extend([xpx(visible[-1][0]), bottom_y])
+            c.coords(self._fill_id, *fill_coords)
+            c.itemconfig(self._fill_id, state='normal')
+        else:
+            c.itemconfig(self._fill_id, state='hidden')
+
+        # Data line (1 px, no smoothing)
+        if len(visible) >= 2:
+            line_coords = []
+            for t, v in visible:
+                line_coords.extend([xpx(t), ypx(v)])
+            c.coords(self._line_id, *line_coords)
+            c.itemconfig(self._line_id, state='normal')
+        elif len(visible) == 1:
+            px, py = xpx(visible[0][0]), ypx(visible[0][1])
+            c.coords(self._line_id, px, py, px + 1, py)
+            c.itemconfig(self._line_id, state='normal')
+
+        badge_text = self._fmt(visible[-1][1])
+        if self._unit_str:
+            badge_text += f' {self._unit_str}'
+        bx = ml + pw - 4
+        by = mt + 4
+        c.coords(self._badge_id, bx, by)
+        c.itemconfig(self._badge_id, text=badge_text, state='normal')
+        c.update_idletasks()
+        bb = c.bbox(self._badge_id)
+        if bb:
+            c.coords(self._badge_bg_id, bb[0] - 3, bb[1] - 1, bb[2] + 3, bb[3] + 1)
+            c.itemconfig(self._badge_bg_id, state='normal')
+
+    @staticmethod
+    def _fmt(v):
+        if v != 0 and abs(v) < 0.001:
+            return f'{v:.3e}'
+        if abs(v) >= 100_000:
+            return f'{v:.1f}'
+        if v == int(v):
+            return str(int(v))
+        return f'{v:.4g}'
+
+    def _toggle(self):
+        self._collapsed = not self._collapsed
+        if self._collapsed:
+            self._content_frame.pack_forget()
+            self._arrow_label.config(text='\u25B2 Signal Preview')
+        else:
+            self._content_frame.pack(
+                fill=tk.BOTH, expand=True, after=self._toggle_frame)
+            self._arrow_label.config(text='\u25BC Signal Preview')
+            self._needs_redraw = True
+            
+    def _on_destroy(self, event):
+        if event.widget is not self:
+            return
+
+        for job_attr in ('_poll_job', '_draw_job'):
+            job_id = getattr(self, job_attr, None)
+            if job_id:
+                self.after_cancel(job_id)
+                setattr(self, job_attr, None)
+
+        if self._chart.winfo_exists():
+            self._chart.delete('all')
+
+        self._chart_ready = False
+        self._unsubscribe_core_events()
+        self._reader = None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -11,7 +11,7 @@ import opendaq as daq
 from .. import utils
 
 class SignalPreviewPanel(ttk.Frame):
-    WINDOW_SECONDS = 1.0
+    DEFAULT_WINDOW_SECONDS = 0.2
     MAX_BUFFER_SIZE = 100_000
     POLL_MS = 33          # drain the reader this often
     _TARGET_PPS = 2000
@@ -44,6 +44,7 @@ class SignalPreviewPanel(ttk.Frame):
 
         # Buffer of (elapsed_seconds, value) pairs.
         self._data = deque(maxlen=self.MAX_BUFFER_SIZE)
+        self._window_seconds = self.DEFAULT_WINDOW_SECONDS
 
         self._tick_res_num = None
         self._tick_res_den = None
@@ -98,7 +99,7 @@ class SignalPreviewPanel(ttk.Frame):
 
         # Duration combobox
         self._duration_presets = [0.01, 0.05, 0.1, 0.2, 0.5, 1]
-        self._duration_var = tk.StringVar(value='0.2s')
+        self._duration_var = tk.StringVar(value=f'{self._window_seconds:g}s')
         dur_cb = ttk.Combobox(
             controls, textvariable=self._duration_var,
             values=[f'{d}s' for d in self._duration_presets], width=6)
@@ -274,7 +275,7 @@ class SignalPreviewPanel(ttk.Frame):
         text = self._duration_var.get()
         match = self._DURATION_RE.match(text)
         if match is None:
-            self._duration_var.set(f'{self.WINDOW_SECONDS:g}s')
+            self._duration_var.set(f'{self.DEFAULT_WINDOW_SECONDS:g}s')
             return
 
         seconds = float(match.group(1))
@@ -284,10 +285,10 @@ class SignalPreviewPanel(ttk.Frame):
         if event is not None and event.type != tk.EventType.FocusOut:
             self._chart.focus_set()
 
-        if seconds == self.WINDOW_SECONDS:
+        if seconds == self._window_seconds:
             return
 
-        self.WINDOW_SECONDS = seconds
+        self._window_seconds = seconds
         self._needs_redraw = True
         self._chart_ready = False
 
@@ -549,7 +550,7 @@ class SignalPreviewPanel(ttk.Frame):
         self._chart_ready = True
 
     def _schedule_draw(self):
-        draw_interval = max(16, min(self.DRAW_MS, int(self.WINDOW_SECONDS * 500)))
+        draw_interval = max(16, min(self.DRAW_MS, int(self.DEFAULT_WINDOW_SECONDS * 500)))
         self._draw_job = self.after(draw_interval, self._draw_tick)
 
     def _draw_tick(self):
@@ -593,7 +594,7 @@ class SignalPreviewPanel(ttk.Frame):
 
         # Visible window
         t_latest = buf[-1][0]
-        t_earliest = t_latest - self.WINDOW_SECONDS
+        t_earliest = t_latest - self._window_seconds
 
         visible = [(t, v) for t, v in buf if t >= t_earliest]
         
@@ -605,8 +606,9 @@ class SignalPreviewPanel(ttk.Frame):
             c.itemconfig(self._badge_bg_id, state='hidden')
             return
 
-        # Y range computed from a stabilized window. 
-        range_earliest = t_latest - max(self.WINDOW_SECONDS, 0.5)
+        # Y range from a stabilized window so a brief spike does not
+        # immediately rescale the whole chart.
+        range_earliest = t_latest - max(self._window_seconds, 0.5)
         range_vals = [v for t, v in buf if t >= range_earliest]
         v_lo, v_hi = min(range_vals), max(range_vals)
 
@@ -622,7 +624,6 @@ class SignalPreviewPanel(ttk.Frame):
             symlog_vals = [symlog(v) for v in range_vals]
             sl_lo = min(symlog_vals)
             sl_hi = max(symlog_vals)
-            ...
             if sl_lo == sl_hi:
                 sl_lo -= 1.0
                 sl_hi += 1.0
@@ -640,7 +641,7 @@ class SignalPreviewPanel(ttk.Frame):
                 v_lo -= pad
                 v_hi += pad
 
-        t_span = self.WINDOW_SECONDS
+        t_span = self._window_seconds
         v_span = v_hi - v_lo
 
         unit_suffix = f' {self._unit_str}' if self._unit_str else ''
@@ -687,7 +688,7 @@ class SignalPreviewPanel(ttk.Frame):
                  1, 2, 5, 10, 15, 30, 60]
         grid_interval = _nice[-1]
         for ni in _nice:
-            if self.WINDOW_SECONDS / ni <= 7:
+            if self._window_seconds / ni <= 7:
                 grid_interval = ni
                 break
 
@@ -702,15 +703,16 @@ class SignalPreviewPanel(ttk.Frame):
 
         slot = 0
         k = 1
-        while (k * grid_interval) < self.WINDOW_SECONDS - 1e-9 \
+        while (k * grid_interval) < self._window_seconds - 1e-9 \
                 and slot < len(self._vgrid_ids):
             secs_ago = k * grid_interval
-            vx = ml + pw - (secs_ago / self.WINDOW_SECONDS) * pw
-            c.coords(self._vgrid_ids[slot], vx, mt, vx, mt + ph)
-            c.itemconfig(self._vgrid_ids[slot], state='normal')
-            c.coords(self._vgrid_label_ids[slot], vx, mt + ph + 3)
-            c.itemconfig(self._vgrid_label_ids[slot],
-                         text=label_fmt.format(secs_ago), state='normal')
+            vx = margin_left + plot_width - (secs_ago / self._window_seconds) * plot_width
+            canvas.coords(self._vgrid_ids[slot],
+                        vx, margin_top, vx, margin_top + plot_height)
+            canvas.itemconfig(self._vgrid_ids[slot], state='normal')
+            canvas.coords(self._vgrid_label_ids[slot], vx, label_y)
+            canvas.itemconfig(self._vgrid_label_ids[slot],
+                            text=label_fmt.format(secs_ago), state='normal')
             slot += 1
             k += 1
 
@@ -719,11 +721,11 @@ class SignalPreviewPanel(ttk.Frame):
             c.itemconfig(self._vgrid_ids[i], state='hidden')
             c.itemconfig(self._vgrid_label_ids[i], state='hidden')
 
-        c.coords(self._xlabel_l, ml, h - 2)
-        c.itemconfig(self._xlabel_l,
-                     text=label_fmt.format(self.WINDOW_SECONDS))
-        c.coords(self._xlabel_r, ml + pw, h - 2)
-        c.itemconfig(self._xlabel_r, text='0s')
+        canvas.coords(self._xlabel_l, margin_left, label_y)
+        canvas.itemconfig(self._xlabel_l,
+                        text=label_fmt.format(self._window_seconds))
+        canvas.coords(self._xlabel_r, margin_left + plot_width, label_y)
+        canvas.itemconfig(self._xlabel_r, text='0s')
 
         if len(visible) > pw * 3:
             n_buckets = max(pw, 4)

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -481,8 +481,8 @@ class SignalPreviewPanel(ttk.Frame):
         self._needs_redraw = True
 
     def _ensure_chart_items(self):
-        c = self._chart
-        c.delete('all')
+        canvas = self._chart
+        canvas.delete('all')
 
         # Z-order: grid -> axes -> line -> labels
 
@@ -490,8 +490,8 @@ class SignalPreviewPanel(ttk.Frame):
         self._hgrid_ids = []
         self._hgrid_label_ids = []
         for _ in range(5):
-            gid = c.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
-            lid = c.create_text(
+            gid = canvas.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
+            lid = canvas.create_text(
                 0, 0, text='', fill=self._TEXT, anchor=tk.E, font=self._AXIS_FONT)
             self._hgrid_ids.append(gid)
             self._hgrid_label_ids.append(lid)
@@ -499,31 +499,31 @@ class SignalPreviewPanel(ttk.Frame):
         self._vgrid_ids = []
         self._vgrid_label_ids = []
         for _ in range(10):
-            vid = c.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
-            vlid = c.create_text(
+            vid = canvas.create_line(0, 0, 0, 0, fill=self._GRID, dash=(2, 6))
+            vlid = canvas.create_text(
                 0, 0, text='', fill=self._TEXT, anchor=tk.N, font=self._AXIS_FONT)
             self._vgrid_ids.append(vid)
             self._vgrid_label_ids.append(vlid)
 
-        self._yaxis_id = c.create_line(0, 0, 0, 0, fill=self._AXIS)
-        self._xaxis_id = c.create_line(0, 0, 0, 0, fill=self._AXIS)
+        self._yaxis_id = canvas.create_line(0, 0, 0, 0, fill=self._AXIS)
+        self._xaxis_id = canvas.create_line(0, 0, 0, 0, fill=self._AXIS)
 
         # Grid numbers
-        self._xlabel_l = c.create_text(
-            0, 0, text='', fill=self._TEXT, anchor=tk.SW, font=self._AXIS_FONT)
-        self._xlabel_r = c.create_text(
-            0, 0, text='', fill=self._TEXT, anchor=tk.SE, font=self._AXIS_FONT)
+        self._xlabel_l = canvas.create_text(
+            0, 0, text='', fill=self._TEXT, anchor=tk.NW, font=self._AXIS_FONT)
+        self._xlabel_r = canvas.create_text(
+            0, 0, text='', fill=self._TEXT, anchor=tk.NE, font=self._AXIS_FONT)
 
-        self._line_id = c.create_line(
+        self._line_id = canvas.create_line(
             0, 0, 0, 0, fill=self._LINE, width=1, smooth=False)
 
-        self._badge_bg_id = c.create_rectangle(
+        self._badge_bg_id = canvas.create_rectangle(
             0, 0, 0, 0, fill=self._BG, outline=self._GRID, width=1,
             state='hidden')
-        self._badge_id = c.create_text(
+        self._badge_id = canvas.create_text(
             0, 0, text='', fill='#111111', anchor=tk.NE, font=self._VAL_FONT)
 
-        self._nodata_id = c.create_text(
+        self._nodata_id = canvas.create_text(
             0, 0, text='', fill=self._TEXT, font=('TkDefaultFont', 10),
             state='hidden')
 
@@ -548,42 +548,44 @@ class SignalPreviewPanel(ttk.Frame):
         if not self._chart_ready:
             self._ensure_chart_items()
 
-        c = self._chart
-        w = c.winfo_width()
-        h = c.winfo_height()
-        if w < 20 or h < 20:
+        canvas = self._chart
+        canvas_width = canvas.winfo_width()
+        canvas_height = canvas.winfo_height()
+        if canvas_width < 20 or canvas_height < 20:
             return
 
-        mr, mt, mb = 12, 10, 22
-        ph = h - mt - mb
-        if ph < 10:
+        margin_right = 12
+        margin_top = 10
+        margin_bottom = 22
+        plot_height = canvas_height - margin_top - margin_bottom
+        if plot_height < 10:
             return
 
         buf = self._data
         has_data = len(buf) > 0
 
         if not has_data:
-            c.coords(self._nodata_id, w // 2, h // 2)
-            c.itemconfig(self._nodata_id, text='None', state='normal')
-            c.itemconfig(self._line_id, state='hidden')
-            c.itemconfig(self._badge_id, state='hidden')
-            c.itemconfig(self._badge_bg_id, state='hidden')
+            canvas.coords(self._nodata_id, canvas_width // 2, canvas_height // 2)
+            canvas.itemconfig(self._nodata_id, text='None', state='normal')
+            canvas.itemconfig(self._line_id, state='hidden')
+            canvas.itemconfig(self._badge_id, state='hidden')
+            canvas.itemconfig(self._badge_bg_id, state='hidden')
             return
 
-        c.itemconfig(self._nodata_id, state='hidden')
+        canvas.itemconfig(self._nodata_id, state='hidden')
 
         # Visible window
         t_latest = buf[-1][0]
         t_earliest = t_latest - self._window_seconds
 
         visible = [(t, v) for t, v in buf if t >= t_earliest]
-        
+
         if len(visible) == 0:
-            c.coords(self._nodata_id, w // 2, h // 2)
-            c.itemconfig(self._nodata_id, text='Waiting...', state='normal')
-            c.itemconfig(self._line_id, state='hidden')
-            c.itemconfig(self._badge_id, state='hidden')
-            c.itemconfig(self._badge_bg_id, state='hidden')
+            canvas.coords(self._nodata_id, canvas_width // 2, canvas_height // 2)
+            canvas.itemconfig(self._nodata_id, text='Waiting...', state='normal')
+            canvas.itemconfig(self._line_id, state='hidden')
+            canvas.itemconfig(self._badge_id, state='hidden')
+            canvas.itemconfig(self._badge_bg_id, state='hidden')
             return
 
         # Y range from a stabilized window so a brief spike does not
@@ -637,35 +639,41 @@ class SignalPreviewPanel(ttk.Frame):
 
         label_font = tkfont.Font(font=self._AXIS_FONT)
         max_label_w = max(label_font.measure(t) for t in y_labels)
-        ml = -(-(max_label_w + 8) // 4) * 4
+        # Round left margin up to not nudge
+        margin_left = -(-(max_label_w + 8) // 4) * 4
 
-        pw = w - ml - mr
-        if pw < 10:
+        plot_width = canvas_width - margin_left - margin_right
+        if plot_width < 10:
             return
 
         def xpx(t):
-            return ml + (t - t_earliest) / t_span * pw
+            return margin_left + (t - t_earliest) / t_span * plot_width
 
         if use_log:
             def ypx(v):
-                return mt + (1.0 - (symlog(v) - sl_lo) / sl_span) * ph
+                return margin_top + (1.0 - (symlog(v) - sl_lo) / sl_span) * plot_height
         else:
             def ypx(v):
-                return mt + (1.0 - (v - v_lo) / v_span) * ph
+                return margin_top + (1.0 - (v - v_lo) / v_span) * plot_height
 
         # Horizontal grid + Y labels
         for i in range(5):
-            gy = mt + ph * i / 4
-            c.coords(self._hgrid_ids[i], ml, gy, ml + pw, gy)
-            c.coords(self._hgrid_label_ids[i], ml - 4, gy)
-            c.itemconfig(self._hgrid_label_ids[i], text=y_labels[i])
+            gy = margin_top + plot_height * i / 4
+            canvas.coords(self._hgrid_ids[i],
+                        margin_left, gy, margin_left + plot_width, gy)
+            canvas.coords(self._hgrid_label_ids[i], margin_left - 4, gy)
+            canvas.itemconfig(self._hgrid_label_ids[i], text=y_labels[i])
 
         # Axes
-        c.coords(self._yaxis_id, ml, mt, ml, mt + ph)
-        c.coords(self._xaxis_id, ml, mt + ph, ml + pw, mt + ph)
+        canvas.coords(self._yaxis_id,
+                    margin_left, margin_top,
+                    margin_left, margin_top + plot_height)
+        canvas.coords(self._xaxis_id,
+                    margin_left, margin_top + plot_height,
+                    margin_left + plot_width, margin_top + plot_height)
 
         _nice = [0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5,
-                 1, 2, 5, 10, 15, 30, 60]
+                1, 2, 5, 10, 15, 30, 60]
         grid_interval = _nice[-1]
         for ni in _nice:
             if self._window_seconds / ni <= 7:
@@ -681,34 +689,40 @@ class SignalPreviewPanel(ttk.Frame):
         else:
             label_fmt = '-{:.3f}s'
 
+        # Single y for every bottom label so the row reads as one axis.
+        label_y = margin_top + plot_height + 3
+
         slot = 0
         k = 1
 
         while (k * grid_interval) < self._window_seconds - 1e-9 \
                 and slot < len(self._vgrid_ids):
             secs_ago = k * grid_interval
-            vx = ml + pw - (secs_ago / self._window_seconds) * pw
-            c.coords(self._vgrid_ids[slot], vx, mt, vx, mt + ph)
-            c.itemconfig(self._vgrid_ids[slot], state='normal')
-            c.coords(self._vgrid_label_ids[slot], vx, mt + ph + 3)
-            c.itemconfig(self._vgrid_label_ids[slot],
+            vx = margin_left + plot_width - (secs_ago / self._window_seconds) * plot_width
+            canvas.coords(self._vgrid_ids[slot], vx, margin_top, vx, margin_top + plot_height)
+            canvas.itemconfig(self._vgrid_ids[slot], state='normal')
+            
+            canvas.coords(self._vgrid_label_ids[slot], vx, label_y)
+            canvas.itemconfig(self._vgrid_label_ids[slot],
                          text=label_fmt.format(secs_ago), state='normal')
             slot += 1
             k += 1
 
         # Hide unused grid slots
         for i in range(slot, len(self._vgrid_ids)):
-            c.itemconfig(self._vgrid_ids[i], state='hidden')
-            c.itemconfig(self._vgrid_label_ids[i], state='hidden')
+            canvas.itemconfig(self._vgrid_ids[i], state='hidden')
+            canvas.itemconfig(self._vgrid_label_ids[i], state='hidden')
 
-        c.coords(self._xlabel_l, ml, h - 2)
-        c.itemconfig(self._xlabel_l,
+        # Bring your missing edge labels back on screen using label_y
+        canvas.coords(self._xlabel_l, margin_left, label_y)
+        canvas.itemconfig(self._xlabel_l,
                      text=label_fmt.format(self._window_seconds))
-        c.coords(self._xlabel_r, ml + pw, h - 2)
-        c.itemconfig(self._xlabel_r, text='0s')
+                     
+        canvas.coords(self._xlabel_r, margin_left + plot_width, label_y)
+        canvas.itemconfig(self._xlabel_r, text='0s')
 
-        if len(visible) > pw * 3:
-            n_buckets = max(pw, 4)
+        if len(visible) > plot_width * 3:
+            n_buckets = max(plot_width, 4)
             bucket_w = t_span / n_buckets
             envelope = []
             bi = 0
@@ -751,29 +765,30 @@ class SignalPreviewPanel(ttk.Frame):
             line_coords = []
             for t, v in visible:
                 line_coords.extend([xpx(t), ypx(v)])
-            c.coords(self._line_id, *line_coords)
-            c.itemconfig(self._line_id, state='normal')
+            canvas.coords(self._line_id, *line_coords)
+            canvas.itemconfig(self._line_id, state='normal')
         elif len(visible) == 1:
             px, py = xpx(visible[0][0]), ypx(visible[0][1])
-            c.coords(self._line_id, px, py, px + 1, py)
-            c.itemconfig(self._line_id, state='normal')
+            canvas.coords(self._line_id, px, py, px + 1, py)
+            canvas.itemconfig(self._line_id, state='normal')
 
         if self._show_badge_var.get():
             badge_text = self._fmt(visible[-1][1])
             if self._unit_str:
                 badge_text += f' {self._unit_str}'
-            bx = ml + pw - 4
-            by = mt + 4
-            c.coords(self._badge_id, bx, by)
-            c.itemconfig(self._badge_id, text=badge_text, state='normal')
-            c.update_idletasks()
-            bb = c.bbox(self._badge_id)
+            bx = margin_left + plot_width - 4
+            by = margin_top + 4
+            canvas.coords(self._badge_id, bx, by)
+            canvas.itemconfig(self._badge_id, text=badge_text, state='normal')
+            canvas.update_idletasks()
+            bb = canvas.bbox(self._badge_id)
             if bb:
-                c.coords(self._badge_bg_id, bb[0] - 3, bb[1] - 1, bb[2] + 3, bb[3] + 1)
-                c.itemconfig(self._badge_bg_id, state='normal')
+                canvas.coords(self._badge_bg_id,
+                            bb[0] - 3, bb[1] - 1, bb[2] + 3, bb[3] + 1)
+                canvas.itemconfig(self._badge_bg_id, state='normal')
         else:
-            c.itemconfig(self._badge_id, state='hidden')
-            c.itemconfig(self._badge_bg_id, state='hidden')
+            canvas.itemconfig(self._badge_id, state='hidden')
+            canvas.itemconfig(self._badge_bg_id, state='hidden')
 
     @staticmethod
     def _fmt(v):

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -12,7 +12,8 @@ from .. import utils
 
 class SignalPreviewPanel(ttk.Frame):
     DEFAULT_WINDOW_SECONDS = 0.2
-    MAX_BUFFER_SIZE = 100_000
+    TARGET_POINTS_PER_FRAME = 50_000
+    MAX_BUFFER_SIZE = int(TARGET_POINTS_PER_FRAME * 1.5)
     POLL_MS = 33          # drain the reader this often
     _TARGET_PPS = 2000
     DRAW_MS = 66         # repaint the chart this often
@@ -38,16 +39,18 @@ class SignalPreviewPanel(ttk.Frame):
         self._selected_descriptor = None
         self._selected_domain_descriptor = None
 
-        self._can_chart = False
         self._poll_job = None
         self._draw_job = None
 
         # Buffer of (elapsed_seconds, value) pairs.
         self._data = deque(maxlen=self.MAX_BUFFER_SIZE)
         self._window_seconds = self.DEFAULT_WINDOW_SECONDS
+        self._window_size_in_samples = None
 
         self._tick_res_num = None
         self._tick_res_den = None
+        self._dt = None
+        self._sr = None
         self._first_tick = None
 
         # name -> ISignal for chartable signals
@@ -173,7 +176,7 @@ class SignalPreviewPanel(ttk.Frame):
             if domain_signal is None:
                 continue
 
-            if not self.check_and_set_is_chartable(signal.descriptor, domain_signal.descriptor):   
+            if not self._is_chartable(signal.descriptor, domain_signal.descriptor):   
                 continue
 
             name = signal.name if signal.name else signal.global_id
@@ -194,11 +197,18 @@ class SignalPreviewPanel(ttk.Frame):
             self._eligible[display] = signal
 
         names = list(self._eligible.keys())
+        names.insert(0, 'None')
         self._dropdown['values'] = names
 
-        if len(names) == 1:
-            self._signal_var.set(names[0])
+        if len(names) > 1:
+            self._signal_var.set(names[1])
             self._on_signal_selected()
+        else:
+            self._deselect_signal()
+        
+    def _deselect_signal(self):
+        self._signal_var.set('None')
+        self._on_signal_selected()
 
     @staticmethod
     def _is_chartable(desc, domain_desc):
@@ -239,24 +249,11 @@ class SignalPreviewPanel(ttk.Frame):
     
         return True
 
-    def check_and_set_is_chartable(self, desc, domain_desc):
-        chartable = self._is_chartable(desc, domain_desc)
-        self._can_chart = chartable
-        if self._reader is not None:
-            self._reader.active = chartable
-
-        return chartable
-
     # MARK: Signal selection
 
-    def _on_signal_selected(self, _event=None):
-        name = self._signal_var.get()
-        signal = self._eligible.get(name)
-        if signal is None:
-            return
-
+    def _on_signal_selected(self):
         self._reader = None
-        self._selected_signal = signal
+        self._selected_signal = None
         self._selected_descriptor = None
         self._selected_domain_descriptor = None
 
@@ -267,6 +264,15 @@ class SignalPreviewPanel(ttk.Frame):
         self._unit_str = ''
         self._tick_res_num = None
         self._tick_res_den = None
+        self._window_size_in_samples = None
+        self._dt = None
+        
+        name = self._signal_var.get()
+        signal = self._eligible.get(name)
+        if signal is None:
+            return
+
+        self._selected_signal = signal
         self._reader = daq.StreamReader(signal, skip_events=False)
 
     # MARK: Polling
@@ -303,13 +309,12 @@ class SignalPreviewPanel(ttk.Frame):
 
         self._reader = daq.StreamReader(
             self._selected_signal, skip_events=False)
-
-        if not self.check_and_set_is_chartable(self._selected_signal.descriptor, domain_signal.descriptor):
-            return
         
         self._unit_str = ''
         self._tick_res_num = None
         self._tick_res_den = None
+        self._window_size_in_samples = None
+        self._dt = None
 
         self._first_tick = None
         self._data.clear()
@@ -371,7 +376,7 @@ class SignalPreviewPanel(ttk.Frame):
                 self._recreate_reader()
                 return
 
-            if len(values) > 0 and self._can_chart:
+            if len(values) > 0:
                 self._ingest(values, domain_ticks)
 
             if status.read_status == daq.ReadStatus.Event:
@@ -402,17 +407,22 @@ class SignalPreviewPanel(ttk.Frame):
 
         if domain_descriptor is not None:
             self._selected_domain_descriptor = daq.IDataDescriptor.cast_from(domain_descriptor)
+            
             if self._is_null_descriptor(self._selected_domain_descriptor):
                 self._tick_res_num = None
                 self._tick_res_den = None
+                self._window_size_in_samples = None
+                self.dt = None
             else:
-                res = getattr(self._selected_domain_descriptor, 'tick_resolution', None)
-                if res is None:
-                    self._tick_res_num = None
-                    self._tick_res_den = None
-                else:
-                    self._tick_res_num = res.numerator
-                    self._tick_res_den = res.denominator
+                res = self._selected_domain_descriptor.tick_resolution
+                self._tick_res_num = res.numerator
+                self._tick_res_den = res.denominator
+
+                # Calculate buffer size based on tick resolution + delta and desired window duration
+                rule = self._selected_domain_descriptor.rule
+                self._dt = rule.parameters['delta']
+                self._sr = self._tick_res_den / self._tick_res_num / self._dt
+                self._data = deque(maxlen=min(self.MAX_BUFFER_SIZE, int((self._window_seconds * 1.5) * self._sr)))
 
     def _handle_event_packet(self, event_packet):
         event_id = event_packet.event_id
@@ -430,7 +440,8 @@ class SignalPreviewPanel(ttk.Frame):
         domain_desc = params['DomainDataDescriptor']
 
         self._apply_descriptors(data_desc, domain_desc)
-        self.check_and_set_is_chartable(self._selected_descriptor, self._selected_domain_descriptor)
+        if not self._is_chartable(self._selected_descriptor, self._selected_domain_descriptor):
+            self._deselect_signal()
 
     def _ingest(self, values, domain_ticks):
         if values is None or domain_ticks is None:
@@ -453,44 +464,14 @@ class SignalPreviewPanel(ttk.Frame):
         t_arr = (domain_ticks.astype(np.float64) - base) * ratio
         v_arr = values.astype(np.float64)
 
-        target = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
+        actual_points_per_frame = int(self._window_seconds * self._sr)
 
         stride = 1
-        if n > 2:
-            dt = t_arr[-1] - t_arr[0]
-            if dt > 0:
-                actual_rate = n / dt
-                if actual_rate > target:
-                    stride = max(1, int(actual_rate / target))
+        if actual_points_per_frame > self.TARGET_POINTS_PER_FRAME:
+            stride = math.ceil(actual_points_per_frame / self.TARGET_POINTS_PER_FRAME)
 
-        if stride <= 1:
-            # Fast path: extend buffer with all points
-            for i in range(n):
-                buf.append((t_arr[i], v_arr[i]))
-        else:
-            usable = (n // stride) * stride
-            if usable > 0:
-                t_chunk = t_arr[:usable].reshape(-1, stride)
-                v_chunk = v_arr[:usable].reshape(-1, stride)
-
-                mn_idx = v_chunk.argmin(axis=1)
-                mx_idx = v_chunk.argmax(axis=1)
-
-                for ci in range(len(v_chunk)):
-                    mni = mn_idx[ci]
-                    mxi = mx_idx[ci]
-                    if mni == mxi:
-                        buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
-                    elif mni < mxi:
-                        buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
-                        buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
-                    else:
-                        buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
-                        buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
-
-            # Handle leftover samples after the last full chunk
-            for i in range(usable, n):
-                buf.append((t_arr[i], v_arr[i]))
+        for i in range(0, n, stride):
+            buf.append((t_arr[i], v_arr[i]))
 
         self._needs_redraw = True
 
@@ -703,16 +684,16 @@ class SignalPreviewPanel(ttk.Frame):
 
         slot = 0
         k = 1
+
         while (k * grid_interval) < self._window_seconds - 1e-9 \
                 and slot < len(self._vgrid_ids):
             secs_ago = k * grid_interval
-            vx = margin_left + plot_width - (secs_ago / self._window_seconds) * plot_width
-            canvas.coords(self._vgrid_ids[slot],
-                        vx, margin_top, vx, margin_top + plot_height)
-            canvas.itemconfig(self._vgrid_ids[slot], state='normal')
-            canvas.coords(self._vgrid_label_ids[slot], vx, label_y)
-            canvas.itemconfig(self._vgrid_label_ids[slot],
-                            text=label_fmt.format(secs_ago), state='normal')
+            vx = ml + pw - (secs_ago / self._window_seconds) * pw
+            c.coords(self._vgrid_ids[slot], vx, mt, vx, mt + ph)
+            c.itemconfig(self._vgrid_ids[slot], state='normal')
+            c.coords(self._vgrid_label_ids[slot], vx, mt + ph + 3)
+            c.itemconfig(self._vgrid_label_ids[slot],
+                         text=label_fmt.format(secs_ago), state='normal')
             slot += 1
             k += 1
 
@@ -721,11 +702,11 @@ class SignalPreviewPanel(ttk.Frame):
             c.itemconfig(self._vgrid_ids[i], state='hidden')
             c.itemconfig(self._vgrid_label_ids[i], state='hidden')
 
-        canvas.coords(self._xlabel_l, margin_left, label_y)
-        canvas.itemconfig(self._xlabel_l,
-                        text=label_fmt.format(self._window_seconds))
-        canvas.coords(self._xlabel_r, margin_left + plot_width, label_y)
-        canvas.itemconfig(self._xlabel_r, text='0s')
+        c.coords(self._xlabel_l, ml, h - 2)
+        c.itemconfig(self._xlabel_l,
+                     text=label_fmt.format(self._window_seconds))
+        c.coords(self._xlabel_r, ml + pw, h - 2)
+        c.itemconfig(self._xlabel_r, text='0s')
 
         if len(visible) > pw * 3:
             n_buckets = max(pw, 4)

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -251,7 +251,7 @@ class SignalPreviewPanel(ttk.Frame):
 
     # MARK: Signal selection
 
-    def _on_signal_selected(self):
+    def _on_signal_selected(self, _event=None):
         self._reader = None
         self._selected_signal = None
         self._selected_descriptor = None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -231,6 +231,10 @@ class SignalPreviewPanel(ttk.Frame):
 
         if getattr(domain_desc, 'tick_resolution', None) is None:
             return False
+        
+        data_rule = getattr(domain_desc, 'rule', None)
+        if data_rule is None or data_rule.type != daq.DataRuleType.Linear:
+            return False
     
         return True
 

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -35,6 +35,10 @@ class SignalPreviewPanel(ttk.Frame):
 
         self._reader = None
         self._selected_signal = None
+        self._selected_descriptor = None
+        self._selected_domain_descriptor = None
+
+        self._can_chart = False
         self._poll_job = None
         self._draw_job = None
 
@@ -43,7 +47,6 @@ class SignalPreviewPanel(ttk.Frame):
 
         self._tick_res_num = None
         self._tick_res_den = None
-        self._origin_epoch = None   # datetime | None
         self._first_tick = None
 
         # name -> ISignal for chartable signals
@@ -165,7 +168,11 @@ class SignalPreviewPanel(ttk.Frame):
             if sig is None or not daq.ISignal.can_cast_from(sig):
                 continue
             signal = daq.ISignal.cast_from(sig)
-            if not self._is_chartable(signal):
+            domain_signal = signal.domain_signal
+            if domain_signal is None:
+                continue
+
+            if not self.check_and_set_is_chartable(signal.descriptor, domain_signal.descriptor):   
                 continue
 
             name = signal.name if signal.name else signal.global_id
@@ -193,11 +200,10 @@ class SignalPreviewPanel(ttk.Frame):
             self._on_signal_selected()
 
     @staticmethod
-    def _is_chartable(signal):
-        desc = getattr(signal, 'descriptor', None)
+    def _is_chartable(desc, domain_desc):
         if desc is None:
             return False
-
+        
         sample_type = getattr(desc, 'sample_type', None)
         if not sample_type:
             return False
@@ -215,14 +221,9 @@ class SignalPreviewPanel(ttk.Frame):
         if fields and len(fields) > 0:
             return False
 
-        domain_sig = getattr(signal, 'domain_signal', None)
-        if domain_sig is None:
-            return False
-
-        domain_desc = getattr(domain_sig, 'descriptor', None)
         if domain_desc is None:
             return False
-
+        
         unit = getattr(domain_desc, 'unit', None)
         symbol = getattr(unit, 'symbol', None)
         if str(symbol) != 's':
@@ -230,8 +231,16 @@ class SignalPreviewPanel(ttk.Frame):
 
         if getattr(domain_desc, 'tick_resolution', None) is None:
             return False
-
+    
         return True
+
+    def check_and_set_is_chartable(self, desc, domain_desc):
+        chartable = self._is_chartable(desc, domain_desc)
+        self._can_chart = chartable
+        if self._reader is not None:
+            self._reader.active = chartable
+
+        return chartable
 
     # MARK: Signal selection
 
@@ -243,6 +252,9 @@ class SignalPreviewPanel(ttk.Frame):
 
         self._reader = None
         self._selected_signal = signal
+        self._selected_descriptor = None
+        self._selected_domain_descriptor = None
+
         self._data.clear()
         self._first_tick = None
         self._needs_redraw = True
@@ -250,7 +262,6 @@ class SignalPreviewPanel(ttk.Frame):
         self._unit_str = ''
         self._tick_res_num = None
         self._tick_res_den = None
-        self._origin_epoch = None
         self._reader = daq.StreamReader(signal, skip_events=False)
 
     # MARK: Polling
@@ -280,19 +291,25 @@ class SignalPreviewPanel(ttk.Frame):
         self._reader = None
         if self._selected_signal is None:
             return
-        if not self._is_chartable(self._selected_signal):
+        
+        domain_signal = self._selected_signal.domain_signal
+        if domain_signal is None:
             return
-
-        self._unit_str = ''
-        self._tick_res_num = None
-        self._tick_res_den = None
-        self._origin_epoch = None
 
         self._reader = daq.StreamReader(
             self._selected_signal, skip_events=False)
+
+        if not self.check_and_set_is_chartable(self._selected_signal.descriptor, domain_signal.descriptor):
+            return
+        
+        self._unit_str = ''
+        self._tick_res_num = None
+        self._tick_res_den = None
+
         self._first_tick = None
         self._data.clear()
         self._needs_redraw = True
+
     def _set_scale_visible(self, visible):
         if visible:
             self._scale_header.grid()
@@ -349,7 +366,7 @@ class SignalPreviewPanel(ttk.Frame):
                 self._recreate_reader()
                 return
 
-            if len(values) > 0:
+            if len(values) > 0 and self._can_chart:
                 self._ingest(values, domain_ticks)
 
             if status.read_status == daq.ReadStatus.Event:
@@ -369,40 +386,37 @@ class SignalPreviewPanel(ttk.Frame):
 
     def _apply_descriptors(self, data_descriptor, domain_descriptor):
         if data_descriptor is not None:
-            if self._is_null_descriptor(data_descriptor):
+            self._selected_descriptor = daq.IDataDescriptor.cast_from(data_descriptor)
+            if self._is_null_descriptor(self._selected_descriptor):
                 self._unit_str = ''
             else:
-                unit = getattr(data_descriptor, 'unit', None)
+                unit = getattr(self._selected_descriptor, 'unit', None)
                 symbol = (getattr(unit, 'symbol', None)
                           if unit is not None else None)
                 self._unit_str = str(symbol) if symbol is not None else ''
 
         if domain_descriptor is not None:
-            if self._is_null_descriptor(domain_descriptor):
+            self._selected_domain_descriptor = daq.IDataDescriptor.cast_from(domain_descriptor)
+            if self._is_null_descriptor(self._selected_domain_descriptor):
                 self._tick_res_num = None
                 self._tick_res_den = None
-                self._origin_epoch = None
             else:
-                res = getattr(domain_descriptor, 'tick_resolution', None)
+                res = getattr(self._selected_domain_descriptor, 'tick_resolution', None)
                 if res is None:
                     self._tick_res_num = None
                     self._tick_res_den = None
-                    self._origin_epoch = None
                 else:
                     self._tick_res_num = res.numerator
                     self._tick_res_den = res.denominator
-                    origin_str = (str(domain_descriptor.origin)
-                                  if hasattr(domain_descriptor, 'origin')
-                                  else '')
-                    if origin_str.strip():
-                        self._origin_epoch = utils.parse_origin(origin_str)
-                    else:
-                        self._origin_epoch = None
 
     def _handle_event_packet(self, event_packet):
         event_id = event_packet.event_id
 
         self._needs_redraw = True
+        self._data.clear()
+        self._first_tick = None
+        self._chart_ready = False
+
         if event_id != 'DATA_DESCRIPTOR_CHANGED':
             return
         
@@ -410,18 +424,8 @@ class SignalPreviewPanel(ttk.Frame):
         data_desc = params['DataDescriptor']
         domain_desc = params['DomainDataDescriptor']
 
-        if (data_desc is not None
-                and daq.IDataDescriptor.can_cast_from(data_desc)):
-            data_desc = daq.IDataDescriptor.cast_from(data_desc)
-        if (domain_desc is not None
-                and daq.IDataDescriptor.can_cast_from(domain_desc)):
-            domain_desc = daq.IDataDescriptor.cast_from(domain_desc)
-
         self._apply_descriptors(data_desc, domain_desc)
-
-        self._data.clear()
-        self._first_tick = None
-        self._chart_ready = False
+        self.check_and_set_is_chartable(self._selected_descriptor, self._selected_domain_descriptor)
 
     def _ingest(self, values, domain_ticks):
         if values is None or domain_ticks is None:
@@ -444,57 +448,44 @@ class SignalPreviewPanel(ttk.Frame):
         t_arr = (domain_ticks.astype(np.float64) - base) * ratio
         v_arr = values.astype(np.float64)
 
-        if t_arr is not None:
-            target = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
+        target = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
 
-            stride = 1
-            if n > 2:
-                dt = t_arr[-1] - t_arr[0]
-                if dt > 0:
-                    actual_rate = n / dt
-                    if actual_rate > target:
-                        stride = max(1, int(actual_rate / target))
+        stride = 1
+        if n > 2:
+            dt = t_arr[-1] - t_arr[0]
+            if dt > 0:
+                actual_rate = n / dt
+                if actual_rate > target:
+                    stride = max(1, int(actual_rate / target))
 
-            if stride <= 1:
-                # Fast path: extend buffer with all points
-                for i in range(n):
-                    buf.append((t_arr[i], v_arr[i]))
-            else:
-                usable = (n // stride) * stride
-                if usable > 0:
-                    t_chunk = t_arr[:usable].reshape(-1, stride)
-                    v_chunk = v_arr[:usable].reshape(-1, stride)
-
-                    mn_idx = v_chunk.argmin(axis=1)
-                    mx_idx = v_chunk.argmax(axis=1)
-
-                    for ci in range(len(v_chunk)):
-                        mni = mn_idx[ci]
-                        mxi = mx_idx[ci]
-                        if mni == mxi:
-                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
-                        elif mni < mxi:
-                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
-                            buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
-                        else:
-                            buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
-                            buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
-
-                # Handle leftover samples after the last full chunk
-                for i in range(usable, n):
-                    buf.append((t_arr[i], v_arr[i]))
+        if stride <= 1:
+            # Fast path: extend buffer with all points
+            for i in range(n):
+                buf.append((t_arr[i], v_arr[i]))
         else:
-            stride = 1
-            if n > 2:
-                dt = (int(domain_ticks[-1]) - int(domain_ticks[0])) * ratio
-                if dt > 0:
-                    actual_rate = n / dt
-                    target_fb = max(self._TARGET_PPS, int(10_000 / max(self.WINDOW_SECONDS, 0.5)))
-                    if actual_rate > target_fb:
-                        stride = max(1, int(actual_rate / target_fb))
-            for i in range(0, n, stride):
-                elapsed = (int(domain_ticks[i]) - base) * ratio
-                buf.append((elapsed, float(values[i])))
+            usable = (n // stride) * stride
+            if usable > 0:
+                t_chunk = t_arr[:usable].reshape(-1, stride)
+                v_chunk = v_arr[:usable].reshape(-1, stride)
+
+                mn_idx = v_chunk.argmin(axis=1)
+                mx_idx = v_chunk.argmax(axis=1)
+
+                for ci in range(len(v_chunk)):
+                    mni = mn_idx[ci]
+                    mxi = mx_idx[ci]
+                    if mni == mxi:
+                        buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+                    elif mni < mxi:
+                        buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+                        buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
+                    else:
+                        buf.append((t_chunk[ci, mxi], v_chunk[ci, mxi]))
+                        buf.append((t_chunk[ci, mni], v_chunk[ci, mni]))
+
+            # Handle leftover samples after the last full chunk
+            for i in range(usable, n):
+                buf.append((t_arr[i], v_arr[i]))
 
         self._needs_redraw = True
 

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -1,38 +1,38 @@
 import math
+import re
 import tkinter as tk
 from tkinter import ttk
 from collections import deque
 import numpy as np
+from tkinter import font as tkfont
 
 import opendaq as daq
 
 from .. import utils
 
-
 class SignalPreviewPanel(ttk.Frame):
-    WINDOW_SECONDS = 5.0
+    WINDOW_SECONDS = 1.0
     MAX_BUFFER_SIZE = 100_000
     POLL_MS = 33          # drain the reader this often
     _TARGET_PPS = 2000
     DRAW_MS = 66         # repaint the chart this often
-    CANVAS_HEIGHT = 160
+    CANVAS_HEIGHT = 180
 
     _BG      = '#ffffff'
     _LINE    = '#1a6dcc'
     _GRID    = '#e4e4e4'
     _TEXT    = '#444444'
     _AXIS    = '#999999'
-    _FILL    = '#dceafa'
 
     _AXIS_FONT = ('TkFixedFont', 7)
     _VAL_FONT  = ('TkFixedFont', 10, 'bold')
+    _DURATION_RE = re.compile(r'^\s*(\d+(?:\.\d+)?|\.\d+)\s*s?\s*$', re.IGNORECASE)
 
     def __init__(self, parent, node, context=None, **kwargs):
         super().__init__(parent, **kwargs)
         self.node = node
         self.context = context
 
-        self._collapsed = False
         self._reader = None
         self._selected_signal = None
         self._poll_job = None
@@ -49,12 +49,6 @@ class SignalPreviewPanel(ttk.Frame):
         # name -> ISignal for chartable signals
         self._eligible = {}
         self._unit_str = ''
-        self._last_descriptor_hash = None
-        self._signal_event_handler = None
-        self._signal_event_component = None
-        self._parent_event_handler = None
-        self._parent_event_component = None
-        self._reader_dirty = False
         self._needs_redraw = True
         self._chart_ready = False
         self._px_ml = 65
@@ -65,54 +59,76 @@ class SignalPreviewPanel(ttk.Frame):
         self._content_frame.pack(
             fill=tk.BOTH, expand=True, after=self._toggle_frame)
         self._populate_dropdown()
-
         self._schedule_poll()
         self._schedule_draw()
         self.bind('<Destroy>', self._on_destroy)
 
     def _build_toggle_bar(self):
-        self._toggle_frame = utils.make_banner(self, '\u25BC Signal Preview')
-        self._toggle_frame.configure(cursor='hand2')
-
-        self._arrow_label = self._toggle_frame.winfo_children()[0]
-        self._arrow_label.configure(cursor='hand2')
-
-        for w in (self._toggle_frame, self._arrow_label):
-            w.bind('<Button-1>', lambda _e: self._toggle())
+        self._toggle_frame = utils.make_banner(self, 'Signal Preview')
+        self._toggle_frame.pack_configure(padx=(0, 17))
 
     def _build_content(self):
         self._content_frame = ttk.Frame(self)
-        dd_row = ttk.Frame(self._content_frame)
-        dd_row.pack(fill=tk.X, padx=4, pady=(4, 2))
 
-        ttk.Label(dd_row, text='Signal:').pack(side=tk.LEFT, padx=(0, 4))
+        controls = ttk.Frame(self._content_frame)
+        controls.pack(fill=tk.X, padx=(12, 29), pady=(4, 2))
 
+        # Headers
+        ttk.Label(controls, text='Signal').grid(
+            row=0, column=0, sticky=tk.W)
+        ttk.Label(controls, text='Duration').grid(
+            row=0, column=1, sticky=tk.W, padx=(8, 0))
+        
+        # Scale
+        self._scale_header = ttk.Label(
+            controls, text='Scale')
+        self._scale_header.grid(row=0, column=2, sticky=tk.W, padx=(8, 0))
+        ttk.Label(controls, text='Last value').grid(
+            row=0, column=3, sticky=tk.W, padx=(8, 0))
+
+        # Signal dropdown
         self._signal_var = tk.StringVar()
         self._dropdown = ttk.Combobox(
-            dd_row, textvariable=self._signal_var, state='readonly')
-        self._dropdown.pack(side=tk.LEFT, fill=tk.X, expand=True)
+            controls, textvariable=self._signal_var, state='readonly')
+        self._dropdown.grid(row=1, column=0, sticky=tk.EW)
         self._dropdown.bind('<<ComboboxSelected>>', self._on_signal_selected)
 
-        # Duration selector
-        self._duration_presets = [1, 2, 5, 10, 30, 60]
-        self._duration_var = tk.StringVar(value='5s')
+        # Duration combobox
+        self._duration_presets = [0.01, 0.05, 0.1, 0.2, 0.5, 1]
+        self._duration_var = tk.StringVar(value='0.2s')
         dur_cb = ttk.Combobox(
-            dd_row, textvariable=self._duration_var, state='readonly',
-            values=[f'{d}s' for d in self._duration_presets], width=5)
-        dur_cb.pack(side=tk.LEFT, padx=(4, 0))
-        dur_cb.bind('<<ComboboxSelected>>', self._on_duration_selected)
+            controls, textvariable=self._duration_var,
+            values=[f'{d}s' for d in self._duration_presets], width=6)
+        dur_cb.grid(row=1, column=1, sticky=tk.W, padx=(8, 0))
+        dur_cb.bind('<<ComboboxSelected>>', self._on_duration_committed)
+        dur_cb.bind('<Return>', self._on_duration_committed)
+        dur_cb.bind('<FocusOut>', self._on_duration_committed)
 
-        self._log_var = tk.BooleanVar(value=False)
-        log_cb = ttk.Checkbutton(
-            dd_row, text='Logarithm', variable=self._log_var,
-            command=self._on_log_toggled)
-        log_cb.pack(side=tk.LEFT, padx=(4, 0))
+        # Scale
+        self._scale_var = tk.StringVar(value='Linear')
+        self._scale_cb = ttk.Combobox(
+            controls, textvariable=self._scale_var, state='readonly',
+            values=['Linear', 'Log'], width=7)
+        self._scale_cb.grid(row=1, column=2, sticky=tk.W, padx=(8, 0))
+        self._scale_cb.bind('<<ComboboxSelected>>', self._on_scale_changed)
+
+        # Last-value toggle
+        self._show_badge_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(
+            controls, variable=self._show_badge_var,
+            command=self._on_badge_toggled
+        ).grid(row=1, column=3, sticky=tk.W, padx=(8,12))
+
+        controls.grid_columnconfigure(0, weight=1)
+
+        # Hide Scale until a signal that supports it is selected.
+        self._set_scale_visible(False)
 
         # Chart canvas
         self._chart = tk.Canvas(
             self._content_frame, bg=self._BG,
             height=self.CANVAS_HEIGHT, highlightthickness=0)
-        self._chart.pack(fill=tk.BOTH, expand=True, padx=4, pady=(2, 4))
+        self._chart.pack(fill=tk.BOTH, expand=True, padx=(12,29), pady=(16, 21))
 
         self._chart.bind('<Configure>', lambda _e: self._invalidate_chart())
         self._block_mousewheel_recursive(self)
@@ -232,79 +248,32 @@ class SignalPreviewPanel(ttk.Frame):
         self._needs_redraw = True
 
         self._unit_str = ''
-        if signal.descriptor.unit is not None:
-            unit = signal.descriptor.unit
-            if unit is not None and unit.symbol is not None:
-                self._unit_str = str(unit.symbol)
-
-        # Cache tick resolution for tick -> seconds conversion.
-        domain_desc = signal.domain_signal.descriptor
-        res = domain_desc.tick_resolution
-        self._tick_res_num = res.numerator
-        self._tick_res_den = res.denominator
-
-        origin_str = str(domain_desc.origin) if hasattr(domain_desc, 'origin') else ''
-        if origin_str.strip():
-            self._origin_epoch = utils.parse_origin(origin_str)
-        else:
-            self._origin_epoch = None
-
-        self._reader = daq.StreamReader(signal)
-        self._last_descriptor_hash = self._descriptor_fingerprint(signal)
-
-        self._unsubscribe_core_events()
-
-        if daq.IComponent.can_cast_from(signal):
-            self._signal_event_component = signal
-            self._signal_event_handler = daq.QueuedEventHandler(self._on_core_event)
-            comp = daq.IComponent.cast_from(signal)
-            comp.on_component_core_event + self._signal_event_handler
-
-        ancestor = getattr(signal, 'parent', None)
-        while ancestor is not None:
-            if (daq.IFunctionBlock.can_cast_from(ancestor)
-                    or daq.IDevice.can_cast_from(ancestor)):
-                break
-            ancestor = getattr(ancestor, 'parent', None)
-
-        if ancestor is not None and daq.IComponent.can_cast_from(ancestor):
-            self._parent_event_component = ancestor
-            self._parent_event_handler = daq.QueuedEventHandler(self._on_core_event)
-            comp = daq.IComponent.cast_from(ancestor)
-            comp.on_component_core_event + self._parent_event_handler
+        self._tick_res_num = None
+        self._tick_res_den = None
+        self._origin_epoch = None
+        self._reader = daq.StreamReader(signal, skip_events=False)
 
     # MARK: Polling
 
-    def _unsubscribe_core_events(self):
-        for handler_attr, comp_attr in (
-            ('_signal_event_handler', '_signal_event_component'),
-            ('_parent_event_handler', '_parent_event_component'),
-        ):
-            handler = getattr(self, handler_attr, None)
-            comp = getattr(self, comp_attr, None)
-            if handler is not None and comp is not None:
-                if daq.IComponent.can_cast_from(comp):
-                    component = daq.IComponent.cast_from(comp)
-                    component.on_component_core_event - handler
-            setattr(self, handler_attr, None)
-            setattr(self, comp_attr, None)
-
-    def _on_core_event(self, sender, args):
-        if args.event_name in ('DescriptorChanged', 'PropertyValueChanged', 'ComponentUpdateEnd'):
-            self._reader_dirty = True
-
-    def _on_duration_selected(self, _event=None):
-        raw = self._duration_var.get().rstrip('s')
-        if float(raw) is not None:
-            seconds = float(raw)
-        else:
+    def _on_duration_committed(self, event=None):
+        text = self._duration_var.get()
+        match = self._DURATION_RE.match(text)
+        if match is None:
+            self._duration_var.set(f'{self.WINDOW_SECONDS:g}s')
             return
-        if seconds <= 0:
+
+        seconds = float(match.group(1))
+        seconds = max(0.01, min(10.0, seconds))
+        self._duration_var.set(f'{seconds:g}s')
+
+        if event is not None and event.type != tk.EventType.FocusOut:
+            self._chart.focus_set()
+
+        if seconds == self.WINDOW_SECONDS:
             return
+
         self.WINDOW_SECONDS = seconds
         self._needs_redraw = True
-
-        # Vertical grid lines are created once for the initial WINDOW_SECONDS.
         self._chart_ready = False
 
     def _recreate_reader(self):
@@ -314,51 +283,40 @@ class SignalPreviewPanel(ttk.Frame):
         if not self._is_chartable(self._selected_signal):
             return
 
-        domain_desc = getattr(
-            getattr(self._selected_signal, 'domain_signal', None),
-            'descriptor', None)
-        if domain_desc is None:
-            return
-        res = getattr(domain_desc, 'tick_resolution', None)
-        if res is None:
-            return
+        self._unit_str = ''
+        self._tick_res_num = None
+        self._tick_res_den = None
+        self._origin_epoch = None
 
-        self._tick_res_num = res.numerator
-        self._tick_res_den = res.denominator
-        self._reader = daq.StreamReader(self._selected_signal)
+        self._reader = daq.StreamReader(
+            self._selected_signal, skip_events=False)
         self._first_tick = None
         self._data.clear()
-        self._last_descriptor_hash = self._descriptor_fingerprint(self._selected_signal)
         self._needs_redraw = True
+    def _set_scale_visible(self, visible):
+        if visible:
+            self._scale_header.grid()
+            self._scale_cb.grid()
+        else:
+            self._scale_header.grid_remove()
+            self._scale_cb.grid_remove()
 
     @staticmethod
-    def _descriptor_fingerprint(signal):
+    def _is_2d_vector_signal(signal):
         desc = getattr(signal, 'descriptor', None)
-        if desc is None:
-            return None
-        d_desc = getattr(getattr(signal, 'domain_signal', None), 'descriptor', None)
+        dims = getattr(desc, 'dimensions', None) if desc else None
+        if not dims or len(dims) != 1:
+            return False
+        size = getattr(dims[0], 'size', None)
+        return size == 2
 
-        st = getattr(getattr(desc, 'sample_type', None), 'name', None)
-        rule = getattr(getattr(desc, 'data_rule', None), 'type', None)
-        rule_name = getattr(rule, 'name', str(rule)) if rule else None
-
-        d_rule = getattr(getattr(d_desc, 'data_rule', None), 'type', None) if d_desc else None
-        d_rule_name = getattr(d_rule, 'name', str(d_rule)) if d_rule else None
-
-        # For linear domain rules, the delta parameter encodes the sample rate.
-        # A change here means the rate changed even if everything else looks the same.
-        d_rule_params = None
-        if d_desc is not None:
-            dr = getattr(d_desc, 'data_rule', None)
-            if dr is not None:
-                params = getattr(dr, 'parameters', None)
-                d_rule_params = str(params) if params is not None else None
-
-        return (st, rule_name, d_rule_name, d_rule_params)
-
-    def _on_log_toggled(self):
+    def _on_badge_toggled(self):
         self._needs_redraw = True
 
+    def _on_scale_changed(self, _event=None):
+        self._needs_redraw = True
+        self._chart.focus_set()
+        
     def _schedule_poll(self):
         self._poll_job = self.after(self.POLL_MS, self._poll_tick)
 
@@ -368,28 +326,102 @@ class SignalPreviewPanel(ttk.Frame):
             return
 
         if self._reader is not None:
-            try:
-                available = self._reader.available_count
-                if available > 0:
-                    values, domain_ticks = self._reader.read_with_domain(available)
-                    self._ingest(values, domain_ticks)
-            except RuntimeError as e:
-                print(f'[SignalPreview] Reader invalidated, recreating: {e}')
-                self._recreate_reader()
-
-        if self._reader is not None and self._selected_signal is not None:
-            current = self._descriptor_fingerprint(self._selected_signal)
-            if current != self._last_descriptor_hash:
-                print('[SignalPreview] Descriptor changed, recreating reader')
-                self._recreate_reader()
-                self._last_descriptor_hash = current
-
-        if self._reader_dirty:
-            self._reader_dirty = False
-            print('[SignalPreview] Property changed, recreating reader')
-            self._recreate_reader()
+            self._drain_reader()
 
         self._poll_job = self.after(self.POLL_MS, self._poll_tick)
+
+    def _drain_reader(self):
+        while True:
+            try:
+                available = self._reader.available_count
+            except RuntimeError as e:
+                print(f'[SignalPreview] Reader query failed: {e}')
+                self._recreate_reader()
+                return
+
+            read_count = min(available, self.MAX_BUFFER_SIZE)
+
+            try:
+                values, domain_ticks, status = self._reader.read_with_domain(
+                    read_count, return_status=True)
+            except RuntimeError as e:
+                print(f'[SignalPreview] Read failed: {e}')
+                self._recreate_reader()
+                return
+
+            if len(values) > 0:
+                self._ingest(values, domain_ticks)
+
+            if status.read_status == daq.ReadStatus.Event:
+                self._handle_event_packet(status.event_packet)
+                continue
+
+            if status.read_status == daq.ReadStatus.Ok and len(values) == 0:
+                return
+            
+    @staticmethod
+    def _is_null_descriptor(desc):
+        sample_type = getattr(desc, 'sample_type', None)
+        if sample_type is None:
+            return True
+        name = getattr(sample_type, 'name', str(sample_type))
+        return name == 'Null'
+
+    def _apply_descriptors(self, data_descriptor, domain_descriptor):
+        if data_descriptor is not None:
+            if self._is_null_descriptor(data_descriptor):
+                self._unit_str = ''
+            else:
+                unit = getattr(data_descriptor, 'unit', None)
+                symbol = (getattr(unit, 'symbol', None)
+                          if unit is not None else None)
+                self._unit_str = str(symbol) if symbol is not None else ''
+
+        if domain_descriptor is not None:
+            if self._is_null_descriptor(domain_descriptor):
+                self._tick_res_num = None
+                self._tick_res_den = None
+                self._origin_epoch = None
+            else:
+                res = getattr(domain_descriptor, 'tick_resolution', None)
+                if res is None:
+                    self._tick_res_num = None
+                    self._tick_res_den = None
+                    self._origin_epoch = None
+                else:
+                    self._tick_res_num = res.numerator
+                    self._tick_res_den = res.denominator
+                    origin_str = (str(domain_descriptor.origin)
+                                  if hasattr(domain_descriptor, 'origin')
+                                  else '')
+                    if origin_str.strip():
+                        self._origin_epoch = utils.parse_origin(origin_str)
+                    else:
+                        self._origin_epoch = None
+
+    def _handle_event_packet(self, event_packet):
+        event_id = event_packet.event_id
+
+        self._needs_redraw = True
+        if event_id != 'DATA_DESCRIPTOR_CHANGED':
+            return
+        
+        params = event_packet.parameters
+        data_desc = params['DataDescriptor']
+        domain_desc = params['DomainDataDescriptor']
+
+        if (data_desc is not None
+                and daq.IDataDescriptor.can_cast_from(data_desc)):
+            data_desc = daq.IDataDescriptor.cast_from(data_desc)
+        if (domain_desc is not None
+                and daq.IDataDescriptor.can_cast_from(domain_desc)):
+            domain_desc = daq.IDataDescriptor.cast_from(domain_desc)
+
+        self._apply_descriptors(data_desc, domain_desc)
+
+        self._data.clear()
+        self._first_tick = None
+        self._chart_ready = False
 
     def _ingest(self, values, domain_ticks):
         if values is None or domain_ticks is None:
@@ -397,6 +429,9 @@ class SignalPreviewPanel(ttk.Frame):
 
         n = len(values)
         if n == 0:
+            return
+
+        if self._tick_res_num is None or self._tick_res_den is None:
             return
 
         ratio = self._tick_res_num / self._tick_res_den
@@ -473,10 +508,7 @@ class SignalPreviewPanel(ttk.Frame):
         c = self._chart
         c.delete('all')
 
-        # Z-order: fill -> grid -> axes -> line -> labels
-
-        self._fill_id = c.create_polygon(
-            0, 0, 0, 0, 0, 0, fill=self._FILL, outline='', state='hidden')
+        # Z-order: grid -> axes -> line -> labels
 
         # Horizontal grid
         self._hgrid_ids = []
@@ -522,14 +554,15 @@ class SignalPreviewPanel(ttk.Frame):
         self._chart_ready = True
 
     def _schedule_draw(self):
-        self._draw_job = self.after(self.DRAW_MS, self._draw_tick)
+        draw_interval = max(16, min(self.DRAW_MS, int(self.WINDOW_SECONDS * 500)))
+        self._draw_job = self.after(draw_interval, self._draw_tick)
 
     def _draw_tick(self):
         self._draw_job = None
         if not self.winfo_exists():
             return
 
-        if not self._collapsed and self._needs_redraw:
+        if self._needs_redraw:
             self._draw_chart()
             self._needs_redraw = False
 
@@ -545,10 +578,9 @@ class SignalPreviewPanel(ttk.Frame):
         if w < 20 or h < 20:
             return
 
-        ml, mr, mt, mb = 65, 12, 10, 22
-        pw = w - ml - mr
+        mr, mt, mb = 12, 10, 22
         ph = h - mt - mb
-        if pw < 10 or ph < 10:
+        if ph < 10:
             return
 
         buf = self._data
@@ -556,9 +588,8 @@ class SignalPreviewPanel(ttk.Frame):
 
         if not has_data:
             c.coords(self._nodata_id, w // 2, h // 2)
-            c.itemconfig(self._nodata_id, text='No data', state='normal')
+            c.itemconfig(self._nodata_id, text='None', state='normal')
             c.itemconfig(self._line_id, state='hidden')
-            c.itemconfig(self._fill_id, state='hidden')
             c.itemconfig(self._badge_id, state='hidden')
             c.itemconfig(self._badge_bg_id, state='hidden')
             return
@@ -575,27 +606,28 @@ class SignalPreviewPanel(ttk.Frame):
             c.coords(self._nodata_id, w // 2, h // 2)
             c.itemconfig(self._nodata_id, text='Waiting...', state='normal')
             c.itemconfig(self._line_id, state='hidden')
-            c.itemconfig(self._fill_id, state='hidden')
             c.itemconfig(self._badge_id, state='hidden')
             c.itemconfig(self._badge_bg_id, state='hidden')
             return
 
-        # Y range with breathing room
-        vals = [v for _, v in visible]
-        v_lo, v_hi = min(vals), max(vals)
+        # Y range computed from a stabilized window. 
+        range_earliest = t_latest - max(self.WINDOW_SECONDS, 0.5)
+        range_vals = [v for t, v in buf if t >= range_earliest]
+        v_lo, v_hi = min(range_vals), max(range_vals)
 
-        use_log = self._log_var.get()
+        use_log = self._scale_var.get() == 'Log'
 
         if use_log:
-            abs_max = max(abs(v) for v in vals)
+            abs_max = max(abs(v) for v in range_vals)
             symlog_thresh = max(abs_max * 0.01, 1e-10)
 
             def symlog(v):
                 return math.copysign(math.log10(1.0 + abs(v) / symlog_thresh), v)
 
-            symlog_vals = [symlog(v) for v in vals]
+            symlog_vals = [symlog(v) for v in range_vals]
             sl_lo = min(symlog_vals)
             sl_hi = max(symlog_vals)
+            ...
             if sl_lo == sl_hi:
                 sl_lo -= 1.0
                 sl_hi += 1.0
@@ -615,7 +647,26 @@ class SignalPreviewPanel(ttk.Frame):
 
         t_span = self.WINDOW_SECONDS
         v_span = v_hi - v_lo
-        
+
+        unit_suffix = f' {self._unit_str}' if self._unit_str else ''
+        y_labels = []
+        for i in range(5):
+            if use_log:
+                sl_val = sl_hi - (sl_hi - sl_lo) * i / 4
+                gv = math.copysign(
+                    symlog_thresh * (10.0 ** abs(sl_val) - 1.0), sl_val)
+            else:
+                gv = v_hi - v_span * i / 4
+            y_labels.append(self._fmt(gv) + unit_suffix)
+
+        label_font = tkfont.Font(font=self._AXIS_FONT)
+        max_label_w = max(label_font.measure(t) for t in y_labels)
+        ml = -(-(max_label_w + 8) // 4) * 4
+
+        pw = w - ml - mr
+        if pw < 10:
+            return
+
         def xpx(t):
             return ml + (t - t_earliest) / t_span * pw
 
@@ -627,59 +678,58 @@ class SignalPreviewPanel(ttk.Frame):
                 return mt + (1.0 - (v - v_lo) / v_span) * ph
 
         # Horizontal grid + Y labels
-        unit_suffix = f' {self._unit_str}' if self._unit_str else ''
         for i in range(5):
             gy = mt + ph * i / 4
             c.coords(self._hgrid_ids[i], ml, gy, ml + pw, gy)
-            if use_log:
-                sl_val = sl_hi - (sl_hi - sl_lo) * i / 4
-                gv = math.copysign(
-                    symlog_thresh * (10.0 ** abs(sl_val) - 1.0), sl_val)
-            else:
-                gv = v_hi - v_span * i / 4
             c.coords(self._hgrid_label_ids[i], ml - 4, gy)
-            c.itemconfig(self._hgrid_label_ids[i],
-                         text=self._fmt(gv) + unit_suffix)
+            c.itemconfig(self._hgrid_label_ids[i], text=y_labels[i])
 
-        _nice = [0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 30, 60]
+        # Axes
+        c.coords(self._yaxis_id, ml, mt, ml, mt + ph)
+        c.coords(self._xaxis_id, ml, mt + ph, ml + pw, mt + ph)
+
+        _nice = [0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5,
+                 1, 2, 5, 10, 15, 30, 60]
         grid_interval = _nice[-1]
         for ni in _nice:
             if self.WINDOW_SECONDS / ni <= 7:
                 grid_interval = ni
                 break
 
-        first_mark = math.ceil(t_earliest / grid_interval) * grid_interval
+        if grid_interval >= 1:
+            label_fmt = '-{:.0f}s'
+        elif grid_interval >= 0.1:
+            label_fmt = '-{:.1f}s'
+        elif grid_interval >= 0.01:
+            label_fmt = '-{:.2f}s'
+        else:
+            label_fmt = '-{:.3f}s'
+
         slot = 0
-        t_mark = first_mark
-        
-        while t_mark < t_latest and slot < len(self._vgrid_ids):
-            vx = xpx(t_mark)
+        k = 1
+        while (k * grid_interval) < self.WINDOW_SECONDS - 1e-9 \
+                and slot < len(self._vgrid_ids):
+            secs_ago = k * grid_interval
+            vx = ml + pw - (secs_ago / self.WINDOW_SECONDS) * pw
             c.coords(self._vgrid_ids[slot], vx, mt, vx, mt + ph)
-            secs_ago = t_latest - t_mark
-            if grid_interval >= 1:
-                label = f'-{secs_ago:.0f}s'
-            else:
-                label = f'-{secs_ago:.1f}s'
+            c.itemconfig(self._vgrid_ids[slot], state='normal')
             c.coords(self._vgrid_label_ids[slot], vx, mt + ph + 3)
-            c.itemconfig(self._vgrid_label_ids[slot], text=label, state='normal')
+            c.itemconfig(self._vgrid_label_ids[slot],
+                         text=label_fmt.format(secs_ago), state='normal')
             slot += 1
-            t_mark += grid_interval
+            k += 1
 
         # Hide unused grid slots
         for i in range(slot, len(self._vgrid_ids)):
             c.itemconfig(self._vgrid_ids[i], state='hidden')
             c.itemconfig(self._vgrid_label_ids[i], state='hidden')
 
-        # Axes
-        c.coords(self._yaxis_id, ml, mt, ml, mt + ph)
-        c.coords(self._xaxis_id, ml, mt + ph, ml + pw, mt + ph)
-
         c.coords(self._xlabel_l, ml, h - 2)
-        c.itemconfig(self._xlabel_l, text=f'-{self.WINDOW_SECONDS:.0f}s')
+        c.itemconfig(self._xlabel_l,
+                     text=label_fmt.format(self.WINDOW_SECONDS))
         c.coords(self._xlabel_r, ml + pw, h - 2)
-        c.itemconfig(self._xlabel_r, text='now')
+        c.itemconfig(self._xlabel_r, text='0s')
 
-        # Min/max envelope downsampl
         if len(visible) > pw * 3:
             n_buckets = max(pw, 4)
             bucket_w = t_span / n_buckets
@@ -719,18 +769,6 @@ class SignalPreviewPanel(ttk.Frame):
                         envelope.append(b_min)
             visible = envelope
 
-        # Filled area under curve
-        bottom_y = mt + ph
-        if len(visible) >= 2:
-            fill_coords = [xpx(visible[0][0]), bottom_y]
-            for t, v in visible:
-                fill_coords.extend([xpx(t), ypx(v)])
-            fill_coords.extend([xpx(visible[-1][0]), bottom_y])
-            c.coords(self._fill_id, *fill_coords)
-            c.itemconfig(self._fill_id, state='normal')
-        else:
-            c.itemconfig(self._fill_id, state='hidden')
-
         # Data line (1 px, no smoothing)
         if len(visible) >= 2:
             line_coords = []
@@ -743,18 +781,22 @@ class SignalPreviewPanel(ttk.Frame):
             c.coords(self._line_id, px, py, px + 1, py)
             c.itemconfig(self._line_id, state='normal')
 
-        badge_text = self._fmt(visible[-1][1])
-        if self._unit_str:
-            badge_text += f' {self._unit_str}'
-        bx = ml + pw - 4
-        by = mt + 4
-        c.coords(self._badge_id, bx, by)
-        c.itemconfig(self._badge_id, text=badge_text, state='normal')
-        c.update_idletasks()
-        bb = c.bbox(self._badge_id)
-        if bb:
-            c.coords(self._badge_bg_id, bb[0] - 3, bb[1] - 1, bb[2] + 3, bb[3] + 1)
-            c.itemconfig(self._badge_bg_id, state='normal')
+        if self._show_badge_var.get():
+            badge_text = self._fmt(visible[-1][1])
+            if self._unit_str:
+                badge_text += f' {self._unit_str}'
+            bx = ml + pw - 4
+            by = mt + 4
+            c.coords(self._badge_id, bx, by)
+            c.itemconfig(self._badge_id, text=badge_text, state='normal')
+            c.update_idletasks()
+            bb = c.bbox(self._badge_id)
+            if bb:
+                c.coords(self._badge_bg_id, bb[0] - 3, bb[1] - 1, bb[2] + 3, bb[3] + 1)
+                c.itemconfig(self._badge_bg_id, state='normal')
+        else:
+            c.itemconfig(self._badge_id, state='hidden')
+            c.itemconfig(self._badge_bg_id, state='hidden')
 
     @staticmethod
     def _fmt(v):
@@ -765,17 +807,6 @@ class SignalPreviewPanel(ttk.Frame):
         if v == int(v):
             return str(int(v))
         return f'{v:.4g}'
-
-    def _toggle(self):
-        self._collapsed = not self._collapsed
-        if self._collapsed:
-            self._content_frame.pack_forget()
-            self._arrow_label.config(text='\u25B2 Signal Preview')
-        else:
-            self._content_frame.pack(
-                fill=tk.BOTH, expand=True, after=self._toggle_frame)
-            self._arrow_label.config(text='\u25BC Signal Preview')
-            self._needs_redraw = True
             
     def _on_destroy(self, event):
         if event.widget is not self:
@@ -791,5 +822,4 @@ class SignalPreviewPanel(ttk.Frame):
             self._chart.delete('all')
 
         self._chart_ready = False
-        self._unsubscribe_core_events()
         self._reader = None

--- a/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/signal_preview_panel.py
@@ -422,7 +422,6 @@ class SignalPreviewPanel(ttk.Frame):
                 rule = self._selected_domain_descriptor.rule
                 self._dt = rule.parameters['delta']
                 self._sr = self._tick_res_den / self._tick_res_num / self._dt
-                self._data = deque(maxlen=min(self.MAX_BUFFER_SIZE, int((self._window_seconds * 1.5) * self._sr)))
 
     def _handle_event_packet(self, event_packet):
         event_id = event_packet.event_id

--- a/examples/applications/python/GUI Application/gui_demo/utils.py
+++ b/examples/applications/python/GUI Application/gui_demo/utils.py
@@ -267,7 +267,7 @@ def value_to_coretype(value, coretype: daq.CoreType):
 def get_item_path(tree, item_id):
     path = []
     while item_id:
-        item_text = tree.item(item_id, 'text')
+        item_text = tree.item(item_id, 'text').strip()
         path.insert(0, item_text)
         item_id = tree.parent(item_id)
     return path

--- a/examples/modules/ref_device_module/src/ref_channel_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_channel_impl.cpp
@@ -337,8 +337,8 @@ void RefChannelImpl::collectSamples(std::chrono::microseconds curTime)
                     if (!acqActive)
                         return;
 
-                    packets.pushBack(std::move(dataPacket));
-                    domainPackets.pushBack(std::move(domainPacket));
+                    packets.pushFront(std::move(dataPacket));
+                    domainPackets.pushFront(std::move(domainPacket));
                 }
 
                 samplesGenerated += packetSize;


### PR DESCRIPTION
# Brief

Backporting signal preview to 3.40 release candidate

# Description

- Default graph duration is nolonger only showing 0.2s but also draws as 0.2s
- Changed handeling of the `WINDOW_SECONDS` to `DEFAULT_WINDOW_SECONDS ` and `self._window_seconds`
- X axis labels are now all vertically aligned
- Buffering mechanisem has been tweeked
- New option in View menue added to be able to disable `view_signal_preview` across the app
- Artifacting (when 100000.0 Hz, FixedPacketSize is on and packet size is 1000 has been fixed in simulator 
- Simpeler and cleaner drawing with better per-descriptor `is_chartable` handeling.

# Usage example
In terminal use:

```shell
py -m opendaq
```