### PR TITLE
Inspect descriptor to allocate buffers for vector signals

### DIFF
--- a/bindings/python/opendaq/generated/reader/py_stream_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_stream_reader.cpp
@@ -36,6 +36,14 @@ void defineIStreamReader(pybind11::module_ m, PyDaqIntf<daq::IStreamReader, daq:
         {
             PyTypedReader::checkTypes(valueType, domainType);
             const auto signalPtr = daq::SignalPtr::Borrow(signal);
+            auto descriptor = signalPtr.getDescriptor();
+            if (skipEvents == daq::True && descriptor.assigned()){
+                auto dimensions = descriptor.getDimensions();
+                if (dimensions.assigned() && dimensions.getCount() > 0)
+                {
+                    throw std::runtime_error("Stream reader: skipEvents must be false when reading vector data.");
+                }
+            }
             return daq::StreamReaderFromBuilder_Create(daq::StreamReaderBuilder()
                     .setSignal(signal)
                     .setValueReadType(valueType)

--- a/bindings/python/opendaq/generated/reader/py_stream_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_stream_reader.cpp
@@ -37,7 +37,8 @@ void defineIStreamReader(pybind11::module_ m, PyDaqIntf<daq::IStreamReader, daq:
             PyTypedReader::checkTypes(valueType, domainType);
             const auto signalPtr = daq::SignalPtr::Borrow(signal);
             auto descriptor = signalPtr.getDescriptor();
-            if (skipEvents == daq::True && descriptor.assigned()){
+            if (skipEvents == daq::True && descriptor.assigned())
+            {
                 auto dimensions = descriptor.getDimensions();
                 if (dimensions.assigned() && dimensions.getCount() > 0)
                 {

--- a/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
+++ b/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
@@ -500,26 +500,30 @@ private:
         assignDescriptorsFromStatus(reader, status);
 
         py::gil_scoped_acquire acquire;
-        py::array::ShapeContainer shape;
+        py::array::ShapeContainer domainShape;
+        py::array::ShapeContainer valueShape;
         if (blockSize > 1)
         {
             if (!isMultiReader)
             {
+                domainShape = {count, blockSize};
                 // BlockReader: count is the number of blocks successfully read.
                 // A block has blockSize samples and each sample consists of valuesPerSample values (=1 for scalar signals)
-                shape = {count, blockSize*valuesPerSample};
+                valueShape = {count, blockSize*valuesPerSample};
             }
             else
             {
+                domainShape = {blockSize, count};
                 // MultiReader: blockSize is the number of signals we read from.
                 // Count is the number of samples that were read. Each sample consists of valuesPerSample values.
-                shape = {blockSize, count*valuesPerSample};
+                valueShape = {blockSize, count*valuesPerSample};
             }
         }
         else
         {
+            domainShape = {count};
             // Normal reading: we read N=count samples and each samples has valuesPerSample values.
-            shape = {count*valuesPerSample};
+            valueShape = {count*valuesPerSample};
         }
 
         py::array::StridesContainer valuesStrides;
@@ -553,8 +557,8 @@ private:
                            });
         }
 
-        auto valuesArray = toPyArray(std::move(values), shape, valuesStrides, dtype);
-        auto domainArray = toPyArray(std::move(domain), shape, domainStrides, domainDtype);
+        auto valuesArray = toPyArray(std::move(values), valueShape, valuesStrides, dtype);
+        auto domainArray = toPyArray(std::move(domain), domainShape, domainStrides, domainDtype);
 
         return returnStatus
                    ? SampleTypeDomainTypeReaderStatusVariant<ReaderType>{std::make_tuple(

--- a/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
+++ b/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
@@ -303,13 +303,14 @@ private:
         if constexpr (isSampleTypeStruct)
         {
             if (!dataDescriptor.assigned())
-            throw std::runtime_error("Data descriptor should be assigned when sample type is Struct");
+                throw std::runtime_error("Data descriptor should be assigned when sample type is Struct");
             sampleSize = dataDescriptor.getSampleSize();
         }
         if (dataDescriptor.assigned() && dataDescriptor.getDimensions().assigned())
         {
             auto dimensions = dataDescriptor.getDimensions();
-            if (dimensions.getCount() > 1){
+            if (dimensions.getCount() > 1)
+            {
                 throw std::runtime_error("Typed reading: cannot read matrix/tensor data.");
             }
             if (dimensions.getCount() == 1)
@@ -362,21 +363,23 @@ private:
         {
             if (!isMultiReader)
             {
-                shape = {count, blockSize};
+                shape = {count, blockSize*valuesPerSample};
             }
             else
             {
-                shape = {blockSize, count};
+                shape = {blockSize, count*valuesPerSample};
             }
         }
         else
-            shape = {count};
+        {
+            shape = {count*valuesPerSample};
+        }
 
-        py::array::StridesContainer strides;
+        py::array::StridesContainer strides = {};
         if (blockSize > 1 && isMultiReader)
         {
             const size_t valueSize = isSampleTypeStruct ? sampleSize : sizeof(SampleType);
-            strides = {valueSize * initialCount, valueSize};
+            strides = {valueSize * initialCount * valuesPerSample, valueSize};
         }
 
         py::dtype dtype{};
@@ -425,7 +428,8 @@ private:
         if (dataDescriptor.assigned() && dataDescriptor.getDimensions().assigned())
         {
             auto dimensions = dataDescriptor.getDimensions();
-            if (dimensions.getCount() > 1){
+            if (dimensions.getCount() > 1)
+            {
                 throw std::runtime_error("Typed reading: cannot read matrix/tensor data.");
             }
             if (dimensions.getCount() == 1)
@@ -480,15 +484,17 @@ private:
         {
             if (!isMultiReader)
             {
-                shape = {count, blockSize};
+                shape = {count, blockSize*valuesPerSample};
             }
             else
             {
-                shape = {blockSize, count};
+                shape = {blockSize, count*valuesPerSample};
             }
         }
         else
-            shape = {count};
+        {
+            shape = {count*valuesPerSample};
+        }
 
         py::array::StridesContainer valuesStrides;
         py::array::StridesContainer domainStrides;
@@ -496,7 +502,7 @@ private:
         {
             const size_t valueSize = isValueSampleTypeStruct ? sampleSize : sizeof(ValueSampleType);
             const size_t domainSize = sizeof(DomainSampleType);
-            valuesStrides = {valueSize * initialCount, valueSize};
+            valuesStrides = {valueSize * initialCount * valuesPerSample, valueSize};
             domainStrides = {domainSize * initialCount, domainSize};
         }
 

--- a/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
+++ b/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
@@ -146,10 +146,9 @@ struct PyTypedReader
         daq::SampleType valueType = daq::SampleType::Undefined;
         reader->getValueReadType(&valueType);
 
-        daq::DataDescriptorPtr dataDescriptor;
+        daq::DataDescriptorPtr dataDescriptor = getDescriptor<ReaderType>(reader, VALUE_DATA_DESCRIPTOR_ATTRIBUTE);
         if (valueType == daq::SampleType::Undefined || valueType == daq::SampleType::Struct)
         {
-            dataDescriptor = getDescriptor<ReaderType>(reader, VALUE_DATA_DESCRIPTOR_ATTRIBUTE);
             if (!dataDescriptor.assigned())
             {
                 auto status = readZeroValues(reader, timeoutMs);
@@ -163,25 +162,25 @@ struct PyTypedReader
         switch (valueType)
         {
             case daq::SampleType::Float32:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Float32>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Float32>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Float64:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Float64>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Float64>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt32:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt32>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt32>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int32:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int32>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int32>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt64:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt64>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt64>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int64:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int64>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int64>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt8:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt8>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt8>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int8:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int8>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int8>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt16:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt16>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::UInt16>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int16:
-                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int16>::Type>(reader, count, timeoutMs, returnStatus);
+                return readWithDomain<daq::SampleTypeToType<daq::SampleType::Int16>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Struct:
                 return readWithDomain<StructPlaceholder>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::RangeInt64:
@@ -412,7 +411,7 @@ private:
                        : SampleTypeDomainTypeReaderStatusVariant<ReaderType>{std::make_tuple(py::array{}, py::array{})};
         }
 
-        size_t blockSize = 1, sampleSize = 1;
+        size_t blockSize = 1, sampleSize = 1, valuesPerSample = 1;
         const size_t initialCount = count;
         constexpr const bool isMultiReader = std::is_base_of_v<daq::MultiReaderPtr, ReaderType>;
         constexpr const bool isValueSampleTypeStruct = std::is_same_v<ValueType, StructPlaceholder>;
@@ -422,6 +421,17 @@ private:
             if (!dataDescriptor.assigned())
                 throw std::runtime_error("Data descriptor should be assigned when sample type is Struct");
             sampleSize = dataDescriptor.getSampleSize();
+        }
+        if (dataDescriptor.assigned() && dataDescriptor.getDimensions().assigned())
+        {
+            auto dimensions = dataDescriptor.getDimensions();
+            if (dimensions.getCount() > 1){
+                throw std::runtime_error("Typed reading: cannot read matrix/tensor data.");
+            }
+            if (dimensions.getCount() == 1)
+            {
+                valuesPerSample = dimensions[0].getSize();
+            }
         }
         if constexpr (std::is_base_of_v<daq::BlockReaderPtr, ReaderType>)
         {
@@ -437,7 +447,7 @@ private:
         using ValueSampleType = typename SampleTypeToBufferType<ValueType>::Type;
         using DomainSampleType = typename SampleTypeToBufferType<DomainType>::Type;
         StatusType status;
-        std::vector<ValueSampleType> values(count * blockSize * sampleSize);
+        std::vector<ValueSampleType> values(count * blockSize * sampleSize * valuesPerSample);
         std::vector<DomainSampleType> domain(count * blockSize);
         if constexpr (ReaderHasReadWithTimeout<ReaderType>::value)
         {
@@ -446,7 +456,7 @@ private:
                 std::vector<void*> valuesPtrs(blockSize), domainPtrs(blockSize);
                 for (size_t i = 0; i < blockSize; i++)
                 {
-                    valuesPtrs[i] = values.data() + i * count * sampleSize;
+                    valuesPtrs[i] = values.data() + i * count * sampleSize * valuesPerSample;
                     domainPtrs[i] = domain.data() + i * count;
                 }
                 reader->readWithDomain(valuesPtrs.data(), domainPtrs.data(), &count, timeoutMs, &status);

--- a/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
+++ b/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
@@ -325,6 +325,7 @@ private:
         if constexpr (isMultiReader)
         {
             daq::ReaderConfigPtr readerConfig = reader.template asPtr<daq::IReaderConfig>();
+            // Block size is abused here to denote number of signals that are being read.
             blockSize = readerConfig.getInputPorts().getCount();
         }
 
@@ -332,6 +333,10 @@ private:
         using SampleType = typename SampleTypeToBufferType<ValueType>::Type;
 
         StatusType status;
+        // Allocate contiguous memory to fit all the samples.
+        // Block reader: count = number of blocks read, blockSize = number of samples in a block
+        // Multi reader: count = number of samples from each port, blockSize = number of signals being read at once
+        // Values per sample: each sample consists of valuesPerSample values - vector signal when valuesPerSample > 1
         std::vector<SampleType> values(count * blockSize * sampleSize * valuesPerSample);
         if constexpr (ReaderHasReadWithTimeout<ReaderType>::value)
         {
@@ -340,6 +345,7 @@ private:
                 std::vector<void*> ptrs(blockSize);
                 for (size_t i = 0; i < blockSize; i++)
                 {
+                    // Divide contiguous memory - one pointer to a section per signal each.
                     ptrs[i] = values.data() + i * count * sampleSize * valuesPerSample;
                 }
                 reader->read(ptrs.data(), &count, timeoutMs, &status);
@@ -363,21 +369,30 @@ private:
         {
             if (!isMultiReader)
             {
+                // BlockReader: count is the number of blocks successfully read.
+                // A block has blockSize samples and each sample consists of valuesPerSample values (=1 for scalar signals)
                 shape = {count, blockSize*valuesPerSample};
             }
             else
             {
+                // MultiReader: blockSize is the number of signals we read from.
+                // Count is the number of samples that were read. Each sample consists of valuesPerSample values.
                 shape = {blockSize, count*valuesPerSample};
             }
         }
         else
         {
+            // Normal reading: we read N=count samples and each samples has valuesPerSample values.
             shape = {count*valuesPerSample};
         }
 
         py::array::StridesContainer strides = {};
         if (blockSize > 1 && isMultiReader)
         {
+            // MultiReader: Strides must be adjusted, because the contiguous memory allocated is not "unused" just at the
+            // trailing end. The memory was divided into sections by passing pointers to the MultiReader. Regardles of how
+            // many samples were actually read, these sections are initialCount*valuesPerSample*valueSize apart, because
+            // they were divided so at allocation (before calling read).
             const size_t valueSize = isSampleTypeStruct ? sampleSize : sizeof(SampleType);
             strides = {valueSize * initialCount * valuesPerSample, valueSize};
         }
@@ -444,6 +459,7 @@ private:
         if constexpr (isMultiReader)
         {
             daq::ReaderConfigPtr readerConfig = reader.template asPtr<daq::IReaderConfig>();
+            // Block size is abused here to denote number of signals that are being read.
             blockSize = readerConfig.getInputPorts().getCount();
         }
 
@@ -451,6 +467,10 @@ private:
         using ValueSampleType = typename SampleTypeToBufferType<ValueType>::Type;
         using DomainSampleType = typename SampleTypeToBufferType<DomainType>::Type;
         StatusType status;
+        // Allocate contiguous memory to fit all the samples.
+        // Block reader: count = number of blocks read, blockSize = number of samples in a block
+        // Multi reader: count = number of samples from each port, blockSize = number of signals being read at once
+        // Values per sample: each sample consists of valuesPerSample values - vector signal when valuesPerSample > 1
         std::vector<ValueSampleType> values(count * blockSize * sampleSize * valuesPerSample);
         std::vector<DomainSampleType> domain(count * blockSize);
         if constexpr (ReaderHasReadWithTimeout<ReaderType>::value)
@@ -460,6 +480,7 @@ private:
                 std::vector<void*> valuesPtrs(blockSize), domainPtrs(blockSize);
                 for (size_t i = 0; i < blockSize; i++)
                 {
+                    // Divide contiguous memory - one pointer to a section for each signal.
                     valuesPtrs[i] = values.data() + i * count * sampleSize * valuesPerSample;
                     domainPtrs[i] = domain.data() + i * count;
                 }
@@ -484,15 +505,20 @@ private:
         {
             if (!isMultiReader)
             {
+                // BlockReader: count is the number of blocks successfully read.
+                // A block has blockSize samples and each sample consists of valuesPerSample values (=1 for scalar signals)
                 shape = {count, blockSize*valuesPerSample};
             }
             else
             {
+                // MultiReader: blockSize is the number of signals we read from.
+                // Count is the number of samples that were read. Each sample consists of valuesPerSample values.
                 shape = {blockSize, count*valuesPerSample};
             }
         }
         else
         {
+            // Normal reading: we read N=count samples and each samples has valuesPerSample values.
             shape = {count*valuesPerSample};
         }
 
@@ -500,6 +526,7 @@ private:
         py::array::StridesContainer domainStrides;
         if (blockSize > 1 && isMultiReader)
         {
+            // MultiReader: See the explanation in the no-domain version of this function.
             const size_t valueSize = isValueSampleTypeStruct ? sampleSize : sizeof(ValueSampleType);
             const size_t domainSize = sizeof(DomainSampleType);
             valuesStrides = {valueSize * initialCount * valuesPerSample, valueSize};

--- a/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
+++ b/bindings/python/opendaq/include/py_opendaq/py_typed_reader.h
@@ -89,10 +89,9 @@ struct PyTypedReader
         daq::SampleType valueType = daq::SampleType::Undefined;
         reader->getValueReadType(&valueType);
 
-        daq::DataDescriptorPtr dataDescriptor;
+        daq::DataDescriptorPtr dataDescriptor = getDescriptor<ReaderType>(reader, VALUE_DATA_DESCRIPTOR_ATTRIBUTE);
         if (valueType == daq::SampleType::Undefined || valueType == daq::SampleType::Struct)
         {
-            dataDescriptor = getDescriptor<ReaderType>(reader, VALUE_DATA_DESCRIPTOR_ATTRIBUTE);
             if (!dataDescriptor.assigned())
             {
                 auto status = readZeroValues(reader, timeoutMs);
@@ -106,25 +105,25 @@ struct PyTypedReader
         switch (valueType)
         {
             case daq::SampleType::Float32:
-                return read<daq::SampleTypeToType<daq::SampleType::Float32>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::Float32>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Float64:
-                return read<daq::SampleTypeToType<daq::SampleType::Float64>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::Float64>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt32:
-                return read<daq::SampleTypeToType<daq::SampleType::UInt32>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::UInt32>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int32:
-                return read<daq::SampleTypeToType<daq::SampleType::Int32>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::Int32>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt64:
-                return read<daq::SampleTypeToType<daq::SampleType::UInt64>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::UInt64>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int64:
-                return read<daq::SampleTypeToType<daq::SampleType::Int64>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::Int64>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt8:
-                return read<daq::SampleTypeToType<daq::SampleType::UInt8>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::UInt8>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int8:
-                return read<daq::SampleTypeToType<daq::SampleType::Int8>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::Int8>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::UInt16:
-                return read<daq::SampleTypeToType<daq::SampleType::UInt16>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::UInt16>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Int16:
-                return read<daq::SampleTypeToType<daq::SampleType::Int16>::Type>(reader, count, timeoutMs, returnStatus);
+                return read<daq::SampleTypeToType<daq::SampleType::Int16>::Type>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::Struct:
                 return read<StructPlaceholder>(reader, count, timeoutMs, returnStatus, dataDescriptor);
             case daq::SampleType::RangeInt64:
@@ -297,7 +296,7 @@ private:
                                 : SampleTypeReaderStatusVariant<ReaderType>{};
         }
 
-        size_t blockSize = 1, sampleSize = 1;
+        size_t blockSize = 1, sampleSize = 1, valuesPerSample = 1;
         const size_t initialCount = count;
         constexpr const bool isMultiReader = std::is_base_of_v<daq::MultiReaderPtr, ReaderType>;
         constexpr const bool isSampleTypeStruct = std::is_same_v<ValueType, StructPlaceholder>;
@@ -305,8 +304,19 @@ private:
         if constexpr (isSampleTypeStruct)
         {
             if (!dataDescriptor.assigned())
-                throw std::runtime_error("Data descriptor should be assigned when sample type is Struct");
+            throw std::runtime_error("Data descriptor should be assigned when sample type is Struct");
             sampleSize = dataDescriptor.getSampleSize();
+        }
+        if (dataDescriptor.assigned() && dataDescriptor.getDimensions().assigned())
+        {
+            auto dimensions = dataDescriptor.getDimensions();
+            if (dimensions.getCount() > 1){
+                throw std::runtime_error("Typed reading: cannot read matrix/tensor data.");
+            }
+            if (dimensions.getCount() == 1)
+            {
+                valuesPerSample = dimensions[0].getSize();
+            }
         }
         if constexpr (std::is_same_v<ReaderType, daq::BlockReaderPtr>)
         {
@@ -322,7 +332,7 @@ private:
         using SampleType = typename SampleTypeToBufferType<ValueType>::Type;
 
         StatusType status;
-        std::vector<SampleType> values(count * blockSize * sampleSize);
+        std::vector<SampleType> values(count * blockSize * sampleSize * valuesPerSample);
         if constexpr (ReaderHasReadWithTimeout<ReaderType>::value)
         {
             if constexpr (isMultiReader)
@@ -330,7 +340,7 @@ private:
                 std::vector<void*> ptrs(blockSize);
                 for (size_t i = 0; i < blockSize; i++)
                 {
-                    ptrs[i] = values.data() + i * count * sampleSize;
+                    ptrs[i] = values.data() + i * count * sampleSize * valuesPerSample;
                 }
                 reader->read(ptrs.data(), &count, timeoutMs, &status);
             }

--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,7 @@
 
 ## Bug fixes
 
+- [#1219](https://github.com/openDAQ/openDAQ/pull/1219) Fixes reading vector signals with stream reader in python.
 - [#1214](https://github.com/openDAQ/openDAQ/pull/1214) Fixes the order in which packets are enqueued in sendPackets. They are now always correctly enqueued front-to-back.
 - [#1213](https://github.com/openDAQ/openDAQ/pull/1213) Forward device locked state core event in native client.
 - [#1205](https://github.com/openDAQ/openDAQ/pull/1205) Fix raw socket access exception on Linux/macOS for non-root users


### PR DESCRIPTION
# Brief

Inspect signal descriptor to allocate buffer for reading vector signals.
Additional requirement: StreamReader must be constructed with `skipEvents=False` for this to work. An exception will be thrown when attempting to skip events with vector signals. An exception will be thrown if matrix signals are attempted to be read (typed reading only supports vectors).

In Python use:

```python
reader = daq.StreamReader(signal, skip_events=False)

# Somewhere vector signal sends a packet with vector descriptor
# DataDescriptor(..., dimensions = [Dimension(..., (0, 1, 4096))], ...)
# This means each sample is a vector with 4096 values

reader.read(0) # read events first (clear them from queue)
values = reader.read(1) # read the first sample,
# Alternatively, you can use
values, domain_values = reader.read_with_domain(1)
```

Closes https://github.com/openDAQ/openDAQ/issues/1218