### PR TITLE
Fix client root device not being synchronized correctly after reconnect if "RestoreClientConfigOnReconnect" is enabled

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,7 @@
 
 ## Bug fixes
 
+- [#1263](https://github.com/openDAQ/openDAQ/pull/1263) Fix client root device not being synchronized correctly after reconnect if "RestoreClientConfigOnReconnect" is enabled
 - [#1219](https://github.com/openDAQ/openDAQ/pull/1219) Fixes reading vector signals with stream reader in python.
 - [#1214](https://github.com/openDAQ/openDAQ/pull/1214) Fixes the order in which packets are enqueued in sendPackets. They are now always correctly enqueued front-to-back.
 - [#1213](https://github.com/openDAQ/openDAQ/pull/1213) Forward device locked state core event in native client.

--- a/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_protocol_client.h
@@ -431,7 +431,9 @@ void ConfigProtocolClient<TRootDeviceImpl>::reconnect(Bool restoreClientConfigOn
     protocolHandshake(clientComm->getProtocolVersion());
     enumerateTypes();
 
-    if (restoreClientConfigOnReconnect && !rootDevice.isLocked())
+    const bool restoreLocalConfig = restoreClientConfigOnReconnect && !rootDevice.isLocked();
+    StringPtr serializedClientRootDevice;
+    if (restoreLocalConfig)
     {
         SerializerPtr serializer;
         if (getProtocolVersion() < 10)
@@ -440,20 +442,21 @@ void ConfigProtocolClient<TRootDeviceImpl>::reconnect(Bool restoreClientConfigOn
             serializer = JsonSerializerWithVersion(2);
 
         rootDevice.asPtr<IUpdatable>().serializeForUpdate(serializer);
-        StringPtr serializedClientRootDevice = serializer.getOutput();
+        serializedClientRootDevice = serializer.getOutput();
+    }
 
+    const StringPtr serializedServerRootDevice = clientComm->requestSerializedRootDevice();
+
+    auto dict = Dict<IString, IBaseObject>();
+    dict.set("SerializedComponent", serializedServerRootDevice);
+
+    auto args = CoreEventArgs(CoreEventId::ComponentUpdateEnd, nullptr, dict);
+    rootDevice.asPtr<IConfigClientObject>()->handleRemoteCoreEvent(rootDevice, args);
+
+    if (restoreLocalConfig)
+    {
         const auto deserializer = JsonDeserializer();
         deserializer.update(rootDevice.asPtr<IUpdatable>(), serializedClientRootDevice);
-    }
-    else
-    {
-        const StringPtr serializedServerRootDevice = clientComm->requestSerializedRootDevice();
-
-        auto dict = Dict<IString, IBaseObject>();
-        dict.set("SerializedComponent", serializedServerRootDevice);
-
-        auto args = CoreEventArgs(CoreEventId::ComponentUpdateEnd, nullptr, dict);
-        rootDevice.asPtr<IConfigClientObject>()->handleRemoteCoreEvent(rootDevice, args);
     }
 }
 

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -22,6 +22,7 @@
 #include "config_protocol/config_client_device_impl.h"
 #include <coreobjects/user_factory.h>
 #include <opendaq/mock/mock_streaming_factory.h>
+#include <opendaq/mock/mock_physical_device.h>
 
 using namespace daq;
 using namespace daq::config_protocol;
@@ -64,9 +65,14 @@ protected:
     ContextPtr clientContext;
     BaseObjectPtr notificationObj;
 
+    //To simulate disconnected server - notifications from server are dropped
+    bool disconnected = false;
+
     // server handling
     void serverNotificationReady(const PacketBuffer& notificationPacket) const
     {
+        if (disconnected)
+            return;
         client->triggerNotificationPacket(notificationPacket);
     }
 
@@ -1775,10 +1781,38 @@ TEST_F(ConfigCoreEventTest, ReconnectRestoreClientConfig)
     };
 
     client->reconnect(True);
-    ASSERT_EQ(updateCount, 1);
+    //ASSERT_EQ(updateCount, 2);
 
     ASSERT_EQ(clientDevice.getPropertyValue("String"), "foo");
     ASSERT_EQ(serverDevice.getPropertyValue("String"), "foo");
+}
+
+TEST_F(ConfigCoreEventTest, ReconnectRestoreClientConfigWithChangedDevice)
+{
+    ASSERT_EQ(serverDevice.getDevices(search::Recursive(search::Any())).getCount(), 2u);
+    ASSERT_EQ(clientDevice.getDevices(search::Recursive(search::Any())).getCount(), 2u);
+
+    disconnected = true;
+
+    const FolderConfigPtr devicesFolder = serverDevice.getItem("Dev");
+    devicesFolder.addItem(MockPhysicalDevice_Create(serverDevice.getContext(), devicesFolder, String("mock_phys_dev_new"), nullptr));
+
+    ASSERT_EQ(serverDevice.getDevices(search::Recursive(search::Any())).getCount(), 3u);
+    ASSERT_EQ(clientDevice.getDevices(search::Recursive(search::Any())).getCount(), 2u);
+
+    int updateCount = 0;
+    clientContext.getOnCoreEvent() += [&](const ComponentPtr& /*comp*/, const CoreEventArgsPtr& args)
+    {
+        ASSERT_EQ(args.getEventName(), "ComponentUpdateEnd");
+        updateCount++;
+    };
+
+    client->reconnect(True);
+
+    disconnected = false;
+
+    ASSERT_EQ(serverDevice.getDevices(search::Recursive(search::Any())).getCount(), 3u);
+    ASSERT_EQ(clientDevice.getDevices(search::Recursive(search::Any())).getCount(), 3u);
 }
 
 TEST_F(ConfigCoreEventTest, ReconnectComponentUpdateEndDeviceInfo)

--- a/shared/libraries/config_protocol/tests/test_core_events.cpp
+++ b/shared/libraries/config_protocol/tests/test_core_events.cpp
@@ -1781,7 +1781,7 @@ TEST_F(ConfigCoreEventTest, ReconnectRestoreClientConfig)
     };
 
     client->reconnect(True);
-    //ASSERT_EQ(updateCount, 2);
+    ASSERT_EQ(updateCount, 2);
 
     ASSERT_EQ(clientDevice.getPropertyValue("String"), "foo");
     ASSERT_EQ(serverDevice.getPropertyValue("String"), "foo");


### PR DESCRIPTION
# Brief

Current issue is that structure of the client device can be out of sync on reconnect if "RestoreClientConfigOnReconnect" is enabled. 

i.e. If a device have additional subdevices after reconnect this is complety unknown to the client device.

# Description

### Before change

There were 2 execution paths:
1) "RestoreClientConfigOnReconnect" = true: 
serialised state of the local device was applied at reconnect

2) "RestoreClientConfigOnReconnect" = false: 
local device was updated from the one on server

### After change :

Local device is always updated from the one on server.

Only if "RestoreClientConfigOnReconnect" = true, serialized state is stored before client device is updated and setting is applied after that.
