### PR TITLE
Implement IDevice::getDomainSignal()

### DIFF
--- a/bindings/c/include/copendaq/device/device.h
+++ b/bindings/c/include/copendaq/device/device.h
@@ -49,6 +49,7 @@ extern "C"
     typedef struct daqSyncComponent daqSyncComponent;
     typedef struct daqServer daqServer;
     typedef struct daqComponentStatusContainer daqComponentStatusContainer;
+    typedef struct daqSignal daqSignal;
 
     EXPORTED extern const daqIntfID DAQ_DEVICE_INTF_ID;
     void EXPORTED daqDevice_getInterfaceId(daqIntfID* intfId);
@@ -89,6 +90,7 @@ extern "C"
     daqErrCode EXPORTED daqDevice_setOperationMode(daqDevice* self, daqOperationModeType modeType);
     daqErrCode EXPORTED daqDevice_setOperationModeRecursive(daqDevice* self, daqOperationModeType modeType);
     daqErrCode EXPORTED daqDevice_addDevices(daqDevice* self, daqDict** devices, daqDict* connectionArgs, daqDict* errCodes, daqDict* errorInfos);
+    daqErrCode EXPORTED daqDevice_getDomainSignal(daqDevice* self, daqSignal** signal);
 
 #ifdef __cplusplus
 }

--- a/bindings/c/include/copendaq/signal/signal.h
+++ b/bindings/c/include/copendaq/signal/signal.h
@@ -50,6 +50,7 @@ extern "C"
     daqErrCode EXPORTED daqSignal_getStreamed(daqSignal* self, daqBool* streamed);
     daqErrCode EXPORTED daqSignal_setStreamed(daqSignal* self, daqBool streamed);
     daqErrCode EXPORTED daqSignal_getLastValue(daqSignal* self, daqBaseObject** value);
+    daqErrCode EXPORTED daqSignal_getLastValueWithTimestamp(daqSignal* self, daqBaseObject** value, daqBaseObject** timestamp);
 
 #ifdef __cplusplus
 }

--- a/bindings/c/src/copendaq/device/device.cpp
+++ b/bindings/c/src/copendaq/device/device.cpp
@@ -201,3 +201,8 @@ daqErrCode daqDevice_addDevices(daqDevice* self, daqDict** devices, daqDict* con
 {
     return reinterpret_cast<daq::IDevice*>(self)->addDevices(reinterpret_cast<daq::IDict**>(devices), reinterpret_cast<daq::IDict*>(connectionArgs), reinterpret_cast<daq::IDict*>(errCodes), reinterpret_cast<daq::IDict*>(errorInfos));
 }
+
+daqErrCode daqDevice_getDomainSignal(daqDevice* self, daqSignal** signal)
+{
+    return reinterpret_cast<daq::IDevice*>(self)->getDomainSignal(reinterpret_cast<daq::ISignal**>(signal));
+}

--- a/bindings/c/src/copendaq/signal/signal.cpp
+++ b/bindings/c/src/copendaq/signal/signal.cpp
@@ -66,3 +66,8 @@ daqErrCode daqSignal_getLastValue(daqSignal* self, daqBaseObject** value)
 {
     return reinterpret_cast<daq::ISignal*>(self)->getLastValue(reinterpret_cast<daq::IBaseObject**>(value));
 }
+
+daqErrCode daqSignal_getLastValueWithTimestamp(daqSignal* self, daqBaseObject** value, daqBaseObject** timestamp)
+{
+    return reinterpret_cast<daq::ISignal*>(self)->getLastValueWithTimestamp(reinterpret_cast<daq::IBaseObject**>(value), reinterpret_cast<daq::IBaseObject**>(timestamp));
+}

--- a/bindings/python/opendaq/generated/device/py_device.cpp
+++ b/bindings/python/opendaq/generated/device/py_device.cpp
@@ -385,7 +385,7 @@ void defineIDevice(pybind11::module_ m, PyDaqIntf<daq::IDevice, daq::IFolder> cl
         },
         py::return_value_policy::take_ownership,
         "Gets a list of available operation modes for the device.");
