### PR TITLE
C++ iterator improvements

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -38,6 +38,7 @@
 
 ## Bug fixes
 
+- [#1210](https://github.com/openDAQ/openDAQ/pull/1210) Fix and optimize comparing with end iterator (C++).
 - [#1200](https://github.com/openDAQ/openDAQ/pull/1200) Recreate binary data packets into `BinaryDataPacketImpl` objects on client side of native streaming protocol.
 - [#1158](https://github.com/openDAQ/openDAQ/pull/1158) Skip logging for identical component statuses.
 - [#1150](https://github.com/openDAQ/openDAQ/pull/1150) Serialize public flag for input ports

--- a/core/corecontainers/include/coretypes/dictptr.h
+++ b/core/corecontainers/include/coretypes/dictptr.h
@@ -549,7 +549,7 @@ NativeIterator<std::pair<KeyPtr, ValuePtr>> DictObjectPtr<T, KeyT, ValueT, KeyPt
 template <class T, class KeyT, class ValueT, class KeyPtr, class ValuePtr>
 NativeIterator<std::pair<KeyPtr, ValuePtr>> DictObjectPtr<T, KeyT, ValueT, KeyPtr, ValuePtr>::end() const
 {
-    return this->createEndIteratorInterface();
+    return {};
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/corecontainers/include/coretypes/listptr.h
+++ b/core/corecontainers/include/coretypes/listptr.h
@@ -485,7 +485,7 @@ NativeIterator<TValuePtr> ListObjectPtr<T, U, TValuePtr>::begin() const
 template <class T, class U, class TValuePtr>
 NativeIterator<TValuePtr> ListObjectPtr<T, U, TValuePtr>::end() const
 {
-    return this->createEndIteratorInterface();
+    return {};
 }
 
 template <class T, class TValueInterface, class TValuePtr>

--- a/core/coreobjects/src/property_object_class_builder_impl.cpp
+++ b/core/coreobjects/src/property_object_class_builder_impl.cpp
@@ -194,9 +194,9 @@ ListPtr<IProperty> PropertyObjectClassBuilderImpl::getProperties() const
         }
     }
 
-    for (const auto& prop : props)
+    for (const auto& prop : props.getValues())
     {
-        properties.unsafePushBack(prop.second);
+        properties.unsafePushBack(prop);
     }
 
     return properties;

--- a/core/coretypes/include/coretypes/iterable_ptr.h
+++ b/core/coretypes/include/coretypes/iterable_ptr.h
@@ -92,8 +92,7 @@ NativeIterator<TValuePtr> IterablePtr<U, TValuePtr>::createStartIteratorInterfac
 template <class U, class TValuePtr>
 NativeIterator<TValuePtr> IterablePtr<U, TValuePtr>::createEndIteratorInterface() const
 {
-    IIterator* iterator = ObjectPtr<IIterable>::createEndIteratorInterface();
-    return NativeIterator<TValuePtr>(std::move(iterator));
+    return {};
 }
 
 template <class U, class TValuePtr>

--- a/core/coretypes/include/coretypes/iterator_support.h
+++ b/core/coretypes/include/coretypes/iterator_support.h
@@ -44,17 +44,25 @@ public:
 
 protected:
     ObjectPtr<IIterator> iterator;
+    bool isEnd {true};
 };
 
 template <class U>
 NativeIterator<U>::NativeIterator(IIterator*&& iterator)
     : iterator(std::move(iterator))
 {
+    if (this->iterator.assigned())
+    {
+        const auto res = this->iterator->moveNext();
+        checkErrorInfo(res);
+        isEnd = res == OPENDAQ_NO_MORE_ITEMS;
+    }
 }
 
 template <class U>
 NativeIterator<U>::NativeIterator(NativeIterator&& it) noexcept
     : iterator(it.iterator)
+    , isEnd(it.isEnd)
 {
     it.iterator = nullptr;
 }
@@ -62,6 +70,7 @@ NativeIterator<U>::NativeIterator(NativeIterator&& it) noexcept
 template <class U>
 NativeIterator<U>::NativeIterator(const NativeIterator& it)
     : iterator(it.iterator)
+    , isEnd(it.isEnd)
 {
 }
 
@@ -71,6 +80,7 @@ NativeIterator<U>& NativeIterator<U>::operator=(const NativeIterator<U>& other)
     if (this != &other)  // not a self-assignment
     {
         iterator = other.iterator;
+        isEnd = other.isEnd;
     }
     return *this;
 }
@@ -80,6 +90,8 @@ NativeIterator<U>& NativeIterator<U>::operator++()
 {
     const auto res = iterator->moveNext();
     checkErrorInfo(res);
+    if (res == OPENDAQ_NO_MORE_ITEMS)
+        isEnd = true;
 
     return *this;
 }
@@ -87,6 +99,12 @@ NativeIterator<U>& NativeIterator<U>::operator++()
 template <class U>
 bool NativeIterator<U>::operator!=(const NativeIterator<U>& other) const
 {
+    if (this->isEnd && other.isEnd)
+        return false;
+
+    if (this->isEnd != other.isEnd)
+        return true;
+
     Bool eq{false};
     const ErrCode errCode = iterator->equals(other.iterator, &eq);
     checkErrorInfo(errCode);

--- a/core/coretypes/include/coretypes/iterator_support.h
+++ b/core/coretypes/include/coretypes/iterator_support.h
@@ -31,6 +31,7 @@ public:
     using reference = U&;
     using const_reference = const U&;
 
+    NativeIterator();
     NativeIterator(IIterator*&& iterator);
     NativeIterator(NativeIterator&& it) noexcept;
     NativeIterator(const NativeIterator& it);
@@ -46,6 +47,13 @@ protected:
     ObjectPtr<IIterator> iterator;
     bool isEnd {true};
 };
+
+template <class U>
+NativeIterator<U>::NativeIterator()
+    : iterator(nullptr)
+    , isEnd(true)
+{
+}
 
 template <class U>
 NativeIterator<U>::NativeIterator(IIterator*&& iterator)

--- a/core/coretypes/include/coretypes/objectptr.h
+++ b/core/coretypes/include/coretypes/objectptr.h
@@ -1717,7 +1717,6 @@ IIterator* ObjectPtr<T>::createStartIteratorInterface() const
     errCode = iterable->createStartIterator(&iterator);
     checkErrorInfo(errCode);
 
-    iterator->moveNext();
     return iterator;
 }
 
