### PR TITLE
Propagate parent active on configuration update

### DIFF
--- a/bindings/c/include/copendaq/component/component_private.h
+++ b/bindings/c/include/copendaq/component/component_private.h
@@ -50,7 +50,7 @@ extern "C"
     daqErrCode EXPORTED daqComponentPrivate_updateOperationMode(daqComponentPrivate* self, daqOperationModeType modeType);
     daqErrCode EXPORTED daqComponentPrivate_setComponentConfig(daqComponentPrivate* self, daqPropertyObject* config);
     daqErrCode EXPORTED daqComponentPrivate_getComponentConfig(daqComponentPrivate* self, daqPropertyObject** config);
-    daqErrCode EXPORTED daqComponentPrivate_setParentActive(daqComponentPrivate* self, daqBool parentActive);
+    daqErrCode EXPORTED daqComponentPrivate_setParentActive(daqComponentPrivate* self, daqBool parentActive, daqBool onUpdate);
 
 #ifdef __cplusplus
 }

--- a/bindings/c/src/copendaq/component/component_private.cpp
+++ b/bindings/c/src/copendaq/component/component_private.cpp
@@ -62,7 +62,7 @@ daqErrCode daqComponentPrivate_getComponentConfig(daqComponentPrivate* self, daq
     return reinterpret_cast<daq::IComponentPrivate*>(self)->getComponentConfig(reinterpret_cast<daq::IPropertyObject**>(config));
 }
 
-daqErrCode daqComponentPrivate_setParentActive(daqComponentPrivate* self, daqBool parentActive)
+daqErrCode daqComponentPrivate_setParentActive(daqComponentPrivate* self, daqBool parentActive, daqBool onUpdate)
 {
-    return reinterpret_cast<daq::IComponentPrivate*>(self)->setParentActive(parentActive);
+    return reinterpret_cast<daq::IComponentPrivate*>(self)->setParentActive(parentActive, onUpdate);
 }

--- a/bindings/python/opendaq/generated/component/py_component_private.cpp
+++ b/bindings/python/opendaq/generated/component/py_component_private.cpp
@@ -109,11 +109,11 @@ void defineIComponentPrivate(pybind11::module_ m, PyDaqIntf<daq::IComponentPriva
         "Retrieves the configuration which was used to create the component. / Sets the configuration which was used to create the component.");
     cls.def_property("parent_active",
         nullptr,
-        [](daq::IComponentPrivate *object, const bool parentActive)
+        [](daq::IComponentPrivate *object, const bool parentActive, const bool onUpdate)
         {
             py::gil_scoped_release release;
             const auto objectPtr = daq::ComponentPrivatePtr::Borrow(object);
-            objectPtr.setParentActive(parentActive);
+            objectPtr.setParentActive(parentActive, onUpdate);
         },
         "Called by parent component to notify this component about parent's active state change.");
 }

--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -106,7 +106,7 @@ public:
     ErrCode INTERFACE_FUNC updateOperationMode(OperationModeType modeType) override;
     ErrCode INTERFACE_FUNC setComponentConfig(IPropertyObject* config) override;
     ErrCode INTERFACE_FUNC getComponentConfig(IPropertyObject** config) override;
-    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive) override;
+    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive, Bool onUpdate) override;
 
     // IRemovable
     ErrCode INTERFACE_FUNC remove() override;
@@ -135,8 +135,8 @@ protected:
     virtual ErrCode lockAllAttributesInternal();
     ListPtr<IComponent> searchItems(const SearchFilterPtr& searchFilter, const std::vector<ComponentPtr>& items);
 
-    void notifyItemsActiveChanged(const std::vector<ComponentPtr>& items);
-    virtual void notifyActiveChanged();
+    void notifyItemsActiveChanged(const std::vector<ComponentPtr>& items, bool onUpdate);
+    virtual void notifyActiveChanged(bool onUpdate);
 
 private:
     bool updateActive();
@@ -400,29 +400,47 @@ ErrCode ComponentImpl<Intf, Intfs...>::setActive(Bool active)
         triggerCoreEvent(args);
     }
 
-    auto errCode = daqTry([this] { notifyActiveChanged(); });
+    auto errCode = daqTry([this] { notifyActiveChanged(false); });
     OPENDAQ_RETURN_IF_FAILED(errCode);
 
     return OPENDAQ_SUCCESS;
 }
 
 template <class Intf, class... Intfs>
