### PR TITLE
Disable spdlog MDC to fix shutdown crash on logger worker thread

### DIFF
--- a/external/spdlog/CMakeLists.txt
+++ b/external/spdlog/CMakeLists.txt
@@ -11,3 +11,17 @@ opendaq_dependency(
     PATCH_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/patches/001-periodic_worker_init_func.patch
 )
+
+# Disable spdlog's Mapped Diagnostic Context (MDC). openDAQ never uses MDC, and in async
+# mode spdlog's `full_formatter`/`mdc_formatter` call `mdc::get_context()` on the logger
+# worker thread, instantiating a `thread_local std::map` there. On mingw-w64 that thread-local
+# is destroyed (via `run_dtor_list`) against already-freed heap during process/thread shutdown,
+# crashing on thread exit (observable when a debugger forces orderly per-thread TLS teardown).
+# `SPDLOG_NO_TLS` compiles out the thread-local entirely. Set PUBLIC so spdlog and every
+# consumer that inlines spdlog headers agree, avoiding an ODR mismatch.
+if (TARGET spdlog)
+    target_compile_definitions(spdlog PUBLIC SPDLOG_NO_TLS)
+endif()
+if (TARGET spdlog_header_only)
+    target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_NO_TLS)
+endif()


### PR DESCRIPTION
# Brief

Fix an occasional crash under MinGW when the logger is being destroyed.

# Description

The async logger worker thread formatted messages through spdlog's `%+` full_formatter, which calls `mdc::get_context()` and instantiates a `thread_local std::map` on that thread. On mingw-w64 the thread-local was destroyed against already-freed heap during thread/process shutdown, crashing on thread exit (e.g. ComponentTest.LockedProperties under a debugger). openDAQ never uses MDC, so define SPDLOG_NO_TLS to compile the thread-local out entirely.