### PR TITLE
Export generatePacketId() from the opendaq shared library

### DIFF
--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -808,7 +808,7 @@ ErrCode DataPacketImpl<TInterface, TInterfaces...>::reuse(IDataDescriptor* newDe
         this->callDestructCallbacks();
     }
 
-    this->packetId = generatePacketId();
+    this->packetId = daqGeneratePacketId();
 
     sampleCount = static_cast<uint32_t>(newSampleCount);
     rawSampleSize = static_cast<uint32_t>(newRawSampleSize);

--- a/core/opendaq/signal/include/opendaq/generic_data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/generic_data_packet_impl.h
@@ -39,12 +39,12 @@ protected:
     }
 };
 
-Int generatePacketId();
+PUBLIC_EXPORT Int daqGeneratePacketId();
 
 template <typename TInterface, typename... TInterfaces>
 GenericDataPacketImpl<TInterface, TInterfaces...>::GenericDataPacketImpl(IDataPacket* domainPacket)
     : domainPacket(domainPacket)
-    , packetId(generatePacketId())
+    , packetId(daqGeneratePacketId())
 {
     this->type = PacketType::Data;
 }

--- a/core/opendaq/signal/src/generic_data_packet_impl.cpp
+++ b/core/opendaq/signal/src/generic_data_packet_impl.cpp
@@ -4,7 +4,7 @@ BEGIN_NAMESPACE_OPENDAQ
 
 std::atomic<Int> globalPacketId {0};
 
-Int generatePacketId()
+Int daqGeneratePacketId()
 {
     return std::atomic_fetch_add_explicit(&globalPacketId, Int(1), std::memory_order_relaxed);
 }


### PR DESCRIPTION
# Brief

Rename generatePacketId() to daqGeneratePacketId() and make it accessible from outside opendaq.dll/.so

# Description

Resolves the issue when DataPacketImpl is used to implement packets outside the opendaq shared library.

generatePacketId() is reached from GenericDataPacketImpl's constructor and from DataPacketImpl::reuse(), both of which are defined in headers. The symbol itself was not exported, so on Windows no DataPacketImpl subclass outside the opendaq DLL could link, as PUBLIC_EXPORT resolves to dllimport for consumers.

Exporting the SDK's single monotonic id source keeps packet ids unique process-wide; a counter local to each consumer would hand out duplicates.

