### PR TITLE
Fix ComparableValue value scaling with large domain resolution 

### DIFF
--- a/core/opendaq/reader/include/opendaq/multi_typed_reader.h
+++ b/core/opendaq/reader/include/opendaq/multi_typed_reader.h
@@ -16,6 +16,7 @@
 #pragma once
 #include <opendaq/reader_domain_info.h>
 #include <opendaq/typed_reader.h>
+#include <type_traits>
 
 BEGIN_NAMESPACE_OPENDAQ
 
@@ -99,7 +100,7 @@ class ComparableValue : public Comparable
 public:
     explicit ComparableValue(ReadType startingValue, const ReaderDomainInfo& domainInfo, bool log = true)
         : Comparable(domainInfo)
-        , value(static_cast<ReadType>(startingValue * domainInfo.multiplier.getNumerator() / static_cast<double>(domainInfo.multiplier.getDenominator())))
+        , value(scaleStartingValue(startingValue, domainInfo))
     {
 
 #if !defined(NDEBUG)
@@ -209,6 +210,18 @@ public:
 #endif
 
 private:
+    [[nodiscard]] static ReadType scaleStartingValue(ReadType startingValue, const ReaderDomainInfo& domainInfo)
+    {
+        const Int num = domainInfo.multiplier.getNumerator();
+        const Int den = domainInfo.multiplier.getDenominator();
+
+        if constexpr (std::is_integral_v<ReadType>)
+            // Split into whole/remainder parts to keep full integer precision and avoid overflow.
+            return static_cast<ReadType>((startingValue / den) * num + (startingValue % den) * num / den);
+
+        return static_cast<ReadType>(startingValue * static_cast<double>(num) / den);
+    }
+
     [[nodiscard]]
     int compare(const Comparable& other) const override
     {

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -955,6 +955,66 @@ TEST_F(MultiReaderTest, Clock10kHzDelta10)
     ASSERT_THAT(time[2], ElementsAreArray(time[0]));
 }
 
+TEST_F(MultiReaderTest, Clock15MHzFromEpoch)
+{
+    constexpr const auto NUM_SIGNALS = 3;
+
+    // prevent vector from re-allocating, so we have "stable" pointers
+    readSignals.reserve(3);
+
+    Int clock = 15000000;
+    Int startOffest = 1781269748ll * clock;
+    auto& sig0 = addSignal(startOffest, 6093750, createDomainSignal("1970-01-01T00:00:00+00:00", Ratio(1, clock)));
+    auto& sig1 = addSignal(startOffest, 2812500, createDomainSignal("1970-01-01T00:00:00+00:00", Ratio(1, clock)));
+    auto& sig2 = addSignal(startOffest, 3750000, createDomainSignal("1970-01-01T00:00:00+00:00", Ratio(1, clock)));
+
+    auto multi =
+        MultiReaderBuilder().setStartOnFullUnitOfDomain(true).setInputPortNotificationMethod(PacketReadyNotification::SameThread).addSignals(signalsToList()).build();
+
+    {
+        SizeT count{0};
+        auto status = multi.read(nullptr, &count);
+        ASSERT_EQ(status.getReadStatus(), ReadStatus::Event);
+    }
+
+    auto available = multi.getAvailableCount();
+    ASSERT_EQ(available, 0u);
+
+    sig0.createAndSendPacket(0);
+    sig1.createAndSendPacket(0);
+    sig2.createAndSendPacket(0);
+
+    sig0.createAndSendPacket(1);
+    sig1.createAndSendPacket(1);
+    sig2.createAndSendPacket(1);
+
+    sig0.createAndSendPacket(2);
+    sig1.createAndSendPacket(2);
+    sig2.createAndSendPacket(2);
+
+    available = multi.getAvailableCount();
+    ASSERT_EQ(available, 2812500*3);
+
+    constexpr const SizeT SAMPLES = 5u;
+
+    std::array<double[SAMPLES], NUM_SIGNALS> values{};
+    std::array<ClockTick[SAMPLES], NUM_SIGNALS> domain{};
+
+    void* valuesPerSignal[NUM_SIGNALS]{values[0], values[1], values[2]};
+    void* domainPerSignal[NUM_SIGNALS]{domain[0], domain[1], domain[2]};
+
+    SizeT count{SAMPLES};
+    multi.readWithDomain(valuesPerSignal, domainPerSignal, &count);
+
+    ASSERT_EQ(count, SAMPLES);
+
+    std::array<std::chrono::system_clock::time_point[SAMPLES], NUM_SIGNALS> time{};
+    printData<std::chrono::microseconds>(SAMPLES, time, values, domain);
+
+    ASSERT_THAT(time[1], ElementsAreArray(time[0]));
+    ASSERT_THAT(time[2], ElementsAreArray(time[0]));
+}
+
 TEST_F(MultiReaderTest, Clock10kHzDelta10Relative)
 {
     constexpr const auto NUM_SIGNALS = 3;


### PR DESCRIPTION


# Brief

Fix crashing multireader with device domain resolution 15M and unix epoch as epoch of the domain


# Description

ComperableValue value calculation was adjusted to avoid issues with double precision causing the assertion error.

Added test for the case.




