### PR TITLE
Try all streaming connection addresses if first fails (#1235)

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -78,6 +78,7 @@
 
 ## Misc
 
+- [#1238](https://github.com/openDAQ/openDAQ/pull/1238), [#1235](https://github.com/openDAQ/openDAQ/pull/1235) Try all streaming connection addresses if first fails
 - [#1216](https://github.com/openDAQ/openDAQ/pull/1216) Speeds up comparison between end sentinel when iterating over openDAQ list and dictionary objects
 - [#1120](https://github.com/openDAQ/openDAQ/pull/1120) Change reachability status to a sparse selection property type.
 - [#1171](https://github.com/openDAQ/openDAQ/pull/1171) MDNS discovery ratelimiting

--- a/core/opendaq/streaming/include/opendaq/streaming_source_manager.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_source_manager.h
@@ -52,8 +52,8 @@ private:
 
     static ListPtr<IMirroredDeviceConfig> getAllDevicesRecursively(const MirroredDeviceConfigPtr& device);
 
-    AddressInfoPtr findMatchingAddress(const ListPtr<IAddressInfo>& availableAddresses,
-                                       const AddressInfoPtr& deviceConnectionAddress);
+    ListPtr<IAddressInfo> getSuitableAddressesInfo(const ListPtr<IAddressInfo>& availableAddressesInfo,
+                                                   const AddressInfoPtr& deviceConnectionAddress);
     static AddressInfoPtr getDeviceConnectionAddress(const DevicePtr& device);
     void completeStreamingConnections(const MirroredDeviceConfigPtr& topDevice);
     void attachStreamingsToDevice(const MirroredDeviceConfigPtr& device);
@@ -393,35 +393,40 @@ inline ListPtr<IMirroredDeviceConfig> StreamingSourceManager::getAllDevicesRecur
     return result;
 }
 
-inline AddressInfoPtr StreamingSourceManager::findMatchingAddress(const ListPtr<IAddressInfo>& availableAddresses, const AddressInfoPtr& deviceConnectionAddress)
+inline ListPtr<IAddressInfo> StreamingSourceManager::getSuitableAddressesInfo(const ListPtr<IAddressInfo>& availableAddressesInfo,
+                                                                              const AddressInfoPtr& deviceConnectionAddress)
 {
+    
+    auto result = List<IAddressInfo>();
+
+    auto const addToResult = [&result, &deviceConnectionAddress](AddressInfoPtr addressInfo)
+    {
+        if (deviceConnectionAddress.assigned() && addressInfo.getAddress() == deviceConnectionAddress.getAddress())
+            result.pushFront(addressInfo);
+        else
+            result.pushBack(addressInfo);
+    };
+
     if (primaryAddressType == "IPv4" || primaryAddressType == "IPv6")
     {
-        // Attempt to reuse the address of device connection if it meets type constraints
-        if (deviceConnectionAddress.assigned() && deviceConnectionAddress.getType() == primaryAddressType)
-        {
-            for (const auto& addressInfo : availableAddresses)
-                if (addressInfo.getAddress() == deviceConnectionAddress.getAddress())
-                    return addressInfo;
-        }
-
-        // If the device connection address is unavailable for streaming, search for any address matching type constraints
-        for (const auto& addressInfo : availableAddresses)
+        for (const auto& addressInfo : availableAddressesInfo)
         {
             if (addressInfo.getType() == primaryAddressType)
-                return addressInfo;
+                addToResult(addressInfo);
         }
+
+        if (!result.empty())
+            return result;
+
         LOG_W("Server streaming capability does not provide any addresses of primary {} type", primaryAddressType);
     }
 
-    // Attempt to reuse the address of device connection
-    for (const auto& addressInfo : availableAddresses)
+    for (const auto& addressInfo : availableAddressesInfo)
     {
-        if (deviceConnectionAddress.assigned() && addressInfo.getAddress() == deviceConnectionAddress.getAddress())
-            return addressInfo;
+        addToResult(addressInfo);
     }
 
-    return nullptr;
+    return result;
 }
 
 inline AddressInfoPtr StreamingSourceManager::getDeviceConnectionAddress(const DevicePtr& device)
@@ -467,7 +472,7 @@ inline void StreamingSourceManager::completeStreamingConnections(const MirroredD
 
 inline void StreamingSourceManager::attachStreamingsToDevice(const MirroredDeviceConfigPtr& device)
 {
-    // Get the address used for device connection
+    // Get the full address information used for device configuration connection
     const auto deviceConnectionAddress = getDeviceConnectionAddress(device);
 
     // protocol priority as a key, streaming source as a value
@@ -503,7 +508,7 @@ inline void StreamingSourceManager::attachStreamingsToDevice(const MirroredDevic
         }
     }
 
-    // connect via all allowed streaming capabilities which are not connected yet
+    // connect to all allowed streaming servers which are not connected to yet
     for (const auto& cap : device.getInfo().getServerCapabilities())
     {
         if (cap.getProtocolType() != ProtocolType::Streaming)
@@ -527,45 +532,68 @@ inline void StreamingSourceManager::attachStreamingsToDevice(const MirroredDevic
         StreamingPtr streaming;
 
         // Prioritize discovery addresses if available for this protocol
-        ListPtr<IAddressInfo> addressesToUse;
+        ListPtr<IAddressInfo> addressesInfoToCheck;
         if (discoveredAddressesByProtocol.count(protocolId) > 0)
         {
-            addressesToUse = discoveredAddressesByProtocol[protocolId];
+            addressesInfoToCheck = discoveredAddressesByProtocol[protocolId];
             LOG_D("Device {} using discovered addresses for protocol {}", device.getGlobalId(), protocolId);
         }
         else
         {
-            addressesToUse = cap.getAddressInfo();
+            addressesInfoToCheck = cap.getAddressInfo();
         }
 
-        const auto streamingAddress = findMatchingAddress(addressesToUse, deviceConnectionAddress);
-        StringPtr connectionString = streamingAddress.assigned() ? streamingAddress.getConnectionString() : cap.getConnectionString();
+        // get the addresses of primary type giving the priority to known config connection address
+        const auto suitableAddressesInfo = getSuitableAddressesInfo(addressesInfoToCheck, deviceConnectionAddress);
 
-        if (!connectionString.assigned())
-            continue;
+        auto streamingConnectionStrings = List<IString>();
+        for (const auto& addressInfo : suitableAddressesInfo)
+            streamingConnectionStrings.pushBack(addressInfo.getConnectionString());
+        if (streamingConnectionStrings.empty())
+            streamingConnectionStrings.pushBack(cap.getConnectionString());
 
-        const auto addedStreamingSources = device.getStreamingSources();
-        auto it = std::find_if(addedStreamingSources.begin(),
-                               addedStreamingSources.end(),
-                               [&connectionString](const StreamingPtr& item)
-                               {
-                                   return connectionString == item.getConnectionString();
-                               });
-        if (it != addedStreamingSources.end())
-            continue;
-
-        auto errCode = daqTry([&]()
+        for (const auto& connectionString : streamingConnectionStrings)
         {
-            streaming = managerUtils.createStreaming(connectionString, deviceConfig);
-            return OPENDAQ_SUCCESS;
-        });
-        if (OPENDAQ_FAILED(errCode))
-            daqClearErrorInfo();
-        if (!streaming.assigned())
-            continue;
+            if (!connectionString.assigned())
+                continue;
 
-        const SizeT protocolPriority = protocolIt->second;
-        prioritizedStreamingSourcesMap.insert_or_assign(protocolPriority, streaming);
+            auto itAlreadyConnected =
+                std::find_if(prioritizedStreamingSourcesMap.begin(),
+                             prioritizedStreamingSourcesMap.end(),
+                             [&protocolId](const std::pair<SizeT, StreamingPtr>& item)
+                             {
+                                 // do not connect to the same streaming server twice e.g. via IPv4 & IPv6 or 2 different network paths
+                                 return protocolId == item.second.getProtocolId();
+                             });
+            if (itAlreadyConnected != prioritizedStreamingSourcesMap.end())
+                continue;
+
+            const auto addedStreamingSources = device.getStreamingSources();
+            auto itAlreadyAdded =
+                std::find_if(addedStreamingSources.begin(),
+                             addedStreamingSources.end(),
+                             [&connectionString](const StreamingPtr& item)
+                             {
+                                 // do not connect if source is already added e.g. in case of reconnection or update
+                                 return connectionString == item.getConnectionString();
+                             });
+            if (itAlreadyAdded != addedStreamingSources.end())
+                continue;
+
+            auto errCode = daqTry(
+                [&]()
+                {
+                    streaming = managerUtils.createStreaming(connectionString, deviceConfig);
+                    return OPENDAQ_SUCCESS;
+                });
+            if (OPENDAQ_FAILED(errCode))
+                daqClearErrorInfo();
+            if (!streaming.assigned())
+                continue;
+
+            const SizeT protocolPriority = protocolIt->second;
+            prioritizedStreamingSourcesMap.insert_or_assign(protocolPriority, streaming);
+        }
     }
 
     // add streaming sources ordered by protocol priority

--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -2832,6 +2832,225 @@ TEST_F(NativeDeviceModulesTest, TestAddressInfoGatewayDevice)
     ASSERT_EQ(ltAddressInfo.getReachabilityStatus(), AddressReachabilityStatus::Reachable);
 }
 
+TEST_F(NativeDeviceModulesTest, TestLeafDeviceUnreachableIPv4Streaming)
+{
+    SKIP_TEST_MAC_CI;
+    if (test_helpers::Ipv6IsDisabled())
+    {
+        GTEST_SKIP();
+    }
+
+    auto server = Instance("[[none]]");
+    {
+        addRefDeviceModule(server);
+        server.setRootDevice("daqref://device0");
+
+        addNativeServerModule(server);
+        server.addServer("OpenDAQNativeStreaming", nullptr);
+    }
+    auto gateway = Instance("[[none]]", "gateway");
+    {
+        addNativeClientModule(gateway);
+        addNativeServerModule(gateway);
+
+        auto serverConfig = gateway.getAvailableServerTypes().get("OpenDAQNativeStreaming").createDefaultConfig();
+        serverConfig.setPropertyValue("NativeStreamingPort", 7421);
+
+        gateway.addServer("OpenDAQNativeStreaming", serverConfig);
+    }
+
+    auto client = Instance("[[none]]");
+    addNativeClientModule(client);
+
+    // register handler before adding the device so it should be called before the one in streaming manager
+    client.getContext().getOnCoreEvent() += [](const ComponentPtr& comp, const CoreEventArgsPtr& args) {
+        auto params = args.getParameters();
+        if (static_cast<CoreEventId>(args.getEventId()) == CoreEventId::ComponentAdded)
+        {
+            ComponentPtr component = params.get("Component");
+            if (auto addedDevice = component.asPtrOrNull<IDevice>(); addedDevice.assigned())
+            {
+                if (addedDevice.getGlobalId() == "/openDAQDevice/Dev/gateway/Dev/RefDev0")
+                {
+                    const auto addedDeviceInfo = addedDevice.getInfo();
+                    const auto addedDeviceInfoInternal = addedDeviceInfo.asPtr<IDeviceInfoInternal>();
+
+                    ServerCapabilityPtr streamingCapability;
+                    for (const auto& cap : addedDeviceInfo.getServerCapabilities())
+                    {
+                        if (cap.getProtocolType() == ProtocolType::Streaming)
+                            streamingCapability = cap;
+                    }
+                    ASSERT_TRUE(streamingCapability.assigned());
+                    addedDeviceInfoInternal.removeServerCapability(streamingCapability.getProtocolId());
+
+                    auto capReplacement =
+                            ServerCapability(streamingCapability.getProtocolId(), streamingCapability.getProtocolName(), streamingCapability.getProtocolType());
+
+                    {
+                        // Set fake port so streaming connection will fail
+                        auto ipv4Address = "127.0.0.1";
+                        auto connectionStringIpv4 =
+                                String(fmt::format("{}://{}:{}", "daq.ns", ipv4Address, 7425));
+                        capReplacement.addConnectionString(connectionStringIpv4);
+                        capReplacement.addAddress(ipv4Address);
+
+                        const auto addressInfo = AddressInfoBuilder().setAddress(ipv4Address)
+                                                                     .setReachabilityStatus(AddressReachabilityStatus::Unknown)
+                                                                     .setType("IPv4")
+                                                                     .setConnectionString(connectionStringIpv4)
+                                                                     .build();
+                        capReplacement.addAddressInfo(addressInfo);
+                    }
+                    {
+
+                        auto ipv6Address = "[::1]";
+                        auto connectionStringIpv6 =
+                                String(fmt::format("{}://{}:{}", "daq.ns", ipv6Address, 7420));
+                        capReplacement.addConnectionString(connectionStringIpv6);
+                        capReplacement.addAddress(ipv6Address);
+
+                        const auto addressInfo = AddressInfoBuilder().setAddress(ipv6Address)
+                                                                     .setReachabilityStatus(AddressReachabilityStatus::Unknown)
+                                                                     .setType("IPv6")
+                                                                     .setConnectionString(connectionStringIpv6)
+                                                                     .build();
+                        capReplacement.addAddressInfo(addressInfo);
+                    }
+
+                    addedDeviceInfoInternal.addServerCapability(capReplacement);
+                }
+            }
+        }
+    };
+
+    auto config = client.createDefaultAddDeviceConfig();
+    PropertyObjectPtr general = config.getPropertyValue("General");
+    general.setPropertyValue("StreamingConnectionHeuristic", 1); // MIN HOPS
+    //general.setPropertyValue("PrimaryAddressType", "IPv4"); // don't use this setting otherwise it will skip any v6 streaming connection
+    const auto dev = client.addDevice("daq.nd://127.0.0.1:7421/", config);
+
+    dev.addDevice("daq.nd://127.0.0.1");
+
+    MirroredSignalConfigPtr sig = dev.getSignalsRecursive()[0];
+
+    ASSERT_EQ(sig.getStreamingSources().getCount(), 2u); // 2 connections: client->gateway and client->leaf
+    auto activeStreaming = sig.getActiveStreamingSource();
+    ASSERT_TRUE(activeStreaming.assigned());
+    ASSERT_TRUE(activeStreaming.toStdString().find("[::1]:7420") != std::string::npos)
+        << "Active streaming expected to be IPv6 client->leaf but it is not" << activeStreaming;
+}
+
+
+TEST_F(NativeDeviceModulesTest, TestLeafDeviceUnreachableIPv6Streaming)
+{
+    SKIP_TEST_MAC_CI;
+    if (test_helpers::Ipv6IsDisabled())
+    {
+        GTEST_SKIP();
+    }
+
+    auto server = Instance("[[none]]");
+    {
+        addRefDeviceModule(server);
+        server.setRootDevice("daqref://device0");
+
+        addNativeServerModule(server);
+        server.addServer("OpenDAQNativeStreaming", nullptr);
+    }
+    auto gateway = Instance("[[none]]", "gateway");
+    {
+        addNativeClientModule(gateway);
+        addNativeServerModule(gateway);
+
+        auto serverConfig = gateway.getAvailableServerTypes().get("OpenDAQNativeStreaming").createDefaultConfig();
+        serverConfig.setPropertyValue("NativeStreamingPort", 7421);
+
+        gateway.addServer("OpenDAQNativeStreaming", serverConfig);
+    }
+
+    auto client = Instance("[[none]]");
+    addNativeClientModule(client);
+
+    // register handler before adding the device so it will be called before the one in streaming manager
+    client.getContext().getOnCoreEvent() += [](const ComponentPtr& comp, const CoreEventArgsPtr& args) {
+        auto params = args.getParameters();
+        if (static_cast<CoreEventId>(args.getEventId()) == CoreEventId::ComponentAdded)
+        {
+            ComponentPtr component = params.get("Component");
+            if (auto addedDevice = component.asPtrOrNull<IDevice>(); addedDevice.assigned())
+            {
+                if (addedDevice.getGlobalId() == "/openDAQDevice/Dev/gateway/Dev/RefDev0")
+                {
+                    const auto addedDeviceInfo = addedDevice.getInfo();
+                    const auto addedDeviceInfoInternal = addedDeviceInfo.asPtr<IDeviceInfoInternal>();
+
+                    ServerCapabilityPtr streamingCapability;
+                    for (const auto& cap : addedDeviceInfo.getServerCapabilities())
+                    {
+                        if (cap.getProtocolType() == ProtocolType::Streaming)
+                            streamingCapability = cap;
+                    }
+                    ASSERT_TRUE(streamingCapability.assigned());
+                    addedDeviceInfoInternal.removeServerCapability(streamingCapability.getProtocolId());
+
+                    auto capReplacement =
+                            ServerCapability(streamingCapability.getProtocolId(), streamingCapability.getProtocolName(), streamingCapability.getProtocolType());
+
+                    {
+                        // Set fake port so streaming connection will fail
+                        auto ipv6Address = "[::1]";
+                        auto connectionStringIpv6 =
+                                String(fmt::format("{}://{}:{}", "daq.ns", ipv6Address, 7425));
+                        capReplacement.addConnectionString(connectionStringIpv6);
+                        capReplacement.addAddress(ipv6Address);
+
+                        const auto addressInfo = AddressInfoBuilder().setAddress(ipv6Address)
+                                                                     .setReachabilityStatus(AddressReachabilityStatus::Unknown)
+                                                                     .setType("IPv6")
+                                                                     .setConnectionString(connectionStringIpv6)
+                                                                     .build();
+                        capReplacement.addAddressInfo(addressInfo);
+                    }
+                    {
+                        auto ipv4Address = "127.0.0.1";
+                        auto connectionStringIpv4 =
+                                String(fmt::format("{}://{}:{}", "daq.ns", ipv4Address, 7420));
+                        capReplacement.addConnectionString(connectionStringIpv4);
+                        capReplacement.addAddress(ipv4Address);
+
+                        const auto addressInfo = AddressInfoBuilder().setAddress(ipv4Address)
+                                                                     .setReachabilityStatus(AddressReachabilityStatus::Unknown)
+                                                                     .setType("IPv4")
+                                                                     .setConnectionString(connectionStringIpv4)
+                                                                     .build();
+                        capReplacement.addAddressInfo(addressInfo);
+                    }
+
+
+                    addedDeviceInfoInternal.addServerCapability(capReplacement);
+                }
+            }
+        }
+    };
+
+    auto config = client.createDefaultAddDeviceConfig();
+    PropertyObjectPtr general = config.getPropertyValue("General");
+    general.setPropertyValue("StreamingConnectionHeuristic", 1); // MIN HOPS
+    //general.setPropertyValue("PrimaryAddressType", "IPv6"); // don't use this setting otherwise it will skip any v4 streaming connection
+    const auto dev = client.addDevice("daq.nd://[::1]:7421/", config);
+
+    dev.addDevice("daq.nd://[::1]");
+
+    MirroredSignalConfigPtr sig = dev.getSignalsRecursive()[0];
+
+    ASSERT_EQ(sig.getStreamingSources().getCount(), 2u); // 2 connections: client->gateway and client->leaf
+    auto activeStreaming = sig.getActiveStreamingSource();
+    ASSERT_TRUE(activeStreaming.assigned());
+    ASSERT_TRUE(activeStreaming.toStdString().find("127.0.0.1:7420") != std::string::npos)
+        << "Active streaming expected to be IPv4 client->leaf but it is not: " << activeStreaming;
+}
+
 TEST_F(NativeDeviceModulesTest, MultiClientReadChangingSignal)
 {
     SKIP_TEST_MAC_CI;


### PR DESCRIPTION
# Brief

Leaf device is connected to gateway device via IPv4 but streaming should go through IPv6 if gateway device is connected by IPv6

# Description

We have the following structure
 
 - GW device (opendaq device IPv4: 192.168.10.10)
 -- leaf device (opendaq device IPv4: 192.168.10.11)
 -- leaf device (opendaq device IPv4: 192.168.10.12)
 
 GW device add subdevice via IPv4 connection string.
 
 When client (PC) tries to connect to GW device and IPv4 is connection is not available (i.e. different subnet) the connection to the GW is established by IPv6. Leafs are running the discovery server so streaming does get the information about possible streaming connections but somehow only "deviceConnectionAddress" is used as possible - which in this case is IPv4 (since GW device is connected to the subdevice via IPv4) and of curse not possible.
 



