### PR TITLE
Fix stale computed-data cache in DataPacketImpl

### DIFF
--- a/core/opendaq/signal/include/opendaq/data_packet_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_packet_impl.h
@@ -317,6 +317,7 @@ protected:
     void freeMemory();
     void freeScaledData();
     void initPacket();
+    void updateCalcFlags();
 
     DeleterPtr deleter;
     DataDescriptorPtr descriptor;
@@ -329,6 +330,10 @@ protected:
     void* data;
     void* scaledData;
 
+    // Bytes allocated for scaledData. The buffer is kept across reuse() and only grown when a
+    // larger one is needed, so recomputing does not reallocate.
+    uint32_t scaledDataCapacity = 0;
+
     std::mutex readLock;
 
     bool hasScalingCalc;
@@ -336,6 +341,10 @@ protected:
     bool hasRawDataOnly;
     bool externalMemory;
     bool hasReferenceDomainOffset;
+
+    // Whether scaledData holds the computed form of the packet's current contents. Kept separate
+    // from the pointer so that the allocation can outlive the data it was computed from.
+    bool scaledDataValid = false;
 };
 
 template <typename TInterface, typename... TInterfaces>
@@ -344,6 +353,12 @@ void DataPacketImpl<TInterface, TInterfaces ...>::initPacket()
     if (descriptor.getSampleType() == SampleType::Struct && rawSampleSize != sampleSize)
         DAQ_THROW_EXCEPTION(InvalidParameterException, "Packets with struct implicit descriptor not supported");
 
+    updateCalcFlags();
+}
+
+template <typename TInterface, typename... TInterfaces>
+void DataPacketImpl<TInterface, TInterfaces ...>::updateCalcFlags()
+{
     hasDataRuleCalc = descriptor.asPtr<IDataRuleCalcPrivate>(true)->hasDataRuleCalc();
     hasScalingCalc = descriptor.asPtr<IScalingCalcPrivate>(true)->hasScalingCalc();
 
@@ -568,58 +583,64 @@ ErrCode DataPacketImpl<TInterface, TInterfaces...>::getData(void** address)
         return OPENDAQ_SUCCESS;
     }
 
-    readLock.lock();
+    std::lock_guard lock{readLock};
 
-    if (scaledData)
+    if (scaledDataValid)
     {
         *address = scaledData;
+        return OPENDAQ_SUCCESS;
     }
-    else
+
+    if (sampleCount == 0 || dataSize == 0)
     {
-        if (sampleCount == 0)
-            *address = nullptr;
-        else
-        {
-            ErrCode err = daqTry(
-                [&]()
-                {
-                    if (hasScalingCalc)
-                    {
-                        scaledData = descriptor.asPtr<IScalingCalcPrivate>(true)->scaleData(data, sampleCount);
-                    }
-                    else if (hasDataRuleCalc)
-                    {
-                        scaledData = descriptor.asPtr<IDataRuleCalcPrivate>(true)->calculateRule(offset, sampleCount, data, rawDataSize);
-                    }
-
-                    if (hasReferenceDomainOffset)
-                    {
-                        auto referenceDomainOffsetAdder = std::unique_ptr<ReferenceDomainOffsetAdder>(createReferenceDomainOffsetAdderTyped(
-                            descriptor.getSampleType(), descriptor.getReferenceDomainInfo().getReferenceDomainOffset(), sampleCount));
-
-                        if (data)
-                        {
-                            // Explicit data rule, apply Reference Domain Offset
-                            // Uses malloc to create a new array
-                            scaledData = referenceDomainOffsetAdder->addReferenceDomainOffset(data);
-                        }
-                        else
-                        {
-                            // Linear data rule, apply Reference Domain Offset
-                            // Modifies existing array
-                            referenceDomainOffsetAdder->addReferenceDomainOffset(&scaledData);
-                        }
-                    }
-
-                    *address = scaledData;
-                    return OPENDAQ_SUCCESS;
-                });
-
-            OPENDAQ_RETURN_IF_FAILED(err);
-        }
+        *address = nullptr;
+        return OPENDAQ_SUCCESS;
     }
 
-    readLock.unlock();
+    const ErrCode errCode = daqTry(
+        [this]
+        {
+            if (scaledDataCapacity < dataSize)
+            {
+                std::free(scaledData);
+                scaledDataCapacity = 0;
+
+                scaledData = std::malloc(dataSize);
+                if (scaledData == nullptr)
+                    DAQ_THROW_EXCEPTION(NoMemoryException);
+
+                scaledDataCapacity = dataSize;
+            }
+
+            // The calculators are handed the buffer to write into rather than allocating one of
+            // their own, so the allocation survives reuse() and recomputing costs nothing.
+            if (hasScalingCalc)
+            {
+                descriptor.asPtr<IScalingCalcPrivate>(true)->scaleData(data, sampleCount, &scaledData);
+            }
+            else if (hasDataRuleCalc)
+            {
+                descriptor.asPtr<IDataRuleCalcPrivate>(true)->calculateRule(offset, sampleCount, data, rawDataSize, &scaledData);
+            }
+            else
+            {
+                // Explicit data rule with nothing but a Reference Domain Offset to apply.
+                std::memcpy(scaledData, data, dataSize);
+            }
+
+            if (hasReferenceDomainOffset)
+            {
+                const auto referenceDomainOffsetAdder = std::unique_ptr<ReferenceDomainOffsetAdder>(createReferenceDomainOffsetAdderTyped(
+                    descriptor.getSampleType(), descriptor.getReferenceDomainInfo().getReferenceDomainOffset(), sampleCount));
+
+                referenceDomainOffsetAdder->addReferenceDomainOffset(&scaledData);
+            }
+
+            scaledDataValid = true;
+        });
+    OPENDAQ_RETURN_IF_FAILED(errCode);
+
+    *address = scaledData;
     return OPENDAQ_SUCCESS;
 }
 
