### PR TITLE
Drop Python 3.8 wheels

### DIFF
--- a/.github/actions/package-bindings-python/action.yml
+++ b/.github/actions/package-bindings-python/action.yml
@@ -9,7 +9,7 @@ inputs:
   python-versions:
     description: 'Space-separated list of Python versions'
     required: false
-    default: '3.8 3.9 3.10 3.11 3.12 3.13 3.14'
+    default: '3.9 3.10 3.11 3.12 3.13 3.14'
   build-path:
     description: 'Path to build directory (must be already configured with CMake)'
     required: false

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ env:
   vm_name: device_simulator
   simulator_app_artifact: SimulatorApp
   python_version_build: 3.11
-  python_versions: 3.8 3.9 3.10 3.11 3.12 3.13 3.14
+  python_versions: 3.9 3.10 3.11 3.12 3.13 3.14
   windows_x64_artifact: SdkWindows64
   linux_x64_artifact: SdkLinux64
 


### PR DESCRIPTION
# Brief

Stop building Python 3.8 wheels — pypa/manylinux dropped CPython 3.8 from the `manylinux_2_28` image (Python 3.8 EOL since 2024-10-07).

# Description

- Remove `3.8` from `python_versions` in `.github/workflows/package.yml`
- Remove `3.8` from the default value of `python-versions` in `.github/actions/package-bindings-python/action.yml`

CI matrix entries that still reference 3.8 (`ubuntu-20.04-*` jobs in `ci.yml`) are left intact — Ubuntu 20.04 stock repos still provide `python3.8`, so those jobs continue to work.

References: pypa/manylinux#1882 (closed by pypa/manylinux#1884, merged 2026-05-07).
