### PR TITLE
Update opcua integration test with a module behavior for connected clients

### DIFF
--- a/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -594,9 +594,9 @@ TEST_F(OpcuaDeviceModulesTest, GetConnectedClientsInfo)
     ASSERT_EQ(serverSideClientsInfo.getCount(), 1u);
     ASSERT_EQ(serverSideClientsInfo[0].getProtocolName(), "OpenDAQOPCUA");
     ASSERT_EQ(serverSideClientsInfo[0].getProtocolType(), ProtocolType::Configuration);
-    ASSERT_EQ(serverSideClientsInfo[0].getHostName(), "");
-    ASSERT_EQ(serverSideClientsInfo[0].getAddress(), "");
-    ASSERT_EQ(serverSideClientsInfo[0].getClientTypeName(), "");
+    ASSERT_GT(serverSideClientsInfo[0].getHostName().getLength(), 0);
+    ASSERT_GT(serverSideClientsInfo[0].getAddress().getLength(), 0);
+    ASSERT_EQ(serverSideClientsInfo[0].getClientTypeName(), "Control");
 }
 
 TEST_F(OpcuaDeviceModulesTest, GetRemoteDeviceObjects)


### PR DESCRIPTION
# Brief

Opcua server was not registering the information about the connected client (control type, ip, address) 
The new module now does do it, so on the opendaq side we should update the test to align with a new behavior 