-void ComponentImpl<Intf, Intfs...>::notifyItemsActiveChanged(const std::vector<ComponentPtr>& items)
+void ComponentImpl<Intf, Intfs...>::notifyItemsActiveChanged(const std::vector<ComponentPtr>& items, bool onUpdate)
 {
     for (const auto& item : items)
     {
-        item.asPtr<IComponentPrivate>(true).setParentActive(this->active);
+        item.asPtr<IComponentPrivate>(true).setParentActive(this->active, onUpdate);
     }
 }
 
 template <class Intf, class... Intfs>
-void ComponentImpl<Intf, Intfs...>::notifyActiveChanged()
+void ComponentImpl<Intf, Intfs...>::notifyActiveChanged(bool)
 {
 }
 
 template <class Intf, class... Intfs>
-ErrCode ComponentImpl<Intf, Intfs...>::setParentActive(Bool parentActive)
+ErrCode ComponentImpl<Intf, Intfs...>::setParentActive(Bool parentActive, Bool onUpdate)
 {
+    if (onUpdate)
+    {
+        if (static_cast<bool>(parentActive) == this->parentActive)
+            return OPENDAQ_IGNORED;
+
+        bool oldActive = active;
+        this->parentActive = parentActive;
+        this->active = this->localActive && this->parentActive;
+
+        if (oldActive != this->active)
+        {
+            auto errCode = daqTry([this] { notifyActiveChanged(true); });
+            OPENDAQ_RETURN_IF_FAILED(errCode);
+        }
+
+        return OPENDAQ_SUCCESS;
+    }
+
     {
         auto lock = this->getRecursiveConfigLock2();
 
@@ -445,7 +463,7 @@ ErrCode ComponentImpl<Intf, Intfs...>::setParentActive(Bool parentActive)
         triggerCoreEvent(args);
     }
 
-    auto errCode = daqTry([this] { notifyActiveChanged(); });
+    auto errCode = daqTry([this] { notifyActiveChanged(false); });
     OPENDAQ_RETURN_IF_FAILED(errCode);
 
     return OPENDAQ_SUCCESS;
@@ -1215,11 +1233,15 @@ void ComponentImpl<Intf, Intfs...>::updateObject(const SerializedObjectPtr& obj,
 {
     if (!lockedAttributes.count("Active"))
     {
+        bool oldActive = active;
         if (obj.hasKey("active"))
             localActive = obj.readBool("active");
         else
             localActive = true;
+
         active = parentActive && localActive;
+        if (oldActive != this->active)
+            notifyActiveChanged(true);
     }
 
     if (!lockedAttributes.count("Visible"))

--- a/core/opendaq/component/include/opendaq/component_private.h
+++ b/core/opendaq/component/include/opendaq/component_private.h
@@ -85,12 +85,13 @@ DECLARE_OPENDAQ_INTERFACE(IComponentPrivate, IBaseObject)
     /*!
      * @brief Called by parent component to notify this component about parent's active state change.
      * @param parentActive True if parent is active.
+     * @param onUpdate True if the call is triggered from config update, false if the call is triggered by a change of the active state.
      *
      * The component updates its internal parentActive flag and recomputes its effective active state.
      * If the effective active state changes, triggers an AttributeChanged event.
      * Container components (folders, devices) propagate this call to their children.
      */
-    virtual ErrCode INTERFACE_FUNC setParentActive(Bool parentActive) = 0;
+    virtual ErrCode INTERFACE_FUNC setParentActive(Bool parentActive, Bool onUpdate) = 0;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/component/include/opendaq/folder_impl.h
+++ b/core/opendaq/component/include/opendaq/folder_impl.h
@@ -88,7 +88,7 @@ protected:
     void onUpdatableUpdateEnd(const BaseObjectPtr& context) override;
 
     virtual void syncComponentOperationMode(const ComponentPtr& component);
-    void notifyActiveChanged() override;
+    void notifyActiveChanged(bool onUpdate) override;
 
 private:
     bool removeItemWithLocalIdInternal(const std::string& str);
@@ -212,12 +212,12 @@ void FolderImpl<Intf, Intfs...>::syncComponentOperationMode(const ComponentPtr& 
 }
 
 template <class Intf, class ... Intfs>
-void FolderImpl<Intf, Intfs...>::notifyActiveChanged()
+void FolderImpl<Intf, Intfs...>::notifyActiveChanged(bool onUpdate)
 {
     std::vector<ComponentPtr> itemsVec;
     for (const auto& [_, item] : this->items)
         itemsVec.emplace_back(item);
-    this->notifyItemsActiveChanged(itemsVec);
+    this->notifyItemsActiveChanged(itemsVec, onUpdate);
 }
 
 template <class Intf, class... Intfs>

--- a/core/opendaq/component/tests/test_folder.cpp
+++ b/core/opendaq/component/tests/test_folder.cpp
@@ -390,3 +390,32 @@ TEST_F(FolderTest, InheritedLocking2)
     ASSERT_EQ(folderInternal, folderInternal1.getMutexOwner());
     ASSERT_EQ(folderInternal, objInternal.getMutexOwner());
 }
+
+TEST_F(FolderTest, HierarchicalUpdate)
+{
+    const auto ctx = daq::NullContext();
+    const auto folder_parent = daq::Folder(ctx, nullptr, "folder_parent");
+    const auto folder_child = daq::Folder(ctx, nullptr, "folder_child");
+    folder_parent.addItem(folder_child);
+
+    const auto component = daq::Component(ctx, nullptr, "component");
+    folder_child.addItem(component);
+    
+    const auto serializer = daq::JsonSerializer(daq::True);
+
+    folder_parent.asPtr<IUpdatable>(true).serializeForUpdate(serializer);
+    const auto str = serializer.getOutput();
+
+    folder_parent.setActive(false);
+
+    ASSERT_FALSE(folder_parent.getActive());
+    ASSERT_FALSE(folder_child.getActive());
+    ASSERT_FALSE(component.getActive());
+
+    const auto deserializer = daq::JsonDeserializer();
+    deserializer.update(folder_parent.asPtr<IUpdatable>(true), str);
+
+    ASSERT_TRUE(folder_parent.getActive());
+    ASSERT_TRUE(folder_child.getActive());
+    ASSERT_TRUE(component.getActive());
+}

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -169,7 +169,7 @@ public:
 
     // IComponentPrivate
     ErrCode INTERFACE_FUNC updateOperationMode(OperationModeType modeType) override;
-    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive) override;
+    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive, Bool onUpdate) override;
 
     // IPropertyObjectInternal
     ErrCode INTERFACE_FUNC enableCoreEventTrigger() override;
