### PR TITLE
Fix rogue IStringObject type hint in context.h

### DIFF
--- a/core/opendaq/context/include/opendaq/context.h
+++ b/core/opendaq/context/include/opendaq/context.h
@@ -127,8 +127,8 @@ DECLARE_OPENDAQ_INTERFACE(IContext, IBaseObject)
  * @{
  */
 
-// [templateType(options, IStringObject, IBaseObject)]
-// [templateType(discoveryServers, IStringObject, IDiscoveryServer)]
+// [templateType(options, IString, IBaseObject)]
+// [templateType(discoveryServers, IString, IDiscoveryServer)]
 OPENDAQ_DECLARE_CLASS_FACTORY(
     LIBRARY_FACTORY, Context,
     IScheduler*, Scheduler,


### PR DESCRIPTION
I am pretty sure using this is a mistake/typo (`IStringObject` doesn't appear anywhere else in the c++ code), otherwise feel free to just close my pull request.