### PR TITLE
Add armv8 wheels to package_linux_wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,7 @@ jobs:
       DST_ROOT_DIR: releases
       SDK_DIR: SDK
       WHEELS_LINUX_X64_DIR: Python Wheels (Linux x86_64)
+      WHEELS_LINUX_ARM_DIR: Python Wheels (Linux ARM)
       WHEELS_WINDOWS_X64_DIR: Python Wheels (Windows amd64)
       WHEELS_MACOS_X64_DIR: Python Wheels (MacOS x86_64)
       WHEELS_MACOS_ARM_DIR: Python Wheels (MacOS ARM)
@@ -209,7 +210,10 @@ jobs:
 
           # Python Wheels
           aws s3 rm "${DST_URI}/${WHEELS_LINUX_X64_DIR}/" --recursive --exclude '*' --include '*.whl'
-          aws s3 cp "${SRC}"/opendaq-*-python-wheels-linux/ "${DST_URI}/${WHEELS_LINUX_X64_DIR}/" --recursive --exclude '*' --include '*.whl'
+          aws s3 cp "${SRC}"/opendaq-*-python-wheels-linux-x86_64/ "${DST_URI}/${WHEELS_LINUX_X64_DIR}/" --recursive --exclude '*' --include '*.whl'
+
+          aws s3 rm "${DST_URI}/${WHEELS_LINUX_ARM_DIR}/" --recursive --exclude '*' --include '*.whl'
+          aws s3 cp "${SRC}"/opendaq-*-python-wheels-linux-arm64/ "${DST_URI}/${WHEELS_LINUX_ARM_DIR}/" --recursive --exclude '*' --include '*.whl'
 
           aws s3 rm "${DST_URI}/${WHEELS_WINDOWS_X64_DIR}/" --recursive --exclude '*' --include '*.whl'
           aws s3 cp "${SRC}"/opendaq-*-python-wheels-windows/ "${DST_URI}/${WHEELS_WINDOWS_X64_DIR}/" --recursive --exclude '*' --include '*.whl'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -193,7 +193,7 @@ jobs:
           retention-days: 1
 
   package_linux_wheels:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
 
     concurrency:
@@ -204,8 +204,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: manylinux_2_28 gcc Release
+          - name: manylinux_2_28 gcc x86_64 Release
+            runner: ubuntu-latest
             image: quay.io/pypa/manylinux_2_28_x86_64
+            cmake-generator: Ninja
+            cmake-build-type: Release
+            cmake-defines: >-
+              -DDAQMODULES_PARQUET_RECORDER_MODULE=ON
+          - name: manylinux_2_28 gcc armv8 Release
+            runner: ubuntu-24.04-arm
+            image: quay.io/pypa/manylinux_2_28_aarch64
             cmake-generator: Ninja
             cmake-build-type: Release
             cmake-defines: >-
@@ -249,6 +257,7 @@ jobs:
           build-path: ${{ steps.build-sdk.outputs.build-path }}
           cmake-build-type: ${{ matrix.cmake-build-type }}
           upload-artifact: true
+          package-artifact-name-include-arch: true
 
   package_macos_wheels:
     name: ${{ matrix.name }}
@@ -309,10 +318,17 @@ jobs:
           upload-artifact: true
           package-artifact-name-include-arch: true
 
-  package_macos_wheels_combined:
-    name: Combine macOS wheels
+  package_wheels_combined:
+    name: Combine ${{ matrix.os }} wheels
     runs-on: ubuntu-latest
-    needs: [package_macos_wheels]
+    needs: [package_linux_wheels, package_macos_wheels]
+    # combine whatever succeeded, even if the other platform failed
+    if: ${{ !cancelled() }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [linux, macos]
 
     steps:
       - name: Checkout
@@ -322,17 +338,17 @@ jobs:
         id: detect
         uses: ./.github/actions/package-version-detect
 
-      - name: Download macOS wheels
+      - name: Download ${{ matrix.os }} wheels
         uses: actions/download-artifact@v4
         with:
-          pattern: opendaq-*-python-wheels-macos-*
+          pattern: opendaq-*-python-wheels-${{ matrix.os }}-*
           path: wheels
           merge-multiple: true
 
       - name: Upload combined wheels
         uses: actions/upload-artifact@v4
         with:
-          name: opendaq-${{ steps.detect.outputs.version-full }}-python-wheels-macos
+          name: opendaq-${{ steps.detect.outputs.version-full }}-python-wheels-${{ matrix.os }}
           path: wheels/*.whl
 
   simulator-build:

--- a/bindings/python/package/build_pip.py
+++ b/bindings/python/package/build_pip.py
@@ -49,7 +49,7 @@ def auto_wheel_tag(opendaq_path, bin_dir):
     linux_pattern = r'linux'
     windows_pattern = r'win'
     macos_pattern = r'macos|darwin'
-    machine_pattern = r'x86_64|amd64|arm64'
+    machine_pattern = r'x86_64|amd64|arm64|aarch64'
 
     wheel_tag = ''
     if re.search(macos_pattern, opendaq_path):
@@ -61,7 +61,9 @@ def auto_wheel_tag(opendaq_path, bin_dir):
             wheel_tag = macos_tag + '_' + arch
     elif re.search(machine_pattern, opendaq_path):
         if re.search(linux_pattern, opendaq_path):
-            wheel_tag = 'manylinux_2_28_x86_64'
+            arch = 'aarch64' if re.search(
+                r'arm64|aarch64', opendaq_path) else 'x86_64'
+            wheel_tag = 'manylinux_2_28_' + arch
         elif re.search(windows_pattern, opendaq_path):
             wheel_tag = 'win_amd64'
     return wheel_tag
@@ -155,6 +157,9 @@ if not python_version:
     sys.exit(1)
 if not package_version:
     print('Could not detect package version')
+    sys.exit(1)
+if not wheel_tag:
+    print(f'Could not detect wheel tag from {modules.opendaq}')
     sys.exit(1)
 
 print(f'Generating pip package for OpenDAQ ver. {package_version}')


### PR DESCRIPTION
# Brief

Build openDAQ Python wheels for Linux armv8, alongside the existing x86_64 ones.

# Description

- Add an armv8 entry to the `package_linux_wheels` matrix, on the `quay.io/pypa/manylinux_2_28_aarch64` image, running on a native arm runner
- Name the Linux wheel artifacts per architecture, so both legs of the matrix upload their own
- Match `aarch64` in `build_pip.py`, so Linux wheels get the `manylinux_2_28_aarch64` platform tag instead of an empty one
- Merge the macOS and Linux combine jobs into a single one, matrixed over the OS
- Upload the Linux armv8 wheels to their own S3 folder, `Python Wheels (Linux ARM)`

Mind the architecture naming in platform tags: the same ARMv8 hardware is `aarch64` on Linux (`manylinux_2_28_aarch64`) and `arm64` on macOS (`macosx_11_0_arm64`). Those names come from the platform vendors and are fixed by PEP 425/600 -- pip looks up exactly them.

# Usage example

On an armv8 Linux host:

```shell
pip install opendaq-<version>-cp311-cp311-manylinux_2_28_aarch64.whl
```

# API changes

None -- CI and packaging only.

# Required application changes

None.

# Required module changes

None.