-    cls.def_property("operation_mode",
+     cls.def_property("operation_mode",
         [](daq::IDevice *object)
         {
             py::gil_scoped_release release;
@@ -417,4 +417,13 @@ void defineIDevice(pybind11::module_ m, PyDaqIntf<daq::IDevice, daq::IFolder> cl
         },
         py::arg("connection_args"), py::arg("err_codes") = nullptr, py::arg("error_infos") = nullptr,
         "Connects to multiple devices in parallel using the provided connection strings and returns the connected devices. Each connection is established concurrently to improve performance when handling multiple devices. The additions, in turn, are performed sequentially in the order specified by connectionArgs.");
+    cls.def_property_readonly("domain_signal",
+        [](daq::IDevice *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::DevicePtr::Borrow(object);
+            return objectPtr.getDomainSignal().detach();
+        },
+        py::return_value_policy::take_ownership,
+        "Gets the domain signal of the device.");
 }

--- a/bindings/python/opendaq/generated/signal/py_input_port_config.cpp
+++ b/bindings/python/opendaq/generated/signal/py_input_port_config.cpp
@@ -83,15 +83,6 @@ void defineIInputPortConfig(pybind11::module_ m, PyDaqIntf<daq::IInputPortConfig
             objectPtr.notifyPacketEnqueuedOnThisThread();
         },
         "Gets called when a packet was enqueued in a connection.");
-    cls.def_property("listener",
-        nullptr,
-        [](daq::IInputPortConfig *object, daq::IInputPortNotifications* port)
-        {
-            py::gil_scoped_release release;
-            const auto objectPtr = daq::InputPortConfigPtr::Borrow(object);
-            objectPtr.setListener(port);
-        },
-        "Set the object receiving input-port related events and notifications.");
     cls.def_property("custom_data",
         [](daq::IInputPortConfig *object)
         {
@@ -132,4 +123,19 @@ void defineIInputPortConfig(pybind11::module_ m, PyDaqIntf<daq::IInputPortConfig
             objectPtr.notifyPacketEnqueuedWithScheduler();
         },
         "Gets called when a packet was enqueued in a connection.");
+    cls.def_property("listener",
+        [](daq::IInputPortConfig *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::InputPortConfigPtr::Borrow(object);
+            return objectPtr.getListener().detach();
+        },
+        [](daq::IInputPortConfig *object, daq::IInputPortNotifications* port)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::InputPortConfigPtr::Borrow(object);
+            objectPtr.setListener(port);
+        },
+        py::return_value_policy::take_ownership,
+        "Gets the object receiving input-port related events and notifications. / Set the object receiving input-port related events and notifications.");
 }

