### PR TITLE
DomainValue and typed reading utils initial implementation

### DIFF
--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <coretypes/ratio_ptr.h>

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include <coretypes/ratio_ptr.h>
+#include <opendaq/range_type.h>
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+struct DomainInfo
+{
+    std::chrono::system_clock::time_point epoch;
+    RatioPtr resolution;
+
+    friend bool operator==(const DomainInfo& lhs, const DomainInfo& rhs)
+    {
+        if (!(lhs.epoch == rhs.epoch))
+            return false;
+        if (!(lhs.resolution.getNumerator() == rhs.resolution.getNumerator()))
+            return false;
+        if (!(lhs.resolution.getDenominator() == rhs.resolution.getDenominator()))
+            return false;
+        return true;
+    }
+    
+    friend bool operator!=(const DomainInfo& lhs, const DomainInfo& rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const DomainInfo& info)
+{
+    os << "DomainInfo{"
+       << "epoch=" << info.epoch.time_since_epoch().count()
+       << ", resolution="
+       << info.resolution.getNumerator() << "/" << info.resolution.getDenominator()
+       << "}";
+
+    return os;
+}
+
+class DomainValue
+{
+public:
+	explicit DomainValue(const DomainInfo& info) : domain(info) {}
+    virtual ~DomainValue() = default;
+
+    const DomainInfo& getDomain() const
+    {
+        return domain;
+    }
+
+	virtual std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) = 0;
+	virtual std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) = 0;
+	
+	virtual double getTime() = 0;
+	
+	friend bool operator<(const DomainValue& lhs, const DomainValue& rhs)
+    {
+        return lhs.compare(rhs) < 0;
+    }
+
+protected:
+	DomainInfo domain;
+private:
+    virtual int compare(const DomainValue& other) const = 0;
+};
+
+template<typename Type>
+class DomainValueImpl : public DomainValue
+{
+public:
+	explicit DomainValueImpl(const DomainInfo& info, Type value) : DomainValue(info), value(value) {
+        if constexpr (std::is_integral_v<Type>){
+            std::cout << "DomainValueImpl(value=" << value << ", domain=" << info << ")" << std::endl;
+        }
+	}
+
+    ~DomainValueImpl() override = default;
+
+	std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
+	{
+	    // Offset of current domain in common domain ticks
+        Int epochOffset = domain.epoch.time_since_epoch().count() - commonDomain.epoch.time_since_epoch().count();
+
+        using SysPeriod = std::chrono::system_clock::period;
+        Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
+        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
+
+        // tick_common = tick * multiplier
+        Int multiplierNumerator = domain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
+        Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
+        Type valueScaledToCommon = static_cast<Type>(value * multiplierNumerator / static_cast<double>(multiplierDenominator));
+	    Type valueInCommon = offsetFromCommon + valueScaledToCommon;
+        
+		return std::make_unique<DomainValueImpl<Type>>(commonDomain, valueInCommon);
+	}
+	
+	std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
+	{
+	    const auto& commonDomain = this->domain;
+	    const auto& valueInCommon = this->value;
+
+	    // Offset of regularDomain domain in common domain ticks
+        Int epochOffset = regularDomain.epoch.time_since_epoch().count() - commonDomain.epoch.time_since_epoch().count();
+
+        using SysPeriod = std::chrono::system_clock::period;
+        Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
+        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
+	    Type valueScaledToCommon = valueInCommon - offsetFromCommon;
+
+        // tick_common = tick * multiplier
+        Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
+        Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
+        Type regularValue = static_cast<Type>(valueScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+	    
+		return std::make_unique<DomainValueImpl<Type>>(regularDomain, regularValue);
+	}
+	
+	Type getValue() const
+	{
+	    return value;
+	}
+	
+	double getTime() override
+	{
+        using SysPeriod = std::chrono::system_clock::period;
+	    return domain.epoch.time_since_epoch().count() * SysPeriod::num / static_cast<double>(SysPeriod::den)
+            + value * domain.resolution.getNumerator() / static_cast<double>(domain.resolution.getDenominator());
+	}
+	
+	int compare(const DomainValue& other) const override
+	{
+	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<Type>*>(&other);
+	    if (otherImpl == nullptr){
+	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
+	    }
+	    if (otherImpl->domain != this->domain) // TODO: Implement equality operator
+	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
+	    
+	    if (this->value > otherImpl->value)
+	        return 1;
+	    else if (this->value == otherImpl->value)
+	        return 0;
+	    else // this->value < otherImpl->value
+	        return -1;
+	}
+
+private:
+	Type value;
+};
+
+// TODO: Support RangeType64
+template<>
+class DomainValueImpl<RangeType64> final : public DomainValue
+{
+public:
+    using RangeValue = RangeType64::Type;
+
+    explicit DomainValueImpl(const DomainInfo& info, RangeType64 value) : DomainValue(info), value(value) {
+        std::cout << "DomainValueImpl(value=" << value.start << ", domain=" << info << ")" << std::endl;
+	}
+
+    std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
+    {
+        return nullptr;
+    }
+
+    std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
+    {
+        return nullptr;
+    }
+
+    RangeType64 getValue() const
+	{
+	    return value;
+	}
+
+    double getTime() override
+	{
+        return 0.0;
+	}
+	
+	int compare(const DomainValue& other) const override
+	{
+	    return 1;
+	}
+
+private:
+    RangeType64 value;
+};
+
+template<>
+class DomainValueImpl<ComplexFloat32> final : public DomainValue
+{
+public:
+    explicit DomainValueImpl(const DomainInfo& info, ComplexFloat32 value) : DomainValue(info) {
+	}
+
+    std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
+
+    std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
+
+    ComplexFloat32 getValue() const
+	{
+	    DAQ_THROW_EXCEPTION(NotSupportedException);
+	}
+
+    double getTime() override
+	{
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+	}
+	
+	int compare(const DomainValue& other) const override
+	{
+	    DAQ_THROW_EXCEPTION(NotSupportedException);
+	}
+};
+
+template<>
+class DomainValueImpl<ComplexFloat64> final : public DomainValue
+{
+public:
+    explicit DomainValueImpl(const DomainInfo& info, ComplexFloat64 value) : DomainValue(info) {
+	}
+
+    std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
+
+    std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
+
+    ComplexFloat64 getValue() const
+	{
+	    DAQ_THROW_EXCEPTION(NotSupportedException);
+	}
+
+    double getTime() override
+	{
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+	}
+	
+	int compare(const DomainValue& other) const override
+	{
+	    DAQ_THROW_EXCEPTION(NotSupportedException);
+	}
+};
+
+
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -17,6 +17,7 @@
 
 #include <coretypes/ratio_ptr.h>
 #include <opendaq/range_type.h>
+#include <opendaq/reader_utils.h>
 
 #include <chrono>
 #include <iostream>
@@ -31,6 +32,9 @@ struct DomainInfo
 
     friend bool operator==(const DomainInfo& lhs, const DomainInfo& rhs)
     {
+        if (!lhs.resolution.assigned() || !rhs.resolution.assigned())
+            DAQ_THROW_EXCEPTION(InvalidParameterException, "DomainInfo::resolution must be assigned.");
+
         if (!(lhs.epoch == rhs.epoch))
             return false;
         if (!(lhs.resolution.getNumerator() == rhs.resolution.getNumerator()))
@@ -71,7 +75,9 @@ public:
 	virtual std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) = 0;
 	virtual std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) = 0;
 	
-	virtual double getTime() = 0;
+#if !defined(NDEBUG)
+    virtual std::string asTime() const = 0;
+#endif
 	
 	friend bool operator<(const DomainValue& lhs, const DomainValue& rhs)
     {
@@ -103,7 +109,7 @@ public:
 
         using SysPeriod = std::chrono::system_clock::period;
         Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
-        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        Int scaleDenominator = SysPeriod::den * commonDomain.resolution.getNumerator();
         Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
 
         // tick_common = tick * multiplier
@@ -125,7 +131,7 @@ public:
 
         using SysPeriod = std::chrono::system_clock::period;
         Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
-        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        Int scaleDenominator = SysPeriod::den * commonDomain.resolution.getNumerator();
         Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
 	    Type valueScaledToCommon = valueInCommon - offsetFromCommon;
 
@@ -142,12 +148,17 @@ public:
 	    return value;
 	}
 	
-	double getTime() override
-	{
-        using SysPeriod = std::chrono::system_clock::period;
-	    return domain.epoch.time_since_epoch().count() * SysPeriod::num / static_cast<double>(SysPeriod::den)
-            + value * domain.resolution.getNumerator() / static_cast<double>(domain.resolution.getDenominator());
-	}
+#if !defined(NDEBUG)
+    virtual std::string asTime() const override
+    {
+        using namespace reader;
+
+        std::stringstream ss;
+        ss << toSysTime(value, domain.epoch, domain.resolution);
+
+        return ss.str();
+    }
+#endif
 	
 	int compare(const DomainValue& other) const override
 	{
@@ -229,7 +240,7 @@ public:
             ? static_cast<RangeValue>(-1)
             : static_cast<RangeValue>(endScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
 	    
-		return std::make_unique<DomainValueImpl<RangeValue>>(regularDomain, RangeType64{startValue, endValue});
+		return std::make_unique<DomainValueImpl<RangeType64>>(regularDomain, RangeType64{startValue, endValue});
     }
 
     RangeType64 getValue() const
@@ -237,16 +248,21 @@ public:
 	    return value;
 	}
 
-    double getTime() override
-	{
-        using SysPeriod = std::chrono::system_clock::period;
-	    return domain.epoch.time_since_epoch().count() * SysPeriod::num / static_cast<double>(SysPeriod::den)
-            + value.start * domain.resolution.getNumerator() / static_cast<double>(domain.resolution.getDenominator());
-	}
+#if !defined(NDEBUG)
+    virtual std::string asTime() const override
+    {
+        using namespace reader;
+
+        std::stringstream ss;
+        ss << toSysTime(value.start, domain.epoch, domain.resolution);
+
+        return ss.str();
+    }
+#endif
 	
 	int compare(const DomainValue& other) const override
 	{
-	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<RangeType64>(&other);
+	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<RangeType64>*>(&other);
 	    if (otherImpl == nullptr){
 	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
 	    }
@@ -287,10 +303,12 @@ public:
 	    DAQ_THROW_EXCEPTION(NotSupportedException);
 	}
 
-    double getTime() override
-	{
+#if !defined(NDEBUG)
+    virtual std::string asTime() const override
+    {
         DAQ_THROW_EXCEPTION(NotSupportedException);
-	}
+    }
+#endif
 	
 	int compare(const DomainValue& other) const override
 	{
@@ -320,10 +338,12 @@ public:
 	    DAQ_THROW_EXCEPTION(NotSupportedException);
 	}
 
-    double getTime() override
-	{
+#if !defined(NDEBUG)
+    virtual std::string asTime() const override
+    {
         DAQ_THROW_EXCEPTION(NotSupportedException);
-	}
+    }
+#endif
 	
 	int compare(const DomainValue& other) const override
 	{

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -203,7 +203,7 @@ public:
 
         using SysPeriod = std::chrono::system_clock::period;
         Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
-        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        Int scaleDenominator = SysPeriod::den * commonDomain.resolution.getNumerator();
         RangeValue offsetFromCommon = static_cast<RangeValue>(epochOffset * scaleNumerator / scaleDenominator);
 
         // tick_common = tick * multiplier
@@ -230,7 +230,7 @@ public:
 
         using SysPeriod = std::chrono::system_clock::period;
         Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
-        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        Int scaleDenominator = SysPeriod::den * commonDomain.resolution.getNumerator();
         Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
 
 	    RangeValue startScaledToCommon = valueInCommon.start - offsetFromCommon;

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -43,7 +43,7 @@ struct DomainInfo
             return false;
         return true;
     }
-    
+
     friend bool operator!=(const DomainInfo& lhs, const DomainInfo& rhs)
     {
         return !(lhs == rhs);
@@ -74,11 +74,11 @@ public:
 
 	virtual std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) = 0;
 	virtual std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) = 0;
-	
+
 #if !defined(NDEBUG)
     virtual std::string asTime() const = 0;
 #endif
-	
+
 	friend bool operator<(const DomainValue& lhs, const DomainValue& rhs)
     {
         return lhs.compare(rhs) < 0;
@@ -120,10 +120,10 @@ public:
         // The cast to double follows the legacy implementation, but it's questionable how it impacts potential precision loss
         Type valueScaledToCommon = static_cast<Type>(value * multiplierNumerator / static_cast<double>(multiplierDenominator));
 	    Type valueInCommon = offsetFromCommon + valueScaledToCommon;
-        
+
 		return std::make_unique<DomainValueImpl<Type>>(commonDomain, valueInCommon);
 	}
-	
+
 	std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
 	{
 	    const auto& commonDomain = this->domain;
@@ -144,15 +144,15 @@ public:
         Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
         Type regularValue = static_cast<Type>(valueScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
-	    
+
 		return std::make_unique<DomainValueImpl<Type>>(regularDomain, regularValue);
 	}
-	
+
 	Type getValue() const
 	{
 	    return value;
 	}
-	
+
 #if !defined(NDEBUG)
     virtual std::string asTime() const override
     {
@@ -164,7 +164,7 @@ public:
         return ss.str();
     }
 #endif
-	
+
 	int compare(const DomainValue& other) const override
 	{
 	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<Type>*>(&other);
@@ -173,7 +173,7 @@ public:
 	    }
 	    if (otherImpl->domain != this->domain)
 	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
-	    
+
 	    if (this->value > otherImpl->value)
 	        return 1;
 	    else if (this->value == otherImpl->value)
@@ -211,12 +211,12 @@ public:
         Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
         RangeValue startScaledToCommon = static_cast<RangeValue>(value.start * multiplierNumerator / static_cast<double>(multiplierDenominator));
         RangeValue endScaledToCommon = static_cast<RangeValue>(value.end * multiplierNumerator / static_cast<double>(multiplierDenominator));
-	    
+
         RangeValue startInCommon = offsetFromCommon + startScaledToCommon;
         RangeValue endInCommon = value.end == -1
             ? static_cast<RangeValue>(-1)
             : offsetFromCommon + endScaledToCommon;
-        
+
 		return std::make_unique<DomainValueImpl<RangeType64>>(commonDomain, RangeType64{startInCommon, endInCommon});
     }
 
@@ -243,7 +243,7 @@ public:
         RangeValue endValue = valueInCommon.end == -1
             ? static_cast<RangeValue>(-1)
             : static_cast<RangeValue>(endScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
-	    
+
 		return std::make_unique<DomainValueImpl<RangeType64>>(regularDomain, RangeType64{startValue, endValue});
     }
 
@@ -263,7 +263,7 @@ public:
         return ss.str();
     }
 #endif
-	
+
 	int compare(const DomainValue& other) const override
 	{
 	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<RangeType64>*>(&other);
@@ -272,7 +272,7 @@ public:
 	    }
 	    if (otherImpl->domain != this->domain)
 	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
-	    
+
 	    if (this->value.start > otherImpl->value.start)
 	        return 1;
 	    else if (this->value.start == otherImpl->value.start)
@@ -313,7 +313,7 @@ public:
         DAQ_THROW_EXCEPTION(NotSupportedException);
     }
 #endif
-	
+
 	int compare(const DomainValue& other) const override
 	{
 	    DAQ_THROW_EXCEPTION(NotSupportedException);
@@ -348,7 +348,7 @@ public:
         DAQ_THROW_EXCEPTION(NotSupportedException);
     }
 #endif
-	
+
 	int compare(const DomainValue& other) const override
 	{
 	    DAQ_THROW_EXCEPTION(NotSupportedException);

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -30,6 +30,17 @@ struct DomainInfo
     std::chrono::system_clock::time_point epoch;
     RatioPtr resolution;
 
+    static DomainInfo fromDescriptor(const DataDescriptorPtr &descriptor)
+    {
+        if (!descriptor.assigned())
+            DAQ_THROW_EXCEPTION(ArgumentNullException, "Descriptor must not be null");
+        
+        auto epoch = daq::reader::parseEpoch(descriptor.getOrigin());
+        auto resolution = descriptor.getTickResolution();
+
+        return {epoch, resolution};
+    }
+
     friend bool operator==(const DomainInfo& lhs, const DomainInfo& rhs)
     {
         if (!lhs.resolution.assigned() || !rhs.resolution.assigned())

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -87,6 +87,8 @@ public:
     virtual std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) = 0;
     virtual std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) = 0;
 
+    virtual void roundUpOnDomainInterval(const RatioPtr& interval) = 0;
+
 #if !defined(NDEBUG)
     virtual std::string asTime() const = 0;
 #endif
@@ -163,6 +165,21 @@ public:
         Type regularValue = static_cast<Type>(valueScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
 
         return std::make_unique<DomainValueImpl<Type>>(regularDomain, regularValue);
+    }
+
+    void roundUpOnDomainInterval(const RatioPtr& interval) override
+    {
+        auto num = domain.resolution.getNumerator() * interval.getDenominator();
+        auto den = domain.resolution.getDenominator() * interval.getNumerator();
+
+        const Int gcd = std::gcd(num, den);
+        num /= gcd;
+        den /= gcd;
+
+        if (den % num != 0) // 1 = k * num/den, the resolution is a fractional divider of a unit
+            DAQ_THROW_EXCEPTION(NotSupportedException, "Resolution must be aligned on full unit of domain");
+
+        value = static_cast<Type>((((value * num + den - 1) / den) * den) / num);
     }
 
     Type getValue() const
@@ -270,6 +287,11 @@ public:
         return std::make_unique<DomainValueImpl<RangeType64>>(regularDomain, RangeType64{startValue, endValue});
     }
 
+    void roundUpOnDomainInterval(const RatioPtr& interval) override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
+
     RangeType64 getValue() const
     {
         return value;
@@ -328,6 +350,11 @@ public:
         DAQ_THROW_EXCEPTION(NotSupportedException);
     }
 
+    void roundUpOnDomainInterval(const RatioPtr& interval) override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
+
     ComplexFloat32 getValue() const
     {
         DAQ_THROW_EXCEPTION(NotSupportedException);
@@ -361,6 +388,11 @@ public:
     }
 
     std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