@@ -1742,7 +1741,6 @@ IIterator* ObjectPtr<T>::createEndIteratorInterface() const
     errCode = iterable->createEndIterator(&iterator);
     checkErrorInfo(errCode);
 
-    iterator->moveNext();
     return iterator;
 }
 

--- a/core/coretypes/tests/integration_test.cpp
+++ b/core/coretypes/tests/integration_test.cpp
@@ -71,6 +71,26 @@ TEST_F(IntegrationTest, ListIterators)
     ASSERT_EQ(sum, 6);
 }
 
+TEST_F(IntegrationTest, ListIteratorsWithNull)
+{
+    auto list = List<IInteger>();
+
+    list.pushBack(1);
+    list.pushBack(2);
+    list.pushBack(nullptr);
+    list.pushBack(3);
+
+    size_t count = 0;
+
+    for (const auto& item : list)
+    {
+        (void) item;
+        count++;
+    }
+
+    ASSERT_EQ(count, 4u);
+}
+
 TEST_F(IntegrationTest, DictKeysIterator)
 {
     auto dict = Dict<IInteger, IInteger>();
@@ -115,6 +135,25 @@ TEST_F(IntegrationTest, DictValuesIterator)
     }
 
     ASSERT_EQ(sum, 66);
+}
+
+TEST_F(IntegrationTest, DictValuesIteratorWithNull)
+{
+    auto dict = Dict<IInteger, IInteger>();
+
+    dict.set(1, 11);
+    dict.set(2, 22);
+    dict.set(3, 33);
+    dict.set(4, nullptr);
+
+    size_t count = 0;
+    for (const auto& item : dict.getValues())
+    {
+        (void) item;
+        count++;
+    }
+
+    ASSERT_EQ(count, 4u);
 }
 
 TEST_F(IntegrationTest, HashStruct)

