### PR TITLE
Fix CMake configure failures with parquet recorder enabled

### DIFF
--- a/external/arrow/CMakeLists.txt
+++ b/external/arrow/CMakeLists.txt
@@ -47,8 +47,10 @@ opendaq_dependency(
     ADD_FETCH_ALIAS     Arrow::arrow_static=arrow_static
     EXPECT_TARGET       Arrow::arrow_static
     SOURCE_SUBDIR       cpp
-    PATCH_FILES        
+    PATCH_FILES
                         "${CMAKE_CURRENT_SOURCE_DIR}/boost_linking.patch"
+                        "${CMAKE_CURRENT_SOURCE_DIR}/apple_libtool_regex.patch"
+                        "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty_dir.patch"
 )
 
 if (Arrow_FETCHED)

--- a/external/arrow/apple_libtool_regex.patch
+++ b/external/arrow/apple_libtool_regex.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/cmake_modules/BuildUtils.cmake b/cpp/cmake_modules/BuildUtils.cmake
+--- a/cpp/cmake_modules/BuildUtils.cmake
++++ b/cpp/cmake_modules/BuildUtils.cmake
+@@ -110,7 +110,7 @@
+     execute_process(COMMAND ${LIBTOOL_MACOS} -V
+                     OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
++    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools[-_]([0-9.a-zA-Z]+).*")
+       message(FATAL_ERROR "libtool found appears not to be Apple's libtool: ${LIBTOOL_MACOS}"
+       )
+     endif()

--- a/external/arrow/thirdparty_dir.patch
+++ b/external/arrow/thirdparty_dir.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -365,7 +365,7 @@
+ # ----------------------------------------------------------------------
+ # Thirdparty versions, environment variables, source URLs
+ 
+-set(THIRDPARTY_DIR "${arrow_SOURCE_DIR}/thirdparty")
++set(THIRDPARTY_DIR "${CMAKE_CURRENT_LIST_DIR}/../thirdparty")
+ 
+ add_library(arrow::flatbuffers INTERFACE IMPORTED)
+ target_include_directories(arrow::flatbuffers


### PR DESCRIPTION
# Brief

Fix CMake configure failures when `DAQMODULES_PARQUET_RECORDER_MODULE=ON` by patching Arrow.

# Description

- Patch Arrow's `THIRDPARTY_DIR` to use `CMAKE_CURRENT_LIST_DIR/../thirdparty`
  instead of `arrow_SOURCE_DIR/thirdparty`. `arrow_SOURCE_DIR` is unreliable
  with FetchContent + SOURCE_SUBDIR on CMake <3.30 (points at Arrow root
  instead of `cpp/`); the file-relative path always resolves correctly.
- Patch Arrow's Apple libtool regex from `cctools-` to `cctools[-_]` so it
  accepts the `cctools_ld-NNN` format from recent Xcode.

> [!NOTE]
> This PR only fixes the misleading Arrow / Thrift errors that appeared first. 
> Parquet recorder still requires CMake 4.0.0 or higher. 
> Users on older CMake now get the proper message instead:
> `Parquet recorder module requires CMake 4.0.0 or higher`