### PR TITLE
implement IContext::getRootDevice

### DIFF
--- a/changelog/changelog_3.40-3.50.md
+++ b/changelog/changelog_3.40-3.50.md
@@ -1,0 +1,33 @@
+# Changes from 3.40 to 3.50
+
+## Features
+
+- [#1242](https://github.com/openDAQ/openDAQ/pull/1242) implement IContext::getRootDevice
+
+## Python
+
+## Bug fixes
+
+## Misc
+
+## Required application changes
+
+## Required module changes
+
+## Interface API changes
+
+### New interfaces
+
+### Removed interfaces
+
+### Modified interfaces
+
+#### `Context`
+```diff
++ IContext::getRootDevice(IBaseObject** device);
+```
+
+#### `IContextInternal`
+```diff
++ IContextInternal::setRootDevice(IBaseObject* device);
+```

--- a/core/opendaq/context/include/opendaq/context.h
+++ b/core/opendaq/context/include/opendaq/context.h
@@ -106,13 +106,18 @@ DECLARE_OPENDAQ_INTERFACE(IContext, IBaseObject)
      */
     virtual ErrCode INTERFACE_FUNC getModuleOptions(IString* moduleId, IDict** options) = 0;
 
-    
     // [templateType(servers, IString, IBaseObject)]
     /*!
      * @brief Gets the dictionary of available discovery servers.
      * @param[out] servers The dictionary of available discovery servers.
      */
     virtual ErrCode INTERFACE_FUNC getDiscoveryServers(IDict** servers) = 0;
+
+    /*!
+     * @brief Gets the root device of the openDAQ instance.
+     * @param[out] device The root device.
+     */
+    virtual ErrCode INTERFACE_FUNC getRootDevice(IBaseObject** device) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/modulemanager/include/opendaq/context_impl.h
+++ b/core/opendaq/modulemanager/include/opendaq/context_impl.h
@@ -38,16 +38,21 @@ public:
                          DictPtr<IString, IDiscoveryServer> discoveryServices);
     ~ContextImpl();
 
+    // IContext interface
     ErrCode INTERFACE_FUNC getScheduler(IScheduler** scheduler) override;
     ErrCode INTERFACE_FUNC getLogger(ILogger** logger) override;
     ErrCode INTERFACE_FUNC getModuleManager(IBaseObject** manager) override;
     ErrCode INTERFACE_FUNC getTypeManager(ITypeManager** manager) override;
     ErrCode INTERFACE_FUNC getAuthenticationProvider(IAuthenticationProvider** authenticationProvider) override;
     ErrCode INTERFACE_FUNC getOnCoreEvent(IEvent** event) override;
-    ErrCode INTERFACE_FUNC moveModuleManager(IModuleManager** manager) override;
     ErrCode INTERFACE_FUNC getOptions(IDict** options) override;
     ErrCode INTERFACE_FUNC getModuleOptions(IString* moduleId, IDict** options) override;
     ErrCode INTERFACE_FUNC getDiscoveryServers(IDict** servers) override;
+    ErrCode INTERFACE_FUNC getRootDevice(IBaseObject** device) override;
+
+    // IContextInternal interface
+    ErrCode INTERFACE_FUNC moveModuleManager(IModuleManager** manager) override;
+    ErrCode INTERFACE_FUNC setRootDevice(IBaseObject* device) override;
 
 private:
     void componentCoreEventCallback(ComponentPtr& component, CoreEventArgsPtr& eventArgs);
@@ -62,6 +67,7 @@ private:
     EventEmitter<ComponentPtr, CoreEventArgsPtr> coreEvent;
     DictPtr<IString, IBaseObject> options;
     DictPtr<IString, IDiscoveryServer> discoveryServers;
+    WeakRefPtr<IBaseObject> rootDeviceWeakRef;
 };
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/modulemanager/include/opendaq/context_internal.h
+++ b/core/opendaq/modulemanager/include/opendaq/context_internal.h
@@ -40,6 +40,12 @@ DECLARE_OPENDAQ_INTERFACE(IContextInternal, IBaseObject)
      * Returns a nullptr on subsequent invocations, and if the manager is not assigned.
      */
     virtual ErrCode INTERFACE_FUNC moveModuleManager(IModuleManager** manager) = 0;
+
+    /*!
+     * @brief Sets the root device of the openDAQ instance.
+     * @param device The root device.
+     */
+    virtual ErrCode INTERFACE_FUNC setRootDevice(IBaseObject* device) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/modulemanager/src/context_impl.cpp
+++ b/core/opendaq/modulemanager/src/context_impl.cpp
@@ -227,6 +227,27 @@ ErrCode ContextImpl::getDiscoveryServers(IDict** servers)
     return OPENDAQ_SUCCESS;
 }
 