--- a/core/coretypes/tests/test_iterable.cpp
+++ b/core/coretypes/tests/test_iterable.cpp
@@ -26,6 +26,19 @@ TEST_F(IterableTest, IterateListDirect)
     ASSERT_THAT(list, testing::ElementsAre(1, 2, 3, 4));
 }
 
+TEST_F(IterableTest, IterateListWithNull)
+{
+    auto list = List<Int>(1, 2, nullptr, 4);
+    size_t count = 0;
+    for (const auto& element : list)
+    {
+        (void) element;
+        count++;
+    }
+
+    ASSERT_EQ(count, 4u);
+}
+
 TEST_F(IterableTest, IterateDict)
 {
     auto dict = Dict<IString, IInteger>();

--- a/core/opendaq/modulemanager/include/opendaq/module_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/module_impl.h
@@ -84,9 +84,9 @@ public:
         const ErrCode errCode = wrapHandlerReturn(this, &Module::onGetAvailableDeviceTypes, types);
         OPENDAQ_RETURN_IF_FAILED(errCode);
 
-        for (const auto& type : types)
+        for (const auto& type : types.getValues())
         {
-            auto componentTypePrivate = type.second.asPtr<IComponentTypePrivate>();
+            auto componentTypePrivate = type.asPtr<IComponentTypePrivate>();
             componentTypePrivate->setModuleInfo(this->moduleInfo);
         }
 
@@ -148,9 +148,9 @@ public:
         const ErrCode errCode = wrapHandlerReturn(this, &Module::onGetAvailableFunctionBlockTypes, types);
         OPENDAQ_RETURN_IF_FAILED(errCode);
     
-        for (const auto& type : types)
+        for (const auto& type : types.getValues())
         {
-            auto componentTypePrivate = type.second.asPtr<IComponentTypePrivate>();
+            auto componentTypePrivate = type.asPtr<IComponentTypePrivate>();
             componentTypePrivate->setModuleInfo(this->moduleInfo);
         }
 
@@ -203,9 +203,9 @@ public:
         ErrCode errCode = wrapHandlerReturn(this, &Module::onGetAvailableServerTypes, types);
         OPENDAQ_RETURN_IF_FAILED(errCode);
 
-        for (const auto& type : types)
+        for (const auto& type : types.getValues())
         {
-            auto componentTypePrivate = type.second.asPtr<IComponentTypePrivate>();
+            auto componentTypePrivate = type.asPtr<IComponentTypePrivate>();
             componentTypePrivate->setModuleInfo(this->moduleInfo);
         }
 
@@ -300,9 +300,9 @@ public:
         ErrCode errCode = wrapHandlerReturn(this, &Module::onGetAvailableStreamingTypes, types);
         OPENDAQ_RETURN_IF_FAILED(errCode);
 
-        for (const auto& type : types)
+        for (const auto& type : types.getValues())
         {
-            auto componentTypePrivate = type.second.asPtr<IComponentTypePrivate>();
+            auto componentTypePrivate = type.asPtr<IComponentTypePrivate>();
             componentTypePrivate->setModuleInfo(this->moduleInfo);
         }
 


### PR DESCRIPTION
# Description

I fixed and speedup comparing with end sentinel. In that case we don't compare by value.

The problem remains with comparing two non-end iterators. But luckly we don't have such use cases.


```
auto list = List<Int>(1, 2, 1, 4);

auto it1 = list.begin();
auto it2 = list.begin();

ASSERT_EQ(it1, it2);

++it2;
ASSERT_NE(it1, it2);

++it2;
ASSERT_NE(it1, it2);  // fails
```