--- a/changelog/changelog_3.40-3.50.md
+++ b/changelog/changelog_3.40-3.50.md
@@ -1,0 +1,28 @@
+# Changes from 3.40 to 3.50
+
+## Features
+
+- [#1241](https://github.com/openDAQ/openDAQ/pull/1241) Implement IDevice::getDomainSignal()
+
+## Python
+
+## Bug fixes
+
+## Misc
+
+## Required application changes
+
+## Required module changes
+
+## Interface API changes
+
+### New interfaces
+
+### Removed interfaces
+
+### Modified interfaces
+
+#### `IDevice`
+```diff
++ IDevice::getDomainSignal(ISignal** signal);
+```

--- a/core/opendaq/device/include/opendaq/device.h
+++ b/core/opendaq/device/include/opendaq/device.h
@@ -404,6 +404,12 @@ DECLARE_OPENDAQ_INTERFACE(IDevice, IFolder)
      *         OPENDAQ_IGNORED if adding the devices from modules is not allowed within the device.
      */
     virtual ErrCode INTERFACE_FUNC addDevices(IDict** devices, IDict* connectionArgs, IDict* errCodes = nullptr, IDict* errorInfos = nullptr) = 0;
+
+    /*!
+     * @brief Gets the domain signal of the device.
+     * @param[out] signal The domain signal.
+     */
+    virtual ErrCode INTERFACE_FUNC getDomainSignal(ISignal** signal) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -124,6 +124,8 @@ public:
     ErrCode INTERFACE_FUNC setOperationModeRecursive(OperationModeType modeType) override;
     ErrCode INTERFACE_FUNC getOperationMode(OperationModeType* modeType) override;
 
+    ErrCode INTERFACE_FUNC getDomainSignal(ISignal** signal) override;
+
     // IDevicePrivate
     ErrCode INTERFACE_FUNC setAsRoot() override;
     ErrCode INTERFACE_FUNC getDeviceConfig(IPropertyObject** config) override;
@@ -251,6 +253,8 @@ protected:
     DevicePtr getParentDevice();
     OperationModeType getOperationMode();
 
+    void setDomainSignal(const SignalPtr& signal);
+
 private:
     void getChannelsFromFolder(ListPtr<IChannel>& channelList, const FolderPtr& folder, const SearchFilterPtr& searchFilter, bool filterChannels = true);
     ListPtr<ISignal> getSignalsRecursiveInternal(const SearchFilterPtr& searchFilter);
@@ -271,6 +275,7 @@ private:
     DeviceDomainPtr deviceDomain;
     OperationModeType operationMode {OperationModeType::Unknown};
     ListPtr<IInteger> availableOperationModes;
+    SignalPtr domainSignal;
 };
 
 template <typename TInterface, typename... Interfaces>
