### PR TITLE
Fix missing Windows runtime DLLs in .NET NuGet package

### DIFF
--- a/bindings/dotnet/openDAQ.Net/openDAQ.Net/openDAQ.Net.csproj
+++ b/bindings/dotnet/openDAQ.Net/openDAQ.Net/openDAQ.Net.csproj
@@ -77,6 +77,8 @@
     <_ciPackageRuntimesPathWinx86>runtimes\win-x86\native</_ciPackageRuntimesPathWinx86>
     <_ciPackageRuntimesPathLinx64>runtimes\linux-x64\native</_ciPackageRuntimesPathLinx64>
     <_ciPackageLib>lib\$(OpenDaqNetVersion.Split(';')[0])</_ciPackageLib>
+    <!-- native DLLs sit under the per-TFM output subdir; pick the first TFM (identical across frameworks) -->
+    <_ciWinTfmSubdir>$(OpenDaqNetVersion.Split(';')[0])</_ciWinTfmSubdir>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
@@ -154,12 +156,12 @@
   <ItemGroup Condition="'$(_IsCiPackBuild)' == 'True'">
     <!-- NuGet package creation in CI -->
     <!-- Windows runtimes -->
-    <OpenDaqWinLibs Include="$(_SdkOutputPathWindows64)\*.dll" Exclude="$(_SdkOutputPathWindows64)\openDAQ.Net.dll;$(_SdkOutputPathWindows64)\openDAQDemo.Net.dll" />
-    <None Include="@(OpenDaqWinLibs)" PackagePath="$(_ciPackageRuntimesPathWinx64)\" Pack="true" Visible="false" Condition="Exists('$(_SdkOutputPathWindows64)')">
+    <OpenDaqWinLibs Include="$(_SdkOutputPathWindows64)\$(_ciWinTfmSubdir)\*.dll" Exclude="$(_SdkOutputPathWindows64)\$(_ciWinTfmSubdir)\openDAQ.Net.dll;$(_SdkOutputPathWindows64)\$(_ciWinTfmSubdir)\openDAQDemo.Net.dll" />
+    <None Include="@(OpenDaqWinLibs)" PackagePath="$(_ciPackageRuntimesPathWinx64)\" Pack="true" Visible="false" Condition="Exists('$(_SdkOutputPathWindows64)\$(_ciWinTfmSubdir)')">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
-    <OpenDaqModuleWinLibs Include="$(_SdkOutputPathWindows64)\modules\*.dll" />
-    <None Include="@(OpenDaqModuleWinLibs)" PackagePath="$(_ciPackageRuntimesPathWinx64)\modules\" Pack="true" Visible="false" Condition="Exists('$(_SdkOutputPathWindows64)\modules')">
+    <OpenDaqModuleWinLibs Include="$(_SdkOutputPathWindows64)\$(_ciWinTfmSubdir)\modules\*.dll" />
+    <None Include="@(OpenDaqModuleWinLibs)" PackagePath="$(_ciPackageRuntimesPathWinx64)\modules\" Pack="true" Visible="false" Condition="Exists('$(_SdkOutputPathWindows64)\$(_ciWinTfmSubdir)\modules')">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
     <!-- Linux runtimes -->


### PR DESCRIPTION
# Brief

The CI-packed package shipped Linux-only after multiversion .NET builds moved native libs into a per-TFM output subdir.

# Description

- Point the Windows CI-pack globs at the per-TFM output subdir (`win-x64\<tfm>\`) instead of the flat root
- Add a `_ciWinTfmSubdir` property that parses the TFM list and takes the first framework as the native source (native libs are .NET-version independent)
- Linux packing and the RID-based `runtimes/win-x64/native/` package layout are unchanged

**Reason:** `AppendTargetFrameworkToOutputPath=True` (from the multiversion .NET bindings build) moved the native SDK DLLs — copied into the .NET output — from `bin/x64/Release/` into `bin/x64/Release/net8.0/`. The CI-pack globs still read the flat root (`$(_SdkOutputPathWindows64)\*.dll`), matched nothing, and dropped every Windows DLL. Linux was unaffected because its `.so` come straight from the SDK `bin/`, not from the per-TFM .NET output.

> [!NOTE]
> **TFM** (Target Framework Moniker) — the targeted .NET version, e.g. `net8.0`. Multi-targeting builds output into a per-TFM subdirectory (`net8.0/`, `net9.0/`, ...).
> **RID** (Runtime Identifier) — the target OS + architecture, e.g. `win-x64`, `linux-x64`. NuGet resolves native binaries from `runtimes/<rid>/native/` at runtime.
> Native libraries depend on the RID but not the TFM, so any single TFM's copy is a valid source for all frameworks.