+ErrCode ContextImpl::getRootDevice(IBaseObject** device)
+{
+    OPENDAQ_PARAM_NOT_NULL(device);
+    *device = nullptr;
+
+    if (!this->rootDeviceWeakRef.assigned())
+        return OPENDAQ_IGNORED;
+
+    *device = this->rootDeviceWeakRef.getRef().detach();
+    return OPENDAQ_SUCCESS;
+}
+
+ErrCode ContextImpl::setRootDevice(IBaseObject* device)
+{
+    if (!device)
+        this->rootDeviceWeakRef = nullptr;
+    else
+        this->rootDeviceWeakRef = device;
+    return OPENDAQ_SUCCESS;
+}
+
 void ContextImpl::registerOpenDaqTypes()
 {
     if (typeManager == nullptr)

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/context.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/context.h
@@ -35,10 +35,13 @@ struct MockContext : daq::ImplementationOf<daq::IContext, daq::IContextInternal>
     MOCK_METHOD(daq::ErrCode, getTypeManager, (daq::ITypeManager** manager), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, getAuthenticationProvider, (daq::IAuthenticationProvider** authenticationProvider), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, getOnCoreEvent, (daq::IEvent** event), (override MOCK_CALL));
-    MOCK_METHOD(daq::ErrCode, moveModuleManager, (daq::IModuleManager** manager), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, getOptions, (daq::IDict** options), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, getModuleOptions, (daq::IString* moduleId, daq::IDict** options), (override MOCK_CALL));
     MOCK_METHOD(daq::ErrCode, getDiscoveryServers, (daq::IDict** services), (override MOCK_CALL));
+    MOCK_METHOD(daq::ErrCode, getRootDevice, (daq::IBaseObject** device), (override MOCK_CALL));
+
+    MOCK_METHOD(daq::ErrCode, moveModuleManager, (daq::IModuleManager** manager), (override MOCK_CALL));
+    MOCK_METHOD(daq::ErrCode, setRootDevice, (daq::IBaseObject* device), (override MOCK_CALL));
 
     daq::ErrCode INTERFACE_FUNC getModuleManager(daq::IBaseObject** manager) override
     {
@@ -82,6 +85,11 @@ struct MockContext : daq::ImplementationOf<daq::IContext, daq::IContextInternal>
         EXPECT_CALL(*this, getOnCoreEvent)
             .Times(AnyNumber())
             .WillRepeatedly(DoAll(Invoke([&](daq::IEvent** event) { *event = coreEvent.addRefAndReturn(); }),
+                                  Return(OPENDAQ_SUCCESS)));
+
+        EXPECT_CALL(*this, setRootDevice)
+            .Times(AnyNumber())
+            .WillRepeatedly(DoAll(Invoke([&](daq::IBaseObject* device) {}),
                                   Return(OPENDAQ_SUCCESS)));
     }
 };

--- a/core/opendaq/opendaq/src/instance_impl.cpp
+++ b/core/opendaq/opendaq/src/instance_impl.cpp
@@ -40,7 +40,7 @@ InstanceImpl::InstanceImpl(ContextPtr context, const StringPtr& localId)
 
 InstanceImpl::InstanceImpl(IInstanceBuilder* instanceBuilder)
     : context(ContextFromInstanceBuilder(instanceBuilder))
-    , moduleManager(this->context.assigned() ? this->context.asPtr<IContextInternal>().moveModuleManager() : nullptr)
+    , moduleManager(this->context.assigned() ? this->context.asPtr<IContextInternal>(true).moveModuleManager() : nullptr)
     , rootDeviceSet(false)
 {
     const auto builderPtr = InstanceBuilderPtr::Borrow(instanceBuilder);
@@ -51,7 +51,7 @@ InstanceImpl::InstanceImpl(IInstanceBuilder* instanceBuilder)
 
     if (connectionString.assigned() && connectionString.getLength())
     {
-        rootDevice = moduleManager.asPtr<IModuleManagerUtils>().createDevice(connectionString, nullptr, rootDeviceConfig);
+        rootDevice = moduleManager.asPtr<IModuleManagerUtils>(true).createDevice(connectionString, nullptr, rootDeviceConfig);
         LOG_I("Root device set to {}", connectionString)
         rootDeviceSet = true;
     }
@@ -62,14 +62,17 @@ InstanceImpl::InstanceImpl(IInstanceBuilder* instanceBuilder)
         rootDevice = Client(this->context, instanceId, builderPtr.getDefaultRootDeviceInfo());
     }
 
-    const auto devicePrivate = rootDevice.asPtrOrNull<IDevicePrivate>();
+    const auto devicePrivate = rootDevice.asPtrOrNull<IDevicePrivate>(true);
     if (devicePrivate.assigned())
+    {
         checkErrorInfo(devicePrivate->setAsRoot());
+        checkErrorInfo(context.asPtr<IContextInternal>(true)->setRootDevice(rootDevice));
+    }
 
     for (const auto& [_, discoveryServer] : context.getDiscoveryServers())
-        discoveryServer.asPtr<IDiscoveryServer>().setRootDevice(rootDevice);
+        discoveryServer.asPtr<IDiscoveryServer>(true).setRootDevice(rootDevice);
 