@@ -738,6 +743,11 @@ ErrCode GenericDevice<TInterface, Interfaces...>::getTicksSinceOrigin(uint64_t* 
 template <typename TInterface, typename... Interfaces>
 uint64_t GenericDevice<TInterface, Interfaces...>::onGetTicksSinceOrigin()
 {
+    if (this->domainSignal.assigned())
+    {
+        if (const auto lastValue = domainSignal.getLastValue(); lastValue.assigned())
+            return lastValue;
+    }
     return 0;
 }
 
@@ -1257,6 +1267,20 @@ ErrCode GenericDevice<TInterface, Interfaces...>::getOperationMode(OperationMode
     OPENDAQ_PARAM_NOT_NULL(modeType);
     *modeType = this->operationMode;
     return OPENDAQ_SUCCESS;
+}
+
+template <typename TInterface, typename... Interfaces>
+ErrCode GenericDevice<TInterface, Interfaces...>::getDomainSignal(ISignal** signal)
+{
+    OPENDAQ_PARAM_NOT_NULL(signal);
+    *signal = this->domainSignal.addRefAndReturn();
+    return OPENDAQ_SUCCESS;
+}
+
+template <typename TInterface, typename... Interfaces>
+void GenericDevice<TInterface, Interfaces...>::setDomainSignal(const SignalPtr& signal)
+{
+    this->domainSignal = signal;
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -741,7 +741,11 @@ ErrCode GenericDevice<TInterface, Interfaces...>::getTicksSinceOrigin(uint64_t* 
 template <typename TInterface, typename... Interfaces>
 uint64_t GenericDevice<TInterface, Interfaces...>::onGetTicksSinceOrigin()
 {
-    if (this->domainSignal.assigned())
+    SignalPtr domainSignal;
+    if (OPENDAQ_FAILED(getDomainSignal(&domainSignal)))
+        daqClearErrorInfo();
+
+    if (domainSignal.assigned())
     {
         if (const auto lastValue = domainSignal.getLastValue(); lastValue.assigned())
             return lastValue;

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -253,8 +253,6 @@ protected:
     DevicePtr getParentDevice();
     OperationModeType getOperationMode();
 
-    void setDomainSignal(const SignalPtr& signal);
-
 private:
     void getChannelsFromFolder(ListPtr<IChannel>& channelList, const FolderPtr& folder, const SearchFilterPtr& searchFilter, bool filterChannels = true);
     ListPtr<ISignal> getSignalsRecursiveInternal(const SearchFilterPtr& searchFilter);
@@ -1273,14 +1271,18 @@ template <typename TInterface, typename... Interfaces>
 ErrCode GenericDevice<TInterface, Interfaces...>::getDomainSignal(ISignal** signal)
 {
     OPENDAQ_PARAM_NOT_NULL(signal);
+
+    if (!this->domainSignal.assigned())
+    {
+        ListPtr<ISignal> signals;
+        OPENDAQ_RETURN_IF_FAILED(getSignals(&signals, search::RequireTags(List<IString>("DeviceDomain"))));
+
+        if (signals.assigned() && signals.getCount() > 0)
+            this->domainSignal = signals[0];
+    }
+
     *signal = this->domainSignal.addRefAndReturn();
     return OPENDAQ_SUCCESS;
-}
-
-template <typename TInterface, typename... Interfaces>
-void GenericDevice<TInterface, Interfaces...>::setDomainSignal(const SignalPtr& signal)
-{
-    this->domainSignal = signal;
 }
 
 template <typename TInterface, typename... Interfaces>

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -20,6 +20,10 @@
 #include <opendaq/mock/mock_streaming_factory.h>
 #include <opendaq/device_network_config_ptr.h>
 #include <opendaq/component_private_ptr.h>
+#include <opendaq/data_descriptor_factory.h>
+#include <opendaq/reference_domain_info_factory.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/device_domain_factory.h>
 #include "testutils/testutils.h"
 
 using DeviceTest = testing::Test;
@@ -154,6 +158,65 @@ public:
     }
 };
 
+
+class DomainSignalDevice final : public daq::Device
+{
+public:
+    DomainSignalDevice(const daq::ContextPtr& ctx = daq::NullContext(),
+                        const daq::ComponentPtr& parent = nullptr,
+                        const daq::StringPtr& localId = "dev")
+        : daq::Device(ctx, parent, localId)
+    {
+        const auto referenceDomainInfo = daq::ReferenceDomainInfoBuilder()
+                                        .setReferenceDomainId("ReferenceDomainId")
+                                        .setReferenceDomainOffset(0)
+                                        .setReferenceTimeProtocol(daq::TimeProtocol::Tai)
+                                        .build();
+
+        const auto deviceDoamin = daq::DeviceDomain(
+            daq::Ratio(1, 1'000'000),
+            "1970-01-01T00:00:00",
+            daq::Unit("s", -1, "seconds", "time"),
+            referenceDomainInfo
+        );
+        this->setDeviceDomain(deviceDoamin);
+
+        auto descriptor = daq::DataDescriptorBuilder()
+                               .setSampleType(daq::SampleType::Int64)
+                               .setReferenceDomainInfo(referenceDomainInfo)
+                               .setRule(daq::LinearDataRule(1, 0))
+                               .setOrigin(deviceDoamin.getOrigin())
+                               .setTickResolution(deviceDoamin.getTickResolution())
+                               .setUnit(deviceDoamin.getUnit())
+                               .build();
+
+        timeSignal = this->createAndAddSignal("Time", descriptor);
+        this->setDomainSignal(timeSignal);
+    }
+
+    daq::SignalConfigPtr timeSignal;
+};
+
+TEST_F(DeviceTest, GetDomainSignal)
+{
+    const auto device = daq::createWithImplementation<daq::IDevice, DomainSignalDevice>();
+
+    ASSERT_TRUE(device.getDomainSignal().assigned());
+    ASSERT_EQ(device.getDomainSignal(), device.getSignals()[0]);
+}
+
+TEST_F(DeviceTest, GetTicksSinceOriginFromDomainSignal)
+{
+    const auto device = daq::createWithImplementation<daq::IDevice, DomainSignalDevice>();
+    daq::SignalConfigPtr deviceDomainSignal = device.getDomainSignal();
+
+    auto packet = daq::DataPacket(deviceDomainSignal.getDescriptor(), 5, 0);
+
+    deviceDomainSignal.sendPacket(packet);
+
+    ASSERT_EQ(device.getTicksSinceOrigin(), packet.getLastValue());
+    ASSERT_EQ(device.getTicksSinceOrigin(), 4);
+}
 
 TEST_F(DeviceTest, DeviceInfoNameLocationSync)
 {

--- a/core/opendaq/device/tests/test_device.cpp
+++ b/core/opendaq/device/tests/test_device.cpp
@@ -190,8 +190,8 @@ public:
                                .setUnit(deviceDoamin.getUnit())
                                .build();
 
-        timeSignal = this->createAndAddSignal("Time", descriptor);
-        this->setDomainSignal(timeSignal);
+        timeSignal = this->createAndAddSignal("Time", descriptor, false);
+        timeSignal.getTags().asPtr<daq::ITagsPrivate>(true).add("DeviceDomain");
     }
 
     daq::SignalConfigPtr timeSignal;
@@ -202,7 +202,7 @@ TEST_F(DeviceTest, GetDomainSignal)
     const auto device = daq::createWithImplementation<daq::IDevice, DomainSignalDevice>();
 
     ASSERT_TRUE(device.getDomainSignal().assigned());
-    ASSERT_EQ(device.getDomainSignal(), device.getSignals()[0]);
+    ASSERT_EQ(device.getDomainSignal(), device.getSignals(daq::search::Any())[0]);
 }
 
 TEST_F(DeviceTest, GetTicksSinceOriginFromDomainSignal)

--- a/core/opendaq/opendaq/include/opendaq/instance_impl.h
+++ b/core/opendaq/opendaq/include/opendaq/instance_impl.h
@@ -95,6 +95,8 @@ public:
     ErrCode INTERFACE_FUNC getOperationMode(OperationModeType* modeType) override;
     ErrCode INTERFACE_FUNC findProperties(IList** properties, ISearchFilter* propertyFilter, ISearchFilter* componentFilter = nullptr) override;
 
+    ErrCode INTERFACE_FUNC getDomainSignal(ISignal** signal) override;
+
     // IDeviceDomain
     ErrCode INTERFACE_FUNC getTicksSinceOrigin(uint64_t* ticks) override;
 

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/device.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/device.h
@@ -61,6 +61,7 @@ struct MockDevice : MockGenericSignalContainer<MockDevice, IDevice>
     MOCK_METHOD(ErrCode, setOperationModeRecursive, (OperationModeType), (override MOCK_CALL));
     MOCK_METHOD(ErrCode, getOperationMode, (OperationModeType*), (override MOCK_CALL));
     MOCK_METHOD(ErrCode, getAvailableOperationModes, (IList**), (override MOCK_CALL));
+    MOCK_METHOD(ErrCode, getDomainSignal, (ISignal**), (override MOCK_CALL));
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -409,6 +409,11 @@ ErrCode InstanceImpl::getSignalsRecursive(IList** signals, ISearchFilter* search
     return rootDevice->getSignalsRecursive(signals, searchFilter);
 }
 
+ErrCode InstanceImpl::getDomainSignal(ISignal** signal)
+{
+    return rootDevice->getDomainSignal(signal);
+}
+
 ErrCode InstanceImpl::getTicksSinceOrigin(uint64_t* ticks)
 {
     return rootDevice->getTicksSinceOrigin(ticks);

--- a/core/opendaq/signal/include/opendaq/last_value_cache.h
+++ b/core/opendaq/signal/include/opendaq/last_value_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
@@ -56,6 +56,9 @@ public:
     // IComponentPrivate
     ErrCode INTERFACE_FUNC setComponentConfig(IPropertyObject* config) override;
 
+    // IDevice
+    ErrCode INTERFACE_FUNC getDomainSignal(ISignal** signal) override;
+
 protected:
     void serializeCustomObjectValues(const SerializerPtr& serializer, bool forUpdate) override;
     void deserializeCustomObjectValues(const SerializedObjectPtr& serializedObject,
@@ -287,12 +290,18 @@ ErrCode MirroredDeviceBase<Interfaces...>::setComponentConfig(IPropertyObject* c
         auto deviceSelf = this->template borrowPtr<DevicePtr>();
         PropertyObjectPtr generalConfig = this->componentConfig.getPropertyValue("General");
         bool automaticallyConnectStreamings = generalConfig.getPropertyValue("AutomaticallyConnectStreaming");
-        if (automaticallyConnectStreamings &&
-            !(generalConfig.getPropertyValue("StreamingConnectionHeuristic") == 2)) // is not "NotConnected"
+        Int streamingConnectionHeuristic = generalConfig.getPropertyValue("StreamingConnectionHeuristic");
+        if (automaticallyConnectStreamings && streamingConnectionHeuristic != 2) // is not "NotConnected"
             streamingSourceManager = std::make_shared<StreamingSourceManager>(this->context, deviceSelf, this->componentConfig);
     }
 
     return errCode;
+}
+
+template <typename... Interfaces>
+ErrCode MirroredDeviceBase<Interfaces...>::getDomainSignal(ISignal** signal)
+{
+    return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOTIMPLEMENTED, "getDomainSignal is not implemented for MirroredDevice");
 }
 
 template <typename... Interfaces>

--- a/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
+++ b/core/opendaq/streaming/include/opendaq/mirrored_device_impl.h
@@ -56,9 +56,6 @@ public:
     // IComponentPrivate
     ErrCode INTERFACE_FUNC setComponentConfig(IPropertyObject* config) override;
 
-    // IDevice
-    ErrCode INTERFACE_FUNC getDomainSignal(ISignal** signal) override;
-
 protected:
     void serializeCustomObjectValues(const SerializerPtr& serializer, bool forUpdate) override;
     void deserializeCustomObjectValues(const SerializedObjectPtr& serializedObject,
@@ -296,12 +293,6 @@ ErrCode MirroredDeviceBase<Interfaces...>::setComponentConfig(IPropertyObject* c
     }
 
     return errCode;
-}
-
-template <typename... Interfaces>
-ErrCode MirroredDeviceBase<Interfaces...>::getDomainSignal(ISignal** signal)
-{
-    return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_NOTIMPLEMENTED, "getDomainSignal is not implemented for MirroredDevice");
 }
 
 template <typename... Interfaces>

--- a/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
+++ b/examples/modules/ref_device_module/include/ref_device_module/ref_device_impl.h
@@ -44,7 +44,6 @@ public:
 
     // IDevice
     DeviceInfoPtr onGetInfo() override;
-    uint64_t onGetTicksSinceOrigin() override;
 
     bool allowAddDevicesFromModules() override;
     bool allowAddFunctionBlocksFromModules() override;

--- a/examples/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_impl.cpp
@@ -593,8 +593,6 @@ void RefDeviceImpl::createSignals()
 {
     timeSignal = createAndAddSignal("Time", nullptr, false);
     timeSignal.getTags().asPtr<ITagsPrivate>(true).add("DeviceDomain");
-
-    setDomainSignal(timeSignal);
 }
 
 #ifdef DAQMODULES_REF_DEVICE_MODULE_SIMULATOR_ENABLED

--- a/examples/modules/ref_device_module/src/ref_device_impl.cpp
+++ b/examples/modules/ref_device_module/src/ref_device_impl.cpp
@@ -138,13 +138,6 @@ DeviceInfoPtr RefDeviceImpl::onGetInfo()
     return RefDeviceImpl::CreateDeviceInfo(moduleInfo, id, serialNumber);
 }
 