+
+    void roundUpOnDomainInterval(const RatioPtr& interval) override
     {
         DAQ_THROW_EXCEPTION(NotSupportedException);
     }

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -168,12 +168,53 @@ public:
 
     std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
     {
-        return nullptr;
+        // Offset of current domain in common domain ticks
+        Int epochOffset = domain.epoch.time_since_epoch().count() - commonDomain.epoch.time_since_epoch().count();
+
+        using SysPeriod = std::chrono::system_clock::period;
+        Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
+        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        RangeValue offsetFromCommon = static_cast<RangeValue>(epochOffset * scaleNumerator / scaleDenominator);
+
+        // tick_common = tick * multiplier
+        Int multiplierNumerator = domain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
+        Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
+        RangeValue startScaledToCommon = static_cast<RangeValue>(value.start * multiplierNumerator / static_cast<double>(multiplierDenominator));
+        RangeValue endScaledToCommon = static_cast<RangeValue>(value.end * multiplierNumerator / static_cast<double>(multiplierDenominator));
+	    
+        RangeValue startInCommon = offsetFromCommon + startScaledToCommon;
+        RangeValue endInCommon = value.end == -1
+            ? static_cast<RangeValue>(-1)
+            : offsetFromCommon + endScaledToCommon;
+        
+		return std::make_unique<DomainValueImpl<RangeType64>>(commonDomain, RangeType64{startInCommon, endInCommon});
     }
 
     std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
     {
-        return nullptr;
+        const auto& commonDomain = this->domain;
+	    const auto& valueInCommon = this->value;
+
+	    // Offset of regularDomain domain in common domain ticks
+        Int epochOffset = regularDomain.epoch.time_since_epoch().count() - commonDomain.epoch.time_since_epoch().count();
+
+        using SysPeriod = std::chrono::system_clock::period;
+        Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
+        Int scaleDenominator = SysPeriod::num * commonDomain.resolution.getNumerator();
+        Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
+
+	    RangeValue startScaledToCommon = valueInCommon.start - offsetFromCommon;
+	    RangeValue endScaledToCommon = valueInCommon.end - offsetFromCommon;
+
+        // tick_common = tick * multiplier
+        Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
+        Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
+        RangeValue startValue = static_cast<RangeValue>(startScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+        RangeValue endValue = valueInCommon.end == -1
+            ? static_cast<RangeValue>(-1)
+            : static_cast<RangeValue>(endScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+	    
+		return std::make_unique<DomainValueImpl<RangeValue>>(regularDomain, RangeType64{startValue, endValue});
     }
 
     RangeType64 getValue() const
@@ -183,12 +224,26 @@ public:
 
     double getTime() override
 	{
-        return 0.0;
+        using SysPeriod = std::chrono::system_clock::period;
+	    return domain.epoch.time_since_epoch().count() * SysPeriod::num / static_cast<double>(SysPeriod::den)
+            + value.start * domain.resolution.getNumerator() / static_cast<double>(domain.resolution.getDenominator());
 	}
 	
 	int compare(const DomainValue& other) const override
 	{
-	    return 1;
+	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<RangeType64>(&other);
+	    if (otherImpl == nullptr){
+	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
+	    }
+	    if (otherImpl->domain != this->domain) // TODO: Implement equality operator
+	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
+	    
+	    if (this->value.start > otherImpl->value.start)
+	        return 1;
+	    else if (this->value.start == otherImpl->value.start)
+	        return 0;
+	    else // this->value.start < otherImpl->value.start
+	        return -1;
 	}
 
 private:

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -95,9 +95,11 @@ class DomainValueImpl : public DomainValue
 {
 public:
 	explicit DomainValueImpl(const DomainInfo& info, Type value) : DomainValue(info), value(value) {
+#if !defined(NDEBUG)
         if constexpr (std::is_integral_v<Type>){
             std::cout << "DomainValueImpl(value=" << value << ", domain=" << info << ")" << std::endl;
         }
+#endif
 	}
 
     ~DomainValueImpl() override = default;
@@ -115,6 +117,7 @@ public:
         // tick_common = tick * multiplier
         Int multiplierNumerator = domain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
+        // The cast to double follows the legacy implementation, but it's questionable how it impacts potential precision loss
         Type valueScaledToCommon = static_cast<Type>(value * multiplierNumerator / static_cast<double>(multiplierDenominator));
 	    Type valueInCommon = offsetFromCommon + valueScaledToCommon;
         
@@ -135,6 +138,8 @@ public:
         Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
 	    Type valueScaledToCommon = valueInCommon - offsetFromCommon;
 
+        // TODO: The regular value should probably be +1 here so that when converted back into fine domain
+        // it is true that regularValue >= valueInCommon (reason: domain value searching)
         // tick_common = tick * multiplier
         Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
@@ -166,7 +171,7 @@ public:
 	    if (otherImpl == nullptr){
 	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
 	    }
-	    if (otherImpl->domain != this->domain) // TODO: Implement equality operator
+	    if (otherImpl->domain != this->domain)
 	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
 	    
 	    if (this->value > otherImpl->value)
@@ -181,7 +186,6 @@ private:
 	Type value;
 };
 
-// TODO: Support RangeType64
 template<>
 class DomainValueImpl<RangeType64> final : public DomainValue
 {
@@ -266,7 +270,7 @@ public:
 	    if (otherImpl == nullptr){
 	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
 	    }
-	    if (otherImpl->domain != this->domain) // TODO: Implement equality operator
+	    if (otherImpl->domain != this->domain)
 	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
 	    
 	    if (this->value.start > otherImpl->value.start)

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -136,8 +136,17 @@ public:
         // tick_common = tick * multiplier
         Int multiplierNumerator = domain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
-        // The cast to double follows the legacy implementation, but it's questionable how it impacts potential precision loss
-        Type valueScaledToCommon = static_cast<Type>(value * multiplierNumerator / static_cast<double>(multiplierDenominator));
+
+        Type valueScaledToCommon = 0;
+        if constexpr (std::is_integral_v<Type>)
+        {
+            valueScaledToCommon = static_cast<Type>((value / multiplierDenominator) * multiplierNumerator +
+                                                    (value % multiplierDenominator) * multiplierNumerator / multiplierDenominator);
+        }
+        else
+        {
+            valueScaledToCommon = static_cast<Type>(value * multiplierNumerator / static_cast<double>(multiplierDenominator));
+        }
         Type valueInCommon = offsetFromCommon + valueScaledToCommon;
 
         return std::make_unique<DomainValueImpl<Type>>(commonDomain, valueInCommon);
@@ -159,10 +168,20 @@ public:
 
         // TODO: The regular value should probably be +1 here so that when converted back into fine domain
         // it is true that regularValue >= valueInCommon (reason: domain value searching)
-        // tick_common = tick * multiplier
+        // tick = tick_common / multiplier
         Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
-        Type regularValue = static_cast<Type>(valueScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+
+        Type regularValue = 0;
+        if constexpr (std::is_integral_v<Type>)
+        {
+            regularValue = static_cast<Type>((valueScaledToCommon / multiplierNumerator) * multiplierDenominator +
+                                             (valueScaledToCommon % multiplierNumerator) * multiplierDenominator / multiplierNumerator);
+        }
+        else
+        {
+            regularValue = static_cast<Type>(valueScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+        }
 
         return std::make_unique<DomainValueImpl<Type>>(regularDomain, regularValue);
     }
@@ -176,7 +195,7 @@ public:
         num /= gcd;
         den /= gcd;
 
-        if (den % num != 0) // 1 = k * num/den, the resolution is a fractional divider of a unit
+        if (den % num != 0)  // 1 = k * num/den, the resolution is a fractional divider of a unit
             DAQ_THROW_EXCEPTION(NotSupportedException, "Resolution must be aligned on full unit of domain");
 
         value = static_cast<Type>((((value * num + den - 1) / den) * den) / num);
@@ -248,9 +267,11 @@ public:
         Int multiplierNumerator = domain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
         RangeValue startScaledToCommon =
-            static_cast<RangeValue>(value.start * multiplierNumerator / static_cast<double>(multiplierDenominator));
+            static_cast<RangeValue>((value.start / multiplierDenominator) * multiplierNumerator +
+                                    (value.start % multiplierDenominator) * multiplierNumerator / multiplierDenominator);
         RangeValue endScaledToCommon =
-            static_cast<RangeValue>(value.end * multiplierNumerator / static_cast<double>(multiplierDenominator));
+            static_cast<RangeValue>((value.end / multiplierDenominator) * multiplierNumerator +
+                                    (value.end % multiplierDenominator) * multiplierNumerator / multiplierDenominator);
 
         RangeValue startInCommon = offsetFromCommon + startScaledToCommon;
         RangeValue endInCommon = value.end == -1 ? static_cast<RangeValue>(-1) : offsetFromCommon + endScaledToCommon;
@@ -278,11 +299,13 @@ public:
         Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
         RangeValue startValue =
-            static_cast<RangeValue>(startScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+            static_cast<RangeValue>((startScaledToCommon / multiplierNumerator) * multiplierDenominator +
+                                    (startScaledToCommon % multiplierNumerator) * multiplierDenominator / multiplierNumerator);
         RangeValue endValue =
             valueInCommon.end == -1
                 ? static_cast<RangeValue>(-1)
-                : static_cast<RangeValue>(endScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+                : static_cast<RangeValue>((endScaledToCommon / multiplierNumerator) * multiplierDenominator +
+                                          (endScaledToCommon % multiplierNumerator) * multiplierDenominator / multiplierNumerator);
 
         return std::make_unique<DomainValueImpl<RangeType64>>(regularDomain, RangeType64{startValue, endValue});
     }

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -140,8 +140,9 @@ public:
         Type valueScaledToCommon = 0;
         if constexpr (std::is_integral_v<Type>)
         {
+            // Round to the closest tick
             valueScaledToCommon = static_cast<Type>((value / multiplierDenominator) * multiplierNumerator +
-                                                    (value % multiplierDenominator) * multiplierNumerator / multiplierDenominator);
+                                                    (2 * (value % multiplierDenominator) * multiplierNumerator + multiplierDenominator) / (2 * multiplierDenominator));
         }
         else
         {
@@ -166,17 +167,15 @@ public:
         Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
         Type valueScaledToCommon = valueInCommon - offsetFromCommon;
 
-        // TODO: The regular value should probably be +1 here so that when converted back into fine domain
-        // it is true that regularValue >= valueInCommon (reason: domain value searching)
-        // tick = tick_common / multiplier
         Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
 
         Type regularValue = 0;
         if constexpr (std::is_integral_v<Type>)
         {
+            // Round to the closest tick
             regularValue = static_cast<Type>((valueScaledToCommon / multiplierNumerator) * multiplierDenominator +
-                                             (valueScaledToCommon % multiplierNumerator) * multiplierDenominator / multiplierNumerator);
+                                             (2 * (valueScaledToCommon % multiplierNumerator) * multiplierDenominator + multiplierNumerator) / (2 * multiplierNumerator));
         }
         else
         {

--- a/core/opendaq/reader/include/opendaq/domain_value.h
+++ b/core/opendaq/reader/include/opendaq/domain_value.h
@@ -30,11 +30,11 @@ struct DomainInfo
     std::chrono::system_clock::time_point epoch;
     RatioPtr resolution;
 
-    static DomainInfo fromDescriptor(const DataDescriptorPtr &descriptor)
+    static DomainInfo fromDescriptor(const DataDescriptorPtr& descriptor)
     {
         if (!descriptor.assigned())
             DAQ_THROW_EXCEPTION(ArgumentNullException, "Descriptor must not be null");
-        
+
         auto epoch = daq::reader::parseEpoch(descriptor.getOrigin());
         auto resolution = descriptor.getTickResolution();
 
@@ -64,10 +64,8 @@ struct DomainInfo
 inline std::ostream& operator<<(std::ostream& os, const DomainInfo& info)
 {
     os << "DomainInfo{"
-       << "epoch=" << info.epoch.time_since_epoch().count()
-       << ", resolution="
-       << info.resolution.getNumerator() << "/" << info.resolution.getDenominator()
-       << "}";
+       << "epoch=" << info.epoch.time_since_epoch().count() << ", resolution=" << info.resolution.getNumerator() << "/"
+       << info.resolution.getDenominator() << "}";
 
     return os;
 }
@@ -75,7 +73,10 @@ inline std::ostream& operator<<(std::ostream& os, const DomainInfo& info)
 class DomainValue
 {
 public:
-	explicit DomainValue(const DomainInfo& info) : domain(info) {}
+    explicit DomainValue(const DomainInfo& info)
+        : domain(info)
+    {
+    }
     virtual ~DomainValue() = default;
 
     const DomainInfo& getDomain() const
@@ -83,41 +84,46 @@ public:
         return domain;
     }
 
-	virtual std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) = 0;
-	virtual std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) = 0;
+    virtual std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) = 0;
+    virtual std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) = 0;
 
 #if !defined(NDEBUG)
     virtual std::string asTime() const = 0;
 #endif
 
-	friend bool operator<(const DomainValue& lhs, const DomainValue& rhs)
+    friend bool operator<(const DomainValue& lhs, const DomainValue& rhs)
     {
         return lhs.compare(rhs) < 0;
     }
 
 protected:
-	DomainInfo domain;
+    DomainInfo domain;
+
 private:
     virtual int compare(const DomainValue& other) const = 0;
 };
 
-template<typename Type>
+template <typename Type>
 class DomainValueImpl : public DomainValue
 {
 public:
-	explicit DomainValueImpl(const DomainInfo& info, Type value) : DomainValue(info), value(value) {
+    explicit DomainValueImpl(const DomainInfo& info, Type value)
+        : DomainValue(info)
+        , value(value)
+    {
 #if !defined(NDEBUG)
-        if constexpr (std::is_integral_v<Type>){
+        if constexpr (std::is_integral_v<Type>)
+        {
             std::cout << "DomainValueImpl(value=" << value << ", domain=" << info << ")" << std::endl;
         }
 #endif
-	}
+    }
 
     ~DomainValueImpl() override = default;
 
-	std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
-	{
-	    // Offset of current domain in common domain ticks
+    std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
+    {
+        // Offset of current domain in common domain ticks
         Int epochOffset = domain.epoch.time_since_epoch().count() - commonDomain.epoch.time_since_epoch().count();
 
         using SysPeriod = std::chrono::system_clock::period;
@@ -130,24 +136,24 @@ public:
         Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
         // The cast to double follows the legacy implementation, but it's questionable how it impacts potential precision loss
         Type valueScaledToCommon = static_cast<Type>(value * multiplierNumerator / static_cast<double>(multiplierDenominator));
-	    Type valueInCommon = offsetFromCommon + valueScaledToCommon;
+        Type valueInCommon = offsetFromCommon + valueScaledToCommon;
 
-		return std::make_unique<DomainValueImpl<Type>>(commonDomain, valueInCommon);
-	}
+        return std::make_unique<DomainValueImpl<Type>>(commonDomain, valueInCommon);
+    }
 
-	std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
-	{
-	    const auto& commonDomain = this->domain;
-	    const auto& valueInCommon = this->value;
+    std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
+    {
+        const auto& commonDomain = this->domain;
+        const auto& valueInCommon = this->value;
 
-	    // Offset of regularDomain domain in common domain ticks
+        // Offset of regularDomain domain in common domain ticks
         Int epochOffset = regularDomain.epoch.time_since_epoch().count() - commonDomain.epoch.time_since_epoch().count();
 
         using SysPeriod = std::chrono::system_clock::period;
         Int scaleNumerator = SysPeriod::num * commonDomain.resolution.getDenominator();
         Int scaleDenominator = SysPeriod::den * commonDomain.resolution.getNumerator();
         Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
-	    Type valueScaledToCommon = valueInCommon - offsetFromCommon;
+        Type valueScaledToCommon = valueInCommon - offsetFromCommon;
 
         // TODO: The regular value should probably be +1 here so that when converted back into fine domain
         // it is true that regularValue >= valueInCommon (reason: domain value searching)
@@ -156,13 +162,13 @@ public:
         Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
         Type regularValue = static_cast<Type>(valueScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
 
-		return std::make_unique<DomainValueImpl<Type>>(regularDomain, regularValue);
-	}
+        return std::make_unique<DomainValueImpl<Type>>(regularDomain, regularValue);
+    }
 
-	Type getValue() const
-	{
-	    return value;
-	}
+    Type getValue() const
+    {
+        return value;
+    }
 
 #if !defined(NDEBUG)
     virtual std::string asTime() const override
@@ -176,36 +182,40 @@ public:
     }
 #endif
 
-	int compare(const DomainValue& other) const override
-	{
-	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<Type>*>(&other);
-	    if (otherImpl == nullptr){
-	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
-	    }
-	    if (otherImpl->domain != this->domain)
-	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
+    int compare(const DomainValue& other) const override
+    {
+        const auto* otherImpl = dynamic_cast<const DomainValueImpl<Type>*>(&other);
+        if (otherImpl == nullptr)
+        {
+            DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
+        }
+        if (otherImpl->domain != this->domain)
+            DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
 
-	    if (this->value > otherImpl->value)
-	        return 1;
-	    else if (this->value == otherImpl->value)
-	        return 0;
-	    else // this->value < otherImpl->value
-	        return -1;
-	}
+        if (this->value > otherImpl->value)
+            return 1;
+        else if (this->value == otherImpl->value)
+            return 0;
+        else  // this->value < otherImpl->value
+            return -1;
+    }
 
 private:
-	Type value;
+    Type value;
 };
 
-template<>
+template <>
 class DomainValueImpl<RangeType64> final : public DomainValue
 {
 public:
     using RangeValue = RangeType64::Type;
 
-    explicit DomainValueImpl(const DomainInfo& info, RangeType64 value) : DomainValue(info), value(value) {
+    explicit DomainValueImpl(const DomainInfo& info, RangeType64 value)
+        : DomainValue(info)
+        , value(value)
+    {
         std::cout << "DomainValueImpl(value=" << value.start << ", domain=" << info << ")" << std::endl;
-	}
+    }
 
     std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
     {
@@ -220,23 +230,23 @@ public:
         // tick_common = tick * multiplier
         Int multiplierNumerator = domain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = domain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
-        RangeValue startScaledToCommon = static_cast<RangeValue>(value.start * multiplierNumerator / static_cast<double>(multiplierDenominator));
-        RangeValue endScaledToCommon = static_cast<RangeValue>(value.end * multiplierNumerator / static_cast<double>(multiplierDenominator));
+        RangeValue startScaledToCommon =
+            static_cast<RangeValue>(value.start * multiplierNumerator / static_cast<double>(multiplierDenominator));
+        RangeValue endScaledToCommon =
+            static_cast<RangeValue>(value.end * multiplierNumerator / static_cast<double>(multiplierDenominator));
 
         RangeValue startInCommon = offsetFromCommon + startScaledToCommon;
-        RangeValue endInCommon = value.end == -1
-            ? static_cast<RangeValue>(-1)
-            : offsetFromCommon + endScaledToCommon;
+        RangeValue endInCommon = value.end == -1 ? static_cast<RangeValue>(-1) : offsetFromCommon + endScaledToCommon;
 
-		return std::make_unique<DomainValueImpl<RangeType64>>(commonDomain, RangeType64{startInCommon, endInCommon});
+        return std::make_unique<DomainValueImpl<RangeType64>>(commonDomain, RangeType64{startInCommon, endInCommon});
     }
 
     std::unique_ptr<DomainValue> fromCommonDomain(const DomainInfo& regularDomain) override
     {
         const auto& commonDomain = this->domain;
-	    const auto& valueInCommon = this->value;
+        const auto& valueInCommon = this->value;
 
-	    // Offset of regularDomain domain in common domain ticks
+        // Offset of regularDomain domain in common domain ticks
         Int epochOffset = regularDomain.epoch.time_since_epoch().count() - commonDomain.epoch.time_since_epoch().count();
 
         using SysPeriod = std::chrono::system_clock::period;
@@ -244,24 +254,26 @@ public:
         Int scaleDenominator = SysPeriod::den * commonDomain.resolution.getNumerator();
         Int offsetFromCommon = epochOffset * scaleNumerator / scaleDenominator;
 
-	    RangeValue startScaledToCommon = valueInCommon.start - offsetFromCommon;
-	    RangeValue endScaledToCommon = valueInCommon.end - offsetFromCommon;
+        RangeValue startScaledToCommon = valueInCommon.start - offsetFromCommon;
+        RangeValue endScaledToCommon = valueInCommon.end - offsetFromCommon;
 
         // tick_common = tick * multiplier
         Int multiplierNumerator = regularDomain.resolution.getNumerator() * commonDomain.resolution.getDenominator();
         Int multiplierDenominator = regularDomain.resolution.getDenominator() * commonDomain.resolution.getNumerator();
-        RangeValue startValue = static_cast<RangeValue>(startScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
-        RangeValue endValue = valueInCommon.end == -1
-            ? static_cast<RangeValue>(-1)
-            : static_cast<RangeValue>(endScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+        RangeValue startValue =
+            static_cast<RangeValue>(startScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
+        RangeValue endValue =
+            valueInCommon.end == -1
+                ? static_cast<RangeValue>(-1)
+                : static_cast<RangeValue>(endScaledToCommon * multiplierDenominator / static_cast<double>(multiplierNumerator));
 
-		return std::make_unique<DomainValueImpl<RangeType64>>(regularDomain, RangeType64{startValue, endValue});
+        return std::make_unique<DomainValueImpl<RangeType64>>(regularDomain, RangeType64{startValue, endValue});
     }
 
     RangeType64 getValue() const
-	{
-	    return value;
-	}
+    {
+        return value;
+    }
 
 #if !defined(NDEBUG)
     virtual std::string asTime() const override
@@ -275,33 +287,36 @@ public:
     }
 #endif
 
-	int compare(const DomainValue& other) const override
-	{
-	    const auto* otherImpl = dynamic_cast<const DomainValueImpl<RangeType64>*>(&other);
-	    if (otherImpl == nullptr){
-	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
-	    }
-	    if (otherImpl->domain != this->domain)
-	        DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
+    int compare(const DomainValue& other) const override
+    {
+        const auto* otherImpl = dynamic_cast<const DomainValueImpl<RangeType64>*>(&other);
+        if (otherImpl == nullptr)
+        {
+            DAQ_THROW_EXCEPTION(InvalidParameterException, "Both DomainValue objects must be of the same type!");
+        }
+        if (otherImpl->domain != this->domain)
+            DAQ_THROW_EXCEPTION(InvalidParameterException, "Have to compare DomainValue objects in the same domain!");
 
-	    if (this->value.start > otherImpl->value.start)
-	        return 1;
-	    else if (this->value.start == otherImpl->value.start)
-	        return 0;
-	    else // this->value.start < otherImpl->value.start
-	        return -1;
-	}
+        if (this->value.start > otherImpl->value.start)
+            return 1;
+        else if (this->value.start == otherImpl->value.start)
+            return 0;
+        else  // this->value.start < otherImpl->value.start
+            return -1;
+    }
 
 private:
     RangeType64 value;
 };
 
-template<>
+template <>
 class DomainValueImpl<ComplexFloat32> final : public DomainValue
 {
 public:
-    explicit DomainValueImpl(const DomainInfo& info, ComplexFloat32 value) : DomainValue(info) {
-	}
+    explicit DomainValueImpl(const DomainInfo& info, ComplexFloat32 value)
+        : DomainValue(info)
+    {
+    }
 
     std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
     {
@@ -314,9 +329,9 @@ public:
     }
 
     ComplexFloat32 getValue() const
-	{
-	    DAQ_THROW_EXCEPTION(NotSupportedException);
-	}
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
 
 #if !defined(NDEBUG)
     virtual std::string asTime() const override
@@ -325,18 +340,20 @@ public:
     }
 #endif
 
-	int compare(const DomainValue& other) const override
-	{
-	    DAQ_THROW_EXCEPTION(NotSupportedException);
-	}
+    int compare(const DomainValue& other) const override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
 };
 
-template<>
+template <>
 class DomainValueImpl<ComplexFloat64> final : public DomainValue
 {
 public:
-    explicit DomainValueImpl(const DomainInfo& info, ComplexFloat64 value) : DomainValue(info) {
-	}
+    explicit DomainValueImpl(const DomainInfo& info, ComplexFloat64 value)
+        : DomainValue(info)
+    {
+    }
 
     std::unique_ptr<DomainValue> toCommonDomain(const DomainInfo& commonDomain) override
     {
@@ -349,9 +366,9 @@ public:
     }
 
     ComplexFloat64 getValue() const
-	{
-	    DAQ_THROW_EXCEPTION(NotSupportedException);
-	}
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
 
 #if !defined(NDEBUG)
     virtual std::string asTime() const override
@@ -360,12 +377,10 @@ public:
     }
 #endif
 
-	int compare(const DomainValue& other) const override
-	{
-	    DAQ_THROW_EXCEPTION(NotSupportedException);
-	}
+    int compare(const DomainValue& other) const override
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException);
+    }
 };
-
-
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/include/opendaq/multi_reader_impl.h
+++ b/core/opendaq/reader/include/opendaq/multi_reader_impl.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <opendaq/multi_reader.h>
+
 #include <opendaq/read_info.h>
 #include <opendaq/reader_config_ptr.h>
 #include <opendaq/signal_reader.h>
@@ -184,10 +185,12 @@ private:
     Clock::duration timeout{};
     Clock::time_point startTime;
 
+    DomainInfo commonDomain;
     StringPtr readOrigin;
     RatioPtr readResolution;
     RatioPtr tickOffsetTolerance;
-    std::unique_ptr<Comparable> commonStart;
+    // std::unique_ptr<Comparable> commonStart;
+    std::unique_ptr<DomainValue> commonDomainStart;
     std::int64_t requiredCommonSampleRate = -1;
     std::int64_t commonSampleRate = -1;
     std::int32_t sampleRateDividerLcm = 1;

