### PR TITLE
Make ComponentImpl's status methods virtual

### DIFF
--- a/core/opendaq/component/include/opendaq/component_impl.h
+++ b/core/opendaq/component/include/opendaq/component_impl.h
@@ -194,11 +194,11 @@ protected:
     static bool validateComponentId(const std::string& id);
 
     // Initialize component status with "Ok" status
-    void initComponentStatus() const;
+    virtual void initComponentStatus() const;
     // Set component status with default message (empty string) and log status and message (if different from previous, and not OK)
-    void setComponentStatus(const ComponentStatus& status) const;
+    virtual void setComponentStatus(const ComponentStatus& status) const;
     // Set component status with message and log status and message (if different from previous, and not OK and empty string)
-    void setComponentStatusWithMessage(const ComponentStatus& status, const StringPtr& message) const;
+    virtual void setComponentStatusWithMessage(const ComponentStatus& status, const StringPtr& message) const;
 
     virtual void onOperationModeChanged(OperationModeType modeType);
 


### PR DESCRIPTION
# Brief

In some cases it is extremely useful to be able to override how the base component status behaves. This PR supports overriding the methods with a custom functionality.

An example use-case of this is to "prioritize" some messages over others while letting the developer call setComponentStatus liberally.