-uint64_t RefDeviceImpl::onGetTicksSinceOrigin()
-{
-    auto microSecondsSinceDeviceStart = getMicroSecondsSinceDeviceStart();
-    auto ticksSinceEpoch = microSecondsFromEpochToDeviceStart + microSecondsSinceDeviceStart;
-    return static_cast<SizeT>(ticksSinceEpoch.count());
-}
-
 bool RefDeviceImpl::allowAddDevicesFromModules()
 {
     return true;
@@ -600,6 +593,8 @@ void RefDeviceImpl::createSignals()
 {
     timeSignal = createAndAddSignal("Time", nullptr, false);
     timeSignal.getTags().asPtr<ITagsPrivate>(true).add("DeviceDomain");
+
+    setDomainSignal(timeSignal);
 }
 
 #ifdef DAQMODULES_REF_DEVICE_MODULE_SIMULATOR_ENABLED

--- a/examples/modules/ref_device_module/tests/test_ref_device_module.cpp
+++ b/examples/modules/ref_device_module/tests/test_ref_device_module.cpp
@@ -22,6 +22,7 @@
 #include <ref_device_module/version.h>
 #include <testutils/testutils.h>
 #include <chrono>
+#include <future>
 #include <thread>
 #include "../../../core/opendaq/opendaq/tests/test_config_provider.h"
 #include <iomanip>
@@ -164,7 +165,26 @@ TEST_F(RefDeviceModuleTest, DeviceDomainTicksSinceEpoch)
     auto module = CreateModule();
 
     auto device = module.createDevice("daqref://device1", nullptr);
+    auto reader = PacketReader(device.getDomainSignal());
 
+    // wait for the first data packet to be available
+    std::promise<void> promise;
+    std::future<void> future = promise.get_future();
+    reader.setOnDataAvailable([&reader, &promise] {
+        auto packets = reader.readAll();
+        for (const auto& packet : packets)
+        {
+            if (packet.getType() == PacketType::Data)
+            {
+                promise.set_value();
+                reader.setOnDataAvailable(nullptr);
+                return;
+            }
+        }
+    });
+
+    auto result = future.wait_for(std::chrono::seconds(1));
+    ASSERT_EQ(result, std::future_status::ready);
     auto res = device.getTicksSinceOrigin();
     ASSERT_GT(res, 0u);
 }