--- a/core/opendaq/reader/include/opendaq/signal_reader.h
+++ b/core/opendaq/reader/include/opendaq/signal_reader.h
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 #pragma once
+#include <opendaq/domain_value.h>
 #include <opendaq/event_packet_ptr.h>
 #include <opendaq/input_port_config_ptr.h>
-#include <opendaq/multi_typed_reader.h>
 #include <opendaq/read_info.h>
 #include <opendaq/reader_domain_info.h>
 #include <opendaq/reader_status.h>
+#include <opendaq/typed_reading_utils.h>
 
 #include <chrono>
 
@@ -60,7 +61,7 @@ struct SignalReader
      */
     SizeT getAvailable(bool acrossDescriptorChanges) const;
     void handleDescriptorChanged(const EventPacketPtr& eventPacket);
-    bool trySetDomainSampleType(const daq::DataPacketPtr& domainPacket) const;
+    bool trySetDomainSampleType(const daq::DataPacketPtr& domainPacket);
     void setCommonSampleRate(const std::int64_t commonSampleRate);
 
     void prepare(void* outValues, SizeT count);
@@ -71,7 +72,16 @@ struct SignalReader
     /**
      * @brief Returns the tick of the first available sample in maxResolution units and relative to the minimum epoch.
      */
-    std::unique_ptr<Comparable> readStartDomain();
+    std::unique_ptr<DomainValue> readDomainStart();
+    const DomainInfo& getDomainInfo() const;
+    SampleType getValueReadType() const;
+
+    void setValueTransformFunction(FunctionPtr transform);
+    void setDomainTransformFunction(FunctionPtr transform);
+    
+    FunctionPtr getValueTransformFunction() const;
+    FunctionPtr getDomainTransformFunction() const;
+
     /**
      * @brief Dequeues first datapacket if available and returns true if first packet is Event.
      *
@@ -83,7 +93,7 @@ struct SignalReader
     bool isFirstPacketEvent();
     EventPacketPtr readUntilNextDataPacket();
     bool skipUntilLastEventPacket();
-    bool sync(const Comparable& commonStart, std::chrono::system_clock::rep* firstSampleAbsoluteTimestamp = nullptr);
+    bool sync(const DomainValue* commonStart, std::chrono::system_clock::rep* firstSampleAbsoluteTimestamp = nullptr);
 
     ErrCode readPackets();
     ErrCode readPacketData();
@@ -96,9 +106,6 @@ struct SignalReader
     bool isConnected() const;
 
     LoggerComponentPtr loggerComponent;
-
-    std::unique_ptr<Reader> valueReader;
-    std::unique_ptr<Reader> domainReader;
 
     InputPortConfigPtr port;
     ConnectionPtr connection;
@@ -118,6 +125,25 @@ struct SignalReader
 
     NumberPtr packetDelta {0};
     std::chrono::system_clock::rep cachedFirstTimestamp;
+
+private:
+
+    bool onValueDescriptorUpdate(const DataDescriptorPtr& valueDescriptor);
+    bool onDomainDescriptorUpdate(const DataDescriptorPtr& domainDescriptor);
+    struct TypedReadingContext
+    {
+        SampleType domainIn;
+        SampleType domainOut;
+        ReadLayout domainLayout;
+        DomainInfo domainInfo;
+        FunctionPtr domainTransform = nullptr;
+        
+        SampleType valueIn;
+        SampleType valueOut;
+        ReadLayout valueLayout;
+        FunctionPtr valueTransform = nullptr;
+    };
+    TypedReadingContext trContext;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/include/opendaq/typed_reading_utils.h
+++ b/core/opendaq/reader/include/opendaq/typed_reading_utils.h
@@ -30,6 +30,9 @@ struct ReadLayout
 
 class TypedReadingUtils
 {
+public:
+    static ReadLayout createReadLayout(const DataDescriptorPtr &descriptor);
+
     static std::unique_ptr<DomainValue> readDomainValue(
         SampleType in,
         SampleType out,

--- a/core/opendaq/reader/include/opendaq/typed_reading_utils.h
+++ b/core/opendaq/reader/include/opendaq/typed_reading_utils.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <coretypes/common.h>

--- a/core/opendaq/reader/include/opendaq/typed_reading_utils.h
+++ b/core/opendaq/reader/include/opendaq/typed_reading_utils.h
@@ -16,8 +16,9 @@
 #pragma once
 
 #include <coretypes/common.h>
-#include <opendaq/domain_value.h>
 #include <opendaq/data_packet_ptr.h>
+#include <opendaq/domain_value.h>
+
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -31,34 +32,31 @@ struct ReadLayout
 class TypedReadingUtils
 {
 public:
-    static ReadLayout createReadLayout(const DataDescriptorPtr &descriptor);
+    static ReadLayout createReadLayout(const DataDescriptorPtr& descriptor);
 
-    static std::unique_ptr<DomainValue> readDomainValue(
-        SampleType in,
-        SampleType out,
-        const ReadLayout& readLayout,
-        const DataPacketPtr& domainPacket,
-        SizeT index,
-        const DomainInfo& domainInfo);
+    static std::unique_ptr<DomainValue> readDomainValue(SampleType in,
+                                                        SampleType out,
+                                                        const ReadLayout& readLayout,
+                                                        const DataPacketPtr& domainPacket,
+                                                        SizeT index,
+                                                        const DomainInfo& domainInfo);
 
-    static SizeT findDomainValue(
-        SampleType in,
-        SampleType out,
-        const ReadLayout& readLayout,
-        const DataPacketPtr& domainPacket,
-        const DomainValue* target,
-        std::chrono::system_clock::rep* firstSampleAbsoluteTime = nullptr);
+    static SizeT findDomainValue(SampleType in,
+                                 SampleType out,
+                                 const ReadLayout& readLayout,
+                                 const DataPacketPtr& domainPacket,
+                                 const DomainValue* target,
+                                 std::chrono::system_clock::rep* firstSampleAbsoluteTime = nullptr);
 
-    static ErrCode readData(
-        SampleType in,
-        SampleType out,
-        bool isDomain,
-        const ReadLayout& readLayout,
-        void* inputBuffer,
-        SizeT offset,
-        void** outputBuffer,
-        SizeT count,
-        const FunctionPtr transform = nullptr);
+    static ErrCode readData(SampleType in,
+                            SampleType out,
+                            bool isDomain,
+                            const ReadLayout& readLayout,
+                            void* inputBuffer,
+                            SizeT offset,
+                            void** outputBuffer,
+                            SizeT count,
+                            const FunctionPtr transform = nullptr);
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/include/opendaq/typed_reading_utils.h
+++ b/core/opendaq/reader/include/opendaq/typed_reading_utils.h
@@ -45,7 +45,7 @@ class TypedReadingUtils
         const DataPacketPtr& domainPacket,
         const DomainValue* target,
         std::chrono::system_clock::rep* firstSampleAbsoluteTime = nullptr);
-    
+
     static ErrCode readData(
         SampleType in,
         SampleType out,

--- a/core/opendaq/reader/include/opendaq/typed_reading_utils.h
+++ b/core/opendaq/reader/include/opendaq/typed_reading_utils.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <coretypes/common.h>
+#include <opendaq/domain_value.h>
+#include <opendaq/data_packet_ptr.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+struct ReadLayout
+{
+    DataDescriptorPtr descriptor = nullptr;
+    SizeT rawSampleSize = 0;
+    SizeT valuesPerSample = 1;
+};
+
+class TypedReadingUtils
+{
+    static std::unique_ptr<DomainValue> readDomainValue(
+        SampleType in,
+        SampleType out,
+        const ReadLayout& readLayout,
+        const DataPacketPtr& domainPacket,
+        SizeT index,
+        const DomainInfo& domainInfo);
+
+    static SizeT findDomainValue(
+        SampleType in,
+        SampleType out,
+        const ReadLayout& readLayout,
+        const DataPacketPtr& domainPacket,
+        const DomainValue* target,
+        std::chrono::system_clock::rep* firstSampleAbsoluteTime = nullptr);
+    
+    static ErrCode readData(
+        SampleType in,
+        SampleType out,
+        bool isDomain,
+        const ReadLayout& readLayout,
+        void* inputBuffer,
+        SizeT offset,
+        void** outputBuffer,
+        SizeT count,
+        const FunctionPtr transform = nullptr);
+};
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/include/opendaq/typed_reading_utils.h
+++ b/core/opendaq/reader/include/opendaq/typed_reading_utils.h
@@ -34,6 +34,8 @@ class TypedReadingUtils
 public:
     static ReadLayout createReadLayout(const DataDescriptorPtr& descriptor);
 
+    static bool isSampleTypeConvertible(SampleType in, SampleType out, bool isDomain);
+
     static std::unique_ptr<DomainValue> readDomainValue(SampleType in,
                                                         SampleType out,
                                                         const ReadLayout& readLayout,
@@ -41,7 +43,7 @@ public:
                                                         SizeT index,
                                                         const DomainInfo& domainInfo);
 
-    static SizeT findDomainValue(SampleType in,
+static SizeT findDomainValue(SampleType in,
                                  SampleType out,
                                  const ReadLayout& readLayout,
                                  const DataPacketPtr& domainPacket,

--- a/core/opendaq/reader/src/CMakeLists.txt
+++ b/core/opendaq/reader/src/CMakeLists.txt
@@ -83,11 +83,14 @@ function(create_component_source_groups_${BASE_NAME})
         ${SDK_HEADERS_DIR}/time_reader.h
         ${SDK_HEADERS_DIR}/read_info.h
         ${SDK_HEADERS_DIR}/typed_reader.h
+        ${SDK_HEADERS_DIR}/typed_reading_utils.h
+        ${SDK_HEADERS_DIR}/domain_value.h
         ${SDK_HEADERS_DIR}/reader_impl.h
         ${SDK_HEADERS_DIR}/reader_status_impl.h
         ${SDK_SRC_DIR}/reader_impl.cpp
         ${SDK_SRC_DIR}/reader_status_impl.cpp
         ${SDK_SRC_DIR}/typed_reader.cpp
+        ${SDK_SRC_DIR}/typed_reading_utils.cpp
     )
     
     source_group("reader//stream" FILES 
@@ -146,6 +149,8 @@ set(SRC_PublicHeaders_Component
     reader_errors.h
     reader_exceptions.h
     typed_reader.h
+    typed_reading_utils.h
+    domain_value.h
     time_reader.h
     read_info.h
     reader_utils.h
@@ -181,6 +186,7 @@ set(SRC_Cpp_Component
     reader_status_impl.cpp
     reader_impl.cpp
     typed_reader.cpp
+    typed_reading_utils.cpp
     multi_reader_impl.cpp
     multi_reader_builder_impl.cpp
     signal_reader.cpp

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -1563,7 +1563,7 @@ ErrCode MultiReaderImpl::getOffset(void* domainStart)
 
     if (commonDomainStart)
     {
-        // TODO:
+        // TODO: What can this be possibly used for?
         // commonStart->getValue(domainStart);
         return OPENDAQ_SUCCESS;
     }

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -24,7 +24,7 @@ using namespace std::chrono;
 using Milliseconds = duration<double, std::milli>;
 
 template <>
-struct fmt::formatter<daq::Comparable> : ostream_formatter
+struct fmt::formatter<daq::DomainValue> : ostream_formatter
 {
 };
 
@@ -575,17 +575,19 @@ void MultiReaderImpl::setStartInfo()
         if (signal.unused)
             continue;
 
-        if (signal.domainInfo.epoch < minEpoch)
+        auto& domainInfo = signal.getDomainInfo();
+        if (domainInfo.epoch < minEpoch)
         {
-            minEpoch = signal.domainInfo.epoch;
+            minEpoch = domainInfo.epoch;
         }
 
-        if (static_cast<double>(signal.domainInfo.resolution) < static_cast<double>(maxResolution))
+        if (static_cast<double>(domainInfo.resolution) < static_cast<double>(maxResolution))
         {
-            maxResolution = signal.domainInfo.resolution;
+            maxResolution = domainInfo.resolution;
         }
     }
 
+    commonDomain = DomainInfo{minEpoch, maxResolution};
     readResolution = maxResolution;
     readOrigin = date::format("%FT%TZ", minEpoch);
 
@@ -624,7 +626,7 @@ ErrCode MultiReaderImpl::getValueReadType(SampleType* sampleType)
         // value read type may differ from what was configured (e. g. Undefined -> Int64).
         // The SignalReader will instantiate the appropriate type reader when descriptors change.
         // Shouldn't be relied on if different signals are read simultaneously.
-        *sampleType = signals.front().valueReader->getReadType();
+        *sampleType = signals.front().getValueReadType();
     else
         *sampleType = valueReadType;
     return OPENDAQ_SUCCESS;
@@ -644,7 +646,7 @@ ErrCode MultiReaderImpl::setValueTransformFunction(IFunction* transform)
 
     for (auto& signal : signals)
     {
-        signal.valueReader->setTransformFunction(transform);
+        signal.setValueTransformFunction(transform);
     }
 
     return OPENDAQ_SUCCESS;
@@ -656,7 +658,7 @@ ErrCode MultiReaderImpl::setDomainTransformFunction(IFunction* transform)
 
     for (auto& signal : signals)
     {
-        signal.domainReader->setTransformFunction(transform);
+        signal.setDomainTransformFunction(transform);
     }
 
     return OPENDAQ_SUCCESS;
@@ -739,7 +741,7 @@ ErrCode INTERFACE_FUNC MultiReaderImpl::removeInput(IString* globalId)
 
     signals.erase(it);
     // Reset common start to avoid holding a reference to the deleted signal reader.
-    commonStart = nullptr;
+    commonDomainStart = nullptr;
 
     portsConnected = allPortsConnected();
     if (!portsConnected)
@@ -1472,27 +1474,21 @@ void MultiReaderImpl::readDomainStart()
         // => SignalReader should be able to handle two domain settings - one native to the signal it is reading and
         // another, "common", that will be set from Multireader parent. Ideally, getting these common domain information,
         // it should be trivial to compare starts.
-        auto sigStart = signal.readStartDomain();
-        if (!commonStart || *commonStart < *sigStart)
+        // auto sigStart = signal.readStartDomain();
+        auto sigStart = signal.readDomainStart();
+        auto sigStartInCommonDomain = sigStart->toCommonDomain(commonDomain);
+        if (!commonDomainStart || *commonDomainStart < *sigStartInCommonDomain)
         {
-            commonStart = std::move(sigStart);
+            commonDomainStart = std::move(sigStartInCommonDomain);
         }
     }
 
     LOG_T("---");
-    LOG_T("DomainStart: {}", *commonStart);
+    LOG_T("DomainStart: {}", *commonDomainStart);
 
-    if (startOnFullUnitOfDomain)
-    {
-        commonStart->roundUpOnUnitOfDomain();
-        LOG_T("Rounded DomainStart: {}", *commonStart);
-    }
-    else
-    {
-        const RatioPtr interval = Ratio(sampleRateDividerLcm, commonSampleRate).simplify();
-        commonStart->roundUpOnDomainInterval(interval);
-        LOG_T("Aligned DomainStart: {}", *commonStart);
-    }
+    const RatioPtr interval = startOnFullUnitOfDomain ? Ratio(1, 1) : Ratio(sampleRateDividerLcm, commonSampleRate).simplify();
+    commonDomainStart->roundUpOnDomainInterval(interval);
+    LOG_T("Aligned DomainStart: {}", *commonDomainStart);
 }
 
 void MultiReaderImpl::sync()
@@ -1507,7 +1503,8 @@ void MultiReaderImpl::sync()
             continue;
 
         system_clock::rep firstSampleAbsoluteTime;
-        synced = signal.sync(*commonStart, &firstSampleAbsoluteTime) && synced;
+        auto startInNativeDomain = commonDomainStart->fromCommonDomain(signal.getDomainInfo());
+        synced = signal.sync(startInNativeDomain.get(), &firstSampleAbsoluteTime) && synced;
 
         if (synced)
         {
@@ -1564,9 +1561,10 @@ ErrCode MultiReaderImpl::getOffset(void* domainStart)
 {
     OPENDAQ_PARAM_NOT_NULL(domainStart);
 
-    if (commonStart)
+    if (commonDomainStart)
     {
-        commonStart->getValue(domainStart);
+        // TODO:
+        // commonStart->getValue(domainStart);
         return OPENDAQ_SUCCESS;
     }
 
@@ -1586,7 +1584,8 @@ ErrCode MultiReaderImpl::getIsSynchronized(Bool* isSynchronized)
 {
     OPENDAQ_PARAM_NOT_NULL(isSynchronized);
 
-    *isSynchronized = static_cast<bool>(commonStart);
+    // TODO: There is a more comlpex answer to this
+    *isSynchronized = commonDomainStart != nullptr;
 
     return OPENDAQ_SUCCESS;
 }
@@ -1634,7 +1633,7 @@ ErrCode MultiReaderImpl::getValueTransformFunction(IFunction** transform)
         return OPENDAQ_ERR_INVALIDSTATE;
     }
 
-    *transform = signals.front().valueReader->getTransformFunction().addRefAndReturn();
+    *transform = signals.front().getValueTransformFunction().addRefAndReturn();
 
     return OPENDAQ_SUCCESS;
 }
@@ -1650,7 +1649,7 @@ ErrCode MultiReaderImpl::getDomainTransformFunction(IFunction** transform)
         return OPENDAQ_ERR_INVALIDSTATE;
     }
 
-    *transform = signals.front().domainReader->getTransformFunction().addRefAndReturn();
+    *transform = signals.front().getDomainTransformFunction().addRefAndReturn();
 
     return OPENDAQ_SUCCESS;
 }

--- a/core/opendaq/reader/src/signal_reader.cpp
+++ b/core/opendaq/reader/src/signal_reader.cpp
@@ -16,8 +16,6 @@ SignalReader::SignalReader(const InputPortConfigPtr& port,
                            const LoggerComponentPtr& logger,
                            bool globalIdFromSignal)
     : loggerComponent(logger)
-    , valueReader(createReaderForType(mode == ReadMode::RawValue ? SampleType::Undefined : valueReadType, nullptr))
-    , domainReader(createReaderForType(domainReadType, nullptr))
     , port(port)
     , connection(port.getConnection())
     , readMode(mode)
@@ -26,6 +24,10 @@ SignalReader::SignalReader(const InputPortConfigPtr& port,
     , commonSampleRate(-1)
     , globalIdFromSignal(globalIdFromSignal)
 {
+    trContext.domainIn = SampleType::Undefined;
+    trContext.domainOut = domainReadType;
+    trContext.valueIn = SampleType::Undefined;
+    trContext.valueOut = mode == ReadMode::RawValue ? SampleType::Undefined : valueReadType;
 }
 
 SignalReader::SignalReader(const SignalReader& old,
@@ -33,9 +35,6 @@ SignalReader::SignalReader(const SignalReader& old,
                            SampleType valueReadType,
                            SampleType domainReadType)
     : loggerComponent(old.loggerComponent)
-    , valueReader(createReaderForType(old.readMode == ReadMode::RawValue ? SampleType::Undefined : valueReadType,
-                                      old.valueReader->getTransformFunction()))
-    , domainReader(createReaderForType(domainReadType, old.domainReader->getTransformFunction()))
     , port(old.port)
     , connection(port.getConnection())
     , readMode(old.readMode)
@@ -44,7 +43,17 @@ SignalReader::SignalReader(const SignalReader& old,
     , commonSampleRate(-1)
     , unused(old.unused)
     , globalIdFromSignal(old.globalIdFromSignal)
+    , trContext{} // In-out types might change
 {
+    // Preserve transform from the old reader
+    trContext.valueTransform = old.trContext.valueTransform;
+    trContext.domainTransform = old.trContext.domainTransform;
+    // Type-related state gets set as in new
+    trContext.domainIn = SampleType::Undefined;
+    trContext.domainOut = domainReadType;
+    trContext.valueIn = SampleType::Undefined;
+    trContext.valueOut = readMode == ReadMode::RawValue ? SampleType::Undefined : valueReadType;
+
     info = old.info;
 
     port.setListener(listener);
@@ -127,29 +136,29 @@ void SignalReader::handleDescriptorChanged(const EventPacketPtr& eventPacket)
     auto [valueDescriptorChanged, domainDescriptorChanged, newValueDescriptor, newDomainDescriptor] =
         parseDataDescriptorEventPacket(eventPacket);
 
-    if (valueDescriptorChanged && newValueDescriptor.assigned() && valueReader->getReadType() == SampleType::Undefined)
-    {
-        SampleType valueType;
-        auto postScaling = newValueDescriptor.getPostScaling();
-        if (!postScaling.assigned() || readMode == ReadMode::Scaled)
-        {
-            valueType = newValueDescriptor.getSampleType();
-        }
-        else
-        {
-            valueType = postScaling.getInputSampleType();
-        }
-
-        valueReader = createReaderForType(valueType, valueReader->getTransformFunction());
-    }
-
     if (valueDescriptorChanged)
     {
-        invalid = !valueReader->handleDescriptorChanged(newValueDescriptor, readMode);
+        if (newValueDescriptor.assigned() && trContext.valueOut == SampleType::Undefined)
+        {
+            SampleType valueType;
+            auto postScaling = newValueDescriptor.getPostScaling();
+            if (!postScaling.assigned() || readMode == ReadMode::Scaled)
+            {
+                valueType = newValueDescriptor.getSampleType();
+            }
+            else
+            {
+                valueType = postScaling.getInputSampleType();
+            }
+    
+            trContext.valueOut = valueType;
+        }
+
+        invalid = !onValueDescriptorUpdate(newValueDescriptor);
     }
     if (domainDescriptorChanged)
     {
-        auto validDomain = domainReader->handleDescriptorChanged(newDomainDescriptor, readMode);
+        auto validDomain = onDomainDescriptorUpdate(newDomainDescriptor);
         if (validDomain && newDomainDescriptor.assigned())
         {
             auto newResolution = newDomainDescriptor.getTickResolution();
@@ -219,7 +228,7 @@ void SignalReader::setStartInfo(std::chrono::system_clock::time_point minEpoch, 
     synced = SyncStatus::Unsynchronized;
 }
 
-std::unique_ptr<Comparable> SignalReader::readStartDomain()
+std::unique_ptr<DomainValue> SignalReader::readDomainStart()
 {
     DataPacketPtr domainPacket = info.dataPacket.getDomainPacket();
     if (!domainPacket.assigned())
@@ -227,14 +236,42 @@ std::unique_ptr<Comparable> SignalReader::readStartDomain()
         DAQ_THROW_EXCEPTION(InvalidStateException, "Packet must have a domain packet assigned!");
     }
 
-    if (domainPacket.getDataDescriptor().getRule().getType() == DataRuleType::Linear)
-    {
-        return domainReader->readStartLinear(domainPacket, info.prevSampleIndex, domainInfo);
-    }
-    else
-    {
-        return domainReader->readStart(domainPacket.getData(), info.prevSampleIndex, domainInfo);
-    }
+    return TypedReadingUtils::readDomainValue(trContext.domainIn,
+                                              trContext.domainOut,
+                                              trContext.domainLayout,
+                                              domainPacket,
+                                              info.prevSampleIndex,
+                                              trContext.domainInfo);
+}
+
+const DomainInfo& SignalReader::getDomainInfo() const
+{
+    return trContext.domainInfo;
+}
+
+SampleType SignalReader::getValueReadType() const
+{
+    return trContext.valueOut;
+}
+
+void SignalReader::setValueTransformFunction(FunctionPtr transform)
+{
+    trContext.valueTransform = std::move(transform);
+}
+
+void SignalReader::setDomainTransformFunction(FunctionPtr transform)
+{
+    trContext.domainTransform = std::move(transform);
+}
+
+FunctionPtr SignalReader::getValueTransformFunction() const
+{
+    return trContext.valueTransform;
+}
+
+FunctionPtr SignalReader::getDomainTransformFunction() const
+{
+    return trContext.domainTransform;
 }
 
 bool SignalReader::isFirstPacketEvent()
@@ -389,7 +426,7 @@ bool SignalReader::skipUntilLastEventPacket()
     return hasEventPacket;
 }
 
-bool SignalReader::sync(const Comparable& commonStart, std::chrono::system_clock::rep* firstSampleAbsoluteTimestamp)
+bool SignalReader::sync(const DomainValue* commonStart, std::chrono::system_clock::rep* firstSampleAbsoluteTimestamp)
 {
     if (synced == SyncStatus::Synchronized)
     {
@@ -411,15 +448,12 @@ bool SignalReader::sync(const Comparable& commonStart, std::chrono::system_clock
     {
         auto domainPacket = info.dataPacket.getDomainPacket();
         // Check if commonStart can be reached within the current packet
-        if (domainPacket.getDataDescriptor().getRule().getType() == DataRuleType::Linear)
-        {
-            info.prevSampleIndex = domainReader->getOffsetToLinear(domainInfo, commonStart, domainPacket, &cachedFirstTimestamp);
-        }
-        else
-        {
-            info.prevSampleIndex = domainReader->getOffsetTo(
-                domainInfo, commonStart, domainPacket.getData(), domainPacket.getSampleCount(), &cachedFirstTimestamp);
-        }
+        info.prevSampleIndex = TypedReadingUtils::findDomainValue(trContext.domainIn,
+                                                                  trContext.domainOut,
+                                                                  trContext.domainLayout,
+                                                                  domainPacket,
+                                                                  commonStart,
+                                                                  &cachedFirstTimestamp);
 
         if (info.prevSampleIndex == static_cast<SizeT>(-1))
         {
@@ -567,7 +601,15 @@ ErrCode SignalReader::readPacketData()
 
     if (info.values != nullptr)
     {
-        ErrCode errCode = valueReader->readData(getValuePacketData(info.dataPacket), info.prevSampleIndex, &info.values, toRead);
+        ErrCode errCode = TypedReadingUtils::readData(trContext.valueIn,
+                                              trContext.valueOut,
+                                              false,
+                                              trContext.valueLayout,
+                                              getValuePacketData(info.dataPacket),
+                                              info.prevSampleIndex,
+                                              &info.values,
+                                              toRead,
+                                              trContext.valueTransform);
         OPENDAQ_RETURN_IF_FAILED(errCode);
     }
 
@@ -582,13 +624,30 @@ ErrCode SignalReader::readPacketData()
         LOG_T("[Reading: {} ", port.getSignal().getLocalId());
 
         auto domainPacket = dataPacket.getDomainPacket();
-        ErrCode errCode = domainReader->readData(domainPacket.getData(), info.prevSampleIndex, &info.domainValues, toRead);
+        ErrCode errCode = TypedReadingUtils::readData(trContext.domainIn,
+                                                      trContext.domainOut,
+                                                      true,
+                                                      trContext.domainLayout,
+                                                      domainPacket.getData(),
+                                                      info.prevSampleIndex,
+                                                      &info.domainValues,
+                                                      toRead,
+                                                      trContext.domainTransform);
+        
         if (errCode == OPENDAQ_ERR_INVALIDSTATE)
         {
             if (!trySetDomainSampleType(domainPacket))
                 return DAQ_EXTEND_ERROR_INFO(errCode, "Failed to set domain sample type for packet");
             daqClearErrorInfo();
-            errCode = domainReader->readData(domainPacket.getData(), info.prevSampleIndex, &info.domainValues, toRead);
+            errCode = TypedReadingUtils::readData(trContext.domainIn,
+                                                  trContext.domainOut,
+                                                  true,
+                                                  trContext.domainLayout,
+                                                  domainPacket.getData(),
+                                                  info.prevSampleIndex,
+                                                  &info.domainValues,
+                                                  toRead,
+                                                  trContext.domainTransform);
         }
 
         LOG_T("]");
@@ -609,18 +668,75 @@ ErrCode SignalReader::readPacketData()
     return OPENDAQ_SUCCESS;
 }
 
-bool SignalReader::trySetDomainSampleType(const daq::DataPacketPtr& domainPacket) const
+bool SignalReader::trySetDomainSampleType(const daq::DataPacketPtr& domainPacket)
 {
     ObjectPtr<IErrorInfo> errorInfo;
     daqGetErrorInfo(&errorInfo);
     daqClearErrorInfo();
 
     auto dataDescriptor = domainPacket.getDataDescriptor();
-    if (domainReader->handleDescriptorChanged(dataDescriptor, readMode))
+    if (onDomainDescriptorUpdate(dataDescriptor))
         return true;
 
     daqSetErrorInfo(errorInfo);
     return false;
 }
+
+bool SignalReader::onValueDescriptorUpdate(const DataDescriptorPtr& valueDescriptor)
+{
+    if (!valueDescriptor.assigned())
+        return false;
+
+    const auto postScaling = valueDescriptor.getPostScaling();
+    if (!postScaling.assigned() || readMode == ReadMode::Scaled)
+    {
+        trContext.valueIn = valueDescriptor.getSampleType();
+    }
+    else
+    {
+        trContext.valueIn = postScaling.getInputSampleType();
+    }
+
+    trContext.valueLayout.rawSampleSize = valueDescriptor.getRawSampleSize();
+    auto dimensions = valueDescriptor.getDimensions();
+    if (dimensions.assigned() && dimensions.getCount() == 1)
+    {
+        trContext.valueLayout.valuesPerSample = dimensions[0].getSize();
+    }
+
+    trContext.valueLayout.descriptor = valueDescriptor;
+
+    return TypedReadingUtils::isSampleTypeConvertible(trContext.valueIn, trContext.valueOut, false);
+}
+
+bool SignalReader::onDomainDescriptorUpdate(const DataDescriptorPtr& domainDescriptor)
+{
+    if (!domainDescriptor.assigned())
+        return false;
+
+    const auto postScaling = domainDescriptor.getPostScaling();
+    if (!postScaling.assigned() || readMode == ReadMode::Scaled)
+    {
+        trContext.domainIn = domainDescriptor.getSampleType();
+    }
+    else
+    {
+        trContext.domainIn = postScaling.getInputSampleType();
+    }
+
+    trContext.domainLayout.rawSampleSize = domainDescriptor.getRawSampleSize();
+    auto dimensions = domainDescriptor.getDimensions();
+    if (dimensions.assigned() && dimensions.getCount() == 1)
+    {
+        trContext.domainLayout.valuesPerSample = dimensions[0].getSize();
+    }
+
+    trContext.domainLayout.descriptor = domainDescriptor;
+
+    trContext.domainInfo = DomainInfo::fromDescriptor(domainDescriptor);
+
+    return TypedReadingUtils::isSampleTypeConvertible(trContext.domainIn, trContext.domainOut, true);
+}
+
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/src/typed_reading_utils.cpp
+++ b/core/opendaq/reader/src/typed_reading_utils.cpp
@@ -137,10 +137,10 @@ decltype(auto) visitTwoSampleTypes(
 {
     if (!validateInputType(inputType, isDomain))
         DAQ_THROW_EXCEPTION(NotSupportedException, "Input sample type not supported.");
-        
+
     if (!validateOutputType(outputType, isDomain))
         DAQ_THROW_EXCEPTION(NotSupportedException, "Output sample type not supported.");
-    
+
     if (!validateInputOutputType(inputType, outputType, isDomain))
         DAQ_THROW_EXCEPTION(NotSupportedException, "Output sample type not supported.");
 
@@ -313,7 +313,7 @@ std::unique_ptr<DomainValue> readDomainValueLinear(
         const auto parameters = dataRule.getParameters();
         OutputT delta, start;
         getDeltaStart<InputT, OutputT>(parameters, delta, start);
-        
+
         int64_t rdOffset = 0;
         auto refDomainInfo = domainPacket.getDataDescriptor().getReferenceDomainInfo();
         if (refDomainInfo.assigned())
@@ -348,7 +348,7 @@ std::unique_ptr<DomainValue> readDomainValue(
         auto descriptor = domainPacket.getDataDescriptor();
         if (!descriptor.assigned())
             DAQ_THROW_EXCEPTION(InvalidStateException, "Packet should have descriptor assigned.");
-        
+
 
 
         OutputT timestamp{};
@@ -471,7 +471,7 @@ SizeT findDomainValue(
 
     if (!inputBuffer)
         DAQ_THROW_EXCEPTION(ArgumentNullException, "Packet with null data buffer");
-    
+
     if constexpr (std::is_convertible_v<InputT, OutputT> && !std::is_same_v<void*, OutputT> && !std::is_same_v<void*, InputT>)
     {
         InputT* domainBuffer = static_cast<InputT*>(inputBuffer);
@@ -482,7 +482,7 @@ SizeT findDomainValue(
         for (std::size_t i = 0; i < size * readLayout.valuesPerSample; ++i)
         {
             OutputT value = static_cast<OutputT>(domainBuffer[i]); // C4244 - possible data loss due to conversion
-            
+
             bool greaterEqual = false;
             if constexpr (IsTemplateOf<OutputT, daq::RangeType>::value)
             {

--- a/core/opendaq/reader/src/typed_reading_utils.cpp
+++ b/core/opendaq/reader/src/typed_reading_utils.cpp
@@ -5,7 +5,6 @@
 #include <opendaq/sample_type.h>
 #include <opendaq/sample_type_traits.h>
 
-
 BEGIN_NAMESPACE_OPENDAQ
 
 namespace
@@ -209,6 +208,20 @@ namespace detail
 {
 
 template <typename InputT, typename OutputT>
+bool isSampleTypeConvertible(bool isDomain)
+{
+    if constexpr (std::is_same_v<OutputT, void*>)
+    {
+        return !isDomain;
+    }
+    else
+    {
+        return std::is_convertible_v<InputT, OutputT>;
+    }
+}
+
+
+template <typename InputT, typename OutputT>
 ErrCode readData(const ReadLayout& readLayout,
                  void* inputBuffer,
                  SizeT offset,
@@ -346,7 +359,7 @@ std::unique_ptr<DomainValue> readDomainValue(const ReadLayout& readLayout,
 
         OutputT timestamp{};
         void* data = &timestamp;
-        readData<InputT, OutputT>(readLayout, domainPacket.getData(), index, &data, 1);
+        readData<InputT, OutputT>(readLayout, domainPacket.getData(), index, &data, 1, nullptr);
         return std::make_unique<DomainValueImpl<OutputT>>(domainInfo, timestamp);
     }
 }
@@ -527,6 +540,30 @@ ReadLayout TypedReadingUtils::createReadLayout(const DataDescriptorPtr& descript
     }
 
     return {descriptor, rawSampleSize, valuesPerSample};
+}
+
+bool TypedReadingUtils::isSampleTypeConvertible(SampleType in, SampleType out, bool isDomain)
+{
+    // TODO: Detais about limiting allowed types (not throwing unless necessary)
+    switch (in){
+        case SampleType::Struct:
+        case SampleType::Invalid:
+        case SampleType::Null:
+        case SampleType::_count:
+            return false;
+        default:
+            break;
+    }
+
+    return visitTwoSampleTypes(in,
+                               out,
+                               isDomain,
+                               [&](auto inputTag, auto outputTag) -> bool
+                               {
+                                   using InputT = typename decltype(inputTag)::Type;
+                                   using OutputT = typename decltype(outputTag)::Type;
+                                   return detail::isSampleTypeConvertible<InputT, OutputT>(isDomain);
+                               });
 }
 
 std::unique_ptr<DomainValue> TypedReadingUtils::readDomainValue(SampleType in,

--- a/core/opendaq/reader/src/typed_reading_utils.cpp
+++ b/core/opendaq/reader/src/typed_reading_utils.cpp
@@ -1,0 +1,605 @@
+#include <opendaq/typed_reading_utils.h>
+
+#include <coretypes/exceptions.h>
+#include <opendaq/sample_type.h>
+#include <opendaq/sample_type_traits.h>
+#include <opendaq/reader_utils.h>
+
+BEGIN_NAMESPACE_OPENDAQ
+
+namespace {
+
+template<typename Visitor>
+decltype(auto) visitSampleType(SampleType sampleType, Visitor&& visitor)
+{
+    switch (sampleType)
+    {
+        case SampleType::Float32:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Float32>::Type>();
+        case SampleType::Float64:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Float64>::Type>();
+        case SampleType::UInt8:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt8>::Type>();
+        case SampleType::Int8:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int8>::Type>();
+        case SampleType::UInt16:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt16>::Type>();
+        case SampleType::Int16:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int16>::Type>();
+        case SampleType::UInt32:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt32>::Type>();
+        case SampleType::Int32:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int32>::Type>();
+        case SampleType::UInt64:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt64>::Type>();
+        case SampleType::Int64:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int64>::Type>();
+        case SampleType::RangeInt64:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::RangeInt64>::Type>();
+        case SampleType::ComplexFloat32:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::ComplexFloat32>::Type>();
+        case SampleType::ComplexFloat64:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::ComplexFloat64>::Type>();
+        case SampleType::Struct:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+        case SampleType::Undefined:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+        case SampleType::Binary:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+        case SampleType::String:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+        case SampleType::Null:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+        case SampleType::_count:
+            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+    }
+    DAQ_THROW_EXCEPTION(NotSupportedException, "The requested sample-type is unsupported or invalid.");
+}
+
+std::string_view format_as(SampleType sampleType);
+
+bool validateInputType(SampleType sampleType, bool isDomain)
+{
+    switch (sampleType)
+    {
+        case SampleType::Float32:
+        case SampleType::Float64:
+        case SampleType::UInt8:
+        case SampleType::Int8:
+        case SampleType::UInt16:
+        case SampleType::Int16:
+        case SampleType::UInt32:
+        case SampleType::Int32:
+        case SampleType::UInt64:
+        case SampleType::Int64:
+            return true;
+        case SampleType::RangeInt64:
+            return true; // TODO: Not sure what kind of support we actually have
+        case SampleType::ComplexFloat32:
+        case SampleType::ComplexFloat64:
+        case SampleType::Struct:
+        case SampleType::Undefined:
+        case SampleType::Binary:
+        case SampleType::String:
+            if (isDomain)
+                DAQ_THROW_EXCEPTION(NotSupportedException, "Using the SampleType {} as a domain is not supported", format_as(sampleType));
+            return true;
+        case SampleType::Null:
+            DAQ_THROW_EXCEPTION(NotSupportedException, "Null input sample type encountered.");
+        case SampleType::_count:
+        default:
+            DAQ_THROW_EXCEPTION(InvalidStateException, "Unexpected input sample type encountered.");
+    }
+}
+
+bool validateOutputType(SampleType sampleType, bool isDomain)
+{
+    switch (sampleType)
+    {
+        case SampleType::Float32:
+        case SampleType::Float64:
+        case SampleType::UInt8:
+        case SampleType::Int8:
+        case SampleType::UInt16:
+        case SampleType::Int16:
+        case SampleType::UInt32:
+        case SampleType::Int32:
+        case SampleType::UInt64:
+        case SampleType::Int64:
+        case SampleType::RangeInt64:
+            return true;
+        case SampleType::ComplexFloat32:
+        case SampleType::ComplexFloat64:
+        case SampleType::Struct:
+        case SampleType::Undefined:
+            return !isDomain;
+        case SampleType::Binary:
+        case SampleType::String:
+        case SampleType::Null:
+        case SampleType::_count:
+        default:
+            DAQ_THROW_EXCEPTION(NotSupportedException, "The requested output sample type is unsupported or invalid.");
+    }
+}
+
+bool validateInputOutputType(SampleType inputType, SampleType outputType, bool isDomain)
+{
+    // TODO: Implement combination checking (float -> int for domains etc.)
+    return true;
+}
+
+template <typename Visitor>
+decltype(auto) visitTwoSampleTypes(
+    SampleType inputType,
+    SampleType outputType,
+    bool isDomain,
+    Visitor&& visitor)
+{
+    if (!validateInputType(inputType, isDomain))
+        DAQ_THROW_EXCEPTION(NotSupportedException, "Input sample type not supported.");
+        
+    if (!validateOutputType(outputType, isDomain))
+        DAQ_THROW_EXCEPTION(NotSupportedException, "Output sample type not supported.");
+    
+    if (!validateInputOutputType(inputType, outputType, isDomain))
+        DAQ_THROW_EXCEPTION(NotSupportedException, "Output sample type not supported.");
+
+
+    return visitSampleType(inputType, [&]<typename InputType>() -> decltype(auto)
+    {
+        return visitSampleType(outputType, [&]<typename OutputType>() -> decltype(auto)
+        {
+            return std::forward<Visitor>(visitor)
+                .template operator()<InputType, OutputType>();
+        });
+    });
+}
+
+std::string_view format_as(SampleType sampleType)
+{
+    switch (sampleType)
+    {
+        case SampleType::Float32:
+            return "Float32";
+        case SampleType::Float64:
+            return "Float64";
+        case SampleType::UInt8:
+            return "UInt8";
+        case SampleType::Int8:
+            return "Int8";
+        case SampleType::UInt16:
+            return "UInt16";
+        case SampleType::Int16:
+            return "Int16";
+        case SampleType::UInt32:
+            return "UInt32";
+        case SampleType::Int32:
+            return "Int32";
+        case SampleType::UInt64:
+            return "UInt64";
+        case SampleType::Int64:
+            return "Int64";
+        case SampleType::RangeInt64:
+            return "RangeInt64";
+        case SampleType::ComplexFloat32:
+            return "ComplexFloat32";
+        case SampleType::ComplexFloat64:
+            return "ComplexFloat64";
+        case SampleType::Struct:
+            return "Struct";
+        case SampleType::Undefined:
+            return "Undefined";
+        case SampleType::Binary:
+            return "Binary";
+        case SampleType::String:
+            return "String";
+        case SampleType::Null:
+            return "Null";
+        case SampleType::_count:
+            return "Count";
+    }
+    return "Unknown";
+}
+
+}
+
+namespace detail {
+
+template<typename InputT, typename OutputT>
+ErrCode readData(
+    const ReadLayout& readLayout,
+    void* inputBuffer,
+    SizeT offset,
+    void** outputBuffer,
+    SizeT toRead,
+    const DataDescriptorPtr& descriptor,
+    const FunctionPtr& transformFunction = nullptr)
+{
+    OPENDAQ_PARAM_NOT_NULL(inputBuffer);
+    OPENDAQ_PARAM_NOT_NULL(outputBuffer);
+    OPENDAQ_PARAM_NOT_NULL(descriptor.getObject());
+
+    const auto& rawSampleSize = readLayout.rawSampleSize;
+    const auto& valuesPerSample = readLayout.valuesPerSample;
+    const auto& dataDescriptor = readLayout.descriptor;
+
+    if constexpr (std::is_same_v<OutputT, void*>)
+    {
+        if (transformFunction.assigned())
+            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOT_SUPPORTED, "Transform function for void reader not supported.");
+
+        const auto dataStart = static_cast<void*>(static_cast<uint8_t*>(inputBuffer) + offset * rawSampleSize);
+        const auto toReadInBytes = rawSampleSize * toRead;
+        const auto dataOut = *outputBuffer;
+        std::memcpy(dataOut, dataStart, toReadInBytes);
+        *outputBuffer = static_cast<void*>(static_cast<uint8_t*>(dataOut) + toReadInBytes);
+        return OPENDAQ_SUCCESS;
+    }
+    else if constexpr (std::is_convertible_v<InputT, OutputT>)
+    {
+        auto dataStart = static_cast<InputT*>(inputBuffer) + (offset * valuesPerSample);
+        auto dataOut = static_cast<OutputT*>(*outputBuffer);
+
+        if (transformFunction.assigned())
+        {
+            transformFunction.call((Int) dataStart, (Int) dataOut, toRead, dataDescriptor);
+
+            *outputBuffer = dataOut + (valuesPerSample * toRead);
+            return OPENDAQ_SUCCESS;
+        }
+
+        // If the type of samples is the same, then just copy
+        if (std::is_same_v<OutputT, InputT>)
+        {
+            // Returns the pointer to the value after the last copied one
+            *outputBuffer = std::copy_n(dataStart, valuesPerSample * toRead, dataOut);  // C4244 - possible data loss due to conversion
+        }
+        else
+        {
+            for (std::size_t i = 0; i < toRead * valuesPerSample; ++i)
+            {
+                dataOut[i] = static_cast<OutputT>(dataStart[i]);  // C4244 - possible data loss due to conversion
+            }
+
+            // Set the pointer to the value after the last copied one
+            *outputBuffer = &dataOut[toRead];
+        }
+
+        return OPENDAQ_SUCCESS;
+    }
+    else
+    {
+        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOT_SUPPORTED,
+                                   "Implicit conversion from packet data-type to the read data-type is not supported.");
+    }
+}
+
+template <typename InputT, typename OutputT>
+void getDeltaStart(
+    const daq::DictPtr<daq::IString, daq::IBaseObject>& params,
+    OutputT& delta,
+    OutputT& start)
+{
+    if constexpr (std::is_same_v<OutputT, void*>)
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException, "Void reader should not be used for domain.");
+    }
+    if constexpr (!std::is_convertible_v<InputT, OutputT>)
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException, "Implicit conversion from packet data-type to the read data-type is not supported.");
+    }
+    else
+    {
+        delta = static_cast<OutputT>(params.get("delta"));
+        start = static_cast<OutputT>(params.get("start"));
+    }
+}
+
+template<typename InputT, typename OutputT>
+std::unique_ptr<DomainValue> readDomainValueLinear(
+    const DataPacketPtr& domainPacket,
+    SizeT index,
+    const DomainInfo& domainInfo)
+{
+    if constexpr (std::is_same_v<void*, OutputT> || !std::is_integral_v<OutputT>)
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException, "ReadDomainValueLinear not supported for the selected output type (void / non-integral).");
+        return {};
+    }
+    else
+    {
+        const DataRulePtr dataRule = domainPacket.getDataDescriptor().getRule();
+        NumberPtr packetOffset = domainPacket.getOffset();
+        const auto parameters = dataRule.getParameters();
+        OutputT delta, start;
+        getDeltaStart<InputT, OutputT>(parameters, delta, start);
+        
+        int64_t rdOffset = 0;
+        auto refDomainInfo = domainPacket.getDataDescriptor().getReferenceDomainInfo();
+        if (refDomainInfo.assigned())
+        {
+            const IntPtr referenceDomainOffset = refDomainInfo.getReferenceDomainOffset();
+            if (referenceDomainOffset.assigned())
+            {
+                rdOffset = referenceDomainOffset;
+            }
+        }
+
+        OutputT timestamp = start + static_cast<OutputT>(rdOffset) + static_cast<OutputT>(packetOffset.getIntValue()) +
+                                delta * static_cast<OutputT>(index);
+        return std::make_unique<DomainValueImpl<OutputT>>(domainInfo, timestamp);
+    }
+}
+
+template<typename InputT, typename OutputT>
+std::unique_ptr<DomainValue> readDomainValue(
+    const ReadLayout& readLayout,
+    const DataPacketPtr& domainPacket,
+    SizeT index,
+    const DomainInfo& domainInfo)
+{
+    if constexpr (std::is_same_v<void*, OutputT>)
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException, "ReadDomainValueLinear not supported for the void output type.");
+        return {};
+    }
+    else
+    {
+        auto descriptor = domainPacket.getDataDescriptor();
+        if (!descriptor.assigned())
+            DAQ_THROW_EXCEPTION(InvalidStateException, "Packet should have descriptor assigned.");
+        
+
+
+        OutputT timestamp{};
+        void* data = &timestamp;
+        readData<InputT, OutputT>(
+            readLayout,
+            domainPacket.getData(),
+            index,
+            &data,
+            1,
+            nullptr);
+        return std::make_unique<DomainValueImpl<OutputT>>(domainInfo, timestamp);
+    }
+}
+
+template<typename InputT, typename OutputT>
+SizeT findDomainValueLinear(
+    const DataPacketPtr& domainPacket,
+    const DomainValue* target,
+    [[maybe_unused]] std::chrono::system_clock::rep* absoluteTimestamp)
+{
+    if constexpr (std::is_same_v<void*, OutputT> || !std::is_integral_v<OutputT>)
+    {
+        // void reader should never be used to read domain info
+        // Only integral ReadType is supported
+        return static_cast<SizeT>(-1);
+    }
+    else if constexpr (std::is_convertible_v<InputT, OutputT>)
+    {
+        const SizeT sampleCount = domainPacket.getSampleCount();
+        if (sampleCount == 0)
+        {
+            return static_cast<SizeT>(-1);
+        }
+
+        const DataRulePtr& dataRule = domainPacket.getDataDescriptor().getRule();
+        const auto parameters = dataRule.getParameters();
+
+        int64_t rdOffset = 0;
+        { // Extract reference domain offset
+            auto refDomainInfo = domainPacket.getDataDescriptor().getReferenceDomainInfo();
+            if (refDomainInfo.assigned())
+            {
+                const IntPtr referenceDomainOffset = refDomainInfo.getReferenceDomainOffset();
+                if (referenceDomainOffset.assigned())
+                {
+                    rdOffset = referenceDomainOffset;
+                }
+            }
+        }
+
+        OutputT ruleDelta, ruleStart;
+        getDeltaStart<InputT, OutputT>(parameters, ruleDelta, ruleStart);
+        NumberPtr packetOffset = domainPacket.getOffset();
+
+         // Total packet offset in signal resolution ticks.
+        const OutputT startTick = ruleStart + static_cast<OutputT>(rdOffset) + static_cast<OutputT>(packetOffset.getIntValue());
+        const OutputT previousEndTick = startTick - ruleDelta;
+
+        // Tick of the last sample in signal resolution ticks
+        const SizeT packetSize = domainPacket.getSampleCount();
+        OutputT endTick = startTick + ruleDelta * static_cast<OutputT>(packetSize - 1);
+
+        const DomainValueImpl<OutputT>* typedTarget = dynamic_cast<const DomainValueImpl<OutputT>*>(target);
+        OutputT targetValue = typedTarget->getValue();
+
+        /*
+        The function returns the index k of the first tick where the tick_k >= target
+        (in max resolution ticks since min epoch). The k-th sample is the answer for any target inside
+        interval (tick_{k-1}, tick_k]. The n-th packet then covers ticks (endTick_{n-1}, endTick].
+        Using the linear rule, the last sample in the previous packet was at endTick_{n-1} = startTick_n - ruleDelta.
+
+        Example: Packet with ticks [12, 15, 18] will return index 0 for targets [10, 11, 12] and -1 for <=9 and >=19.
+        */
+        if (targetValue <= previousEndTick || targetValue > endTick)
+        {
+            // Target is outside this packet
+            return static_cast<SizeT>(-1);
+        }
+
+        // Ticks from the end of the previous packet's end.
+        SizeT ticksToTarget = targetValue - previousEndTick;
+        // Minus one due to calculation from the previous packet end tick.
+        SizeT index = static_cast<SizeT>((ticksToTarget + ruleDelta - 1) / ruleDelta) - 1;
+
+        assert(index < packetSize && "Index out of bounds");
+
+        if (absoluteTimestamp)
+        {
+            if constexpr (IsTemplateOf<OutputT, daq::RangeType>::value || IsTemplateOf<OutputT, daq::Complex_Number>::value)
+            {
+                DAQ_THROW_EXCEPTION(NotSupportedException);
+            }
+            else
+            {
+                // Tick corresponding to index in signal's resolution ticks.
+                OutputT tick = startTick + static_cast<OutputT>(index) * ruleDelta;
+                auto readValueSysTime = reader::toSysTime(tick, target->getDomain().epoch, target->getDomain().resolution);
+                *absoluteTimestamp = readValueSysTime.time_since_epoch().count();
+            }
+        }
+        return index;
+    }
+    else
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException,
+                                   "Implicit conversion from packet data-type to the read data-type is not supported.");
+    }
+}
+
+template<typename InputT, typename OutputT>
+SizeT findDomainValue(
+    const ReadLayout& readLayout,
+    const DataPacketPtr& domainPacket,
+    const DomainValue* target,
+    [[maybe_unused]] std::chrono::system_clock::rep* absoluteTimestamp)
+{
+    void* inputBuffer = domainPacket.getData();
+    SizeT size = domainPacket.getSampleCount();
+
+    if (!inputBuffer)
+        DAQ_THROW_EXCEPTION(ArgumentNullException, "Packet with null data buffer");
+    
+    if constexpr (std::is_convertible_v<InputT, OutputT> && !std::is_same_v<void*, OutputT> && !std::is_same_v<void*, InputT>)
+    {
+        InputT* domainBuffer = static_cast<InputT*>(inputBuffer);
+
+        const DomainValueImpl<OutputT>* typedTarget = dynamic_cast<const DomainValueImpl<OutputT>*>(target);
+        OutputT targetValue = typedTarget->getValue();
+
+        for (std::size_t i = 0; i < size * readLayout.valuesPerSample; ++i)
+        {
+            OutputT value = static_cast<OutputT>(domainBuffer[i]); // C4244 - possible data loss due to conversion
+            
+            bool greaterEqual = false;
+            if constexpr (IsTemplateOf<OutputT, daq::RangeType>::value)
+            {
+                if (value.start >= targetValue.start)
+                {
+                    if (absoluteTimestamp){
+                        auto readValueSysTime = reader::toSysTime(value.start, target->getDomain().epoch, target->getDomain().resolution);
+                        *absoluteTimestamp = readValueSysTime.time_since_epoch().count();
+                    }
+                    greaterEqual = true;
+                }
+            }
+            else if constexpr (!IsTemplateOf<OutputT, daq::Complex_Number>::value)
+            {
+                if (value >= targetValue)
+                {
+                    if (absoluteTimestamp)
+                    {
+                        auto readValueSysTime = reader::toSysTime(value, target->getDomain().epoch, target->getDomain().resolution);
+                        *absoluteTimestamp = readValueSysTime.time_since_epoch().count();
+                    }
+                    greaterEqual = true;
+                }
+            }
+            else
+            {
+                DAQ_THROW_EXCEPTION(NotSupportedException);
+            }
+
+            if (greaterEqual)
+            {
+                return i / readLayout.valuesPerSample;
+            }
+        }
+
+        return static_cast<SizeT>(-1);
+    }
+    else
+    {
+        DAQ_THROW_EXCEPTION(NotSupportedException,
+                                   "Implicit conversion from packet data-type to the read data-type is not supported.");
+    }
+}
+
+}
+
+
+std::unique_ptr<DomainValue> readDomainValue(
+    SampleType in,
+    SampleType out,
+    const ReadLayout& readLayout,
+    const DataPacketPtr& domainPacket,
+    SizeT index,
+    const DomainInfo& domainInfo)
+{
+    const DataRulePtr dataRule = domainPacket.getDataDescriptor().getRule();
+    if (dataRule.getType() == DataRuleType::Linear)
+    {
+        return visitTwoSampleTypes(in, out, true,
+        [&]<typename InputT, typename OutputT>() -> std::unique_ptr<DomainValue>
+        {
+            return detail::readDomainValueLinear<InputT, OutputT>(domainPacket, index, domainInfo);
+        });
+    }
+    else
+    {
+        return visitTwoSampleTypes(in, out, true,
+        [&]<typename InputT, typename OutputT>() -> std::unique_ptr<DomainValue>
+        {
+            return detail::readDomainValue<InputT, OutputT>(readLayout, domainPacket, index, domainInfo);
+        });
+    }
+}
+
+SizeT findDomainValue(
+    SampleType in,
+    SampleType out,
+    const ReadLayout& readLayout,
+    const DataPacketPtr& domainPacket,
+    const DomainValue* target,
+    std::chrono::system_clock::rep* firstSampleAbsoluteTime)
+{
+    const DataRulePtr dataRule = domainPacket.getDataDescriptor().getRule();
+    if (dataRule.getType() == DataRuleType::Linear)
+    {
+        return visitTwoSampleTypes(in, out, true,
+        [&]<typename InputT, typename OutputT>() -> SizeT
+        {
+            return detail::findDomainValueLinear<InputT, OutputT>(domainPacket, target, firstSampleAbsoluteTime);
+        });
+    }
+    else
+    {
+        return visitTwoSampleTypes(in, out, true,
+        [&]<typename InputT, typename OutputT>() -> SizeT
+        {
+            return detail::findDomainValue<InputT, OutputT>(readLayout, domainPacket, target, firstSampleAbsoluteTime);
+        });
+    }
+}
+
+ErrCode readData(
+    SampleType in,
+    SampleType out,
+    bool isDomain,
+    const ReadLayout& readLayout,
+    void* inputBuffer,
+    SizeT offset,
+    void** outputBuffer,
+    SizeT count,
+    const FunctionPtr transform = nullptr)
+{
+    return visitTwoSampleTypes(in, out, isDomain,
+    [&]<typename InputT, typename OutputT>() -> ErrCode
+    {
+        return detail::readData<InputT, OutputT>(readLayout, inputBuffer, offset, outputBuffer, count, transform);
+    });
+}
+
+END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/src/typed_reading_utils.cpp
+++ b/core/opendaq/reader/src/typed_reading_utils.cpp
@@ -217,12 +217,11 @@ ErrCode readData(
     SizeT offset,
     void** outputBuffer,
     SizeT toRead,
-    const DataDescriptorPtr& descriptor,
     const FunctionPtr& transformFunction = nullptr)
 {
     OPENDAQ_PARAM_NOT_NULL(inputBuffer);
     OPENDAQ_PARAM_NOT_NULL(outputBuffer);
-    OPENDAQ_PARAM_NOT_NULL(descriptor.getObject());
+    OPENDAQ_PARAM_NOT_NULL(readLayout.descriptor.getObject());
 
     const auto& rawSampleSize = readLayout.rawSampleSize;
     const auto& valuesPerSample = readLayout.valuesPerSample;
@@ -363,8 +362,7 @@ std::unique_ptr<DomainValue> readDomainValue(
             domainPacket.getData(),
             index,
             &data,
-            1,
-            nullptr);
+            1);
         return std::make_unique<DomainValueImpl<OutputT>>(domainInfo, timestamp);
     }
 }