@@ -796,6 +817,7 @@ ErrCode DataPacketImpl<TInterface, TInterfaces...>::reuse(IDataDescriptor* newDe
 
         freeMemory();
         scaledData = nullptr;
+        scaledDataCapacity = 0;
 
         memorySize = static_cast<uint32_t>(newRawDataSize);
         data = std::malloc(newRawDataSize);
@@ -822,6 +844,11 @@ ErrCode DataPacketImpl<TInterface, TInterfaces...>::reuse(IDataDescriptor* newDe
 
     sampleSize = static_cast<uint32_t>(descriptor.getSampleSize());
     dataSize = sampleCount * sampleSize;
+
+    // A new descriptor can change which calculators apply, and the cached computed data describes
+    // the previous contents in any case. The buffer itself is kept and only grown on demand.
+    updateCalcFlags();
+    scaledDataValid = false;
 
     *success = True;
     return OPENDAQ_SUCCESS;

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -466,6 +466,46 @@ TEST_F(DataPacketTest, ReuseSameDescriptorOffsetAndSampleCount)
     ASSERT_EQ(packet.getDataDescriptor(), descriptor);
 }
 
+TEST_F(DataPacketTest, ReuseInvalidatesComputedImplicitData)
+{
+    // An implicit descriptor has a raw sample size of 0, so the reused packet never needs more
+    // memory and reuse() takes the path that does not touch the previously computed values.
+    const auto descriptor = setupDescriptor(SampleType::Int64, LinearDataRule(1, 0), nullptr);
+    const auto packet = DataPacket(descriptor, 5, 100);
+
+    const auto* const before = static_cast<const int64_t*>(packet.getData());
+    ASSERT_EQ(before[0], 100);
+    ASSERT_EQ(before[4], 104);
+
+    const bool success = packet.asPtr<IReusableDataPacket>(true).reuse(nullptr, 5, 200, nullptr, false);
+    ASSERT_TRUE(success);
+
+    // The offset changed, so every computed sample must change with it.
+    const auto* const after = static_cast<const int64_t*>(packet.getData());
+    ASSERT_EQ(after[0], 200);
+    ASSERT_EQ(after[4], 204);
+}
+
+TEST_F(DataPacketTest, ReuseRefreshesCalculatorFlags)
+{
+    // Post-scaled to begin with, so getData() has to compute and cache.
+    const auto scaledDescriptor =
+        setupDescriptor(SampleType::Float64, ExplicitDataRule(), LinearScaling(2, 1, SampleType::Int32, ScaledSampleType::Float64));
+    const auto packet = createExplicitPacket<int32_t, 4>(scaledDescriptor);
+
+    ASSERT_NE(packet.getData(), packet.getRawData()) << "post-scaling must compute into a separate buffer";
+
+    // Reused with a descriptor that needs no calculation at all. Its raw sample size matches, so
+    // reuse() again takes its non-reallocating path.
+    const auto rawDescriptor = setupDescriptor(SampleType::Int32, ExplicitDataRule(), nullptr);
+    const bool success = packet.asPtr<IReusableDataPacket>(true).reuse(rawDescriptor, 4, nullptr, nullptr, false);
+    ASSERT_TRUE(success);
+
+    // There is nothing left to compute, so getData() must hand back the raw buffer itself. This
+    // only holds if reuse() re-derived hasScalingCalc/hasRawDataOnly from the new descriptor.
+    ASSERT_EQ(packet.getData(), packet.getRawData());
+}
+
 TEST_F(DataPacketTest, ReuseDenyBiggerSampleType)
 {
     auto descriptor = setupDescriptor(SampleType::Float32, ExplicitDataRule(), nullptr);


### PR DESCRIPTION
# Brief

Fix data packet scaling cache that references old data when the packet is reused.

# Description

getData() used the scaledData pointer itself as its cache-validity flag, so the buffer could not be kept without also being treated as current. Three defects followed from that:

- reuse() left scaledData in place on its non-reallocating path, so a recycled packet kept returning the values computed for its previous contents.

- reuse() never re-derived hasScalingCalc, hasDataRuleCalc, hasRawDataOnly or hasReferenceDomainOffset after replacing the descriptor, so those flags went on describing the old one. The stale buffer masked this by being returned without recomputation, which means fixing only the first defect would have turned stale data into a call to a calculator the new descriptor does not have.

- getData() returned through OPENDAQ_RETURN_IF_FAILED while still holding readLock, leaving the packet permanently locked after any calculator failure.

Validity is now tracked by a separate scaledDataValid flag, with scaledDataCapacity recording the size of the allocation, and the calculators are handed the buffer to write into instead of allocating their own. Recomputing a packet's data therefore no longer allocates. reuse() invalidates the cache and refreshes the derived flags through updateCalcFlags(), split out of initPacket(). getData() takes readLock with std::lock_guard.

The first two defects are covered by new tests that fail without this change. The lock leak is not covered: provoking it needs a calculator failure that cannot be produced through the public API.