--- a/shared/tools/RTGen/bin/Templates/c.header.template
+++ b/shared/tools/RTGen/bin/Templates/c.header.template
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Brief

Implement IDevice::getDomainSignal()

# Description

The device now considers the signal with tag `DeviceDomain` as a domain signal of this device.  at that case, the method Device::getTicksSinceOrigin() will automatically return the signal value by calling domainSignal.getLastValue();

# Usage example

In C++ use:

```cpp
class SomeDeviceImpl::Device
{
SomeDeviceImpl(const ContextPtr& ctx,
                          const ComponentPtr& parent,
                          const StringPtr& localId)
  : Device(ctx, parent, localId)
{
    createSignals();
}

void createSignals()
{
    auto timeSignal = createAndAddSignal("Time", nullptr, false);
    timeSignal.getTags().asPtr<ITagsPrivate>(true).add("DeviceDomain");
}
};

// outside from device
// get the domain signal
auto deviceDomainSignal = device.getDomainSignal();

// get the last domain signal value
auto lastValue = device.getTicksSinceOrigin();
// which is the same as 
auto lastValueAnotherWay = deviceDomainSignal.getLastValue();
```

# API changes

```diff
+ IDevice::getDomainSignal(ISignal** signal);
```

# Required application changes

None
But if device has the domain signal with correct domain , the overridden method `onGetTicksSinceOrigin` can be removed inside of your Implementation

# Required module changes

None