### PR TITLE
Use patched cmake utils with boost aliases fix

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     opendaq-cmake-utils
     GIT_REPOSITORY  https://github.com/openDAQ/opendaq-cmake-utils.git
-    GIT_TAG         v1.0.1
+    GIT_TAG         v1.0.2
     GIT_PROGRESS    ON
 )
 FetchContent_MakeAvailable(opendaq-cmake-utils)


### PR DESCRIPTION
# Brief

Switches to newer https://github.com/openDAQ/opendaq-cmake-utils/releases/tag/v1.0.2 