### PR TITLE
ReadWithDomain should return Event status even in invalid

### DIFF
--- a/core/opendaq/reader/include/opendaq/multi_reader_impl.h
+++ b/core/opendaq/reader/include/opendaq/multi_reader_impl.h
@@ -146,6 +146,8 @@ private:
     void prepare(void** outValues, SizeT count, std::chrono::milliseconds timeoutTime);
     void prepareWithDomain(void** outValues, void** domain, SizeT count, std::chrono::milliseconds timeoutTime);
 
+    ErrCode readInternal(bool withDomain, void* samples, void* domain, SizeT* count, SizeT timeoutMs, IMultiReaderStatus** status);
+
     [[nodiscard]] Duration durationFromStart() const;
 
     /**

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -822,10 +822,25 @@ ErrCode INTERFACE_FUNC MultiReaderImpl::getInputUsed(IString* globalId, Bool* is
 
 ErrCode MultiReaderImpl::read(void* samples, SizeT* count, SizeT timeoutMs, IMultiReaderStatus** status)
 {
+    return readInternal(false, samples, nullptr, count, timeoutMs, status);
+}
+
+ErrCode MultiReaderImpl::readWithDomain(void* samples, void* domain, SizeT* count, SizeT timeoutMs, IMultiReaderStatus** status)
+{
+    return readInternal(true, samples, domain, count, timeoutMs, status);
+}
+
+ErrCode MultiReaderImpl::readInternal(
+    bool withDomain, void* samples, void* domain, SizeT* count, SizeT timeoutMs, IMultiReaderStatus** status)
+{
     OPENDAQ_PARAM_NOT_NULL(count);
     if (*count != 0)
     {
         OPENDAQ_PARAM_NOT_NULL(samples);
+        if (withDomain)
+        {
+            OPENDAQ_PARAM_NOT_NULL(domain);
+        }
 
         if (minReadCount > *count)
             return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDPARAMETER, "Count parameter has to be either 0 or larger than minReadCount.");
@@ -853,53 +868,14 @@ ErrCode MultiReaderImpl::read(void* samples, SizeT* count, SizeT timeoutMs, IMul
     }
 
     SizeT samplesToRead = (*count / sampleRateDividerLcm) * sampleRateDividerLcm;
-    prepare(static_cast<void**>(samples), samplesToRead, milliseconds(timeoutMs));
-
-    auto statusPtr = readPackets();
-    if (status)
-        *status = statusPtr.detach();
-
-    SizeT samplesRead = samplesToRead - remainingSamplesToRead;
-    *count = samplesRead;
-    return OPENDAQ_SUCCESS;
-}
-
-ErrCode MultiReaderImpl::readWithDomain(void* samples, void* domain, SizeT* count, SizeT timeoutMs, IMultiReaderStatus** status)
-{
-    OPENDAQ_PARAM_NOT_NULL(count);
-    if (*count != 0)
+    if (withDomain)
     {
-        OPENDAQ_PARAM_NOT_NULL(samples);
-        OPENDAQ_PARAM_NOT_NULL(domain);
-
-        if (minReadCount > *count)
-            return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDPARAMETER, "Count parameter has to be either 0 or larger than minReadCount.");
+        prepareWithDomain(static_cast<void**>(samples), static_cast<void**>(domain), samplesToRead, milliseconds(timeoutMs));
     }
-
-    std::scoped_lock lock(mutex);
-
-    MultiReaderStatusPtr earlyReturnStatus;
-    if (nextPacketIsEvent)
+    else
     {
-        earlyReturnStatus = readPackets();
+        prepare(static_cast<void**>(samples), samplesToRead, milliseconds(timeoutMs));
     }
-
-    if (invalid)
-    {
-        earlyReturnStatus = createReaderStatus();
-    }
-
-    if (earlyReturnStatus.assigned())
-    {
-        if (status)
-            *status = earlyReturnStatus.detach();
-
-        *count = 0;
-        return OPENDAQ_SUCCESS;
-    }
-
-    SizeT samplesToRead = (*count / sampleRateDividerLcm) * sampleRateDividerLcm;
-    prepareWithDomain((void**) samples, (void**) domain, samplesToRead, milliseconds(timeoutMs));
 
     auto statusPtr = readPackets();
     if (status)

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -5252,8 +5252,8 @@ TEST_F(MultiReaderTest, SharedDomainDescriptorChangeInvalidatesReaderAcrossCallb
     auto domainSignal = Signal(context, nullptr, "shared_domain");
     domainSignal.setDescriptor(initialDomainDescriptor);
 
-    auto& signal0 = addSignal(12345, 50, domainSignal, daq::SampleType::Float32);
-    auto& signal1 = addSignal(12345, 40, domainSignal, daq::SampleType::Float32);
+    addSignal(12345, 50, domainSignal, daq::SampleType::Float32);
+    addSignal(12345, 40, domainSignal, daq::SampleType::Float32);
 
     auto ports = portsList();
     auto signals = signalsToList();

--- a/core/opendaq/reader/tests/test_multi_reader.cpp
+++ b/core/opendaq/reader/tests/test_multi_reader.cpp
@@ -7,6 +7,7 @@
 #include <opendaq/reader_factory.h>
 #include <opendaq/time_reader.h>
 #include <opendaq/typed_reader.h>
+#include <opendaq/event_packet_utils.h>
 #include "reader_common.h"
 
 #include <gmock/gmock-matchers.h>
@@ -5232,5 +5233,124 @@ TEST_F(MultiReaderTest, UsedUnusedInput)
         auto status = multi.read(nullptr, &count);
         ASSERT_EQ(status.getReadStatus(), ReadStatus::Ok);
         ASSERT_TRUE(status.getValid());
+    }
+}
+
+TEST_F(MultiReaderTest, SharedDomainDescriptorChangeInvalidatesReaderAcrossCallbacks)
+{
+    constexpr SizeT NUM_SIGNALS = 2;
+    constexpr SizeT NUM_SAMPLES = 64;
+    float dataBuffers[NUM_SIGNALS][NUM_SAMPLES];
+    Int domainBuffers[NUM_SIGNALS][NUM_SAMPLES];
+    std::array<float*, NUM_SIGNALS> dataJagged{dataBuffers[0], dataBuffers[1]};
+    std::array<Int*, NUM_SIGNALS> domainJagged{domainBuffers[0], domainBuffers[1]};
+
+    const auto initialDomainDescriptor = createDomainDescriptor("2022-09-27T00:00:00+00:00", Ratio(1, 1000000), LinearDataRule(1000, 0));
+
+    const auto changedDomainDescriptor = createDomainDescriptor("2022-09-27T00:00:00+00:00", Ratio(1, 1000000), LinearDataRule(100, 0));
+
+    auto domainSignal = Signal(context, nullptr, "shared_domain");
+    domainSignal.setDescriptor(initialDomainDescriptor);
+
+    auto& signal0 = addSignal(12345, 50, domainSignal, daq::SampleType::Float32);
+    auto& signal1 = addSignal(12345, 40, domainSignal, daq::SampleType::Float32);
+
+    auto ports = portsList();
+    auto signals = signalsToList();
+
+    auto multi = MultiReaderBuilder()
+                     .addInputPorts(ports)
+                     .setDomainReadType(SampleType::Int64)
+                     .setValueReadType(SampleType::Float32)
+                     .setAllowDifferentSamplingRates(false)
+                     .setInputPortNotificationMethod(PacketReadyNotification::SameThread)
+                     .build();
+
+    SizeT initialCallbackCount = 0;
+    multi.setOnDataAvailable(Procedure(
+        [&]
+        {
+            ++initialCallbackCount;
+
+            SizeT count = 0;
+            auto status = multi.readWithDomain(dataJagged.data(), domainJagged.data(), &count);
+
+            ASSERT_EQ(count, 0u);
+            ASSERT_EQ(status.getReadStatus(), ReadStatus::Event);
+            ASSERT_TRUE(status.getValid());
+        }));
+
+    // Connecting each signal produces its own initial descriptor event.
+    ports[0].connect(signals[0]);
+    ports[1].connect(signals[1]);
+
+    // Only get callback once all ports are connected
+    ASSERT_EQ(initialCallbackCount, 1u);
+
+    SizeT descriptorChangeCallbackCount = 0;
+    MultiReaderStatusPtr firstChangeStatus;
+    MultiReaderStatusPtr secondChangeStatus;
+
+    multi.setOnDataAvailable(Procedure(
+        [&]
+        {
+            ++descriptorChangeCallbackCount;
+
+            // The callback itself is entered with a valid reader on the
+            // first domain-descriptor event.
+            const daq::Bool validBeforeRead = multi.asPtr<IReaderConfig>().getIsValid();
+
+            SizeT count = 0;
+            const auto status = multi.readWithDomain(dataJagged.data(), domainJagged.data(), &count);
+
+            ASSERT_EQ(count, 0u);
+            ASSERT_EQ(status.getReadStatus(), ReadStatus::Event);
+
+            if (descriptorChangeCallbackCount == 1)
+            {
+                ASSERT_TRUE(validBeforeRead);
+
+                // Processing the first descriptor change discovers that
+                // the two inputs no longer have compatible sample rates.
+                ASSERT_FALSE(multi.asPtr<IReaderConfig>().getIsValid());
+                ASSERT_FALSE(status.getValid());
+
+                firstChangeStatus = status;
+            }
+            else if (descriptorChangeCallbackCount == 2)
+            {
+                // The second callback is generated while the reader is
+                // already invalid.
+                ASSERT_FALSE(validBeforeRead);
+                ASSERT_FALSE(status.getValid());
+
+                secondChangeStatus = status;
+            }
+        }));
+
+    domainSignal.setDescriptor(changedDomainDescriptor);
+
+    ASSERT_EQ(descriptorChangeCallbackCount, 2u);
+    ASSERT_TRUE(firstChangeStatus.assigned());
+    ASSERT_TRUE(secondChangeStatus.assigned());
+
+    for (size_t i = 0; i < 2; ++i)
+    {
+        auto& status = (i == 0) ? firstChangeStatus : secondChangeStatus;
+        const auto eventPackets = status.getEventPackets();
+
+        ASSERT_EQ(eventPackets.getCount(), 1u);
+
+        // Which port receives the shared-domain event first is an
+        // implementation detail, so only verify the descriptor contents here.
+        const auto eventPacket = eventPackets.getValueList()[0];
+
+        ASSERT_EQ(eventPacket.getEventId(), event_packet_id::DATA_DESCRIPTOR_CHANGED);
+
+        const auto [valueChanged, domainChanged, valueDescriptor, domainDescriptor] = parseDataDescriptorEventPacket(eventPacket);
+
+        ASSERT_FALSE(valueChanged);
+        ASSERT_TRUE(domainChanged);
+        ASSERT_EQ(domainDescriptor, changedDomainDescriptor);
     }
 }


### PR DESCRIPTION
# Brief

ReadWithDomain had a typo bug where invalid reader would not return events in the status even when the callback was triggered for this specific reason (overwriting a valid status with an empty one).

# Description

Refactor `read` and `readWithDomain` methods to delegate to a single `readInternal` where the logic is identical with exception of two operations that include domain buffer in `withDomain` version.

This does not change the usage of `Multireader` or its expected behavior.