### PR TITLE
Forward device locked state core event in native client

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -38,6 +38,7 @@
 
 ## Bug fixes
 
+- [#1213](https://github.com/openDAQ/openDAQ/pull/1213) Forward device locked state core event in native client.
 - [#1200](https://github.com/openDAQ/openDAQ/pull/1200) Recreate binary data packets into `BinaryDataPacketImpl` objects on client side of native streaming protocol.
 - [#1158](https://github.com/openDAQ/openDAQ/pull/1158) Skip logging for identical component statuses.
 - [#1150](https://github.com/openDAQ/openDAQ/pull/1150) Serialize public flag for input ports

--- a/core/coreobjects/include/coreobjects/core_event_args.h
+++ b/core/coreobjects/include/coreobjects/core_event_args.h
@@ -253,6 +253,17 @@ BEGIN_NAMESPACE_OPENDAQ
  *
  * The ID of the event is 150, and the event name is "DeviceDomainChanged".
  *
+ * @subsubsection opendaq_core_event_types_device_lock_state_changed Device locked state changed
+ *
+ * Triggered whenever the device is locked or unlocked.
+ *
+ * The sender of the event is the device of which locked state changed.
+ *
+ * The event contains the following parameters:
+ *  - The new locked state Bool value under the key "IsLocked" (always present).
+ *
+ * The ID of the event is 160, and the event name is "DeviceLockStateChanged".
+ *
  * @subsubsection opendaq_core_event_types_device_connection_status Device connection status changed
  *
  * Triggered whenever connection status of a device changes.

--- a/core/opendaq/device/include/opendaq/core_opendaq_event_args.h
+++ b/core/opendaq/device/include/opendaq/core_opendaq_event_args.h
@@ -140,7 +140,7 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
 
 /*!
  * @brief Creates Core event args that are passed as argument when the device is locked or unlocked.
- * @param isLock New lock state of the device.
+ * @param isLocked New lock state of the device.
  *
  * The ID of the event is 160, and the event name is "DeviceLockStateChanged".
  */

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_device_impl.h
@@ -628,6 +628,9 @@ inline void GenericConfigClientDeviceImpl<TDeviceBase>::deviceLockStatusChanged(
 
     if (isLocked)
         this->userLock.lock();
+
+    if (!this->coreEventMuted && this->coreEvent.assigned())
+        this->triggerCoreEvent(CoreEventArgsDeviceLockStateChanged(isLocked));
 }
 
 template <class TDeviceBase>

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -86,7 +86,6 @@ public:
     void lock(const std::string& globalId);
     void unlock(const std::string& globalId);
     void forceUnlock(const std::string& globalId);
-    bool isLocked(const std::string& globalId);
     void beginUpdate(const std::string& globalId, const std::string& path = "");
     void endUpdate(const std::string& globalId, const std::string& path = "", const ListPtr<IDict>& props = nullptr);
     void clearPropertyValues(const std::string& globalId, const std::string& path = "");

--- a/shared/libraries/config_protocol/src/config_protocol_client.cpp
+++ b/shared/libraries/config_protocol/src/config_protocol_client.cpp
@@ -455,14 +455,6 @@ void ConfigProtocolClientComm::forceUnlock(const std::string& globalId)
     sendCommand(ClientCommand("ForceUnlock", 6), params);
 }
 
-bool ConfigProtocolClientComm::isLocked(const std::string& globalId)
-{
-    auto params = Dict<IString, IBaseObject>();
-    params.set("ComponentGlobalId", String(globalId));
-
-    return sendCommand(ClientCommand("IsLocked", 6), params);
-}
-
 BaseObjectPtr ConfigProtocolClientComm::createRpcRequest(const StringPtr& name, const ParamsDictPtr& params) const
 {
     auto obj = Dict<IString, IBaseObject>();

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -1818,3 +1818,40 @@ TEST_F(ConfigCoreEventTest, ComponentSetActiveWithParentNonActive)
 
     ASSERT_TRUE(sig.getActive());
 }
+
+TEST_F(ConfigCoreEventTest, DeviceLockUnlock)
+{
+    int callCount = 0;
+    const auto srvSubDev = serverDevice.getDevices(search::Recursive(search::LocalId("mock_phys_dev")))[0];
+    const auto clSubDev = clientDevice.getDevices(search::Recursive(search::LocalId("mock_phys_dev")))[0];
+
+    clientContext.getOnCoreEvent() +=
+        [&](const ComponentPtr& comp, const CoreEventArgsPtr& args)
+    {
+        ASSERT_EQ(args.getEventId(), static_cast<Int>(CoreEventId::DeviceLockStateChanged));
+        ASSERT_EQ(args.getEventName(), "DeviceLockStateChanged");
+        ASSERT_EQ(comp, clSubDev);
+        ASSERT_TRUE(args.getParameters().hasKey("IsLocked"));
+
+        if (callCount == 0)
+        {
+            ASSERT_EQ(args.getParameters().get("IsLocked"), True);
+        }
+        else
+        {
+            ASSERT_EQ(args.getParameters().get("IsLocked"), False);
+        }
+
+        callCount++;
+    };
+
+    ASSERT_FALSE(clSubDev.isLocked());
+
+    srvSubDev.lock();
+    ASSERT_TRUE(clSubDev.isLocked());
+
+    srvSubDev.unlock();
+    ASSERT_FALSE(clSubDev.isLocked());
+
+    ASSERT_EQ(callCount, 2);
+}


### PR DESCRIPTION
# Brief

Fixes an issue where the device locked state was not correctly propagated to the client for subdevices connected through a chained native connection (`subdevice -> gateway device -> client instance`). The problem was caused by missing core event triggering.

# Description

- Trigger the corresponding local core event in the remote core event handler within the config protocol client device implementation, in addition to updating the internal state.
- Add missing doxygen comments.
- Remove the unused "IsLocked" RPC, which was neither sent by the client nor handled by the server.