--- a/core/opendaq/reader/src/typed_reading_utils.cpp
+++ b/core/opendaq/reader/src/typed_reading_utils.cpp
@@ -9,49 +9,55 @@ BEGIN_NAMESPACE_OPENDAQ
 
 namespace {
 
+template<typename T>
+struct TypeTag
+{
+    using Type = T;
+};
+
 template<typename Visitor>
 decltype(auto) visitSampleType(SampleType sampleType, Visitor&& visitor)
 {
     switch (sampleType)
     {
         case SampleType::Float32:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Float32>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Float32>::Type>{});
         case SampleType::Float64:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Float64>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Float64>::Type>{});
         case SampleType::UInt8:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt8>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::UInt8>::Type>{});
         case SampleType::Int8:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int8>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Int8>::Type>{});
         case SampleType::UInt16:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt16>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::UInt16>::Type>{});
         case SampleType::Int16:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int16>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Int16>::Type>{});
         case SampleType::UInt32:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt32>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::UInt32>::Type>{});
         case SampleType::Int32:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int32>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Int32>::Type>{});
         case SampleType::UInt64:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::UInt64>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::UInt64>::Type>{});
         case SampleType::Int64:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Int64>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Int64>::Type>{});
         case SampleType::RangeInt64:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::RangeInt64>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::RangeInt64>::Type>{});
         case SampleType::ComplexFloat32:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::ComplexFloat32>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::ComplexFloat32>::Type>{});
         case SampleType::ComplexFloat64:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::ComplexFloat64>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::ComplexFloat64>::Type>{});
         case SampleType::Struct:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Struct>::Type>{});
         case SampleType::Undefined:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Struct>::Type>{});
         case SampleType::Binary:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Struct>::Type>{});
         case SampleType::String:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Struct>::Type>{});
         case SampleType::Null:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Struct>::Type>{});
         case SampleType::_count:
-            return std::forward<Visitor>(visitor).template operator()<SampleTypeToType<SampleType::Struct>::Type>();
+            return std::forward<Visitor>(visitor)(TypeTag<SampleTypeToType<SampleType::Struct>::Type>{});
     }
     DAQ_THROW_EXCEPTION(NotSupportedException, "The requested sample-type is unsupported or invalid.");
 }
@@ -145,12 +151,11 @@ decltype(auto) visitTwoSampleTypes(
         DAQ_THROW_EXCEPTION(NotSupportedException, "Output sample type not supported.");
 
 
-    return visitSampleType(inputType, [&]<typename InputType>() -> decltype(auto)
+    return visitSampleType(inputType, [&](auto inputTag) -> decltype(auto)
     {
-        return visitSampleType(outputType, [&]<typename OutputType>() -> decltype(auto)
+        return visitSampleType(outputType, [&](auto outputTag) -> decltype(auto)
         {
-            return std::forward<Visitor>(visitor)
-                .template operator()<InputType, OutputType>();
+            return std::forward<Visitor>(visitor)(inputTag, outputTag);
         });
     });
 }
@@ -529,8 +534,23 @@ SizeT findDomainValue(
 
 }
 
+ReadLayout TypedReadingUtils::createReadLayout(const DataDescriptorPtr &descriptor)
+{
+    if (!descriptor.assigned())
+        DAQ_THROW_EXCEPTION(ArgumentNullException, "Descriptor must be assigned!");
+    
+    const SizeT rawSampleSize = descriptor.getRawSampleSize();
+    SizeT valuesPerSample = 1;
+    auto dimensions = descriptor.getDimensions();
+    if (dimensions.assigned() && dimensions.getCount() == 1)
+    {
+        valuesPerSample = dimensions[0].getSize();
+    }
 
-std::unique_ptr<DomainValue> readDomainValue(
+    return {descriptor, rawSampleSize, valuesPerSample};
+}
+
+std::unique_ptr<DomainValue> TypedReadingUtils::readDomainValue(
     SampleType in,
     SampleType out,
     const ReadLayout& readLayout,
@@ -542,22 +562,26 @@ std::unique_ptr<DomainValue> readDomainValue(
     if (dataRule.getType() == DataRuleType::Linear)
     {
         return visitTwoSampleTypes(in, out, true,
-        [&]<typename InputT, typename OutputT>() -> std::unique_ptr<DomainValue>
+        [&](auto inputTag, auto outputTag) -> std::unique_ptr<DomainValue>
         {
+            using InputT = typename decltype(inputTag)::Type;
+            using OutputT = typename decltype(outputTag)::Type;
             return detail::readDomainValueLinear<InputT, OutputT>(domainPacket, index, domainInfo);
         });
     }
     else
     {
         return visitTwoSampleTypes(in, out, true,
-        [&]<typename InputT, typename OutputT>() -> std::unique_ptr<DomainValue>
+        [&](auto inputTag, auto outputTag) -> std::unique_ptr<DomainValue>
         {
+            using InputT = typename decltype(inputTag)::Type;
+            using OutputT = typename decltype(outputTag)::Type;
             return detail::readDomainValue<InputT, OutputT>(readLayout, domainPacket, index, domainInfo);
         });
     }
 }
 
-SizeT findDomainValue(
+SizeT TypedReadingUtils::findDomainValue(
     SampleType in,
     SampleType out,
     const ReadLayout& readLayout,
@@ -569,22 +593,26 @@ SizeT findDomainValue(
     if (dataRule.getType() == DataRuleType::Linear)
     {
         return visitTwoSampleTypes(in, out, true,
-        [&]<typename InputT, typename OutputT>() -> SizeT
+        [&](auto inputTag, auto outputTag) -> SizeT
         {
+            using InputT = typename decltype(inputTag)::Type;
+            using OutputT = typename decltype(outputTag)::Type;
             return detail::findDomainValueLinear<InputT, OutputT>(domainPacket, target, firstSampleAbsoluteTime);
         });
     }
     else
     {
         return visitTwoSampleTypes(in, out, true,
-        [&]<typename InputT, typename OutputT>() -> SizeT
+        [&](auto inputTag, auto outputTag) -> SizeT
         {
+            using InputT = typename decltype(inputTag)::Type;
+            using OutputT = typename decltype(outputTag)::Type;
             return detail::findDomainValue<InputT, OutputT>(readLayout, domainPacket, target, firstSampleAbsoluteTime);
         });
     }
 }
 
-ErrCode readData(
+ErrCode TypedReadingUtils::readData(
     SampleType in,
     SampleType out,
     bool isDomain,
@@ -593,11 +621,13 @@ ErrCode readData(
     SizeT offset,
     void** outputBuffer,
     SizeT count,
-    const FunctionPtr transform = nullptr)
+    const FunctionPtr transform)
 {
     return visitTwoSampleTypes(in, out, isDomain,
-    [&]<typename InputT, typename OutputT>() -> ErrCode
+    [&](auto inputTag, auto outputTag) -> ErrCode
     {
+        using InputT = typename decltype(inputTag)::Type;
+        using OutputT = typename decltype(outputTag)::Type;
         return detail::readData<InputT, OutputT>(readLayout, inputBuffer, offset, outputBuffer, count, transform);
     });
 }

--- a/core/opendaq/reader/src/typed_reading_utils.cpp
+++ b/core/opendaq/reader/src/typed_reading_utils.cpp
@@ -1,21 +1,23 @@
 #include <opendaq/typed_reading_utils.h>
 
 #include <coretypes/exceptions.h>
+#include <opendaq/reader_utils.h>
 #include <opendaq/sample_type.h>
 #include <opendaq/sample_type_traits.h>
-#include <opendaq/reader_utils.h>
+
 
 BEGIN_NAMESPACE_OPENDAQ
 
-namespace {
+namespace
+{
 
-template<typename T>
+template <typename T>
 struct TypeTag
 {
     using Type = T;
 };
 
-template<typename Visitor>
+template <typename Visitor>
 decltype(auto) visitSampleType(SampleType sampleType, Visitor&& visitor)
 {
     switch (sampleType)
@@ -80,7 +82,7 @@ bool validateInputType(SampleType sampleType, bool isDomain)
         case SampleType::Int64:
             return true;
         case SampleType::RangeInt64:
-            return true; // TODO: Not sure what kind of support we actually have
+            return true;  // TODO: Not sure what kind of support we actually have
         case SampleType::ComplexFloat32:
         case SampleType::ComplexFloat64:
         case SampleType::Struct:
@@ -135,11 +137,7 @@ bool validateInputOutputType(SampleType inputType, SampleType outputType, bool i
 }
 
 template <typename Visitor>
-decltype(auto) visitTwoSampleTypes(
-    SampleType inputType,
-    SampleType outputType,
-    bool isDomain,
-    Visitor&& visitor)
+decltype(auto) visitTwoSampleTypes(SampleType inputType, SampleType outputType, bool isDomain, Visitor&& visitor)
 {
     if (!validateInputType(inputType, isDomain))
         DAQ_THROW_EXCEPTION(NotSupportedException, "Input sample type not supported.");
@@ -150,14 +148,13 @@ decltype(auto) visitTwoSampleTypes(
     if (!validateInputOutputType(inputType, outputType, isDomain))
         DAQ_THROW_EXCEPTION(NotSupportedException, "Output sample type not supported.");
 
-
-    return visitSampleType(inputType, [&](auto inputTag) -> decltype(auto)
-    {
-        return visitSampleType(outputType, [&](auto outputTag) -> decltype(auto)
-        {
-            return std::forward<Visitor>(visitor)(inputTag, outputTag);
-        });
-    });
+    return visitSampleType(inputType,
+                           [&](auto inputTag) -> decltype(auto)
+                           {
+                               return visitSampleType(outputType,
+                                                      [&](auto outputTag) -> decltype(auto)
+                                                      { return std::forward<Visitor>(visitor)(inputTag, outputTag); });
+                           });
 }
 
 std::string_view format_as(SampleType sampleType)
@@ -208,16 +205,16 @@ std::string_view format_as(SampleType sampleType)
 
 }
 
-namespace detail {
+namespace detail
+{
 
-template<typename InputT, typename OutputT>
-ErrCode readData(
-    const ReadLayout& readLayout,
-    void* inputBuffer,
-    SizeT offset,
-    void** outputBuffer,
-    SizeT toRead,
-    const FunctionPtr& transformFunction = nullptr)
+template <typename InputT, typename OutputT>
+ErrCode readData(const ReadLayout& readLayout,
+                 void* inputBuffer,
+                 SizeT offset,
+                 void** outputBuffer,
+                 SizeT toRead,
+                 const FunctionPtr& transformFunction = nullptr)
 {
     OPENDAQ_PARAM_NOT_NULL(inputBuffer);
     OPENDAQ_PARAM_NOT_NULL(outputBuffer);
@@ -279,10 +276,7 @@ ErrCode readData(
 }
 
 template <typename InputT, typename OutputT>
-void getDeltaStart(
-    const daq::DictPtr<daq::IString, daq::IBaseObject>& params,
-    OutputT& delta,
-    OutputT& start)
+void getDeltaStart(const daq::DictPtr<daq::IString, daq::IBaseObject>& params, OutputT& delta, OutputT& start)
 {
     if constexpr (std::is_same_v<OutputT, void*>)
     {
@@ -299,15 +293,13 @@ void getDeltaStart(
     }
 }
 
-template<typename InputT, typename OutputT>
-std::unique_ptr<DomainValue> readDomainValueLinear(
-    const DataPacketPtr& domainPacket,
-    SizeT index,
-    const DomainInfo& domainInfo)
+template <typename InputT, typename OutputT>
+std::unique_ptr<DomainValue> readDomainValueLinear(const DataPacketPtr& domainPacket, SizeT index, const DomainInfo& domainInfo)
 {
     if constexpr (std::is_same_v<void*, OutputT> || !std::is_integral_v<OutputT>)
     {
-        DAQ_THROW_EXCEPTION(NotSupportedException, "ReadDomainValueLinear not supported for the selected output type (void / non-integral).");
+        DAQ_THROW_EXCEPTION(NotSupportedException,
+                            "ReadDomainValueLinear not supported for the selected output type (void / non-integral).");
         return {};
     }
     else
@@ -329,18 +321,17 @@ std::unique_ptr<DomainValue> readDomainValueLinear(
             }
         }
 
-        OutputT timestamp = start + static_cast<OutputT>(rdOffset) + static_cast<OutputT>(packetOffset.getIntValue()) +
-                                delta * static_cast<OutputT>(index);
+        OutputT timestamp =
+            start + static_cast<OutputT>(rdOffset) + static_cast<OutputT>(packetOffset.getIntValue()) + delta * static_cast<OutputT>(index);
         return std::make_unique<DomainValueImpl<OutputT>>(domainInfo, timestamp);
     }
 }
 
-template<typename InputT, typename OutputT>
-std::unique_ptr<DomainValue> readDomainValue(
-    const ReadLayout& readLayout,
-    const DataPacketPtr& domainPacket,
-    SizeT index,
-    const DomainInfo& domainInfo)
+template <typename InputT, typename OutputT>
+std::unique_ptr<DomainValue> readDomainValue(const ReadLayout& readLayout,
+                                             const DataPacketPtr& domainPacket,
+                                             SizeT index,
+                                             const DomainInfo& domainInfo)
 {
     if constexpr (std::is_same_v<void*, OutputT>)
     {
@@ -353,25 +344,17 @@ std::unique_ptr<DomainValue> readDomainValue(
         if (!descriptor.assigned())
             DAQ_THROW_EXCEPTION(InvalidStateException, "Packet should have descriptor assigned.");
 
-
-
         OutputT timestamp{};
         void* data = &timestamp;
-        readData<InputT, OutputT>(
-            readLayout,
-            domainPacket.getData(),
-            index,
-            &data,
-            1);
+        readData<InputT, OutputT>(readLayout, domainPacket.getData(), index, &data, 1);
         return std::make_unique<DomainValueImpl<OutputT>>(domainInfo, timestamp);
     }
 }
 
-template<typename InputT, typename OutputT>
-SizeT findDomainValueLinear(
-    const DataPacketPtr& domainPacket,
-    const DomainValue* target,
-    [[maybe_unused]] std::chrono::system_clock::rep* absoluteTimestamp)
+template <typename InputT, typename OutputT>
+SizeT findDomainValueLinear(const DataPacketPtr& domainPacket,
+                            const DomainValue* target,
+                            [[maybe_unused]] std::chrono::system_clock::rep* absoluteTimestamp)
 {
     if constexpr (std::is_same_v<void*, OutputT> || !std::is_integral_v<OutputT>)
     {
@@ -391,7 +374,7 @@ SizeT findDomainValueLinear(
         const auto parameters = dataRule.getParameters();
 
         int64_t rdOffset = 0;
-        { // Extract reference domain offset
+        {  // Extract reference domain offset
             auto refDomainInfo = domainPacket.getDataDescriptor().getReferenceDomainInfo();
             if (refDomainInfo.assigned())
             {
@@ -407,7 +390,7 @@ SizeT findDomainValueLinear(
         getDeltaStart<InputT, OutputT>(parameters, ruleDelta, ruleStart);
         NumberPtr packetOffset = domainPacket.getOffset();
 
-         // Total packet offset in signal resolution ticks.
+        // Total packet offset in signal resolution ticks.
         const OutputT startTick = ruleStart + static_cast<OutputT>(rdOffset) + static_cast<OutputT>(packetOffset.getIntValue());
         const OutputT previousEndTick = startTick - ruleDelta;
 
@@ -457,17 +440,15 @@ SizeT findDomainValueLinear(
     }
     else
     {
-        DAQ_THROW_EXCEPTION(NotSupportedException,
-                                   "Implicit conversion from packet data-type to the read data-type is not supported.");
+        DAQ_THROW_EXCEPTION(NotSupportedException, "Implicit conversion from packet data-type to the read data-type is not supported.");
     }
 }
 
-template<typename InputT, typename OutputT>
-SizeT findDomainValue(
-    const ReadLayout& readLayout,
-    const DataPacketPtr& domainPacket,
-    const DomainValue* target,
-    [[maybe_unused]] std::chrono::system_clock::rep* absoluteTimestamp)
+template <typename InputT, typename OutputT>
+SizeT findDomainValue(const ReadLayout& readLayout,
+                      const DataPacketPtr& domainPacket,
+                      const DomainValue* target,
+                      [[maybe_unused]] std::chrono::system_clock::rep* absoluteTimestamp)
 {
     void* inputBuffer = domainPacket.getData();
     SizeT size = domainPacket.getSampleCount();
@@ -484,14 +465,15 @@ SizeT findDomainValue(
 
         for (std::size_t i = 0; i < size * readLayout.valuesPerSample; ++i)
         {
-            OutputT value = static_cast<OutputT>(domainBuffer[i]); // C4244 - possible data loss due to conversion
+            OutputT value = static_cast<OutputT>(domainBuffer[i]);  // C4244 - possible data loss due to conversion
 
             bool greaterEqual = false;
             if constexpr (IsTemplateOf<OutputT, daq::RangeType>::value)
             {
                 if (value.start >= targetValue.start)
                 {
-                    if (absoluteTimestamp){
+                    if (absoluteTimestamp)
+                    {
                         auto readValueSysTime = reader::toSysTime(value.start, target->getDomain().epoch, target->getDomain().resolution);
                         *absoluteTimestamp = readValueSysTime.time_since_epoch().count();
                     }
@@ -525,18 +507,17 @@ SizeT findDomainValue(
     }
     else
     {
-        DAQ_THROW_EXCEPTION(NotSupportedException,
-                                   "Implicit conversion from packet data-type to the read data-type is not supported.");
+        DAQ_THROW_EXCEPTION(NotSupportedException, "Implicit conversion from packet data-type to the read data-type is not supported.");
     }
 }
 
 }
 
-ReadLayout TypedReadingUtils::createReadLayout(const DataDescriptorPtr &descriptor)
+ReadLayout TypedReadingUtils::createReadLayout(const DataDescriptorPtr& descriptor)
 {
     if (!descriptor.assigned())
         DAQ_THROW_EXCEPTION(ArgumentNullException, "Descriptor must be assigned!");
-    
+
     const SizeT rawSampleSize = descriptor.getRawSampleSize();
     SizeT valuesPerSample = 1;
     auto dimensions = descriptor.getDimensions();
@@ -548,86 +529,95 @@ ReadLayout TypedReadingUtils::createReadLayout(const DataDescriptorPtr &descript
     return {descriptor, rawSampleSize, valuesPerSample};
 }
 
-std::unique_ptr<DomainValue> TypedReadingUtils::readDomainValue(
-    SampleType in,
-    SampleType out,
-    const ReadLayout& readLayout,
-    const DataPacketPtr& domainPacket,
-    SizeT index,
-    const DomainInfo& domainInfo)
+std::unique_ptr<DomainValue> TypedReadingUtils::readDomainValue(SampleType in,
+                                                                SampleType out,
+                                                                const ReadLayout& readLayout,
+                                                                const DataPacketPtr& domainPacket,
+                                                                SizeT index,
+                                                                const DomainInfo& domainInfo)
 {
     const DataRulePtr dataRule = domainPacket.getDataDescriptor().getRule();
     if (dataRule.getType() == DataRuleType::Linear)
     {
-        return visitTwoSampleTypes(in, out, true,
-        [&](auto inputTag, auto outputTag) -> std::unique_ptr<DomainValue>
-        {
-            using InputT = typename decltype(inputTag)::Type;
-            using OutputT = typename decltype(outputTag)::Type;
-            return detail::readDomainValueLinear<InputT, OutputT>(domainPacket, index, domainInfo);
-        });
+        return visitTwoSampleTypes(in,
+                                   out,
+                                   true,
+                                   [&](auto inputTag, auto outputTag) -> std::unique_ptr<DomainValue>
+                                   {
+                                       using InputT = typename decltype(inputTag)::Type;
+                                       using OutputT = typename decltype(outputTag)::Type;
+                                       return detail::readDomainValueLinear<InputT, OutputT>(domainPacket, index, domainInfo);
+                                   });
     }
     else
     {
-        return visitTwoSampleTypes(in, out, true,
-        [&](auto inputTag, auto outputTag) -> std::unique_ptr<DomainValue>
-        {
-            using InputT = typename decltype(inputTag)::Type;
-            using OutputT = typename decltype(outputTag)::Type;
-            return detail::readDomainValue<InputT, OutputT>(readLayout, domainPacket, index, domainInfo);
-        });
+        return visitTwoSampleTypes(in,
+                                   out,
+                                   true,
+                                   [&](auto inputTag, auto outputTag) -> std::unique_ptr<DomainValue>
+                                   {
+                                       using InputT = typename decltype(inputTag)::Type;
+                                       using OutputT = typename decltype(outputTag)::Type;
+                                       return detail::readDomainValue<InputT, OutputT>(readLayout, domainPacket, index, domainInfo);
+                                   });
     }
 }
 
-SizeT TypedReadingUtils::findDomainValue(
-    SampleType in,
-    SampleType out,
-    const ReadLayout& readLayout,
-    const DataPacketPtr& domainPacket,
-    const DomainValue* target,
-    std::chrono::system_clock::rep* firstSampleAbsoluteTime)
+SizeT TypedReadingUtils::findDomainValue(SampleType in,
+                                         SampleType out,
+                                         const ReadLayout& readLayout,
+                                         const DataPacketPtr& domainPacket,
+                                         const DomainValue* target,
+                                         std::chrono::system_clock::rep* firstSampleAbsoluteTime)
 {
     const DataRulePtr dataRule = domainPacket.getDataDescriptor().getRule();
     if (dataRule.getType() == DataRuleType::Linear)
     {
-        return visitTwoSampleTypes(in, out, true,
-        [&](auto inputTag, auto outputTag) -> SizeT
-        {
-            using InputT = typename decltype(inputTag)::Type;
-            using OutputT = typename decltype(outputTag)::Type;
-            return detail::findDomainValueLinear<InputT, OutputT>(domainPacket, target, firstSampleAbsoluteTime);
-        });
+        return visitTwoSampleTypes(in,
+                                   out,
+                                   true,
+                                   [&](auto inputTag, auto outputTag) -> SizeT
+                                   {
+                                       using InputT = typename decltype(inputTag)::Type;
+                                       using OutputT = typename decltype(outputTag)::Type;
+                                       return detail::findDomainValueLinear<InputT, OutputT>(domainPacket, target, firstSampleAbsoluteTime);
+                                   });
     }
     else
     {
-        return visitTwoSampleTypes(in, out, true,
-        [&](auto inputTag, auto outputTag) -> SizeT
-        {
-            using InputT = typename decltype(inputTag)::Type;
-            using OutputT = typename decltype(outputTag)::Type;
-            return detail::findDomainValue<InputT, OutputT>(readLayout, domainPacket, target, firstSampleAbsoluteTime);
-        });
+        return visitTwoSampleTypes(in,
+                                   out,
+                                   true,
+                                   [&](auto inputTag, auto outputTag) -> SizeT
+                                   {
+                                       using InputT = typename decltype(inputTag)::Type;
+                                       using OutputT = typename decltype(outputTag)::Type;
+                                       return detail::findDomainValue<InputT, OutputT>(
+                                           readLayout, domainPacket, target, firstSampleAbsoluteTime);
+                                   });
     }
 }
 
-ErrCode TypedReadingUtils::readData(
-    SampleType in,
-    SampleType out,
-    bool isDomain,
-    const ReadLayout& readLayout,
-    void* inputBuffer,
-    SizeT offset,
-    void** outputBuffer,
-    SizeT count,
-    const FunctionPtr transform)
+ErrCode TypedReadingUtils::readData(SampleType in,
+                                    SampleType out,
+                                    bool isDomain,
+                                    const ReadLayout& readLayout,
+                                    void* inputBuffer,
+                                    SizeT offset,
+                                    void** outputBuffer,
+                                    SizeT count,
+                                    const FunctionPtr transform)
 {
-    return visitTwoSampleTypes(in, out, isDomain,
-    [&](auto inputTag, auto outputTag) -> ErrCode
-    {
-        using InputT = typename decltype(inputTag)::Type;
-        using OutputT = typename decltype(outputTag)::Type;
-        return detail::readData<InputT, OutputT>(readLayout, inputBuffer, offset, outputBuffer, count, transform);
-    });
+    return visitTwoSampleTypes(in,
+                               out,
+                               isDomain,
+                               [&](auto inputTag, auto outputTag) -> ErrCode
+                               {
+                                   using InputT = typename decltype(inputTag)::Type;
+                                   using OutputT = typename decltype(outputTag)::Type;
+                                   return detail::readData<InputT, OutputT>(
+                                       readLayout, inputBuffer, offset, outputBuffer, count, transform);
+                               });
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/reader/tests/CMakeLists.txt
+++ b/core/opendaq/reader/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SOURCES test_factories.cpp
                  test_time_reader.cpp
                  test_multi_reader.cpp
                  test_stream_reader_from_input_port.cpp
+                 test_domain_value.cpp
 )
 
 opendaq_prepare_test_runner(TEST_APP FOR ${MODULE_NAME}

--- a/core/opendaq/reader/tests/CMakeLists.txt
+++ b/core/opendaq/reader/tests/CMakeLists.txt
@@ -14,6 +14,8 @@ set(TEST_SOURCES test_factories.cpp
                  test_multi_reader.cpp
                  test_stream_reader_from_input_port.cpp
                  test_domain_value.cpp
+                 test_typed_reading.cpp
+                 ../src/typed_reading_utils.cpp
 )
 
 opendaq_prepare_test_runner(TEST_APP FOR ${MODULE_NAME}
@@ -33,12 +35,13 @@ if (MSVC)
     target_compile_options(${TEST_APP} PRIVATE /bigobj)
 endif()
 
-target_link_libraries(${TEST_APP} PRIVATE daq::coreobjects
-)
 
 add_test(NAME ${TEST_APP}
          COMMAND $<TARGET_FILE_NAME:${TEST_APP}>
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_APP}>
+)
+
+target_link_libraries(${TEST_APP} PRIVATE daq::coreobjects daq::opendaq
 )
 
 if (OPENDAQ_ENABLE_COVERAGE)

--- a/core/opendaq/reader/tests/test_domain_value.cpp
+++ b/core/opendaq/reader/tests/test_domain_value.cpp
@@ -68,6 +68,7 @@ void checkTypedDomainValue(){
     std::unique_ptr<daq::DomainValue> greaterValue = std::make_unique<daq::DomainValueImpl<T>>(domain, greaterTick);
     ASSERT_TRUE(*value < *greaterValue);
     ASSERT_FALSE(*greaterValue < *value);
+    ASSERT_FALSE(*value < *value);
 }
 
 TEST_F(DomainValueTest, StoresDaqInt)
@@ -118,28 +119,120 @@ TEST_F(DomainValueTest, ThrowsForComplex)
     checkTypedDomainValueComplex<daq::ComplexFloat64>();
 }
 
-TEST_F(DomainValueTest, Basic)
+TEST_F(DomainValueTest, Scaling)
+{
+    std::string commonEpochString = "2026-01-01T00:00:00+00:00";
+    std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
+    daq::RatioPtr commonResolution = daq::Ratio(1, 1000000);
+    
+    daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
+
+    daq::RatioPtr resolution1 = daq::Ratio(1, 5000);
+    daq::DomainInfo domain1 = {commonEpoch, resolution1};
+
+    auto value1 = std::make_unique<daq::DomainValueImpl<daq::Int>>(domain1, 10000);
+    ASSERT_EQ(value1->getValue(), 10000u);
+
+    auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
+    auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());
+    ASSERT_EQ(value1InCommonDomainP->getValue(), 2000000u);
+    
+    auto value1BackInRegularDomain = value1InCommonDomain->fromCommonDomain(domain1);
+    auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1BackInRegularDomain.get());
+    ASSERT_EQ(value1BackInRegularDomainP->getValue(), 10000u);
+}
+
+TEST_F(DomainValueTest, Offset)
 {
     std::string commonEpochString = "1970-01-01T00:00:00+00:00";
     std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
     daq::RatioPtr commonResolution = daq::Ratio(1, 1000);
     
     daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
-
+    
     std::string epochString1 = "1970-01-01T00:00:50+00:00";
     std::chrono::system_clock::time_point epoch1 = daq::reader::parseEpoch(epochString1);
-    daq::RatioPtr resolution1 = daq::Ratio(1, 500);
-
+    daq::RatioPtr resolution1 = daq::Ratio(1, 1000);
     daq::DomainInfo domain1 = {epoch1, resolution1};
 
-    auto value1 = std::make_unique<daq::DomainValueImpl<int64_t>>(domain1, 2000);
-    ASSERT_EQ(value1->getValue(), 2000u);
+    auto value1 = std::make_unique<daq::DomainValueImpl<daq::Int>>(domain1, 13000);
+    ASSERT_EQ(value1->getValue(), 13000u);
 
     auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
-    auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<int64_t>*>(value1InCommonDomain.get());
-    ASSERT_EQ(value1InCommonDomainP->getValue(), 54000u);
+    auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());
+    ASSERT_EQ(value1InCommonDomainP->getValue(), 63000u);
+    ASSERT_EQ(value1InCommonDomainP->getDomain(), commonDomain);
     
     auto value1BackInRegularDomain = value1InCommonDomain->fromCommonDomain(domain1);
-    auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<int64_t>*>(value1BackInRegularDomain.get());
-    ASSERT_EQ(value1BackInRegularDomainP->getValue(), 2000u);
+    auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1BackInRegularDomain.get());
+    ASSERT_EQ(value1BackInRegularDomainP->getValue(), 13000u);
+    ASSERT_EQ(value1BackInRegularDomainP->getDomain(), domain1);
+}
+
+TEST_F(DomainValueTest, SameDomainSameType)
+{
+    std::string commonEpochString = "1970-01-01T00:00:00+00:00";
+    std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
+    daq::RatioPtr commonResolution = daq::Ratio(1, 1000);
+    
+    daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
+    
+    std::string epochString1 = "1970-01-01T00:00:50+00:00";
+    std::chrono::system_clock::time_point epoch1 = daq::reader::parseEpoch(epochString1);
+    daq::RatioPtr resolution1 = daq::Ratio(1, 1000);
+    daq::DomainInfo domain1 = {epoch1, resolution1};
+
+    auto value1 = std::make_unique<daq::DomainValueImpl<daq::Int>>(domain1, 13000);
+    daq::DomainValue* value1P = value1.get();
+    auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
+    auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());    
+    
+    ASSERT_THROW((void)(*value1P < *value1InCommonDomainP), daq::InvalidParameterException);
+
+    auto value2 = std::make_unique<daq::DomainValueImpl<daq::UInt>>(domain1, 1213000);
+    daq::DomainValue* value2P = value2.get();
+
+    ASSERT_THROW((void)(*value1 < *value2), daq::InvalidParameterException);
+}
+
+TEST_F(DomainValueTest, RealisticTimeStamp)
+{
+    std::string commonEpochString = "1970-01-01T00:00:00+00:00";
+    std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
+    daq::RatioPtr commonResolution = daq::Ratio(1, 1000000000);
+    daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
+
+    std::string epochString1 = "2026-05-27T00:00:01+00:00";
+    std::chrono::system_clock::time_point epoch1 = daq::reader::parseEpoch(epochString1);
+    daq::RatioPtr resolution1 = daq::Ratio(1, 1000000);
+    daq::DomainInfo domain1 = {epoch1, resolution1};
+
+    auto value1 = std::make_unique<daq::DomainValueImpl<daq::Int>>(domain1, 50000001);
+    auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
+    
+    auto value1BackInRegularDomain = value1InCommonDomain->fromCommonDomain(domain1);
+    auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1BackInRegularDomain.get());
+    ASSERT_EQ(value1BackInRegularDomainP->getValue(), value1->getValue());
+}
+
+TEST_F(DomainValueTest, NonRepresentibleConversions)
+{
+    std::string commonEpochString = "1970-01-01T00:00:00+00:00";
+    std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
+    daq::RatioPtr commonResolution = daq::Ratio(1, 1000000);
+    daq::RatioPtr coarseResolution = daq::Ratio(1, 1000);
+
+    daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
+    daq::DomainInfo coarseDomain = {commonEpoch, coarseResolution};
+
+    std::unique_ptr<daq::DomainValue> valueInFine = std::make_unique<daq::DomainValueImpl<daq::Int>>(commonDomain, 1002);
+    auto valueInCoarse = valueInFine->fromCommonDomain(coarseDomain);
+    auto valueBackInFine = valueInCoarse->toCommonDomain(commonDomain);
+
+    // TODO: For the domain value finding it would probably be required that during a lossful conversion fine1->coarse->fine2
+    // where coars == fine2 (but in different domains) it also holds that fine2 >= fine1. Because then if we find index that
+    // satisfies domain[index] >= coarse we found the correct one. Right now the situation is reversed, lossful conversion
+    // rounds down. 
+    ASSERT_FALSE(*valueInFine < *valueBackInFine);
+
 }

--- a/core/opendaq/reader/tests/test_domain_value.cpp
+++ b/core/opendaq/reader/tests/test_domain_value.cpp
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+
+#include <coretypes/exceptions.h>
+
+#include <opendaq/domain_value.h>
+#include <opendaq/reader_utils.h>
+
+#include <chrono>
+
+using DomainValueTest = testing::Test;
+
+TEST_F(DomainValueTest, DomainInfoComparison)
+{
+    daq::DomainInfo info1 = {daq::reader::parseEpoch("1970-01-01T00:00:00+00:00"), daq::Ratio(1, 1000)};
+    daq::DomainInfo info2 = {daq::reader::parseEpoch("1970-01-01T00:00:00+00:00"), daq::Ratio(1, 1000)};
+    ASSERT_TRUE(info1 == info2);
+
+    // Different epoch
+    daq::DomainInfo  info3 = {daq::reader::parseEpoch("1999-01-01T00:00:00+00:00"), daq::Ratio(1, 1000)};
+    ASSERT_FALSE(info3 == info1);
+
+    // Different resolution denominator
+    daq::DomainInfo info4 = {daq::reader::parseEpoch("1970-01-01T00:00:00+00:00"), daq::Ratio(1, 2000)};
+    ASSERT_FALSE(info4 == info1);
+    
+    // Different resolution numerator
+    daq::DomainInfo info5 = {daq::reader::parseEpoch("1970-01-01T00:00:00+00:00"), daq::Ratio(4, 1000)};
+    ASSERT_FALSE(info5 == info1);
+
+    // Different everything
+    daq::DomainInfo info6 = {daq::reader::parseEpoch("1999-01-01T00:00:00+00:00"), daq::Ratio(5, 2000)};
+    ASSERT_FALSE(info6 == info1);
+
+    // Unassigned resolution
+    daq::DomainInfo info7 = {daq::reader::parseEpoch("1999-01-01T00:00:00+00:00"), nullptr};
+    ASSERT_THROW((void)(info7 == info1), daq::InvalidParameterException);
+}
+
+template<typename T>
+void checkTypedDomainValue(){
+    auto epoch = daq::reader::parseEpoch("2026-01-01T00:00:00+00:00");
+    daq::DomainInfo domain = {epoch, daq::Ratio(1, 1000000)};
+
+    T tick;
+    if constexpr (std::is_same_v<T, daq::RangeType64>){
+        tick = {12345, 12350};
+    }
+    else
+    {
+        tick = 12345;
+    }
+    std::unique_ptr<daq::DomainValue> value = std::make_unique<daq::DomainValueImpl<T>>(domain, tick);
+    ASSERT_TRUE(value->getDomain() == domain);
+    
+    auto* castValue = dynamic_cast<daq::DomainValueImpl<T>*>(value.get());
+    ASSERT_TRUE(castValue != nullptr);
+    
+    ASSERT_EQ(castValue->getValue(), tick);
+    
+    T greaterTick;
+    if constexpr (std::is_same_v<T, daq::RangeType64>){
+        greaterTick = {12351, 12360};
+    }
+    else
+    {
+        greaterTick = 12351;
+    }
+    std::unique_ptr<daq::DomainValue> greaterValue = std::make_unique<daq::DomainValueImpl<T>>(domain, greaterTick);
+    ASSERT_TRUE(*value < *greaterValue);
+    ASSERT_FALSE(*greaterValue < *value);
+}
+
+TEST_F(DomainValueTest, StoresDaqInt)
+{
+    checkTypedDomainValue<daq::Int>();
+}
+
+TEST_F(DomainValueTest, StoresDaqUInt)
+{
+    checkTypedDomainValue<daq::UInt>();
+}
+
+TEST_F(DomainValueTest, StoresDaqFloat)
+{
+    checkTypedDomainValue<daq::Float>();
+}
+
+TEST_F(DomainValueTest, StoresDaqRange)
+{
+    checkTypedDomainValue<daq::RangeType64>();
+}
+
+template<typename T>
+void checkTypedDomainValueComplex()
+{
+    auto epoch = daq::reader::parseEpoch("2026-01-01T00:00:00+00:00");
+    daq::DomainInfo domain = {epoch, daq::Ratio(1, 1000000)};
+
+    T tick = {12.3, 15.4};
+    std::unique_ptr<daq::DomainValue> value = std::make_unique<daq::DomainValueImpl<T>>(domain, tick);
+    ASSERT_TRUE(value->getDomain() == domain);
+    
+    auto* castValue = dynamic_cast<daq::DomainValueImpl<T>*>(value.get());
+    ASSERT_TRUE(castValue != nullptr);
+    
+    ASSERT_THROW(castValue->getValue(), daq::NotSupportedException);
+    
+    T greaterTick = {16.2, 25.3};
+    
+    std::unique_ptr<daq::DomainValue> greaterValue = std::make_unique<daq::DomainValueImpl<T>>(domain, greaterTick);
+    ASSERT_THROW((void)(*value < *greaterValue), daq::NotSupportedException);
+    ASSERT_THROW((void)(*greaterValue < *value), daq::NotSupportedException);
+}
+
+TEST_F(DomainValueTest, ThrowsForComplex)
+{
+    checkTypedDomainValueComplex<daq::ComplexFloat32>();
+    checkTypedDomainValueComplex<daq::ComplexFloat64>();
+}
+
+TEST_F(DomainValueTest, Basic)
+{
+    std::string commonEpochString = "1970-01-01T00:00:00+00:00";
+    std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
+    daq::RatioPtr commonResolution = daq::Ratio(1, 1000);
+    
+    daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
+
+    std::string epochString1 = "1970-01-01T00:00:50+00:00";
+    std::chrono::system_clock::time_point epoch1 = daq::reader::parseEpoch(epochString1);
+    daq::RatioPtr resolution1 = daq::Ratio(1, 500);
+
+    daq::DomainInfo domain1 = {epoch1, resolution1};
+
+    auto value1 = std::make_unique<daq::DomainValueImpl<int64_t>>(domain1, 2000);
+    ASSERT_EQ(value1->getValue(), 2000u);
+
+    auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
+    auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<int64_t>*>(value1InCommonDomain.get());
+    ASSERT_EQ(value1InCommonDomainP->getValue(), 54000u);
+    
+    auto value1BackInRegularDomain = value1InCommonDomain->fromCommonDomain(domain1);
+    auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<int64_t>*>(value1BackInRegularDomain.get());
+    ASSERT_EQ(value1BackInRegularDomainP->getValue(), 2000u);
+}

--- a/core/opendaq/reader/tests/test_domain_value.cpp
+++ b/core/opendaq/reader/tests/test_domain_value.cpp
@@ -16,7 +16,7 @@ TEST_F(DomainValueTest, DomainInfoComparison)
     ASSERT_TRUE(info1 == info2);
 
     // Different epoch
-    daq::DomainInfo  info3 = {daq::reader::parseEpoch("1999-01-01T00:00:00+00:00"), daq::Ratio(1, 1000)};
+    daq::DomainInfo info3 = {daq::reader::parseEpoch("1999-01-01T00:00:00+00:00"), daq::Ratio(1, 1000)};
     ASSERT_FALSE(info3 == info1);
 
     // Different resolution denominator
@@ -33,16 +33,18 @@ TEST_F(DomainValueTest, DomainInfoComparison)
 
     // Unassigned resolution
     daq::DomainInfo info7 = {daq::reader::parseEpoch("1999-01-01T00:00:00+00:00"), nullptr};
-    ASSERT_THROW((void)(info7 == info1), daq::InvalidParameterException);
+    ASSERT_THROW((void) (info7 == info1), daq::InvalidParameterException);
 }
 
-template<typename T>
-void checkTypedDomainValue(){
+template <typename T>
+void checkTypedDomainValue()
+{
     auto epoch = daq::reader::parseEpoch("2026-01-01T00:00:00+00:00");
     daq::DomainInfo domain = {epoch, daq::Ratio(1, 1000000)};
 
     T tick;
-    if constexpr (std::is_same_v<T, daq::RangeType64>){
+    if constexpr (std::is_same_v<T, daq::RangeType64>)
+    {
         tick = {12345, 12350};
     }
     else
@@ -58,7 +60,8 @@ void checkTypedDomainValue(){
     ASSERT_EQ(castValue->getValue(), tick);
 
     T greaterTick;
-    if constexpr (std::is_same_v<T, daq::RangeType64>){
+    if constexpr (std::is_same_v<T, daq::RangeType64>)
+    {
         greaterTick = {12351, 12360};
     }
     else
@@ -91,7 +94,7 @@ TEST_F(DomainValueTest, StoresDaqRange)
     checkTypedDomainValue<daq::RangeType64>();
 }
 
-template<typename T>
+template <typename T>
 void checkTypedDomainValueComplex()
 {
     auto epoch = daq::reader::parseEpoch("2026-01-01T00:00:00+00:00");
@@ -109,8 +112,8 @@ void checkTypedDomainValueComplex()
     T greaterTick = {16.2, 25.3};
 
     std::unique_ptr<daq::DomainValue> greaterValue = std::make_unique<daq::DomainValueImpl<T>>(domain, greaterTick);
-    ASSERT_THROW((void)(*value < *greaterValue), daq::NotSupportedException);
-    ASSERT_THROW((void)(*greaterValue < *value), daq::NotSupportedException);
+    ASSERT_THROW((void) (*value < *greaterValue), daq::NotSupportedException);
+    ASSERT_THROW((void) (*greaterValue < *value), daq::NotSupportedException);
 }
 
 TEST_F(DomainValueTest, ThrowsForComplex)
@@ -187,12 +190,12 @@ TEST_F(DomainValueTest, SameDomainSameType)
     auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
     auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());
 
-    ASSERT_THROW((void)(*value1P < *value1InCommonDomainP), daq::InvalidParameterException);
+    ASSERT_THROW((void) (*value1P < *value1InCommonDomainP), daq::InvalidParameterException);
 
     auto value2 = std::make_unique<daq::DomainValueImpl<daq::UInt>>(domain1, 1213000);
     daq::DomainValue* value2P = value2.get();
 
-    ASSERT_THROW((void)(*value1 < *value2), daq::InvalidParameterException);
+    ASSERT_THROW((void) (*value1 < *value2), daq::InvalidParameterException);
 }
 
 TEST_F(DomainValueTest, RealisticTimeStamp)
@@ -234,5 +237,4 @@ TEST_F(DomainValueTest, NonRepresentibleConversions)
     // satisfies domain[index] >= coarse we found the correct one. Right now the situation is reversed, lossful conversion
     // rounds down.
     ASSERT_FALSE(*valueInFine < *valueBackInFine);
-
 }

--- a/core/opendaq/reader/tests/test_domain_value.cpp
+++ b/core/opendaq/reader/tests/test_domain_value.cpp
@@ -22,7 +22,7 @@ TEST_F(DomainValueTest, DomainInfoComparison)
     // Different resolution denominator
     daq::DomainInfo info4 = {daq::reader::parseEpoch("1970-01-01T00:00:00+00:00"), daq::Ratio(1, 2000)};
     ASSERT_FALSE(info4 == info1);
-    
+
     // Different resolution numerator
     daq::DomainInfo info5 = {daq::reader::parseEpoch("1970-01-01T00:00:00+00:00"), daq::Ratio(4, 1000)};
     ASSERT_FALSE(info5 == info1);
@@ -51,12 +51,12 @@ void checkTypedDomainValue(){
     }
     std::unique_ptr<daq::DomainValue> value = std::make_unique<daq::DomainValueImpl<T>>(domain, tick);
     ASSERT_TRUE(value->getDomain() == domain);
-    
+
     auto* castValue = dynamic_cast<daq::DomainValueImpl<T>*>(value.get());
     ASSERT_TRUE(castValue != nullptr);
-    
+
     ASSERT_EQ(castValue->getValue(), tick);
-    
+
     T greaterTick;
     if constexpr (std::is_same_v<T, daq::RangeType64>){
         greaterTick = {12351, 12360};
@@ -100,14 +100,14 @@ void checkTypedDomainValueComplex()
     T tick = {12.3, 15.4};
     std::unique_ptr<daq::DomainValue> value = std::make_unique<daq::DomainValueImpl<T>>(domain, tick);
     ASSERT_TRUE(value->getDomain() == domain);
-    
+
     auto* castValue = dynamic_cast<daq::DomainValueImpl<T>*>(value.get());
     ASSERT_TRUE(castValue != nullptr);
-    
+
     ASSERT_THROW(castValue->getValue(), daq::NotSupportedException);
-    
+
     T greaterTick = {16.2, 25.3};
-    
+
     std::unique_ptr<daq::DomainValue> greaterValue = std::make_unique<daq::DomainValueImpl<T>>(domain, greaterTick);
     ASSERT_THROW((void)(*value < *greaterValue), daq::NotSupportedException);
     ASSERT_THROW((void)(*greaterValue < *value), daq::NotSupportedException);
@@ -124,7 +124,7 @@ TEST_F(DomainValueTest, Scaling)
     std::string commonEpochString = "2026-01-01T00:00:00+00:00";
     std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
     daq::RatioPtr commonResolution = daq::Ratio(1, 1000000);
-    
+
     daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
 
     daq::RatioPtr resolution1 = daq::Ratio(1, 5000);
@@ -136,7 +136,7 @@ TEST_F(DomainValueTest, Scaling)
     auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
     auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());
     ASSERT_EQ(value1InCommonDomainP->getValue(), 2000000u);
-    
+
     auto value1BackInRegularDomain = value1InCommonDomain->fromCommonDomain(domain1);
     auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1BackInRegularDomain.get());
     ASSERT_EQ(value1BackInRegularDomainP->getValue(), 10000u);
@@ -147,9 +147,9 @@ TEST_F(DomainValueTest, Offset)
     std::string commonEpochString = "1970-01-01T00:00:00+00:00";
     std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
     daq::RatioPtr commonResolution = daq::Ratio(1, 1000);
-    
+
     daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
-    
+
     std::string epochString1 = "1970-01-01T00:00:50+00:00";
     std::chrono::system_clock::time_point epoch1 = daq::reader::parseEpoch(epochString1);
     daq::RatioPtr resolution1 = daq::Ratio(1, 1000);
@@ -162,7 +162,7 @@ TEST_F(DomainValueTest, Offset)
     auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());
     ASSERT_EQ(value1InCommonDomainP->getValue(), 63000u);
     ASSERT_EQ(value1InCommonDomainP->getDomain(), commonDomain);
-    
+
     auto value1BackInRegularDomain = value1InCommonDomain->fromCommonDomain(domain1);
     auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1BackInRegularDomain.get());
     ASSERT_EQ(value1BackInRegularDomainP->getValue(), 13000u);
@@ -174,9 +174,9 @@ TEST_F(DomainValueTest, SameDomainSameType)
     std::string commonEpochString = "1970-01-01T00:00:00+00:00";
     std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
     daq::RatioPtr commonResolution = daq::Ratio(1, 1000);
-    
+
     daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
-    
+
     std::string epochString1 = "1970-01-01T00:00:50+00:00";
     std::chrono::system_clock::time_point epoch1 = daq::reader::parseEpoch(epochString1);
     daq::RatioPtr resolution1 = daq::Ratio(1, 1000);
@@ -185,8 +185,8 @@ TEST_F(DomainValueTest, SameDomainSameType)
     auto value1 = std::make_unique<daq::DomainValueImpl<daq::Int>>(domain1, 13000);
     daq::DomainValue* value1P = value1.get();
     auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
-    auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());    
-    
+    auto* value1InCommonDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1InCommonDomain.get());
+
     ASSERT_THROW((void)(*value1P < *value1InCommonDomainP), daq::InvalidParameterException);
 
     auto value2 = std::make_unique<daq::DomainValueImpl<daq::UInt>>(domain1, 1213000);
@@ -209,7 +209,7 @@ TEST_F(DomainValueTest, RealisticTimeStamp)
 
     auto value1 = std::make_unique<daq::DomainValueImpl<daq::Int>>(domain1, 50000001);
     auto value1InCommonDomain = value1->toCommonDomain(commonDomain);
-    
+
     auto value1BackInRegularDomain = value1InCommonDomain->fromCommonDomain(domain1);
     auto* value1BackInRegularDomainP = dynamic_cast<daq::DomainValueImpl<daq::Int>*>(value1BackInRegularDomain.get());
     ASSERT_EQ(value1BackInRegularDomainP->getValue(), value1->getValue());
@@ -232,7 +232,7 @@ TEST_F(DomainValueTest, NonRepresentibleConversions)
     // TODO: For the domain value finding it would probably be required that during a lossful conversion fine1->coarse->fine2
     // where coars == fine2 (but in different domains) it also holds that fine2 >= fine1. Because then if we find index that
     // satisfies domain[index] >= coarse we found the correct one. Right now the situation is reversed, lossful conversion
-    // rounds down. 
+    // rounds down.
     ASSERT_FALSE(*valueInFine < *valueBackInFine);
 
 }

--- a/core/opendaq/reader/tests/test_domain_value.cpp
+++ b/core/opendaq/reader/tests/test_domain_value.cpp
@@ -228,13 +228,50 @@ TEST_F(DomainValueTest, NonRepresentibleConversions)
     daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
     daq::DomainInfo coarseDomain = {commonEpoch, coarseResolution};
 
-    std::unique_ptr<daq::DomainValue> valueInFine = std::make_unique<daq::DomainValueImpl<daq::Int>>(commonDomain, 1002);
-    auto valueInCoarse = valueInFine->fromCommonDomain(coarseDomain);
-    auto valueBackInFine = valueInCoarse->toCommonDomain(commonDomain);
+    {
+        std::unique_ptr<daq::DomainValue> valueInFine = std::make_unique<daq::DomainValueImpl<daq::Int>>(commonDomain, 1002); // 1002 / 1 000 000
+        auto valueInCoarse = valueInFine->fromCommonDomain(coarseDomain); // 1 / 1 000
+        auto valueBackInFine = valueInCoarse->toCommonDomain(commonDomain); // 1 000 / 1 000 000
+    
+        // During a lossful conversion fine1->coarse->fine2 where coarse == fine2 it may be fine2 != fine1. Currently, the nearest tick is taken in the coarse domain.
+        // It may be required that if we find index that satisfies domain[index] >= coarse we found the correct sample.
+        // Rounding down case
+        ASSERT_FALSE(*valueInFine < *valueBackInFine);
+    }
 
-    // TODO: For the domain value finding it would probably be required that during a lossful conversion fine1->coarse->fine2
-    // where coars == fine2 (but in different domains) it also holds that fine2 >= fine1. Because then if we find index that
-    // satisfies domain[index] >= coarse we found the correct one. Right now the situation is reversed, lossful conversion
-    // rounds down.
-    ASSERT_FALSE(*valueInFine < *valueBackInFine);
+    {
+        std::unique_ptr<daq::DomainValue> valueInFine = std::make_unique<daq::DomainValueImpl<daq::Int>>(commonDomain, 998); // 998 / 1 000 000
+        auto valueInCoarse = valueInFine->fromCommonDomain(coarseDomain); // 1 / 1 000
+        auto valueBackInFine = valueInCoarse->toCommonDomain(commonDomain); // 1 000 / 1 000 000
+    
+        // Rounding up case
+        ASSERT_TRUE(*valueInFine < *valueBackInFine);
+    }
+}
+
+TEST_F(DomainValueTest, NonRepresentibleConversions2)
+{
+    std::string commonEpochString = "1970-01-01T00:00:00+00:00";
+    std::chrono::system_clock::time_point commonEpoch = daq::reader::parseEpoch(commonEpochString);
+    daq::RatioPtr commonResolution = daq::Ratio(1, 7);
+    daq::RatioPtr coarseResolution = daq::Ratio(1, 3);
+
+    daq::DomainInfo commonDomain = {commonEpoch, commonResolution};
+    daq::DomainInfo coarseDomain = {commonEpoch, coarseResolution};
+
+    {
+        std::unique_ptr<daq::DomainValue> valueInFine = std::make_unique<daq::DomainValueImpl<daq::Int>>(commonDomain, 2);
+        auto valueInCoarse = valueInFine->fromCommonDomain(coarseDomain);
+        auto valueBackInFine = valueInCoarse->toCommonDomain(commonDomain);
+    
+        ASSERT_FALSE(*valueInFine < *valueBackInFine || *valueBackInFine < *valueInFine);
+    }
+    
+    {
+        std::unique_ptr<daq::DomainValue> valueInCoarse = std::make_unique<daq::DomainValueImpl<daq::Int>>(coarseDomain, 5);
+        auto valueInFine = valueInCoarse->toCommonDomain(commonDomain);
+        auto valueBackInCoarse = valueInFine->fromCommonDomain(coarseDomain);
+    
+        ASSERT_FALSE(*valueInCoarse < *valueBackInCoarse || *valueBackInCoarse < *valueInCoarse);
+    }
 }

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -955,6 +955,70 @@ TEST_F(MultiReaderTest, Clock10kHzDelta10)
     ASSERT_THAT(time[2], ElementsAreArray(time[0]));
 }
 
+TEST_F(MultiReaderTest, Clock15MHzFromEpoch)
+{
+    constexpr const auto NUM_SIGNALS = 3;
+
+    // prevent vector from re-allocating, so we have "stable" pointers
+    readSignals.reserve(3);
+
+    Int clock = 15000000;
+    Int startOffest = 1781269748ll * clock;
+    auto& sig0 = addSignal(startOffest, 6093750, createDomainSignal("1970-01-01T00:00:00+00:00", Ratio(1, clock)));
+    auto& sig1 = addSignal(startOffest, 2812500, createDomainSignal("1970-01-01T00:00:00+00:00", Ratio(1, clock)));
+    auto& sig2 = addSignal(startOffest, 3750000, createDomainSignal("1970-01-01T00:00:00+00:00", Ratio(1, clock)));
+
+    auto multi = MultiReaderBuilder()
+                     .setStartOnFullUnitOfDomain(true)
+                     .setInputPortNotificationMethod(PacketReadyNotification::SameThread)
+                     .addSignals(signalsToList())
+                     .build();
+
+    {
+        SizeT count{0};
+        auto status = multi.read(nullptr, &count);
+        ASSERT_EQ(status.getReadStatus(), ReadStatus::Event);
+    }
+
+    auto available = multi.getAvailableCount();
+    ASSERT_EQ(available, 0u);
+
+    sig0.createAndSendPacket(0);
+    sig1.createAndSendPacket(0);
+    sig2.createAndSendPacket(0);
+
+    sig0.createAndSendPacket(1);
+    sig1.createAndSendPacket(1);
+    sig2.createAndSendPacket(1);
+
+    sig0.createAndSendPacket(2);
+    sig1.createAndSendPacket(2);
+    sig2.createAndSendPacket(2);
+
+    available = multi.getAvailableCount();
+    ASSERT_EQ(available, 2812500 * 3);
+
+    constexpr const SizeT SAMPLES = 5u;
+
+    std::array<double[SAMPLES], NUM_SIGNALS> values{};
+    std::array<ClockTick[SAMPLES], NUM_SIGNALS> domain{};
+
+    void* valuesPerSignal[NUM_SIGNALS]{values[0], values[1], values[2]};
+    void* domainPerSignal[NUM_SIGNALS]{domain[0], domain[1], domain[2]};
+
+    SizeT count{SAMPLES};
+    multi.readWithDomain(valuesPerSignal, domainPerSignal, &count);
+
+    ASSERT_EQ(count, SAMPLES);
+
+    std::array<std::chrono::system_clock::time_point[SAMPLES], NUM_SIGNALS> time{};
+    printData<std::chrono::microseconds>(SAMPLES, time, values, domain);
+
+    ASSERT_THAT(time[1], ElementsAreArray(time[0]));
+    ASSERT_THAT(time[2], ElementsAreArray(time[0]));
+}
+
+
 TEST_F(MultiReaderTest, Clock10kHzDelta10Relative)
 {
     constexpr const auto NUM_SIGNALS = 3;

--- a/core/opendaq/reader/tests/test_typed_reading.cpp
+++ b/core/opendaq/reader/tests/test_typed_reading.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+
+#include <coretypes/exceptions.h>
+#include <coretypes/ratio_factory.h>
+#include <coreobjects/unit_factory.h>
+
+#include <opendaq/data_descriptor_factory.h>
+#include <opendaq/data_rule_factory.h>
+#include <opendaq/domain_value.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/reader_utils.h>
+#include <opendaq/typed_reading_utils.h>
+
+
+#include <chrono>
+
+using TypedReadingTest = testing::Test;
+
+TEST_F(TypedReadingTest, LinearRuleDomainReading)
+{
+
+    daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
+    daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
+                                                .setSampleType(daq::SampleType::UInt64)
+                                                .setRule(daq::LinearDataRule(1'000'000, 0))
+                                                .setTickResolution(resolution)
+                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                .setOrigin("1970-01-01T00:00:00")
+                                                .setName("Time")
+                                                .build();
+
+    daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, 100, 115);
+
+    daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
+    daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
+    std::unique_ptr<daq::DomainValue> domainStart = daq::TypedReadingUtils::readDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, 12, domainInfo);
+
+    auto *domainStartP = dynamic_cast<daq::DomainValueImpl<daq::UInt>*>(domainStart.get());
+    ASSERT_FALSE(domainStartP == nullptr);
+
+    ASSERT_EQ(domainStartP->getValue(), 12'000'115u);
+}
+
+TEST_F(TypedReadingTest, ExplicitRuleDomainReading)
+{
+
+    daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
+    daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
+                                                .setSampleType(daq::SampleType::UInt64)
+                                                .setTickResolution(resolution)
+                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                .setOrigin("1970-01-01T00:00:00")
+                                                .setName("Time")
+                                                .build();
+
+    constexpr daq::SizeT packetSize = 100;
+    daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, packetSize, 0);
+    daq::UInt* data = static_cast<daq::UInt*>(domainPacket.getRawData());
+    for (daq::SizeT i = 0; i < packetSize; ++i)
+    {
+        data[i] = 112 + 1'000'000 * i;
+    }
+
+    daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
+    daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
+    std::unique_ptr<daq::DomainValue> domainStart = daq::TypedReadingUtils::readDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, 12, domainInfo);
+
+    auto *domainStartP = dynamic_cast<daq::DomainValueImpl<daq::UInt>*>(domainStart.get());
+    ASSERT_FALSE(domainStartP == nullptr);
+
+    ASSERT_EQ(domainStartP->getValue(), 12'000'112u);
+}
+
+TEST_F(TypedReadingTest, LinearRuleFindDomain)
+{
+
+    daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
+    daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
+                                                .setSampleType(daq::SampleType::UInt64)
+                                                .setRule(daq::LinearDataRule(1'000'000, 0))
+                                                .setTickResolution(resolution)
+                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                .setOrigin("1970-01-01T00:00:00")
+                                                .setName("Time")
+                                                .build();
+
+    daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, 100, 1'000'000'115);
+
+    daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
+    daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
+    std::unique_ptr<daq::DomainValue> domainTarget = std::make_unique<daq::DomainValueImpl<daq::UInt>>(domainInfo, 1'009'000'115);
+    daq::SizeT index = daq::TypedReadingUtils::findDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, domainTarget.get());
+
+    ASSERT_EQ(index, 9u);
+}
+
+TEST_F(TypedReadingTest, ExplicitRuleFindDomain)
+{
+
+    daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
+    daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
+                                                .setSampleType(daq::SampleType::UInt64)
+                                                .setTickResolution(resolution)
+                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                .setOrigin("1970-01-01T00:00:00")
+                                                .setName("Time")
+                                                .build();
+
+    constexpr daq::SizeT packetSize = 100;
+    daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, packetSize, 0);
+    daq::UInt* data = static_cast<daq::UInt*>(domainPacket.getRawData());
+    for (daq::SizeT i = 0; i < packetSize; ++i)
+    {
+        data[i] = 1'000'000'112 + 1'000'000 * i;
+    }
+
+    daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
+    daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
+    std::unique_ptr<daq::DomainValue> domainTarget = std::make_unique<daq::DomainValueImpl<daq::UInt>>(domainInfo, 1'012'000'112);
+    daq::SizeT index = daq::TypedReadingUtils::findDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, domainTarget.get());
+
+    ASSERT_EQ(index, 12u);
+}
+
+TEST_F(TypedReadingTest, ExplicitRuleReadData)
+{
+
+    daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
+    daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
+                                                .setSampleType(daq::SampleType::UInt64)
+                                                .setTickResolution(resolution)
+                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                .setOrigin("1970-01-01T00:00:00")
+                                                .setName("Time")
+                                                .build();
+
+    constexpr daq::SizeT packetSize = 15;
+    daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, packetSize, 0);
+    daq::UInt* data = static_cast<daq::UInt*>(domainPacket.getRawData());
+    for (daq::SizeT i = 0; i < packetSize; ++i)
+    {
+        data[i] = 1'000'000'119 + 1'000'000 * i;
+    }
+
+    daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
+    daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
+
+    std::vector<daq::UInt> buffer(packetSize);
+    for (int i = 0; i < packetSize; ++i)
+    {
+        void* bufferP = buffer.data();
+        daq::SizeT count = packetSize - i;
+        daq::ErrCode err = daq::TypedReadingUtils::readData(daq::SampleType::UInt64,
+                                                            daq::SampleType::UInt64,
+                                                            true,
+                                                            readLayout, 
+                                                            domainPacket.getRawData(),
+                                                            i,
+                                                            &bufferP,
+                                                            count);
+        
+        for (daq::SizeT j = 0; j < count; ++j)
+        {
+            ASSERT_EQ(buffer[j], data[i+j]);
+        }
+    }
+}

--- a/core/opendaq/reader/tests/test_typed_reading.cpp
+++ b/core/opendaq/reader/tests/test_typed_reading.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
 
+#include <coreobjects/unit_factory.h>
 #include <coretypes/exceptions.h>
 #include <coretypes/ratio_factory.h>
-#include <coreobjects/unit_factory.h>
+
 
 #include <opendaq/data_descriptor_factory.h>
 #include <opendaq/data_rule_factory.h>
@@ -11,31 +12,30 @@
 #include <opendaq/reader_utils.h>
 #include <opendaq/typed_reading_utils.h>
 
-
 #include <chrono>
 
 using TypedReadingTest = testing::Test;
 
 TEST_F(TypedReadingTest, LinearRuleDomainReading)
 {
-
     daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
     daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
-                                                .setSampleType(daq::SampleType::UInt64)
-                                                .setRule(daq::LinearDataRule(1'000'000, 0))
-                                                .setTickResolution(resolution)
-                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
-                                                .setOrigin("1970-01-01T00:00:00")
-                                                .setName("Time")
-                                                .build();
+                                                  .setSampleType(daq::SampleType::UInt64)
+                                                  .setRule(daq::LinearDataRule(1'000'000, 0))
+                                                  .setTickResolution(resolution)
+                                                  .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                  .setOrigin("1970-01-01T00:00:00")
+                                                  .setName("Time")
+                                                  .build();
 
     daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, 100, 115);
 
     daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
     daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
-    std::unique_ptr<daq::DomainValue> domainStart = daq::TypedReadingUtils::readDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, 12, domainInfo);
+    std::unique_ptr<daq::DomainValue> domainStart =
+        daq::TypedReadingUtils::readDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, 12, domainInfo);
 
-    auto *domainStartP = dynamic_cast<daq::DomainValueImpl<daq::UInt>*>(domainStart.get());
+    auto* domainStartP = dynamic_cast<daq::DomainValueImpl<daq::UInt>*>(domainStart.get());
     ASSERT_FALSE(domainStartP == nullptr);
 
     ASSERT_EQ(domainStartP->getValue(), 12'000'115u);
@@ -43,15 +43,14 @@ TEST_F(TypedReadingTest, LinearRuleDomainReading)
 
 TEST_F(TypedReadingTest, ExplicitRuleDomainReading)
 {
-
     daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
     daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
-                                                .setSampleType(daq::SampleType::UInt64)
-                                                .setTickResolution(resolution)
-                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
-                                                .setOrigin("1970-01-01T00:00:00")
-                                                .setName("Time")
-                                                .build();
+                                                  .setSampleType(daq::SampleType::UInt64)
+                                                  .setTickResolution(resolution)
+                                                  .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                  .setOrigin("1970-01-01T00:00:00")
+                                                  .setName("Time")
+                                                  .build();
 
     constexpr daq::SizeT packetSize = 100;
     daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, packetSize, 0);
@@ -63,9 +62,10 @@ TEST_F(TypedReadingTest, ExplicitRuleDomainReading)
 
     daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
     daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
-    std::unique_ptr<daq::DomainValue> domainStart = daq::TypedReadingUtils::readDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, 12, domainInfo);
+    std::unique_ptr<daq::DomainValue> domainStart =
+        daq::TypedReadingUtils::readDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, 12, domainInfo);
 
-    auto *domainStartP = dynamic_cast<daq::DomainValueImpl<daq::UInt>*>(domainStart.get());
+    auto* domainStartP = dynamic_cast<daq::DomainValueImpl<daq::UInt>*>(domainStart.get());
     ASSERT_FALSE(domainStartP == nullptr);
 
     ASSERT_EQ(domainStartP->getValue(), 12'000'112u);
@@ -73,38 +73,37 @@ TEST_F(TypedReadingTest, ExplicitRuleDomainReading)
 
 TEST_F(TypedReadingTest, LinearRuleFindDomain)
 {
-
     daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
     daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
-                                                .setSampleType(daq::SampleType::UInt64)
-                                                .setRule(daq::LinearDataRule(1'000'000, 0))
-                                                .setTickResolution(resolution)
-                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
-                                                .setOrigin("1970-01-01T00:00:00")
-                                                .setName("Time")
-                                                .build();
+                                                  .setSampleType(daq::SampleType::UInt64)
+                                                  .setRule(daq::LinearDataRule(1'000'000, 0))
+                                                  .setTickResolution(resolution)
+                                                  .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                  .setOrigin("1970-01-01T00:00:00")
+                                                  .setName("Time")
+                                                  .build();
 
     daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, 100, 1'000'000'115);
 
     daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
     daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
     std::unique_ptr<daq::DomainValue> domainTarget = std::make_unique<daq::DomainValueImpl<daq::UInt>>(domainInfo, 1'009'000'115);
-    daq::SizeT index = daq::TypedReadingUtils::findDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, domainTarget.get());
+    daq::SizeT index = daq::TypedReadingUtils::findDomainValue(
+        daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, domainTarget.get());
 
     ASSERT_EQ(index, 9u);
 }
 
 TEST_F(TypedReadingTest, ExplicitRuleFindDomain)
 {
-
     daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
     daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
-                                                .setSampleType(daq::SampleType::UInt64)
-                                                .setTickResolution(resolution)
-                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
-                                                .setOrigin("1970-01-01T00:00:00")
-                                                .setName("Time")
-                                                .build();
+                                                  .setSampleType(daq::SampleType::UInt64)
+                                                  .setTickResolution(resolution)
+                                                  .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                  .setOrigin("1970-01-01T00:00:00")
+                                                  .setName("Time")
+                                                  .build();
 
     constexpr daq::SizeT packetSize = 100;
     daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, packetSize, 0);
@@ -117,22 +116,22 @@ TEST_F(TypedReadingTest, ExplicitRuleFindDomain)
     daq::ReadLayout readLayout = daq::TypedReadingUtils::createReadLayout(domainDescriptor);
     daq::DomainInfo domainInfo = daq::DomainInfo::fromDescriptor(domainDescriptor);
     std::unique_ptr<daq::DomainValue> domainTarget = std::make_unique<daq::DomainValueImpl<daq::UInt>>(domainInfo, 1'012'000'112);
-    daq::SizeT index = daq::TypedReadingUtils::findDomainValue(daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, domainTarget.get());
+    daq::SizeT index = daq::TypedReadingUtils::findDomainValue(
+        daq::SampleType::UInt64, daq::SampleType::UInt64, readLayout, domainPacket, domainTarget.get());
 
     ASSERT_EQ(index, 12u);
 }
 
 TEST_F(TypedReadingTest, ExplicitRuleReadData)
 {
-
     daq::RatioPtr resolution = daq::Ratio(1, 1'000'000'000);
     daq::DataDescriptorPtr domainDescriptor = daq::DataDescriptorBuilder()
-                                                .setSampleType(daq::SampleType::UInt64)
-                                                .setTickResolution(resolution)
-                                                .setUnit(daq::Unit("s", -1, "seconds", "time"))
-                                                .setOrigin("1970-01-01T00:00:00")
-                                                .setName("Time")
-                                                .build();
+                                                  .setSampleType(daq::SampleType::UInt64)
+                                                  .setTickResolution(resolution)
+                                                  .setUnit(daq::Unit("s", -1, "seconds", "time"))
+                                                  .setOrigin("1970-01-01T00:00:00")
+                                                  .setName("Time")
+                                                  .build();
 
     constexpr daq::SizeT packetSize = 15;
     daq::DataPacketPtr domainPacket = daq::DataPacket(domainDescriptor, packetSize, 0);
@@ -150,18 +149,12 @@ TEST_F(TypedReadingTest, ExplicitRuleReadData)
     {
         void* bufferP = buffer.data();
         daq::SizeT count = packetSize - i;
-        daq::ErrCode err = daq::TypedReadingUtils::readData(daq::SampleType::UInt64,
-                                                            daq::SampleType::UInt64,
-                                                            true,
-                                                            readLayout, 
-                                                            domainPacket.getRawData(),
-                                                            i,
-                                                            &bufferP,
-                                                            count);
-        
+        daq::ErrCode err = daq::TypedReadingUtils::readData(
+            daq::SampleType::UInt64, daq::SampleType::UInt64, true, readLayout, domainPacket.getRawData(), i, &bufferP, count);
+
         for (daq::SizeT j = 0; j < count; ++j)
         {
-            ASSERT_EQ(buffer[j], data[i+j]);
+            ASSERT_EQ(buffer[j], data[i + j]);
         }
     }
 }


### PR DESCRIPTION
# Brief

Replace `Comparable` and `TypedReader` with a new system.

# Description

There is a hierarchy of classes in terms of responsibilities from upper to lower level: `MultiReader -> SignalReader -> TypedReader` and `Comparable` class that is intertwined through all of them. The `Comparable` class depends on knowing at its creation what the common domain is. But common domain can only be determined at the `MultiReader` level and it is unreasonable to have it sent down and up the call stack.

Furthermore, while the common domain is needed and used in the current system, there is a concrete need to access the "native value" in the native domain of a signal. Therefore, I propose that common domain is a concept limited to the `MultiReader` level (multipliers and domain offsets with it), which will also be responsible for conversions between domains. To achieve this, I introduce `DomainValue` class that has the same implementation pattern (non-templated base class and templated implementation) with the following abilities:
- create a `DomainValue` object without knowledge of a "common domain"
- convert to common domain by returning a new object (instead of having conversion auxiliaries built in. Conversion to common domain can assume an earlier epoch and a finer resolution (domain time period).
- convert from common domain to an arbitrary domain. This is effectively done all the time in the current implementation, but it is implicit. By making this explicit, we can easily test it and have a better defined behavior. When converting to a more coarse domain some domain values are not exactly representable - it is important to know which tick is selected during conversion and this approach enables detailed testing of this.
- templated implementation has a `getValue` getter to the raw underlying tick. This is of the same type as the timestamps in domain data packets and will enable much simpler comparisons without conversion taking most of the implementors attention at the data packet level.

`TypedReader` class mainly serves to perform a runtime dispatch to compile-time generated templated functions. Essentially, there is a need (at runtime) to convert two sample types `(inputSampleType, outputSampleType)` into corresponding compile-time types in a function template `readData<InputT, OutputT>`. This was done in two stages - one at creation of the `Reader` and one by setting deduced data type and then calling a member function. The result was a repeated usage of switch statements, the need to pass descriptor changes down to the class etc.

This is not needed, as apart from the type dispatch, `TypedReader` has very little state (mostly stateless) that can be passed into static methods as a lightweight context. Therefore I propose a set of static methods with generalized signature `readData(inputSampleType, outputSampleType, context, ...args...)`. The dispatch is implemented generically and there is a way to impose rules based on sample types (separately for domain). There are only three methods:
- `readDomainValue(..., domainPacket, index, domainInfo)`
- `findDomainValue(..., domainPacket, target, firstSampleAbsoluteTime = nullptr)`
- `readData(..., inputBuffer, offset, outputBuffer, count, transform = nullptr)`

The optimizations for linear data rule can be contained inside as soon as we pass the entire packet down to the function.

Limitations:
- all domains have to be of the same type (e. g. all signals must have int64 domains, int32 and int64 domains are not compatible) [existing limitation]