### PR TITLE
New capability API and discovery mechanism

### DIFF
--- a/changelog/changelog_3.40-3.50.md
+++ b/changelog/changelog_3.40-3.50.md
@@ -4,6 +4,7 @@
 
 - [#1242](https://github.com/openDAQ/openDAQ/pull/1242) Implement IContext::getRootDevice
 - [#1244](https://github.com/openDAQ/openDAQ/pull/1244) Static objects and object pool
+- [#1262](https://github.com/openDAQ/openDAQ/pull/1262) Add protocol group ID and security level to server capabilities. Streaming protocols sharing a group ID are treated as variants of one another, so only the most preferred source of each group is attached. A single server can now advertise multiple discovery services.
 
 ## Python
 
@@ -31,4 +32,21 @@
 #### `IContextInternal`
 ```diff
 + IContextInternal::setRootDevice(IBaseObject* device);
+```
+
+#### `IServerCapability`
+```diff
++ IServerCapability::getProtocolGroupId(IString** protocolGroupId);
++ IServerCapability::getProtocolSecurityLevel(IInteger** securityLevel);
+```
+
+#### `IServerCapabilityConfig`
+```diff
++ IServerCapabilityConfig::setProtocolGroupId(IString* protocolGroupId);
++ IServerCapabilityConfig::setProtocolSecurityLevel(IInteger* securityLevel);
+```
+
+#### `IStreaming`
+```diff
++ IStreaming::getProtocolGroupId(IString** protocolGroupId);
 ```

--- a/core/coretypes/tests/test_object_pool.cpp
+++ b/core/coretypes/tests/test_object_pool.cpp
@@ -117,7 +117,7 @@ TEST(ObjectPoolTest, SpeedNoPool)
         const auto s = fast_rand() % 2;
         if (s == 0 || objects.empty())
         {
-            auto obj = new StandardObject(i);
+            auto obj = new StandardObject(static_cast<int>(i));
             obj->addRef();
             objects.push(obj);
         }
@@ -150,7 +150,7 @@ TEST(ObjectPoolTest, SpeedWithPool)
         const auto s = fast_rand() % 2;
         if (s == 0 || objects.empty())
         {
-            auto obj = pool.get(i);
+            auto obj = pool.get(static_cast<int>(i));
             obj->addRef();
 
             objects.push(obj);

--- a/core/opendaq/device/include/opendaq/server_capability.h
+++ b/core/opendaq/device/include/opendaq/server_capability.h
@@ -83,6 +83,13 @@ DECLARE_OPENDAQ_INTERFACE(IServerCapability, IPropertyObject)
     virtual ErrCode INTERFACE_FUNC getProtocolName(IString** protocolName) = 0;
 
     /*!
+     * @brief Gets the id of the protocol group supported by the device. Should not contain spaces or special characters except for '_' and '-'.
+     * Could be empty if the protocol is not part of any group.
+     * @param[out] protocolGropuId The id of the protocol group.
+     */
+    virtual ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGropuId) = 0;
+
+    /*!
      * @brief Gets the id of the protocol supported by the device. Should not contain spaces or special characters except for '_' and '-'.
      * @param[out] protocolId The id of the protocol.
      */
@@ -140,6 +147,16 @@ DECLARE_OPENDAQ_INTERFACE(IServerCapability, IPropertyObject)
      * @param[out] version The protocol version.
      */
     virtual ErrCode INTERFACE_FUNC getProtocolVersion(IString** version) = 0;
+
+    /*!
+     * @brief Gets the security level of the protocol.
+     * @param[out] securityLevel The security level of the protocol.
+     *
+     * Could be '-1' if the protocol does not define any security level or if the security level is not known,
+     * '0' if the protocol is not secure, and positive integer values for different security levels defined by the protocol.
+     * The higher the value, the more secure the protocol is considered to be.
+     */
+    virtual ErrCode INTERFACE_FUNC getProtocolSecurityLevel(IInteger** securityLevel) = 0;
 };
 /*!@}*/
 

--- a/core/opendaq/device/include/opendaq/server_capability.h
+++ b/core/opendaq/device/include/opendaq/server_capability.h
@@ -87,7 +87,7 @@ DECLARE_OPENDAQ_INTERFACE(IServerCapability, IPropertyObject)
      * Could be empty if the protocol is not part of any group.
      * @param[out] protocolGropuId The id of the protocol group.
      */
-    virtual ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGropuId) = 0;
+    virtual ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGroupId) = 0;
 
     /*!
      * @brief Gets the id of the protocol supported by the device. Should not contain spaces or special characters except for '_' and '-'.

--- a/core/opendaq/device/include/opendaq/server_capability_config.h
+++ b/core/opendaq/device/include/opendaq/server_capability_config.h
@@ -44,6 +44,13 @@ DECLARE_OPENDAQ_INTERFACE(IServerCapabilityConfig, IServerCapability)
 
     // [returnSelf]
     /*!
+     * @brief Sets the ID of protocol group. Empty protocol group ID means that the protocol is not part of any group.
+     * @param protocolGroupId The ID of protocol group
+     */
+    virtual ErrCode INTERFACE_FUNC setProtocolGroupId(IString* protocolGroupId) = 0;
+
+    // [returnSelf]
+    /*!
      * @brief Sets the ID of protocol
      * @param protocolId The ID of protocol
      */
@@ -107,6 +114,17 @@ DECLARE_OPENDAQ_INTERFACE(IServerCapabilityConfig, IServerCapability)
      * @param version The protocol version
      */
     virtual ErrCode INTERFACE_FUNC setProtocolVersion(IString* version) = 0;