@@ -1203,11 +1203,11 @@ ErrCode GenericDevice<TInterface, Interfaces...>::updateOperationMode(OperationM
 }
 
 template <typename TInterface, typename... Interfaces>
-ErrCode GenericDevice<TInterface, Interfaces...>::setParentActive(Bool parentActive)
+ErrCode GenericDevice<TInterface, Interfaces...>::setParentActive(Bool parentActive, Bool onUpdate)
 {
     if (this->isRootDevice)
         return OPENDAQ_IGNORED;
-    return Super::setParentActive(parentActive);
+    return Super::setParentActive(parentActive, onUpdate);
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/signal/include/opendaq/signal_container_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_container_impl.h
@@ -147,7 +147,7 @@ public:
                         const StringPtr& name = nullptr);
     
 protected:
-    void notifyActiveChanged() override;
+    void notifyActiveChanged(bool onUpdate) override;
 
     virtual ErrCode INTERFACE_FUNC getItems(IList** items, ISearchFilter* searchFilter) override;
     ErrCode INTERFACE_FUNC getItem(IString* localId, IComponent** item) override;
@@ -214,9 +214,9 @@ SignalContainerImpl<Intf, Intfs...>::SignalContainerImpl(const ContextPtr& conte
 }
 
 template <class Intf, class ... Intfs>
-void SignalContainerImpl<Intf, Intfs...>::notifyActiveChanged()
+void SignalContainerImpl<Intf, Intfs...>::notifyActiveChanged(bool onUpdate)
 {
-    this->notifyItemsActiveChanged(this->components);
+    this->notifyItemsActiveChanged(this->components, onUpdate);
 }
 
 template <class Intf, class ... Intfs>

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_component_impl.h
@@ -45,7 +45,7 @@ public:
     ErrCode INTERFACE_FUNC getComponentConfig(IPropertyObject** config) override;
 
     // IComponentPrivate overrides
-    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive) override;
+    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive, Bool onUpdate) override;
 
     static ErrCode Deserialize(ISerializedObject* serialized, IBaseObject* context, IFunction* factoryCallback, IBaseObject** obj);
 protected:
@@ -89,22 +89,28 @@ ErrCode ConfigClientComponentBaseImpl<Impl>::setActive(Bool active)
 }
 
 template <class Impl>
-ErrCode ConfigClientComponentBaseImpl<Impl>::setParentActive(Bool parentActive)
+ErrCode ConfigClientComponentBaseImpl<Impl>::setParentActive(Bool parentActive, Bool onUpdate)
 {
-    ErrCode errCode = Impl::setParentActive(parentActive);
+    ErrCode errCode = Impl::setParentActive(parentActive, onUpdate);
     OPENDAQ_RETURN_IF_FAILED(errCode);
-    if (this->clientComm->getProtocolVersion() > 21)
+
+    if (!onUpdate)
+    {
+        if (this->clientComm->getProtocolVersion() > 21)
+            return errCode;
+
+        const bool muted = this->coreEventMuted;
+        if (!muted)
+            Impl::disableCoreEventTrigger();
+
+        errCode = Impl::setActive(parentActive);
+
+        if (!muted)
+            Impl::enableCoreEventTrigger();
         return errCode;
+    }
 
-    const bool muted = this->coreEventMuted;
-    if (!muted)
-        Impl::disableCoreEventTrigger();
-
-    errCode = Impl::setActive(parentActive);
-
-    if (!muted)
-        Impl::enableCoreEventTrigger();
-    return errCode;
+    return OPENDAQ_SUCCESS;
 }
 
 template <class Impl>
@@ -274,11 +280,17 @@ void ConfigClientComponentBaseImpl<Impl>::onRemoteUpdate(const SerializedObjectP
 {
     ConfigClientPropertyObjectBaseImpl<Impl>::onRemoteUpdate(serialized);
 
+    bool oldActive = this->active;
     if (serialized.hasKey("active"))
         this->localActive = serialized.readBool("active");
     else
         this->localActive = true;
+
     this->active = this->parentActive && this->localActive;
+    if (oldActive != this->active)
+    {
+        this->notifyActiveChanged(true);
+    }
 
     if (serialized.hasKey("visible"))
         this->visible = serialized.readBool("visible");

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -71,7 +71,7 @@ public:
     ErrCode INTERFACE_FUNC setOperationModeRecursive(OperationModeType modeType) override;
     ErrCode INTERFACE_FUNC getOperationMode(OperationModeType* modeType) override;
 
-    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive) override;
+    ErrCode INTERFACE_FUNC setParentActive(Bool parentActive, Bool onUpdate) override;
     ErrCode INTERFACE_FUNC setAsRoot() override;
 
     template <class Implementation>
@@ -386,11 +386,11 @@ inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::getOperationMode(Oper
 }
 
 template <class TDeviceBase>
-inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::setParentActive(Bool parentActive)
+inline ErrCode GenericConfigClientDeviceImpl<TDeviceBase>::setParentActive(Bool parentActive, Bool onUpdate)
 {
     if (this->isRootDevice)
         return OPENDAQ_IGNORED;
-    return Super::setParentActive(parentActive);
+    return Super::setParentActive(parentActive, onUpdate);
 }
 
 template <class TDeviceBase>

--- a/shared/libraries/config_protocol/tests/test_remote_update.cpp
+++ b/shared/libraries/config_protocol/tests/test_remote_update.cpp
@@ -215,3 +215,23 @@ TEST_F(ConfigRemoteUpdateTest, UpdateChannelActive)
     ASSERT_TRUE(serverChannel.getActive());
     ASSERT_TRUE(clientChannel.getActive());
 }
+
+TEST_F(ConfigRemoteUpdateTest, UpdateHierarchicalActive)
+{
+    auto serverChannel = serverDevice.getChannelsRecursive()[0];
+    auto clientChannel = clientDevice.getChannelsRecursive()[0];
+
+    ASSERT_TRUE(serverChannel.getActive());
+    ASSERT_TRUE(clientChannel.getActive());
+    const auto str = serializeHelper(serverDevice);
+
+    serverDevice.setActive(false);
+
+    ASSERT_FALSE(serverChannel.getActive());
+    ASSERT_FALSE(clientChannel.getActive());
+
+    updateHelper(serverDevice, str);
+
+    ASSERT_TRUE(serverChannel.getActive());
+    ASSERT_TRUE(clientChannel.getActive());
+}


### PR DESCRIPTION
# Brief

Properly propagate the parent-active attribute to child components via IUpdatable.update.