### PR TITLE
Fix Linux mingw cross-build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,7 @@ endif()
 set(RTGEN_NAMESPACE ${SDK_TARGET_NAMESPACE})
 include(RTGen)
 
-if(NOT WIN32)
+if(NOT CMAKE_HOST_WIN32)
     # Make sure mono is found properly and exists
     find_program(MONO_C
         NAMES "mono"

--- a/core/coretypes/src/customalloc.cpp
+++ b/core/coretypes/src/customalloc.cpp
@@ -3,7 +3,7 @@
 #ifdef WINHEAP
     #undef DECLARE_OPENDAQ_INTERFACE
     #undef DECLARE_OPENDAQ_INTERFACE_EX
-    #include <Windows.h>
+    #include <windows.h>
 #endif
 
 BEGIN_NAMESPACE_OPENDAQ

--- a/core/opendaq/modulemanager/src/CMakeLists.txt
+++ b/core/opendaq/modulemanager/src/CMakeLists.txt
@@ -155,8 +155,8 @@ if (WIN32)
     )
 
     set(PING_LIBS
-        Ws2_32
-        IPHLPAPI
+        ws2_32
+        iphlpapi
     )
 endif()
 

--- a/external/mdns/CMakeLists.txt
+++ b/external/mdns/CMakeLists.txt
@@ -9,6 +9,7 @@ opendaq_dependency(
     EXPECT_TARGET       mdns::mdns
     PATCH_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-Multicast-commands-ip6-ifindex.patch
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/0003-mdns-mingw-compatibility.patch
 )
 
 install(

--- a/external/mdns/patches/0003-mdns-mingw-compatibility.patch
+++ b/external/mdns/patches/0003-mdns-mingw-compatibility.patch
@@ -1,0 +1,11 @@
+diff --git a/mdns.h b/mdns.h
+--- a/mdns.h
++++ b/mdns.h
+@@ -23,5 +23,5 @@
+ #ifdef _WIN32
+-#include <Winsock2.h>
+-#include <Ws2tcpip.h>
++#include <winsock2.h>
++#include <ws2tcpip.h>
+ #define strncasecmp _strnicmp
+ #else

--- a/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
+++ b/shared/libraries/discovery/include/daq_discovery/mdnsdiscovery_client.h
@@ -41,7 +41,7 @@
 
 #ifdef _WIN32
 #include <iphlpapi.h>
-#include <WinSock2.h>
+#include <winsock2.h>
 #else
 #include <ifaddrs.h>
 #include <net/if.h>

--- a/shared/libraries/utils/src/thread_ex.cpp
+++ b/shared/libraries/utils/src/thread_ex.cpp
@@ -4,7 +4,7 @@
 #include <stdexcept>
 
 #if defined(_WIN32) && !defined(__WINPTHREADS_VERSION)
-    #include <Windows.h>
+    #include <windows.h>
 #endif
 
 using namespace std;

--- a/shared/libraries/utils/src/thread_name.cpp
+++ b/shared/libraries/utils/src/thread_name.cpp
@@ -2,7 +2,7 @@
 #include <cstring>
 
 #if defined(_WIN32) && !defined(__WINPTHREADS_VERSION)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #ifdef __linux


### PR DESCRIPTION
# Brief

Fixes cross-compilation for Windows on Linux/mingw.

# Description

We are cross-compiling OpenDAQ for Windows on our Linux build machine using mingw. These are the changes I had to make to get the build working, mainly due to case sensitivity on Linux and one CMake issue where the target platform was used instead of the host platform.