### PR TITLE
Optimize: make default permissions static to reduce allocations

### DIFF
--- a/core/coreobjects/include/coreobjects/property_object_utils.h
+++ b/core/coreobjects/include/coreobjects/property_object_utils.h
@@ -28,9 +28,12 @@ BEGIN_NAMESPACE_OPENDAQ
 namespace object_utils
 {
     inline const auto UnrestrictedPermissions = []() { 
-        daqDisableObjectTracking();
-        auto permissions = PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
-        daqEnableObjectTracking();
+        static PermissionsPtr permissions;
+        if (!permissions.assigned())
+        {
+            permissions = PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
+            daqUntrackObject(permissions);
+        }
         return permissions;
     }();
 }

--- a/core/coreobjects/include/coreobjects/property_object_utils.h
+++ b/core/coreobjects/include/coreobjects/property_object_utils.h
@@ -20,6 +20,7 @@
 #include <coreobjects/object_lock_guard.h>
 #include <map>
 #include <coreobjects/permissions_builder_factory.h>
+#include <coreobjects/permissions_internal_ptr.h>
 #include <coreobjects/permission_mask_builder_factory.h>
 #include <coreobjects/object_lock_guard_ptr.h>
 
@@ -33,6 +34,15 @@ namespace object_utils
         {
             permissions = PermissionsBuilder().assign("everyone", PermissionMaskBuilder().read().write().execute()).build();
             daqUntrackObject(permissions);
+            daqUntrackObject(permissions.getAllowed());
+            daqUntrackObject(permissions.getDenied());
+            daqUntrackObject(permissions.asPtr<IPermissionsInternal>(true).getAssigned());
+            for (const auto& [key, _] : permissions.getAllowed())
+                daqUntrackObject(key);
+            for (const auto& [key, _] : permissions.getDenied())
+                daqUntrackObject(key);
+            for (const auto& [key, _] : permissions.asPtr<IPermissionsInternal>(true).getAssigned())
+                daqUntrackObject(key);
         }
         return permissions;
     }();

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -1,4 +1,5 @@
 #include <coreobjects/permission_manager_impl.h>
+#include <coreobjects/permissions_internal_ptr.h>
 #include <coretypes/impl.h>
 #include <coretypes/string_ptr.h>
 #include <coreobjects/user_ptr.h>
@@ -19,6 +20,15 @@ namespace detail
         {
             permissions = PermissionsBuilder().inherit(true).build();
             daqUntrackObject(permissions);
+            daqUntrackObject(permissions.getAllowed());
+            daqUntrackObject(permissions.getDenied());
+            daqUntrackObject(permissions.asPtr<IPermissionsInternal>(true).getAssigned());
+            for (const auto& [key, _] : permissions.getAllowed())
+                daqUntrackObject(key);
+            for (const auto& [key, _] : permissions.getDenied())
+                daqUntrackObject(key);
+            for (const auto& [key, _] : permissions.asPtr<IPermissionsInternal>(true).getAssigned())
+                daqUntrackObject(key);
         }
         return permissions;
     }();

--- a/core/coreobjects/src/permission_manager_impl.cpp
+++ b/core/coreobjects/src/permission_manager_impl.cpp
@@ -14,9 +14,12 @@ namespace detail
 {
     static const auto DefaultPermissions = []()
     {
-        daqDisableObjectTracking();
-        auto permissions = PermissionsBuilder().inherit(true).build();
-        daqEnableObjectTracking();
+        static PermissionsPtr permissions;
+        if (!permissions.assigned())
+        {
+            permissions = PermissionsBuilder().inherit(true).build();
+            daqUntrackObject(permissions);
+        }
         return permissions;
     }();
 }


### PR DESCRIPTION
# Brief

Default permissions are initialized once and removed from tracked objects to reduce the number of objects created.