+
+    // [returnSelf]
+    /*!
+     * @brief Sets the security level of the protocol.
+     * @param securityLevel The security level of the protocol.
+     *
+     * Could be '-1' if the protocol does not define any security level or if the security level is not known,
+     * '0' if the protocol is not secure, and positive integer values for different security levels defined by the protocol.
+     * The higher the value, the more secure the protocol is considered to be.
+     */
+    virtual ErrCode INTERFACE_FUNC setProtocolSecurityLevel(IInteger* securityLevel) = 0;
 };
 
 OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(

--- a/core/opendaq/device/include/opendaq/server_capability_impl.h
+++ b/core/opendaq/device/include/opendaq/server_capability_impl.h
@@ -506,6 +506,7 @@ inline ErrCode ServerCapabilityConfigImpl::getProtocolSecurityLevel(IInteger** s
 
 inline ErrCode ServerCapabilityConfigImpl::setProtocolSecurityLevel(IInteger* securityLevel)
 {
+    OPENDAQ_PARAM_NOT_NULL(securityLevel);
     return Super::setPropertyValue(String(SecurityLevel), securityLevel);
 }
 

--- a/core/opendaq/device/include/opendaq/server_capability_impl.h
+++ b/core/opendaq/device/include/opendaq/server_capability_impl.h
@@ -44,6 +44,9 @@ public:
     ErrCode INTERFACE_FUNC getProtocolName(IString** protocolName) override;
     ErrCode INTERFACE_FUNC setProtocolName(IString* protocolName) override;
 
+    ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGroupId) override;
+    ErrCode INTERFACE_FUNC setProtocolGroupId(IString* protocolGroupId) override;
+
     ErrCode INTERFACE_FUNC getProtocolId(IString** protocolId) override;
     ErrCode INTERFACE_FUNC setProtocolId(IString* protocolId) override;
     
@@ -71,6 +74,9 @@ public:
     ErrCode INTERFACE_FUNC getAddressInfo(IList** addressesInfo) override;
     ErrCode INTERFACE_FUNC addAddressInfo(IAddressInfo* addressInfo) override;
 
+    ErrCode INTERFACE_FUNC getProtocolSecurityLevel(IInteger** securityLevel) override;
+    ErrCode INTERFACE_FUNC setProtocolSecurityLevel(IInteger* securityLevel) override;
+
     ErrCode INTERFACE_FUNC getInterfaceIds(SizeT* idCount, IntfID** ids) override;
 
     ErrCode INTERFACE_FUNC clone(IPropertyObject** cloned) override;
@@ -87,11 +93,13 @@ private:
     const char* ProtocolVersonName = "ProtocolVersion";
     const char* ConnectionType = "ConnectionType";
     const char* CoreEventsEnabled = "CoreEventsEnabled"; 
+    const char* ProtocolGroupId = "ProtocolGroupId";
     const char* ProtocolId = "protocolId";
     const char* Prefix = "Prefix";
     const char* Addresses = "Addresses";
     const char* AddressInfo = "AddressInfo";
     const char* Port = "Port";
+    const char* SecurityLevel = "SecurityLevel";
 
 
     template <typename T>
@@ -134,6 +142,7 @@ inline ServerCapabilityConfigImpl::ServerCapabilityConfigImpl(const StringPtr& p
     Super::addProperty(StringProperty(PrimaryConnectionString, ""));
     Super::addProperty(ListProperty(ConnectionStrings, List<IString>()));
     Super::addProperty(StringProperty(ProtocolName, ""));
+    Super::addProperty(StringProperty(ProtocolGroupId, ""));
     Super::addProperty(StringProperty(ProtocolId, ""));
     Super::addProperty(StringProperty(ProtocolTypeName, ProtocolTypeToString(ProtocolType::Unknown)));
     Super::addProperty(StringProperty(ProtocolVersonName, ""));
@@ -143,6 +152,7 @@ inline ServerCapabilityConfigImpl::ServerCapabilityConfigImpl(const StringPtr& p
     Super::addProperty(ListProperty(Addresses, List<IString>()));
     Super::addProperty(IntProperty(Port, -1));
     Super::addProperty(ObjectProperty(AddressInfo, PropertyObject()));
+    Super::addProperty(IntProperty(SecurityLevel, -1));
 
     Super::setPropertyValue(String(ProtocolId), protocolId);
     Super::setPropertyValue(String(ProtocolName), protocolName);
@@ -219,6 +229,21 @@ inline ErrCode ServerCapabilityConfigImpl::setProtocolName(IString* protocolName
 {
     OPENDAQ_PARAM_NOT_NULL(protocolName);
     return Super::setPropertyValue(String(ProtocolName), protocolName);
+}
+
+inline ErrCode ServerCapabilityConfigImpl::getProtocolGroupId(IString** protocolGroupId)
+{
+    return daqTry([&]
+                  {
+                      *protocolGroupId = getTypedProperty<IString>(ProtocolGroupId).detach();
+                      return OPENDAQ_SUCCESS;
+                  });
+}
+
+inline ErrCode ServerCapabilityConfigImpl::setProtocolGroupId(IString* protocolGroupId)
+{
+    OPENDAQ_PARAM_NOT_NULL(protocolGroupId);
+    return Super::setPropertyValue(String(ProtocolGroupId), protocolGroupId);
 }
 
 inline ErrCode ServerCapabilityConfigImpl::getProtocolId(IString** protocolId)
@@ -466,6 +491,22 @@ inline ErrCode ServerCapabilityConfigImpl::clone(IPropertyObject** cloned)
         *cloned = obj.detach();
         return OPENDAQ_SUCCESS;
     });
+}
+
+inline ErrCode ServerCapabilityConfigImpl::getProtocolSecurityLevel(IInteger** securityLevel)
+{
+    OPENDAQ_PARAM_NOT_NULL(securityLevel);
+
+    return daqTry([&]
+                  {
+                      *securityLevel = getTypedProperty<IInteger>(SecurityLevel).detach();
+                      return OPENDAQ_SUCCESS;
+                  });
+}
+
+inline ErrCode ServerCapabilityConfigImpl::setProtocolSecurityLevel(IInteger* securityLevel)
+{
+    return Super::setPropertyValue(String(SecurityLevel), securityLevel);
 }
 
 OPENDAQ_REGISTER_DESERIALIZE_FACTORY(ServerCapabilityConfigImpl)

--- a/core/opendaq/device/tests/test_server_capability.cpp
+++ b/core/opendaq/device/tests/test_server_capability.cpp
@@ -1,8 +1,11 @@
 #include <opendaq/device_info_factory.h>
 #include <opendaq/context_factory.h>
-#include <gtest/gtest.h>
+#include <testutils/testutils.h>
 #include <coreobjects/property_object_factory.h>
 #include <coreobjects/property_factory.h>
+#include <coreobjects/property_object_internal_ptr.h>
+#include <coretypes/json_serializer_factory.h>
+#include <coretypes/json_deserializer_factory.h>
 #include <opendaq/device_type_factory.h>
 
 using ServerCapabilityTest = testing::Test;
@@ -17,18 +20,44 @@ TEST_F(ServerCapabilityTest, Factory)
     ASSERT_EQ(capability.getConnectionString(), "");
     ASSERT_EQ(capability.getConnectionType(), "Unknown");
     ASSERT_EQ(capability.getCoreEventsEnabled(), false);
+    ASSERT_EQ(capability.getProtocolGroupId(), "");
+    ASSERT_EQ(capability.getProtocolSecurityLevel(), -1);
 }
 
 TEST_F(ServerCapabilityTest, SetGet)
 {
     ServerCapabilityPtr capability = ServerCapability("protocol_id", "Protocol name", ProtocolType::Streaming).addConnectionString("connection string")
                                                                                                   .setConnectionType("connection type")
-                                                                                                  .setCoreEventsEnabled(true);
+                                                                                                  .setCoreEventsEnabled(true)
+                                                                                                  .setProtocolGroupId("protocol_group_id")
+                                                                                                  .setProtocolSecurityLevel(2);
     ASSERT_EQ(capability.getProtocolName(), "Protocol name");
     ASSERT_EQ(capability.getProtocolType(), ProtocolType::Streaming);
     ASSERT_EQ(capability.getConnectionString(), "connection string");
     ASSERT_EQ(capability.getConnectionType(), "connection type");
     ASSERT_EQ(capability.getCoreEventsEnabled(), true);
+    ASSERT_EQ(capability.getProtocolGroupId(), "protocol_group_id");
+    ASSERT_EQ(capability.getProtocolSecurityLevel(), 2);
+}
+
+TEST_F(ServerCapabilityTest, SetGetEmptyProtocolGroupId)
+{
+    // an empty group id means the protocol is not part of any group
+    ServerCapabilityConfigPtr capability = ServerCapability("protocol_id", "Protocol name", ProtocolType::Streaming);
+
+    ASSERT_NO_THROW(capability.setProtocolGroupId(""));
+    ASSERT_EQ(capability.getProtocolGroupId(), "");
+}
+
+TEST_F(ServerCapabilityTest, SetGetNegativeSecurityLevel)
+{
+    ServerCapabilityConfigPtr capability = ServerCapability("protocol_id", "Protocol name", ProtocolType::Streaming);
+
+    ASSERT_NO_THROW(capability.setProtocolSecurityLevel(0));
+    ASSERT_EQ(capability.getProtocolSecurityLevel(), 0);
+
+    ASSERT_NO_THROW(capability.setProtocolSecurityLevel(-1));
+    ASSERT_EQ(capability.getProtocolSecurityLevel(), -1);
 }
 
 TEST_F(ServerCapabilityTest, Freezable)
