### PR TITLE
[BUG] Replace modified native client property metadata if changed while updating

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,8 @@
 
 ## Bug fixes
 
+- [#1266](https://github.com/openDAQ/openDAQ/pull/1266) Native client updates `IProperty` metadata that changed on the server during `onUpdateEnded`
+- [#1266](https://github.com/openDAQ/openDAQ/pull/1266) Native client deserializes properties into their `ConfigClient` variant during `onUpdateEnded`
 - [#1219](https://github.com/openDAQ/openDAQ/pull/1219) Fixes reading vector signals with stream reader in python.
 - [#1214](https://github.com/openDAQ/openDAQ/pull/1214) Fixes the order in which packets are enqueued in sendPackets. They are now always correctly enqueued front-to-back.
 - [#1213](https://github.com/openDAQ/openDAQ/pull/1213) Forward device locked state core event in native client.

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -1237,6 +1237,91 @@ public:
         return daqDuplicateCharPtr(stream.str().c_str(), str);
     }
 
+    ErrCode INTERFACE_FUNC equals(IBaseObject* other, Bool* equal) const override
+    {
+        OPENDAQ_PARAM_NOT_NULL(equal);
+
+        *equal = false;
+        if (other == nullptr)
+            return OPENDAQ_SUCCESS;
+
+        const ErrCode errCode = daqTry([&]()
+        {
+            const auto otherProperty = BaseObjectPtr::Borrow(other).asPtrOrNull<IProperty>(true);
+            if (!otherProperty.assigned())
+                return OPENDAQ_SUCCESS;
+
+            if (otherProperty.getObject() == propPtr.getObject())
+            {
+                *equal = true;
+                return OPENDAQ_SUCCESS;
+            }
+
+            const auto otherInternal = otherProperty.asPtrOrNull<IPropertyInternal>(true);
+            if (!otherInternal.assigned())
+                return OPENDAQ_SUCCESS;
+
+            if (this->valueType != otherInternal.getValueTypeUnresolved())
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->name, otherProperty.getName()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->refProp, otherInternal.getReferencedPropertyUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->description, otherInternal.getDescriptionUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->unit, otherInternal.getUnitUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->minValue, otherInternal.getMinValueUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->maxValue, otherInternal.getMaxValueUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->defaultValue, otherInternal.getDefaultValueUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->readOnly, otherInternal.getReadOnlyUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->visible, otherInternal.getVisibleUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->selectionValues, otherInternal.getSelectionValuesUnresolved()))
+                return OPENDAQ_SUCCESS;
+            if (!equalsMetadataField(this->suggestedValues, otherInternal.getSuggestedValuesUnresolved()))
+                return OPENDAQ_SUCCESS;
+
+            const auto thisInternal = propPtr.asPtr<IPropertyInternal>(true);
+            if (thisInternal.getHasOnReadListeners() != otherInternal.getHasOnReadListeners())
+                return OPENDAQ_SUCCESS;
+            if (thisInternal.getHasOnGetSelectionValuesListeners() != otherInternal.getHasOnGetSelectionValuesListeners())
+                return OPENDAQ_SUCCESS;
+            if (thisInternal.getHasOnGetSuggestedValuesListeners() != otherInternal.getHasOnGetSuggestedValuesListeners())
+                return OPENDAQ_SUCCESS;
+
+            if (!this->refProp.assigned())
+            {
+                if (!equalsEvalField(this->coercer, otherInternal.getCoercerNoLock()))
+                    return OPENDAQ_SUCCESS;
+                if (!equalsEvalField(this->validator, otherInternal.getValidatorNoLock()))
+                    return OPENDAQ_SUCCESS;
+                if (!equalsMetadataField(this->callableInfo, otherInternal.getCallableInfoNoLock()))
+                    return OPENDAQ_SUCCESS;
+            }
+
+            if (this->selectionValues.assigned() && !this->selectionValues.asPtrOrNull<IEvalValue>(true).assigned())
+            {
+                PropertyType otherType = PropertyType::Undefined;
+                OPENDAQ_RETURN_IF_FAILED(otherProperty->getPropertyType(&otherType));
+
+                const PropertyType thisType =
+                    this->propertyType != PropertyType::Undefined ? this->propertyType : inferPropertyTypeFromMetadata();
+                if (thisType != otherType)
+                    return OPENDAQ_SUCCESS;
+            }
+
+            *equal = true;
+            return OPENDAQ_SUCCESS;
+        });
+        OPENDAQ_RETURN_IF_FAILED(errCode);
+        return errCode;
+    }
+
     //
     // ISerializable
     //
@@ -1764,6 +1849,34 @@ private:
 
         // Fallback: mirror CoreType
         return static_cast<PropertyType>(this->valueType);
+    }
+
+    // Value comparison; EvalValues are compared via their eval strings, without evaluation.
+    static bool equalsMetadataField(const BaseObjectPtr& a, const BaseObjectPtr& b)
+    {
+        if (!a.assigned() || !b.assigned())
+            return a.assigned() == b.assigned();
+
+        const auto evalA = a.asPtrOrNull<IEvalValue>(true);
+        const auto evalB = b.asPtrOrNull<IEvalValue>(true);
+        if (evalA.assigned() || evalB.assigned())
+        {
+            if (!evalA.assigned() || !evalB.assigned())
+                return false;
+            return evalA.getEval() == evalB.getEval();
+        }
+
+        Bool eq = False;
+        return OPENDAQ_SUCCEEDED(a->equals(b, &eq)) && eq;
+    }
+
+    // Coercers and validators have no value-based equals; compared via their eval strings.
+    template <typename TPtr>
+    static bool equalsEvalField(const TPtr& a, const TPtr& b)
+    {
+        if (!a.assigned() || !b.assigned())
+            return a.assigned() == b.assigned();
+        return a.getEval() == b.getEval();
     }
 
     PropertyPtr bindAndGetRefProp(bool lock)

--- a/core/coreobjects/include/coreobjects/property_impl.h
+++ b/core/coreobjects/include/coreobjects/property_impl.h
@@ -1854,17 +1854,17 @@ private:
     // Value comparison; EvalValues are compared via their eval strings, without evaluation.
     static bool equalsMetadataField(const BaseObjectPtr& a, const BaseObjectPtr& b)
     {
-        if (!a.assigned() || !b.assigned())
-            return a.assigned() == b.assigned();
+        if (a.assigned() != b.assigned())
+            return false;
+        if (!a.assigned())
+            return true;
 
         const auto evalA = a.asPtrOrNull<IEvalValue>(true);
         const auto evalB = b.asPtrOrNull<IEvalValue>(true);
-        if (evalA.assigned() || evalB.assigned())
-        {
-            if (!evalA.assigned() || !evalB.assigned())
-                return false;
+        if (evalA.assigned() != evalB.assigned())
+            return false;
+        if (evalA.assigned())
             return evalA.getEval() == evalB.getEval();
-        }
 
         Bool eq = False;
         return OPENDAQ_SUCCEEDED(a->equals(b, &eq)) && eq;
@@ -1874,9 +1874,9 @@ private:
     template <typename TPtr>
     static bool equalsEvalField(const TPtr& a, const TPtr& b)
     {
-        if (!a.assigned() || !b.assigned())
-            return a.assigned() == b.assigned();
-        return a.getEval() == b.getEval();
+        if (a.assigned() != b.assigned())
+            return false;
+        return !a.assigned() || a.getEval() == b.getEval();
     }
 
     PropertyPtr bindAndGetRefProp(bool lock)

--- a/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
+++ b/shared/libraries/config_protocol/include/config_protocol/config_client_property_object_impl.h
@@ -607,16 +607,52 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::updateProperties(const Serialized
     const auto propertyList = serObj.readSerializedList(keyStr);
     const TypeManagerPtr typeManager = this->getTypeManager();
     std::unordered_set<std::string> serializedProps{};
+    std::vector<StringPtr> serializedOrder{};
+
+    // Deserialize via the config-protocol factory so incoming properties are config-client
+    // properties.
+    const auto deserializeContext = createWithImplementation<IComponentDeserializeContext, ConfigProtocolDeserializeContextImpl>(
+        this->clientComm, this->remoteGlobalId, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, typeManager);
+    const FunctionPtr factoryCallback =
+        [this](const StringPtr& typeId, const SerializedObjectPtr& object, const BaseObjectPtr& context, const FunctionPtr& factoryCallback)
+        {
+            return clientComm->deserializeConfigComponent(typeId, object, context, factoryCallback);
+        };
+
+    bool propertyReplaced = false;
 
     for (SizeT i = 0; i < propertyList.getCount(); i++)
     {
-        const PropertyPtr prop = propertyList.readObject(typeManager);
+        const PropertyPtr prop = propertyList.readObject(deserializeContext, factoryCallback);
 
         const auto propName = prop.getName();
         serializedProps.insert(propName);
+        serializedOrder.push_back(propName);
 
         if (!thisPtr.hasProperty(propName))
+        {
             thisPtr.addProperty(prop);
+            propertyReplaced = true;
+            continue;
+        }
+
+        // Object-type properties are merged recursively in updatePropertyValues
+        const auto propInternal = prop.asPtrOrNull<IPropertyInternal>(true);
+        if (propInternal.assigned() && propInternal.getValueTypeUnresolved() == ctObject)
+            continue;
+
+        // Replace the property if its metadata changed on the server.
+        if (prop != thisPtr.getProperty(propName))
+        {
+            const ErrCode errCode = Impl::removeProperty(propName);
+            if (OPENDAQ_SUCCEEDED(errCode))
+            {
+                thisPtr.addProperty(prop);
+                propertyReplaced = true;
+            }
+            else
+                daqClearErrorInfo();
+        }
     }
 
     for (const auto& prop : thisPtr.getAllProperties())
@@ -628,6 +664,31 @@ void ConfigClientPropertyObjectBaseImpl<Impl>::updateProperties(const Serialized
             if (OPENDAQ_FAILED(errCode))
                 daqClearErrorInfo();
         }
+    }
+
+    // Replaced and added properties end up at the end of the insertion order, which determines
+    // the property order unless a custom order is defined.
+    if (propertyReplaced && Impl::customOrder.empty())
+    {
+        auto lock = Impl::getRecursiveConfigLock2();
+
+        PropertyOrderedMap orderedProps;
+        orderedProps.reserve(Impl::localProperties.size());
+        for (const auto& propName : serializedOrder)
+        {
+            const auto it = Impl::localProperties.find(propName);
+            if (it != Impl::localProperties.end())
+                orderedProps.insert(*it);
+        }
+
+        // Non-serialized leftovers keep their relative order after the serialized ones.
+        for (const auto& prop : Impl::localProperties)
+        {
+            if (orderedProps.find(prop.first) == orderedProps.end())
+                orderedProps.insert(prop);
+        }
+
+        Impl::localProperties = std::move(orderedProps);
     }
 }
 

--- a/shared/libraries/config_protocol/tests/test_remote_update.cpp
+++ b/shared/libraries/config_protocol/tests/test_remote_update.cpp
@@ -53,11 +53,13 @@ protected:
     std::unique_ptr<ConfigProtocolClient<ConfigClientDeviceImpl>> client;
     ContextPtr clientContext;
     BaseObjectPtr notificationObj;
+    bool muteNotifications = false;
 
     // server handling
     void serverNotificationReady(const PacketBuffer& notificationPacket) const
     {
-        client->triggerNotificationPacket(notificationPacket);
+        if (!muteNotifications)
+            client->triggerNotificationPacket(notificationPacket);
     }
 
     // client handling
@@ -194,6 +196,49 @@ TEST_F(ConfigRemoteUpdateTest, TestRemoveStaticComponents)
 
     auto fb = clientDevice.getFunctionBlocks()[0];
     ASSERT_THROW(clientDevice.removeFunctionBlock(fb), InvalidOperationException);
+}
+
+TEST_F(ConfigRemoteUpdateTest, UpdateReplacesChangedProperty)
+{
+    auto serverComponent = serverDevice.getCustomComponents()[0];
+    auto clientComponent = clientDevice.getCustomComponents()[0];
+
+    // Replace a property on the server while notifications are muted; the client keeps the old metadata
+    muteNotifications = true;
+    serverComponent.removeProperty("Ratio");
+    serverComponent.addProperty(RatioPropertyBuilder("Ratio", Ratio(1, 10)).setDescription("changed").build());
+    muteNotifications = false;
+
+    ASSERT_EQ(clientComponent.getProperty("Ratio").getDefaultValue(), Ratio(1, 1000));
+
+    // A server-side update re-syncs the client via remoteUpdate
+    updateHelper(serverComponent, serializeHelper(serverComponent));
+
+    const auto clientProp = clientComponent.getProperty("Ratio");
+    ASSERT_EQ(clientProp.getDefaultValue(), Ratio(1, 10));
+    ASSERT_EQ(clientProp.getDescription(), "changed");
+    ASSERT_EQ(clientComponent.getPropertyValue("Ratio"), Ratio(1, 10));
+
+    // The property order matches the server after the replacement
+    auto serverNames = List<IString>();
+    for (const auto& prop : serverComponent.getAllProperties())
+        serverNames.pushBack(prop.getName());
+    auto clientNames = List<IString>();
+    for (const auto& prop : clientComponent.getAllProperties())
+        clientNames.pushBack(prop.getName());
+    ASSERT_EQ(serverNames, clientNames);
+}
+
+TEST_F(ConfigRemoteUpdateTest, UpdateKeepsUnchangedProperties)
+{
+    auto serverComponent = serverDevice.getCustomComponents()[0];
+    auto clientComponent = clientDevice.getCustomComponents()[0];
+
+    const auto clientPropBefore = clientComponent.getProperty("Ratio");
+    updateHelper(serverComponent, serializeHelper(serverComponent));
+
+    // Unchanged properties are not replaced
+    ASSERT_EQ(clientComponent.getProperty("Ratio").getObject(), clientPropBefore.getObject());
 }
 
 TEST_F(ConfigRemoteUpdateTest, UpdateChannelActive)


### PR DESCRIPTION
# Brief

Native client now:
- Updates `IProperty` metadata that changed on the server during `onUpdateEnded`
- Deserializes properties into their `ConfigClient` variant during `onUpdateEnded`

# Description

On a remote update (config load, reconnect), the native client reconciled properties by name only:
new ones were added, missing ones removed, but existing ones were never touched. A property removed
and re-added on the server with different metadata kept its stale metadata on the client.

Additionally, newly added properties were incorrectly deserialized into `PropertyImpl` instead of
the `ConfigClient` variant, losing the config-client behavior (e.g. server-side listener flags). This fix introduces a small overhead during property deserialization; The equality check is negligible.

# Solution

- The native config client now deserializes properties into `ConfigClientPropertyImpl` when
  applying the `ComponentUpdateEnd` core event.
- It compares each newly deserialized property with the existing one via the new value-based
  `Property::equals` and replaces the existing property when they are not equal.