### PR TITLE
Track pooled objects only while they are handed out

### DIFF
--- a/core/coretypes/include/coretypes/pooled_object.h
+++ b/core/coretypes/include/coretypes/pooled_object.h
@@ -24,13 +24,13 @@ namespace daq::object_pool
 {
 
 /*!
- * Debug object tracking normally spans construction to destruction, but a pooled object is
- * constructed once and then recycled indefinitely: it is never destroyed while the pool lives, so
- * it would stay tracked for the whole process. Every object the pool has to construct to meet peak
- * demand would then be reported as a leak by the first test that pushed the demand up, even though
- * nothing leaked. Tracking is therefore bound to the period the object is handed out, which is what
- * the leak checks mean by "alive": marked live when the pool resets it for a caller, and parked
- * again when its last reference goes. Objects sitting in the free list are not tracked.
+ * @brief An object owned by an ObjectPool and recycled rather than destroyed.
+ *
+ * Reaching reference count 0 returns the object to the pool's free list instead of deleting it, so a
+ * single instance serves many callers in turn. The pool destroys them when it is cleaned up.
+ *
+ * A derived type must call markLive() from its reset(), which is what ObjectPool::get() invokes as it
+ * hands the object over.
  */
 template <class Derived, class Impl>
 class PooledObject : public Impl
@@ -43,8 +43,7 @@ public:
         , next(nullptr)
         , pool(pool)
     {
-        // Born parked: the pool either pushes this straight onto the free list or hands it out
-        // through get(), which marks it live.
+        // Not handed out yet.
         markParked();
     }
 
@@ -62,6 +61,7 @@ public:
     }
 
 protected:
+    /// Counts the object as in use for debug object tracking. Call when handing it to a caller.
     void markLive()
     {
 #ifndef NDEBUG
@@ -69,6 +69,7 @@ protected:
 #endif
     }
 
+    /// Stops counting the object as in use, for while it sits in the pool's free list.
     void markParked()
     {
 #ifndef NDEBUG
@@ -89,7 +90,8 @@ public:
     void reset(T value)
     {
         this->value = value;
-        // Called by ObjectPool::get() as the object is handed to a caller.
+
+        // get() calls reset() as it hands the object over, so this is where it becomes live.
         this->markLive();
     }
 };

--- a/core/coretypes/include/coretypes/pooled_object.h
+++ b/core/coretypes/include/coretypes/pooled_object.h
@@ -18,10 +18,20 @@
 
 #include <coretypes/object_pool.h>
 #include <coretypes/common.h>
+#include <coretypes/intfs.h>
 
 namespace daq::object_pool
 {
 
+/*!
+ * Debug object tracking normally spans construction to destruction, but a pooled object is
+ * constructed once and then recycled indefinitely: it is never destroyed while the pool lives, so
+ * it would stay tracked for the whole process. Every object the pool has to construct to meet peak
+ * demand would then be reported as a leak by the first test that pushed the demand up, even though
+ * nothing leaked. Tracking is therefore bound to the period the object is handed out, which is what
+ * the leak checks mean by "alive": marked live when the pool resets it for a caller, and parked
+ * again when its last reference goes. Objects sitting in the free list are not tracked.
+ */
 template <class Derived, class Impl>
 class PooledObject : public Impl
 {
@@ -33,6 +43,9 @@ public:
         , next(nullptr)
         , pool(pool)
     {
+        // Born parked: the pool either pushes this straight onto the free list or hands it out
+        // through get(), which marks it live.
+        markParked();
     }
 
     int INTERFACE_FUNC releaseRef() override
@@ -41,10 +54,26 @@ public:
         assert(newRefCount >= 0);
         if (newRefCount == 0)
         {
+            markParked();
             this->pool->addToFreeList(static_cast<Derived*>(this));
         }
 
         return newRefCount;
+    }
+
+protected:
+    void markLive()
+    {
+#ifndef NDEBUG
+        daqTrackObject(this->getThisAsBaseObject());
+#endif
+    }
+
+    void markParked()
+    {
+#ifndef NDEBUG
+        daqUntrackObject(this->getThisAsBaseObject());
+#endif
     }
 
 private:
@@ -60,6 +89,8 @@ public:
     void reset(T value)
     {
         this->value = value;
+        // Called by ObjectPool::get() as the object is handed to a caller.
+        this->markLive();
     }
 };
 

--- a/core/coretypes/tests/test_objcount.cpp
+++ b/core/coretypes/tests/test_objcount.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <coretypes/coretypes.h>
+#include <vector>
 
 using namespace daq;
 
@@ -16,6 +17,29 @@ TEST_F(ObjCountTest, CountObjects)
     auto obj = BaseObject();
     size_t val3 = daqGetTrackedObjectCount();
     ASSERT_EQ(val1 + 1, val3);
+}
+
+TEST_F(ObjCountTest, PooledObjectsTrackedOnlyWhileAlive)
+{
+    // Above the small-integer cache so the pool is actually used, and well past the pool's
+    // pre-allocated objects so it has to construct ones it will never destroy.
+    constexpr size_t count = 300;
+    const size_t baseline = daqGetTrackedObjectCount();
+
+    {
+        std::vector<ObjectPtr<IInteger>> integers;
+        integers.reserve(count);
+        for (size_t i = 0; i < count; ++i)
+            integers.push_back(IntegerFromPool(static_cast<Int>(1000 + i)));
+
+        // Handed out to a caller, so alive and tracked: leaking one has to remain detectable.
+        ASSERT_EQ(daqGetTrackedObjectCount(), baseline + count);
+    }
+
+    // Back on the free list. A pooled object is not destroyed, but it is no longer alive either, so
+    // it must not stay tracked - otherwise the next leak check reports every object the pool had to
+    // construct as leaked, and blames whichever test happened to raise the pool's high-water mark.
+    ASSERT_EQ(daqGetTrackedObjectCount(), baseline);
 }
 
 #endif


### PR DESCRIPTION
# Brief

Track pooled objects only while they are handed out.

# Description

ObjectPool never destroys its objects: at refcount 0 PooledObject::releaseRef() pushes the object onto the free list instead of deleting it. Debug object tracking registers in GenericObjInstance's constructor and unregisters in its destructor, so a pooled object stayed tracked for the lifetime of the process.

Every object a pool had to construct to meet peak demand was therefore reported as a leak by DaqMemCheckListener, blaming whichever test raised the pool's high-water mark past the 100 objects each static pool pre-allocates. The dump gives it away: every entry stringifies as a bare number and values repeat, because free-list residents keep whatever value they were last assigned.

Bind tracking to the period an object is handed out instead, which is what the leak checks mean by "alive": marked live when the pool resets it for a caller, parked again at construction and when its last reference goes. Objects sitting in the free list are no longer tracked, while one that leaks while handed out stays detectable.

The hooks live in PooledObject rather than in ObjectPool because test_object_pool.cpp instantiates the pool with a plain class that is not an openDAQ object and has no tracking to bind.
