### PR TITLE
Fix reading of multi-dimensional (vector/matrix) signals in typed reader

### DIFF
--- a/core/opendaq/reader/src/typed_reader.cpp
+++ b/core/opendaq/reader/src/typed_reader.cpp
@@ -733,9 +733,15 @@ bool TypedReader<ReadType>::handleDescriptorChanged(DataDescriptorPtr& descripto
 
         rawSampleSize = descriptor.getRawSampleSize();
         auto dimensions = descriptor.getDimensions();
-        if (dimensions.assigned() && dimensions.getCount() == 1)
+        if (dimensions.assigned() && dimensions.getCount() >= 1)
         {
-            valuesPerSample = dimensions[0].getSize();
+            SizeT count = 1;
+            for (SizeT i = 0; i < dimensions.getCount(); ++i)
+            {
+                count *= dimensions[i].getSize();
+            }
+
+            valuesPerSample = count;
         }
 
         dataDescriptor = descriptor;

--- a/core/opendaq/reader/src/typed_reader.cpp
+++ b/core/opendaq/reader/src/typed_reader.cpp
@@ -659,7 +659,7 @@ ErrCode TypedReader<TReadType>::readValues(void* inputBuffer, SizeT offset, void
             }
 
             // Set the pointer to the value after the last copied one
-            *outputBuffer = &dataOut[toRead];
+            *outputBuffer = &dataOut[toRead * valuesPerSample];
         }
 
         return OPENDAQ_SUCCESS;
@@ -696,7 +696,7 @@ ErrCode TypedReader<ClockTick>::readValues<ClockRange>(void* inputBuffer, SizeT 
     }
 
     // Set the pointer to the value after the last copied one
-    *outputBuffer = &dataOut[toRead];
+    *outputBuffer = &dataOut[toRead * valuesPerSample];
     return OPENDAQ_SUCCESS;
 }
 


### PR DESCRIPTION
#Brief

Fixes reading of multi-dimensional (vector/matrix) signals in TypedReader. Previously the reader only accounted for values-per-sample on single-dimension signals, so matrix signals (2+ dimensions) computed the wrong number of values per sample and advanced the output buffer pointer incorrectly during type-converting reads — corrupting data on multi-block reads. The reader now derives values-per-sample from the product of all dimension sizes and advances the output pointer accordingly.

#Description

- Compute values-per-sample across all dimensions (handleDescriptorChanged): The descriptor handler previously set valuesPerSample only when a signal had exactly one dimension, reading dimensions[0].getSize(). It now handles any signal with one or more dimensions by multiplying the sizes of all dimensions together, so matrix signals (e.g. an N×M sample) report the correct total values per sample.
- Fix output-buffer pointer advance in type-converting reads (readValues): After copying with a type conversion, the output buffer pointer was advanced by toRead (sample count) instead of toRead * valuesPerSample. For multi-dimensional signals this left the pointer short, so subsequent reads overwrote or misaligned previously read data. Corrected in both the generic TypedReader<TReadType>::readValues path and the TypedReader<ClockTick>::readValues<ClockRange> specialization.