-    rootDevice.asPtr<IPropertyObjectInternal>().enableCoreEventTrigger();
+    rootDevice.asPtr<IPropertyObjectInternal>(true).enableCoreEventTrigger();
 }
 
 InstanceImpl::~InstanceImpl()
@@ -364,16 +367,19 @@ ErrCode InstanceImpl::setRootDevice(IString* connectionString, IPropertyObject* 
     this->rootDevice = newRootDevice;
     rootDeviceSet = true;
 
-    const auto devicePrivate = rootDevice.asPtrOrNull<IDevicePrivate>();
+    const auto devicePrivate = rootDevice.asPtrOrNull<IDevicePrivate>(true);
     if (devicePrivate.assigned())
-        devicePrivate->setAsRoot();
+    {
+        OPENDAQ_RETURN_IF_FAILED(devicePrivate->setAsRoot());
+        OPENDAQ_RETURN_IF_FAILED(context.asPtr<IContextInternal>(true)->setRootDevice(rootDevice));
+    }
 
     for (const auto& [_, discoveryServer] : context.getDiscoveryServers())
-        discoveryServer.asPtr<IDiscoveryServer>().setRootDevice(rootDevice);
+        discoveryServer.asPtr<IDiscoveryServer>(true).setRootDevice(rootDevice);
 
     LOG_I("Root device explicitly set to {}", connectionStringPtr);
 
-    this->rootDevice.asPtr<IPropertyObjectInternal>().enableCoreEventTrigger();
+    this->rootDevice.asPtr<IPropertyObjectInternal>(true).enableCoreEventTrigger();
     return OPENDAQ_SUCCESS;
 }
 
@@ -452,7 +458,6 @@ ErrCode InstanceImpl::getParent(IComponent** parent)
 
     return OPENDAQ_SUCCESS;
 }
-
 
 ErrCode InstanceImpl::getName(IString** name)
 {
@@ -613,10 +618,11 @@ ErrCode InstanceImpl::saveConfiguration(IString** configuration)
         const auto prettyPrint = getPrettyPrintOnSaveConfig(this->context.getOptions());
         auto serializer = JsonSerializer(prettyPrint);
 
-        const ErrCode errCode = this->serializeForUpdate(serializer);
-        OPENDAQ_RETURN_IF_FAILED(errCode);
+        OPENDAQ_RETURN_IF_FAILED(this->serializeForUpdate(serializer));
 
-        return serializer->getOutput(configuration);
+        const ErrCode errCode = serializer->getOutput(configuration);
+        OPENDAQ_RETURN_IF_FAILED(errCode);
+        return errCode;
     });
     OPENDAQ_RETURN_IF_FAILED(errCode);
     return errCode;
@@ -633,9 +639,9 @@ ErrCode InstanceImpl::loadConfiguration(IString* configuration, IUpdateParameter
 
         auto updatable = this->template borrowInterface<IUpdatable>();
 
-        deserializer.update(updatable, configuration, configPtr);
-
-        return OPENDAQ_SUCCESS;
+        const ErrCode errCode = deserializer->update(updatable, configuration, configPtr);
+        OPENDAQ_RETURN_IF_FAILED(errCode);
+        return errCode;
     });
     OPENDAQ_RETURN_IF_FAILED(errCode);
     return errCode;

--- a/core/opendaq/opendaq/tests/test_instance.cpp
+++ b/core/opendaq/opendaq/tests/test_instance.cpp
@@ -1231,4 +1231,12 @@ TEST_F(InstanceTest, TestUpdateMissingStaticFB)
     ASSERT_FALSE(fb.isRemoved());
 }
 
+TEST_F(InstanceTest, SetRootDeviceUpdatesContextRootDevice)
+{
+    auto instance = test_helpers::setupInstance();
+    ASSERT_EQ(instance.getRootDevice(), instance.getContext().getRootDevice());
+    
+    instance.setRootDevice("daqmock://phys_device");
+    ASSERT_EQ(instance.getRootDevice(), instance.getContext().getRootDevice());
+}
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/signal/include/opendaq/last_value_cache.h
+++ b/core/opendaq/signal/include/opendaq/last_value_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Brief

add possibility to get the root device via context method getRootDevice()

# Usage example

In C++ use:

```cpp
class SubDeviceImpl::Device
{
SubDeviceImpl(const ContextPtr& ctx,
                          const ComponentPtr& parent,
                          const StringPtr& localId)
  : Device(ctx, parent, localId)
{
     DevicePtr rootDevice = context.getRootDevice();
     // get something from the root device, for example 
     // SignalPtr rootDomainSignal = rootDevice.getDomainSignal();
}
};
```

# API changes


```diff
+ IContext::getRootDevice(IBaseObject** device);
+ IContextInternal::setRootDevice(IBaseObject* device);

```

# Required application changes

None

# Required module changes

None
