### PR TITLE
Fix packet enqueue order in `sendPackets`

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -105,5 +105,11 @@ On load configuration, all non-static function blocks will be removed and recrea
 
 ## Required module changes
 
+### [#1214](https://github.com/openDAQ/openDAQ/pull/1214) Fix packet enqueue order in sendPackets
+
+`ISignalConfig::sendPackets` had an issue where packets were sometimes enqueued front-to-back (first packet in list is enqueued first) and sometimes back-to-front. This inconsistency was addressed to always enqueue packets front-to-back.
+
+Module implementations where `sendPackets` is used should check whether this change in behaviour reversed the order in which packets are enqueued and adjust the packet list order accordingly.
+
 ### [#1037](https://github.com/openDAQ/openDAQ/pull/1037) Mandatory device types
 To enable static components, devices must include the Device Type in their Device Info objects. Modules set the value within the onGetInfo overriding method by calling IDeviceInfoConfig::setDeviceType().

--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -38,6 +38,7 @@
 
 ## Bug fixes
 
+- [#1214](https://github.com/openDAQ/openDAQ/pull/1214) Fixes the order in which packets are enqueued in sendPackets. They are now always correctly enqueued front-to-back.
 - [#1213](https://github.com/openDAQ/openDAQ/pull/1213) Forward device locked state core event in native client.
 - [#1205](https://github.com/openDAQ/openDAQ/pull/1205) Fix raw socket access exception on Linux/macOS for non-root users
 - [#1200](https://github.com/openDAQ/openDAQ/pull/1200) Recreate binary data packets into `BinaryDataPacketImpl` objects on client side of native streaming protocol.

--- a/core/opendaq/signal/src/connection_impl.cpp
+++ b/core/opendaq/signal/src/connection_impl.cpp
@@ -139,7 +139,7 @@ ErrCode ConnectionImpl::enqueueMultipleInternal(ListPtr<IPacket>&& packets)
             const size_t cnt = packets.getCount();
             for (size_t i = 0; i < cnt; ++i)
             {
-                auto packet = packets.popBack();
+                auto packet = packets.popFront();
                 onPacketEnqueued(packet);
                 this->packets.push_back(packet);
             }
@@ -175,7 +175,7 @@ ErrCode ConnectionImpl::enqueueMultipleInternal(P&& packets)
                     PacketPtr packet;
                     if constexpr (std::is_rvalue_reference_v<P&&>)
                     {
-                        packet = packets.popBack();
+                        packet = packets.popFront();
                     }
                     else
                     {

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <coreobjects/property_factory.h>
 #include <opendaq/binary_data_packet_factory.h>
+#include <opendaq/connection_factory.h>
 
 using SignalTest = testing::Test;
 
@@ -613,6 +614,31 @@ TEST_F(SignalTest, SendAndReleasePackets)
 
     ASSERT_EQ(connImpl->packetsEnqueued, 3u);
     ASSERT_TRUE(connImpl->packetEnqueued);
+}
+
+TEST_F(SignalTest, SendPacketsCheckOrder)
+{
+    auto context = NullContext();
+    const auto sig = Signal(context, nullptr, "sig");
+    auto ip = InputPort(context, nullptr, "port");
+
+    ip.connect(sig);
+    auto conn = ip.getConnection();
+
+    auto dataPacket = DataPacket(DataDescriptorBuilder().build(), 0);
+    auto eventPacket = EventPacket("test", Dict<IString, IString>());
+
+    auto packets = List<IPacket>(dataPacket, eventPacket, dataPacket, eventPacket);
+    sig.sendPackets(std::move(packets));
+
+    for (int i = 0; i < 5; ++i)
+    {
+        auto packet = conn.dequeue();
+        if (i % 2 == 0)
+            ASSERT_EQ(packet.getType(), PacketType::Event);
+        else
+            ASSERT_EQ(packet.getType(), PacketType::Data);
+    }
 }
 
 TEST_F(SignalTest, SetDescriptorWithConnection)


### PR DESCRIPTION
# Brief

Fixes the order in which packets are enqueued in `sendPackets`. They are now always correctly enqueued front-to-back.

# Required module changes

`ISignalConfig::sendPackets` had an issue where packets were sometimes enqueued front-to-back (first packet in list is enqueued first) and sometimes back-to-front. This inconsistency was addressed to always enqueue packets front-to-back.

Module implementations where `sendPackets` is used should check whether this change in behaviour reversed the order in which packets are enqueued and adjust the packet list order accordingly.