@@ -43,7 +72,9 @@ TEST_F(ServerCapabilityTest, Freezable)
     ASSERT_THROW(capability.setConnectionType("String"), FrozenException);
     ASSERT_THROW(capability.setCoreEventsEnabled(false), FrozenException);
     ASSERT_THROW(capability.setProtocolName("String"), FrozenException);
-    
+    ASSERT_THROW(capability.setProtocolGroupId("String"), FrozenException);
+    ASSERT_THROW(capability.setProtocolSecurityLevel(1), FrozenException);
+
     ASSERT_THROW(capability.addProperty(StringProperty("test_key", "test_value")), FrozenException);
 }
 
@@ -60,6 +91,49 @@ TEST_F(ServerCapabilityTest, CustomProperties)
     ASSERT_NO_THROW(capability.addProperty(BoolProperty("IsAsleep", true)));
 
     ASSERT_EQ(capability.getAllProperties().getCount(), 4u + defaultPropertiesCnt);
+}
+
+TEST_F(ServerCapabilityTest, SerializeDeserialize)
+{
+    ServerCapabilityConfigPtr capability = ServerCapability("protocol_id", "Protocol name", ProtocolType::Streaming)
+                                               .addConnectionString("connection string")
+                                               .setConnectionType("connection type")
+                                               .setProtocolGroupId("protocol_group_id")
+                                               .setProtocolSecurityLevel(3);
+
+    const auto serializer = JsonSerializer();
+    capability.serialize(serializer);
+    const auto serializedCapability = serializer.getOutput();
+
+    const auto deserializer = JsonDeserializer();
+    const ServerCapabilityPtr newCapability = deserializer.deserialize(serializedCapability, nullptr, nullptr);
+
+    ASSERT_EQ(newCapability.getProtocolId(), "protocol_id");
+    ASSERT_EQ(newCapability.getProtocolName(), "Protocol name");
+    ASSERT_EQ(newCapability.getProtocolType(), ProtocolType::Streaming);
+    ASSERT_EQ(newCapability.getProtocolGroupId(), "protocol_group_id");
+    ASSERT_EQ(newCapability.getProtocolSecurityLevel(), 3);
+
+    serializer.reset();
+    newCapability.serialize(serializer);
+    ASSERT_EQ(serializedCapability, serializer.getOutput());
+}
+
+TEST_F(ServerCapabilityTest, Clone)
+{
+    ServerCapabilityConfigPtr capability = ServerCapability("protocol_id", "Protocol name", ProtocolType::Streaming)
+                                               .addConnectionString("connection string")
+                                               .setProtocolGroupId("protocol_group_id")
+                                               .setProtocolSecurityLevel(3);
+
+    const ServerCapabilityPtr cloned = capability.asPtr<IPropertyObjectInternal>().clone();
+
+    ASSERT_EQ(cloned.getProtocolId(), "protocol_id");
+    ASSERT_EQ(cloned.getProtocolName(), "Protocol name");
+    ASSERT_EQ(cloned.getProtocolType(), ProtocolType::Streaming);
+    ASSERT_EQ(cloned.getConnectionString(), "connection string");
+    ASSERT_EQ(cloned.getProtocolGroupId(), "protocol_group_id");
+    ASSERT_EQ(cloned.getProtocolSecurityLevel(), 3);
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/opendaq/mocks/include/opendaq/gmock/streaming.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/gmock/streaming.h
@@ -40,6 +40,16 @@ struct MockStreaming : daq::StreamingImpl<IMockStreaming>
         const daq::ContextPtr&
     > Strict;
 
+    // Same mock, but with a caller-defined protocol group id
+    typedef MockPtr<
+        daq::IStreaming,
+        daq::StreamingPtr,
+        MockStreaming,
+        const daq::StringPtr&,
+        const daq::ContextPtr&,
+        const daq::StringPtr&
+    > StrictWithGroup;
+
     MOCK_METHOD(void, onSetActive, (bool active), (override));
     MOCK_METHOD(void, onAddSignal, (const daq::MirroredSignalConfigPtr& signal), (override));
     MOCK_METHOD(void, onRemoveSignal, (const daq::MirroredSignalConfigPtr& signal), (override));
@@ -62,8 +72,10 @@ struct MockStreaming : daq::StreamingImpl<IMockStreaming>
 
     daq::MirroredSignalConfigPtr signal;
 
-    MockStreaming(const daq::StringPtr& connectionString, const daq::ContextPtr& context)
-        : daq::StreamingImpl<IMockStreaming>(connectionString, context, false, "MockStreaming", true)
+    MockStreaming(const daq::StringPtr& connectionString,
+                  const daq::ContextPtr& context,
+                  const daq::StringPtr& protocolGroupId = nullptr)
+        : daq::StreamingImpl<IMockStreaming>(connectionString, context, false, "MockStreaming", true, protocolGroupId)
     {
         using namespace testing;
 

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_streaming.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_streaming.h
@@ -23,6 +23,11 @@ class MockStreamingImpl : public daq::Streaming
 public:
     explicit MockStreamingImpl(const daq::StringPtr& connectionString, const daq::ContextPtr& context);
 
+    MockStreamingImpl(const daq::StringPtr& connectionString,
+                      const daq::ContextPtr& context,
+                      const daq::StringPtr& protocolId,
+                      const daq::StringPtr& protocolGroupId);
+
 protected:
     void onSetActive(bool active) override;
     void onAddSignal(const daq::MirroredSignalConfigPtr& signal) override;
@@ -38,4 +43,15 @@ OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE(
     MockStreaming, daq::IStreaming,
     daq::IString*, connectionString,
     daq::IContext*, context
+)
+
+// Same mock, but with a caller-defined protocol id and protocol group id
+OPENDAQ_DECLARE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC(
+    INTERNAL_FACTORY,
+    MockStreamingWithProtocol, daq::IStreaming,
+    createMockStreamingWithProtocol,
+    daq::IString*, connectionString,
+    daq::IContext*, context,
+    daq::IString*, protocolId,
+    daq::IString*, protocolGroupId
 )

--- a/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_streaming_factory.h
+++ b/core/opendaq/opendaq/mocks/include/opendaq/mock/mock_streaming_factory.h
@@ -25,4 +25,13 @@ inline StreamingPtr MockStreaming(const daq::StringPtr& connectionString, const 
     return obj;
 }
 
+inline StreamingPtr MockStreamingWithProtocol(const daq::StringPtr& connectionString,
+                                              const ContextPtr& context,
+                                              const daq::StringPtr& protocolId,
+                                              const daq::StringPtr& protocolGroupId)
+{
+    StreamingPtr obj(MockStreamingWithProtocol_Create(connectionString, context, protocolId, protocolGroupId));
+    return obj;
+}
+
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/opendaq/mocks/src/mock_streaming.cpp
+++ b/core/opendaq/opendaq/mocks/src/mock_streaming.cpp
@@ -8,6 +8,20 @@ MockStreamingImpl::MockStreamingImpl(const StringPtr& connectionString, const Co
 {
 }
 
+MockStreamingImpl::MockStreamingImpl(const StringPtr& connectionString,
+                                     const ContextPtr& context,
+                                     const StringPtr& protocolId,
+                                     const StringPtr& protocolGroupId)
+    // client-to-device streaming requires a protocol id, so it is only enabled when one is given
+    : Streaming(connectionString,
+                context,
+                false,
+                protocolId,
+                protocolId.assigned() && protocolId.getLength() > 0,
+                protocolGroupId)
+{
+}
+
 void MockStreamingImpl::onSetActive(bool /*active*/)
 {
 }
@@ -41,4 +55,14 @@ OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE(
     MockStreaming, IStreaming,
     IString*, connectionString,
     IContext*, context
+)
+
+OPENDAQ_DEFINE_CLASS_FACTORY_WITH_INTERFACE_AND_CREATEFUNC_OBJ(
+    INTERNAL_FACTORY,
+    MockStreamingImpl, IStreaming,
+    createMockStreamingWithProtocol,
+    IString*, connectionString,
+    IContext*, context,
+    IString*, protocolId,
+    IString*, protocolGroupId
 )

--- a/core/opendaq/server/include/opendaq/server_impl.h
+++ b/core/opendaq/server/include/opendaq/server_impl.h
@@ -71,7 +71,10 @@ public:
         {
             DeviceInfoPtr rootDeviceInfo = rootDevice.getInfo();
             for (const auto& [_, discoveryServer] : context.getDiscoveryServers())
-                discoveryServer.template asPtr<IDiscoveryServer>(true).registerService(id, getDiscoveryConfig(), rootDeviceInfo);
+            {
+                for (const auto& discoveryConfig : getDiscoveryConfigs())
+                    discoveryServer.template asPtr<IDiscoveryServer>().registerService(id, discoveryConfig, rootDeviceInfo);
+            }
         }
         return OPENDAQ_SUCCESS;
     }
@@ -177,6 +180,11 @@ protected:
     virtual PropertyObjectPtr getDiscoveryConfig()
     {
         return PropertyObject();
+    }
+
+    virtual ListPtr<IPropertyObject> getDiscoveryConfigs()
+    {
+        return List<IPropertyObject>(getDiscoveryConfig());
     }
 
     virtual void onStopServer()

--- a/core/opendaq/server/tests/test_app.cpp
+++ b/core/opendaq/server/tests/test_app.cpp
@@ -1,12 +1,14 @@
 #include <testutils/testutils.h>
 #include <testutils/daq_memcheck_listener.h>
 #include <coreobjects/util.h>
+#include <opendaq/module_manager_init.h>
 
 int main(int argc, char** args)
 {
     daq::daqInitializeCoreObjectsTesting();
 
     testing::InitGoogleTest(&argc, args);
+    daqInitModuleManagerLibrary();
 
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new DaqMemCheckListener());

--- a/core/opendaq/server/tests/test_server.cpp
+++ b/core/opendaq/server/tests/test_server.cpp
@@ -4,6 +4,11 @@
 #include <gtest/gtest.h>
 #include <opendaq/component_deserialize_context_factory.h>
 #include <opendaq/component_exceptions.h>
+#include <opendaq/discovery_server_ptr.h>
+#include <opendaq/instance_factory.h>
+#include <opendaq/module_manager_factory.h>
+#include <coreobjects/property_factory.h>
+#include <coreobjects/property_object_factory.h>
 
 using ServerTest = testing::Test;
 
@@ -93,5 +98,192 @@ TEST_F(ServerTest, BeginUpdateEndUpdate)
 
     ASSERT_EQ(srv.getPropertyValue("SrvProp"), "s");
     ASSERT_EQ(sig.getPropertyValue("SigProp"), "cs");
+}
+
+class RecordingDiscoveryServer final : public daq::ImplementationOf<daq::IDiscoveryServer>
+{
+public:
+    daq::ErrCode INTERFACE_FUNC registerService(daq::IString* id, daq::IPropertyObject* config, daq::IDeviceInfo* deviceInfo) override
+    {
+        registeredIds.emplace_back(daq::StringPtr::Borrow(id).toStdString());
+        registeredConfigs.emplace_back(daq::PropertyObjectPtr(config));
+        registeredDeviceInfoAssigned.push_back(deviceInfo != nullptr);
+        return OPENDAQ_SUCCESS;
+    }
+
+    daq::ErrCode INTERFACE_FUNC unregisterService(daq::IString* id) override
+    {
+        unregisteredIds.emplace_back(daq::StringPtr::Borrow(id).toStdString());
+        return OPENDAQ_SUCCESS;
+    }
+
+    daq::ErrCode INTERFACE_FUNC setRootDevice(daq::IDevice* /*device*/) override
+    {
+        return OPENDAQ_SUCCESS;
+    }
+
+    std::vector<std::string> registeredIds;
+    std::vector<daq::PropertyObjectPtr> registeredConfigs;
+    std::vector<bool> registeredDeviceInfoAssigned;
+    std::vector<std::string> unregisteredIds;
+};
+
+// Server advertising two discovery services under a single server id.
+class MultiServiceServer final : public daq::Server
+{
+public:
+    MultiServiceServer(const daq::StringPtr& id, const daq::DevicePtr& rootDevice, const daq::ContextPtr& ctx)
+        : daq::Server(id, nullptr, rootDevice, ctx)
+    {
+    }
+
+protected:
+    daq::ListPtr<daq::IPropertyObject> getDiscoveryConfigs() override
+    {
+        return daq::List<daq::IPropertyObject>(makeConfig("_first._tcp.local.", 1234), makeConfig("_second._tcp.local.", 5678));
+    }
+
+private:
+    static daq::PropertyObjectPtr makeConfig(const daq::StringPtr& serviceName, daq::Int port)
+    {
+        auto config = daq::PropertyObject();
+        config.addProperty(daq::StringProperty("ServiceName", serviceName));
+        config.addProperty(daq::IntProperty("Port", port));
+        return config;
+    }
+};
+
+class SingleServiceServer final : public daq::Server
+{
+public:
+    SingleServiceServer(const daq::StringPtr& id, const daq::DevicePtr& rootDevice, const daq::ContextPtr& ctx)
+        : daq::Server(id, nullptr, rootDevice, ctx)
+    {
+    }
+
+protected:
+    daq::PropertyObjectPtr getDiscoveryConfig() override
+    {
+        auto config = daq::PropertyObject();
+        config.addProperty(daq::StringProperty("ServiceName", "_only._tcp.local."));
+        return config;
+    }
+};
+
+class ServerDiscoveryTest : public testing::Test
+{
+protected:
+    daq::ContextPtr createContext(const daq::DictPtr<daq::IString, daq::IDiscoveryServer>& discoveryServers)
+    {
+        return daq::Context(nullptr,
+                            daq::Logger(),
+                            daq::TypeManager(),
+                            daq::ModuleManager("[[none]]"),
+                            nullptr,
+                            daq::Dict<daq::IString, daq::IBaseObject>(),
+                            discoveryServers);
+    }
+};
+
+TEST_F(ServerDiscoveryTest, EnableDiscoveryRegistersEveryConfig)
+{
+    auto* fakeImpl = new RecordingDiscoveryServer();
+    const daq::DiscoveryServerPtr fake = fakeImpl;
+
+    const auto ctx = createContext(daq::Dict<daq::IString, daq::IDiscoveryServer>({{"fake", fake}}));
+    const auto instance = daq::InstanceBuilder().setContext(ctx).build();
+
+    const auto srv = daq::createWithImplementation<daq::IServer, MultiServiceServer>("MultiServiceServerId",
+                                                                                    instance.getRootDevice(),
+                                                                                    ctx);
+    ASSERT_NO_THROW(srv.enableDiscovery());
+
+    ASSERT_EQ(fakeImpl->registeredIds.size(), 2u);
+    ASSERT_EQ(fakeImpl->registeredIds[0], "MultiServiceServerId");
+    ASSERT_EQ(fakeImpl->registeredIds[1], "MultiServiceServerId");
+
+    ASSERT_EQ(fakeImpl->registeredConfigs[0].getPropertyValue("ServiceName"), "_first._tcp.local.");
+    ASSERT_EQ(fakeImpl->registeredConfigs[1].getPropertyValue("ServiceName"), "_second._tcp.local.");
+    ASSERT_EQ(fakeImpl->registeredConfigs[0].getPropertyValue("Port"), 1234);
+    ASSERT_EQ(fakeImpl->registeredConfigs[1].getPropertyValue("Port"), 5678);
+
+    // the root device info must be forwarded to the discovery server
+    ASSERT_TRUE(fakeImpl->registeredDeviceInfoAssigned[0]);
+    ASSERT_TRUE(fakeImpl->registeredDeviceInfoAssigned[1]);
+}
+
+TEST_F(ServerDiscoveryTest, EnableDiscoverySingleConfigBackCompat)
+{
+    auto* fakeImpl = new RecordingDiscoveryServer();
+    const daq::DiscoveryServerPtr fake = fakeImpl;
+
+    const auto ctx = createContext(daq::Dict<daq::IString, daq::IDiscoveryServer>({{"fake", fake}}));
+    const auto instance = daq::InstanceBuilder().setContext(ctx).build();
+
+    const auto srv = daq::createWithImplementation<daq::IServer, SingleServiceServer>("SingleServiceServerId",
+                                                                                     instance.getRootDevice(),
+                                                                                     ctx);
+    ASSERT_NO_THROW(srv.enableDiscovery());
+
+    ASSERT_EQ(fakeImpl->registeredIds.size(), 1u);
+    ASSERT_EQ(fakeImpl->registeredIds[0], "SingleServiceServerId");
+    ASSERT_EQ(fakeImpl->registeredConfigs[0].getPropertyValue("ServiceName"), "_only._tcp.local.");
+}
+
+TEST_F(ServerDiscoveryTest, EnableDiscoveryAcrossMultipleDiscoveryServers)
+{
+    auto* firstImpl = new RecordingDiscoveryServer();
+    auto* secondImpl = new RecordingDiscoveryServer();
+    const daq::DiscoveryServerPtr first = firstImpl;
+    const daq::DiscoveryServerPtr second = secondImpl;
+
+    const auto ctx = createContext(daq::Dict<daq::IString, daq::IDiscoveryServer>({{"first", first}, {"second", second}}));
+    const auto instance = daq::InstanceBuilder().setContext(ctx).build();
+
+    const auto srv = daq::createWithImplementation<daq::IServer, MultiServiceServer>("MultiServiceServerId",
+                                                                                    instance.getRootDevice(),
+                                                                                    ctx);
+    ASSERT_NO_THROW(srv.enableDiscovery());
+
+    ASSERT_EQ(firstImpl->registeredIds.size(), 2u);
+    ASSERT_EQ(secondImpl->registeredIds.size(), 2u);
+}
+
+TEST_F(ServerDiscoveryTest, DisableDiscoveryUnregistersOnceById)
+{
+    auto* fakeImpl = new RecordingDiscoveryServer();
+    const daq::DiscoveryServerPtr fake = fakeImpl;
+
+    const auto ctx = createContext(daq::Dict<daq::IString, daq::IDiscoveryServer>({{"fake", fake}}));
+    const auto instance = daq::InstanceBuilder().setContext(ctx).build();
+
+    const auto srv = daq::createWithImplementation<daq::IServer, MultiServiceServer>("MultiServiceServerId",
+                                                                                    instance.getRootDevice(),
+                                                                                    ctx);
+    srv.enableDiscovery();
+    ASSERT_EQ(fakeImpl->registeredIds.size(), 2u);
+
+    ASSERT_NO_THROW(srv.disableDiscovery());
+
+    ASSERT_EQ(fakeImpl->unregisteredIds.size(), 1u);
+    ASSERT_EQ(fakeImpl->unregisteredIds[0], "MultiServiceServerId");
+}
+
+TEST_F(ServerDiscoveryTest, StopUnregistersDiscovery)
+{
+    auto* fakeImpl = new RecordingDiscoveryServer();
+    const daq::DiscoveryServerPtr fake = fakeImpl;
+
+    const auto ctx = createContext(daq::Dict<daq::IString, daq::IDiscoveryServer>({{"fake", fake}}));
+    const auto instance = daq::InstanceBuilder().setContext(ctx).build();
+
+    const auto srv = daq::createWithImplementation<daq::IServer, MultiServiceServer>("MultiServiceServerId",
+                                                                                    instance.getRootDevice(),
+                                                                                    ctx);
+    srv.enableDiscovery();
+    ASSERT_NO_THROW(srv.stop());
+
+    ASSERT_EQ(fakeImpl->unregisteredIds.size(), 1u);
+    ASSERT_EQ(fakeImpl->unregisteredIds[0], "MultiServiceServerId");
 }
 

--- a/core/opendaq/streaming/include/opendaq/streaming.h
+++ b/core/opendaq/streaming/include/opendaq/streaming.h
@@ -158,6 +158,13 @@ DECLARE_OPENDAQ_INTERFACE(IStreaming, IBaseObject)
     virtual ErrCode INTERFACE_FUNC getOwnerDeviceRemoteId(IString** deviceRemoteId) const = 0;
 
     /*!
+     * @brief Gets the group identifier of the data transfer protocol (e.g., "OpenDAQNativeStreamingGroup", "OpenDAQLTStreamingGroup")
+     * used by this streaming object.
+     * @param[out] protocolId The string representing the protocol ID.
+     */
+    virtual ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGroupId) const = 0;
+
+    /*!
      * @brief Gets the identifier of the data transfer protocol (e.g., "OpenDAQNativeStreaming", "OpenDAQLTStreaming")
      * used by this streaming object.
      * @param[out] protocolId The string representing the protocol ID.

--- a/core/opendaq/streaming/include/opendaq/streaming_impl.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_impl.h
@@ -216,9 +216,9 @@ StreamingImpl<Interfaces...>::StreamingImpl(const StringPtr& connectionString,
     , loggerComponent(this->context.getLogger().getOrAddComponent(fmt::format("Streaming({})", connectionString)))
     , connectionStatus(Enumeration("ConnectionStatusType", "Connected", this->context.getTypeManager()))
     , skipDomainSignalSubscribe(skipDomainSignalSubscribe)
+    , protocolGroupId(protocolGroupId.assigned() ? protocolGroupId : "")
     , protocolId(protocolId)
     , isClientToDeviceStreamingSupported(isClientToDeviceStreamingSupported)
-    , protocolGroupId(protocolGroupId.assigned() ? protocolGroupId : "")
 {
     const auto validateClientToDeviceStreamingParameters = [this]()
     {

--- a/core/opendaq/streaming/include/opendaq/streaming_impl.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_impl.h
@@ -55,7 +55,8 @@ public:
                            ContextPtr context,
                            bool skipDomainSignalSubscribe,
                            const StringPtr& protocolId = nullptr,
-                           bool isClientToDeviceStreamingSupported = false);
+                           bool isClientToDeviceStreamingSupported = false,
+                           const StringPtr& protocolGroupId = nullptr);
 
     ~StreamingImpl() override;
 
@@ -73,6 +74,7 @@ public:
     ErrCode INTERFACE_FUNC removeAllInputPorts() override;
 
     ErrCode INTERFACE_FUNC getOwnerDeviceRemoteId(IString** deviceRemoteId) const override;
+    ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGroupId) const override;
     ErrCode INTERFACE_FUNC getProtocolId(IString** protocolId) const override;
 
     ErrCode INTERFACE_FUNC getClientToDeviceStreamingEnabled(Bool* enabled) const override;
@@ -194,6 +196,7 @@ private:
 
     std::unordered_set<StringPtr, StringHash, StringEqualTo> availableSignalIds;
 
+    StringPtr protocolGroupId;
     StringPtr protocolId;
     const bool isClientToDeviceStreamingSupported;
 
@@ -206,7 +209,8 @@ StreamingImpl<Interfaces...>::StreamingImpl(const StringPtr& connectionString,
                                             ContextPtr context,
                                             bool skipDomainSignalSubscribe,
                                             const StringPtr& protocolId,
-                                            bool isClientToDeviceStreamingSupported)
+                                            bool isClientToDeviceStreamingSupported,
+                                            const StringPtr& protocolGroupId)
     : connectionString(connectionString)
     , context(std::move(context))
     , loggerComponent(this->context.getLogger().getOrAddComponent(fmt::format("Streaming({})", connectionString)))
@@ -214,6 +218,7 @@ StreamingImpl<Interfaces...>::StreamingImpl(const StringPtr& connectionString,
     , skipDomainSignalSubscribe(skipDomainSignalSubscribe)
     , protocolId(protocolId)
     , isClientToDeviceStreamingSupported(isClientToDeviceStreamingSupported)
+    , protocolGroupId(protocolGroupId.assigned() ? protocolGroupId : "")
 {
     const auto validateClientToDeviceStreamingParameters = [this]()
     {
@@ -1085,6 +1090,15 @@ ErrCode StreamingImpl<Interfaces...>::getOwnerDeviceRemoteId(IString** deviceRem
     {
         return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_INVALIDSTATE, "Owner device is not assigned");
     }
+}
+
+template <typename... Interfaces>
+ErrCode StreamingImpl<Interfaces...>::getProtocolGroupId(IString** protocolGroupId) const
+{
+    OPENDAQ_PARAM_NOT_NULL(protocolGroupId);
+
+    *protocolGroupId = this->protocolGroupId.addRefAndReturn();
+    return OPENDAQ_SUCCESS;
 }
 
 template <typename... Interfaces>

--- a/core/opendaq/streaming/include/opendaq/streaming_source_manager.h
+++ b/core/opendaq/streaming/include/opendaq/streaming_source_manager.h
@@ -18,6 +18,7 @@
 
 #include <opendaq/mirrored_device_config_ptr.h>
 #include <map>
+#include <optional>
 #include <unordered_set>
 #include <opendaq/ids_parser.h>
 #include <opendaq/custom_log.h>
@@ -57,6 +58,7 @@ private:
     static AddressInfoPtr getDeviceConnectionAddress(const DevicePtr& device);
     void completeStreamingConnections(const MirroredDeviceConfigPtr& topDevice);
     void attachStreamingsToDevice(const MirroredDeviceConfigPtr& device);
+    std::unordered_map<std::string, ListPtr<IAddressInfo>> buildDiscoveredStreamingAddrsByProtocol(const MirroredDeviceConfigPtr& device);
 
     ContextPtr context;
     WeakRefPtr<IDevice> ownerDeviceRef;
@@ -470,16 +472,168 @@ inline void StreamingSourceManager::attachStreamingsToDevice(const MirroredDevic
     // Get the address used for device connection
     const auto deviceConnectionAddress = getDeviceConnectionAddress(device);
 
-    // protocol priority as a key, streaming source as a value
-    std::map<SizeT, StreamingPtr> prioritizedStreamingSourcesMap;
     const ModuleManagerUtilsPtr managerUtils = this->context.getModuleManager().template asPtr<IModuleManagerUtils>();
 
     // Build a map of discovered addresses by protocol ID for quick lookup
-    std::unordered_map<std::string, ListPtr<IAddressInfo>> discoveredAddressesByProtocol;
+    const auto discoveredAddrsByProtocol = buildDiscoveredStreamingAddrsByProtocol(device);
+
+    // Will be sorted later.
+    std::vector<std::pair<SizeT, StreamingPtr>> prioritizedStreaming;
+
+    // Streaming sources selected within this call are attached to the device only afterwards,
+    // so the pending ones have to be checked along with the already attached ones
+    const auto anyStreamingMatches = [&prioritizedStreaming](const auto& attachedSources, const auto& predicate) -> bool
+    {
+        return std::any_of(attachedSources.begin(), attachedSources.end(), predicate) ||
+               std::any_of(prioritizedStreaming.begin(),
+                           prioritizedStreaming.end(),
+                           [&predicate](const auto& item) { return predicate(item.second); });
+    };
+
+    const auto capabilityPriority = [this](const ServerCapabilityPtr& cap) -> std::optional<SizeT>
+    {
+        if (cap.getProtocolType() != ProtocolType::Streaming)
+            return std::nullopt;
+
+        const StringPtr protocolId = cap.getProtocolId();
+        if (!allowedProtocolsOnly.empty() && !allowedProtocolsOnly.count(protocolId.toStdString()))
+            return std::nullopt;
+
+        const auto protocolIt = prioritizedProtocolsMap.find(protocolId);
+        if (protocolIt == prioritizedProtocolsMap.end())
+            return std::nullopt;
+
+        return protocolIt->second;
+    };
+
+    const auto capabilityGroupId = [](const ServerCapabilityPtr& cap) -> StringPtr
+    {
+        const auto groupId = cap.getProtocolGroupId();
+        return groupId.assigned() && groupId.getLength() > 0 ? groupId : nullptr;
+    };
+
+    std::unordered_map<std::string, SizeT> bestPriorityPerGroup;
+    for (const auto& cap : device.getInfo().getServerCapabilities())
+    {
+        const auto groupId = capabilityGroupId(cap);
+        if (!groupId.assigned())
+            continue;
+
+        const auto priority = capabilityPriority(cap);
+        if (!priority.has_value())
+            continue;
+
+        const auto [it, inserted] = bestPriorityPerGroup.try_emplace(groupId.toStdString(), *priority);
+        if (!inserted)
+            it->second = std::min(it->second, *priority);
+    }
+
+    // connect via all allowed streaming capabilities which are not connected yet
+    for (const auto& cap : device.getInfo().getServerCapabilities())
+    {
+        if (cap.getProtocolType() != ProtocolType::Streaming)
+            continue;
+
+        const auto protoGroupId = capabilityGroupId(cap);
+
+        LOG_D("Device {} has streaming capability: name [{}] group id [{}] id [{}] string [{}] prefix [{}]",
+              device.getGlobalId(),
+              cap.getProtocolName(),
+              protoGroupId.assigned() ? protoGroupId : "<none>",
+              cap.getProtocolId(),
+              cap.getConnectionString(),
+              cap.getPrefix());
+
+        const StringPtr protocolId = cap.getProtocolId();
+        const auto priority = capabilityPriority(cap);
+        if (!priority.has_value())
+            continue;
+
+        const auto addedStreamingSources = device.getStreamingSources();
+        if (protoGroupId.assigned())
+        {
+            // only the most preferred protocol of the group is connected
+            if (*priority != bestPriorityPerGroup.at(protoGroupId.toStdString()))
+            {
+                LOG_D("Device {} has a more preferred protocol in group [{}] than [{}], skipping it",
+                      device.getGlobalId(),
+                      protoGroupId,
+                      protocolId);
+                continue;
+            }
+
+            // the group may already have been connected by a previous call
+            const auto sameGroup = [&protoGroupId](const StreamingPtr& item)
+            {
+                return item.getProtocolGroupId() == protoGroupId;
+            };
+
+            if (anyStreamingMatches(addedStreamingSources, sameGroup))
+            {
+                LOG_D("Device {} already has streaming source with protocol group id [{}], skipping adding another one",
+                      device.getGlobalId(),
+                      protoGroupId);
+                continue;
+            }
+        }
+
+        // Prioritize discovery addresses if available for this protocol
+        ListPtr<IAddressInfo> addressesToUse =
+            (discoveredAddrsByProtocol.count(protocolId) > 0) ? discoveredAddrsByProtocol.at(protocolId) : cap.getAddressInfo();
+
+        const auto streamingAddress = findMatchingAddress(addressesToUse, deviceConnectionAddress);
+        const auto connectionString = streamingAddress.assigned() ? streamingAddress.getConnectionString() : cap.getConnectionString();
+
+        if (!connectionString.assigned())
+            continue;
+
+        const auto sameConnectionString = [&connectionString](const StreamingPtr& item)
+        {
+            return connectionString == item.getConnectionString();
+        };
+
+        if (anyStreamingMatches(addedStreamingSources, sameConnectionString))
+            continue;
+
+        StreamingPtr streaming;
+
+        auto errCode = daqTry(
+            [&]()
+            {
+                streaming = managerUtils.createStreaming(connectionString, deviceConfig);
+                return OPENDAQ_SUCCESS;
+            });
+        if (OPENDAQ_FAILED(errCode))
+            daqClearErrorInfo();
+        if (!streaming.assigned())
+            continue;
+
+        prioritizedStreaming.emplace_back(*priority, streaming);
+    }
+
+    std::stable_sort(prioritizedStreaming.begin(),
+                     prioritizedStreaming.end(),
+                     [](const auto& item0, const auto& item1) { return item0.first < item1.first; });
+
+    // add streaming sources ordered by protocol priority
+    for (const auto& [_, streaming] : prioritizedStreaming)
+    {
+        streaming.setActive(true);
+        device.addStreamingSource(streaming);
+        LOG_I("Device {} added new streaming connection {}", device.getGlobalId(), streaming.getConnectionString());
+    }
+}
+
+inline std::unordered_map<std::string, ListPtr<IAddressInfo>>
+StreamingSourceManager::buildDiscoveredStreamingAddrsByProtocol(const MirroredDeviceConfigPtr& device)
+{
+    std::unordered_map<std::string, ListPtr<IAddressInfo>> output;
+
+    const ModuleManagerUtilsPtr managerUtils = this->context.getModuleManager().template asPtr<IModuleManagerUtils>();
     const auto deviceInfo = device.getInfo();
     const StringPtr deviceManufacturer = deviceInfo.getManufacturer();
     const StringPtr deviceSerialNumber = deviceInfo.getSerialNumber();
-    
+
     if (deviceManufacturer.assigned() && deviceManufacturer.getLength() > 0 &&
         deviceSerialNumber.assigned() && deviceSerialNumber.getLength() > 0)
     {
@@ -491,90 +645,16 @@ inline void StreamingSourceManager::attachStreamingsToDevice(const MirroredDevic
 
         if (discoveryInfo.assigned())
         {
-            LOG_D("Device {} using discovery info for streaming address prioritization", device.getGlobalId());
             for (const auto& discoveryCap : discoveryInfo.getServerCapabilities())
             {
                 if (discoveryCap.getProtocolType() != ProtocolType::Streaming)
                     continue;
 
-                const StringPtr protocolId = discoveryCap.getPropertyValue("protocolId");
-                discoveredAddressesByProtocol[protocolId] = discoveryCap.getAddressInfo();
+                output[discoveryCap.getProtocolId().toStdString()] = discoveryCap.getAddressInfo();
             }
         }
     }
-
-    // connect via all allowed streaming capabilities which are not connected yet
-    for (const auto& cap : device.getInfo().getServerCapabilities())
-    {
-        if (cap.getProtocolType() != ProtocolType::Streaming)
-            continue;
-
-        LOG_D("Device {} has streaming capability: name [{}] id [{}] string [{}] prefix [{}]",
-              device.getGlobalId(),
-              cap.getProtocolName(),
-              cap.getProtocolId(),
-              cap.getConnectionString(),
-              cap.getPrefix());
-
-        const StringPtr protocolId = cap.getPropertyValue("protocolId");
-        if (!allowedProtocolsOnly.empty() && !allowedProtocolsOnly.count(protocolId.toStdString()))
-            continue;
-
-        const auto protocolIt = prioritizedProtocolsMap.find(protocolId);
-        if (protocolIt == prioritizedProtocolsMap.end())
-            continue;
-
-        StreamingPtr streaming;
-
-        // Prioritize discovery addresses if available for this protocol
-        ListPtr<IAddressInfo> addressesToUse;
-        if (discoveredAddressesByProtocol.count(protocolId) > 0)
-        {
-            addressesToUse = discoveredAddressesByProtocol[protocolId];
-            LOG_D("Device {} using discovered addresses for protocol {}", device.getGlobalId(), protocolId);
-        }
-        else
-        {
-            addressesToUse = cap.getAddressInfo();
-        }
-
-        const auto streamingAddress = findMatchingAddress(addressesToUse, deviceConnectionAddress);
-        StringPtr connectionString = streamingAddress.assigned() ? streamingAddress.getConnectionString() : cap.getConnectionString();
-
-        if (!connectionString.assigned())
-            continue;
-
-        const auto addedStreamingSources = device.getStreamingSources();
-        auto it = std::find_if(addedStreamingSources.begin(),
-                               addedStreamingSources.end(),
-                               [&connectionString](const StreamingPtr& item)
-                               {
-                                   return connectionString == item.getConnectionString();
-                               });
-        if (it != addedStreamingSources.end())
-            continue;
-
-        auto errCode = daqTry([&]()
-        {
-            streaming = managerUtils.createStreaming(connectionString, deviceConfig);
-            return OPENDAQ_SUCCESS;
-        });
-        if (OPENDAQ_FAILED(errCode))
-            daqClearErrorInfo();
-        if (!streaming.assigned())
-            continue;
-
-        const SizeT protocolPriority = protocolIt->second;
-        prioritizedStreamingSourcesMap.insert_or_assign(protocolPriority, streaming);
-    }
-
-    // add streaming sources ordered by protocol priority
-    for (const auto& [_, streaming] : prioritizedStreamingSourcesMap)
-    {
-        streaming.setActive(true);
-        device.addStreamingSource(streaming);
-        LOG_I("Device {} added new streaming connection {}", device.getGlobalId(), streaming.getConnectionString());
-    }
+    return output;
 }
 
 END_NAMESPACE_OPENDAQ

--- a/core/opendaq/streaming/tests/test_streaming.cpp
+++ b/core/opendaq/streaming/tests/test_streaming.cpp
@@ -31,6 +31,27 @@ TEST_F(StreamingTest, ConnectionString)
     ASSERT_EQ(streaming.ptr.getConnectionString(), "MockStreaming");
 }
 
+TEST_F(StreamingTest, ProtocolId)
+{
+    ASSERT_EQ(streaming.ptr.getProtocolId(), "MockStreaming");
+}
+
+TEST_F(StreamingTest, ProtocolGroupIdDefaultsToEmpty)
+{
+    ASSERT_EQ(streaming.ptr.getProtocolGroupId(), "");
+}
+
+TEST_F(StreamingTest, ProtocolGroupId)
+{
+    MockStreaming::StrictWithGroup grouped("MockStreamingGrouped", context, "MockStreamingGroup");
+    ASSERT_EQ(grouped.ptr.getProtocolGroupId(), "MockStreamingGroup");
+}
+
+TEST_F(StreamingTest, ProtocolGroupIdNullOutParam)
+{
+    ASSERT_ERROR_CODE_EQ(streaming.ptr->getProtocolGroupId(nullptr), OPENDAQ_ERR_ARGUMENT_NULL);
+}
+
 TEST_F(StreamingTest, InactiveByDefault)
 {
     daq::Bool active;

--- a/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
+++ b/shared/libraries/discovery_server/include/discovery_server/mdnsdiscovery_server.h
@@ -176,7 +176,7 @@ private:
     std::atomic<bool> running {false};
     std::thread serviceThread;
     
-    std::map<std::string, MdnsDiscoveredService> services;
+    std::multimap<std::string, MdnsDiscoveredService> services;
     std::unordered_map<std::string, AdapterInfo> adapters;
 
     std::string manufacturer;

--- a/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
+++ b/shared/libraries/discovery_server/src/mdnsdiscovery_server.cpp
@@ -17,6 +17,7 @@
 
 #include <discovery_server/mdnsdiscovery_server.h>
 #include <discovery_common/daq_discovery_common.h>
+#include <algorithm>
 #include <stdexcept>
 #include <opendaq/utils/thread_name.h>
 
@@ -338,7 +339,13 @@ bool MDNSDiscoveryServer::registerService(const std::string& id, MdnsDiscoveredS
     bool success;
     {
         std::lock_guard<std::mutex> lock(mx);
-        success = services.emplace(id, service).second;
+        const auto range = services.equal_range(id);
+        success = std::none_of(range.first,
+                               range.second,
+                               [&service](const auto& registered)
+                               { return registered.second.serviceName == service.serviceName; });
+        if (success)
+            services.emplace(id, service);
     }
     if (success)
     {
@@ -356,15 +363,14 @@ void MDNSDiscoveryServer::goodbyeMulticast(const MdnsDiscoveredService& service)
 
 bool MDNSDiscoveryServer::unregisterService(const std::string& id)
 {
-    bool success = false;
     std::lock_guard<std::mutex> lock(mx);
-    auto it = services.find(id);
-    if (it != services.end())
-    {
-        success = true;
+
+    const auto range = services.equal_range(id);
+    const bool success = range.first != range.second;
+
+    for (auto it = range.first; it != range.second; ++it)
         goodbyeMulticast(it->second);
-        services.erase(it);
-    }
+    services.erase(range.first, range.second);
 
     return success;
 }


### PR DESCRIPTION
# Brief

Adds `ProtocolGroupId` and `ProtocolSecurityLevel` to `IServerCapability`/`IServerCapabilityConfig` and `getProtocolGroupId` to `IStreaming`, so that protocols which are variants of one another (e.g. plain and TLS-secured transports of the same protocol) can be grouped — `StreamingSourceManager` then attaches only the single most preferred streaming source per group instead of one per protocol. Also allows a single server to advertise more than one discovery service.

# Description

**Server capability API**

- `IServerCapability::getProtocolGroupId` / `IServerCapabilityConfig::setProtocolGroupId` — an empty group ID means the protocol belongs to no group. Backed by a new `ProtocolGroupId` string property, default `""`.
- `IServerCapability::getProtocolSecurityLevel` / `IServerCapabilityConfig::setProtocolSecurityLevel` — backed by a new `SecurityLevel` int property, default `-1` (unknown/undefined), `0` for insecure, positive values ordered by increasing security. Nothing in this PR consumes the security level yet.

**Streaming API**

- `IStreaming::getProtocolGroupId` and a new trailing `protocolGroupId` parameter on the `StreamingImpl` constructor (defaults to `nullptr`, stored as `""`).

**Streaming source selection (`StreamingSourceManager::attachStreamingsToDevice`)**

- For each protocol group present on the device, computes the best (lowest) priority in `prioritizedProtocolsMap` and skips every capability in that group that is not the best one; also skips a group that already has an attached — or pending, within the same call — streaming source.

**Multiple discovery services per server**

- New `virtual ServerImpl::getDiscoveryConfigs()`, defaulting to a one-element list wrapping the existing `getDiscoveryConfig()`; `enableDiscovery` now registers every returned config against every discovery server.
- `MDNSDiscoveryServer::services` becomes a `std::multimap`, keyed by server id; `registerService` rejects a duplicate only when the same `serviceName` is already registered under that id, and `unregisterService` sends goodbye for and erases the whole range for an id.

**Mocks and tests**

- `MockStreaming::StrictWithGroup` and a `MockStreamingWithProtocol` factory taking an explicit protocol ID and group ID.
- New tests: server capability get/set, freeze, serialize/deserialize and clone round-trips for both new fields; `IStreaming::getProtocolGroupId` incl. the null-out-param error; a `RecordingDiscoveryServer` fake driving five `ServerDiscoveryTest` cases over multi- and single-config servers.
- `WebsocketModulesChannelTest.ConnectAndDisconnectBackwardCompatibility` now skips in the secure parameterisation instead of connecting over `daq.wss://`.

# API changes

```diff
  IServerCapability : IPropertyObject
+ ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGroupId)
+ ErrCode INTERFACE_FUNC getProtocolSecurityLevel(IInteger** securityLevel)

  IServerCapabilityConfig : IServerCapability
+ ErrCode INTERFACE_FUNC setProtocolGroupId(IString* protocolGroupId)
+ ErrCode INTERFACE_FUNC setProtocolSecurityLevel(IInteger* securityLevel)

  IStreaming : IBaseObject
+ ErrCode INTERFACE_FUNC getProtocolGroupId(IString** protocolGroupId) const
```

# Required application changes

None. Both capability properties have defaults (`""` and `-1`), and `getProtocolGroupId` on an existing streaming implementation returns `""`.

# Required module changes

- Any out-of-tree implementation of `IServerCapability` / `IServerCapabilityConfig` / `IStreaming` that does not derive from `ServerCapabilityConfigImpl` / `StreamingImpl` must implement the new methods.
- Modules that want group-based deduplication of streaming sources must call `setProtocolGroupId` on their server capability and pass `protocolGroupId` to the `StreamingImpl` constructor. Without it, behaviour is unchanged.
- Servers advertising several mDNS services under one server id should override `getDiscoveryConfigs()` instead of `getDiscoveryConfig()`.