### PR TITLE
Fix IcmpPing leaking its object, socket and reply buffer

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,7 @@
 
 ## Bug fixes
 
+- [#1268](https://github.com/openDAQ/openDAQ/pull/1268) Fix IcmpPing leaking its object, socket and reply buffer.
 - [#1263](https://github.com/openDAQ/openDAQ/pull/1263) Fix client root device not being synchronized correctly after reconnect if "RestoreClientConfigOnReconnect" is enabled
 - [#1266](https://github.com/openDAQ/openDAQ/pull/1266) Native client updates `IProperty` metadata that changed on the server during `onUpdateEnded`
 - [#1266](https://github.com/openDAQ/openDAQ/pull/1266) Native client deserializes properties into their `ConfigClient` variant during `onUpdateEnded`

--- a/core/opendaq/modulemanager/include/opendaq/icmp_ping.h
+++ b/core/opendaq/modulemanager/include/opendaq/icmp_ping.h
@@ -15,8 +15,11 @@
  */
 #pragma once
 #include <boost/asio.hpp>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <mutex>
+#include <unordered_set>
 #include <opendaq/logger_ptr.h>
 #include <opendaq/logger_component_ptr.h>
 
@@ -72,7 +75,7 @@ private:
     std::atomic<std::size_t> numSent;
     std::mutex mutexRequests;
     std::condition_variable allRequestsSent;
-    std::mutex mutexReplies;
+    mutable std::mutex mutexReplies;
     std::condition_variable allRepliesReceived;
 
     uint16_t identifier;
@@ -87,7 +90,7 @@ private:
     boost::asio::streambuf replyBuffer{};
     uint16_t sequenceNumber;
 
-    std::size_t numReplies;
+    std::atomic<std::size_t> numReplies;
     std::unordered_set<std::string> responseAddresses;
 };
 

--- a/core/opendaq/modulemanager/src/icmp_ping.cpp
+++ b/core/opendaq/modulemanager/src/icmp_ping.cpp
@@ -4,6 +4,7 @@
 #include <opendaq/format.h>
 #include <opendaq/custom_log.h>
 #include <chrono>
+#include <memory>
 #include <thread>
 
 using namespace boost;
@@ -60,9 +61,6 @@ void IcmpPing::start(const std::vector<boost::asio::ip::address_v4>& remotes, co
     socket.get_option(unicastHopsDefault);
     // LOG("Socket ping TTL default M: {} U: {}\n", mulitcastHopsDefault.value(), unicastHopsDefault.value());
 
-    numReplies = 0;
-    sequenceNumber = 0;
-
     if (maxHops == -1)
     {
         maxHops = 64;
@@ -77,6 +75,12 @@ void IcmpPing::start(const std::vector<boost::asio::ip::address_v4>& remotes, co
     // socket.get_option(unicastHopsDefault);
     // LOG("Socket ping TTL set M: {} U: {}\n", mulitcastHopsDefault.value(), unicastHopsDefault.value());
 
+    // Set up all state the handlers observe before arming the first operation.
+    numReplies = 0;
+    numRemotes = remotes.size();
+    numSent = 0;
+    ++sequenceNumber;
+
     startReceive();
     startSend(remotes);
 }
@@ -90,7 +94,8 @@ void IcmpPing::stop()
 
     system::error_code ec;
     socket.shutdown(boost::asio::socket_base::shutdown_both, ec);
-    if (ec && ec != boost::asio::error::bad_descriptor)
+    // A raw ICMP socket is never connected.
+    if (ec && ec != boost::asio::error::bad_descriptor && ec != boost::asio::error::not_connected)
     {
         LOG_E("Error shutting ICMP socket [{}] \n", ec.message());
     }
@@ -117,22 +122,19 @@ void IcmpPing::startSend(const std::vector<boost::asio::ip::address_v4>& remotes
     echoRequest.setType(ICMPHeader::EchoRequest);
     echoRequest.setCode(0);
     echoRequest.setIdentifier(identifier);
-    echoRequest.setSequenceNumber(++sequenceNumber);
+    echoRequest.setSequenceNumber(sequenceNumber);
     computeChecksum(echoRequest, body.begin(), body.end());
 
-    // Encode the request packet.
-    boost::asio::streambuf requestBuffer;
-    std::ostream os(&requestBuffer);
+    // Encode the request packet. Kept alive by every send handler until it completes.
+    const auto requestBuffer = std::make_shared<boost::asio::streambuf>();
+    std::ostream os(requestBuffer.get());
     os << echoRequest << body;
-
-    // Send the request.
-    numReplies = 0;
-    numRemotes = remotes.size();
-    numSent = 0;
 
     // LOG("Ping remotes: {}\n", numRemotes);
 
     timeStart = std::chrono::steady_clock::now();
+    // Read by handleReceive, so set before the first send is armed.
+    timeSent = timeStart;
 
     for (std::size_t i = 0; i < numRemotes; ++i)
     {
@@ -143,9 +145,9 @@ void IcmpPing::startSend(const std::vector<boost::asio::ip::address_v4>& remotes
         auto ip = remotes[i];
 
         socket.async_send_to(
-            requestBuffer.data(),
+            requestBuffer->data(),
             ip::icmp::endpoint(ip, 0),
-            [i, ip, this, ptr = shared_from_this()](boost::system::error_code ec, std::size_t)
+            [i, ip, this, requestBuffer, ptr = shared_from_this()](boost::system::error_code ec, std::size_t)
         {
             if (++numSent == numRemotes)
             {
@@ -167,8 +169,6 @@ void IcmpPing::startSend(const std::vector<boost::asio::ip::address_v4>& remotes
             LOG_T("[{}] Sent ping to {} on thread id: {}\n", i, ip, fmt::streamed(std::this_thread::get_id()));
         });
     }
-
-    timeSent = steady_timer::clock_type::now();
 }
 
 void IcmpPing::waitSendAndReply()
@@ -259,9 +259,6 @@ void IcmpPing::handleReceive(std::size_t length)
         chrono::steady_clock::duration elapsed = now - timeSent;
 
         auto sourceAddr = ipv4Header.getSourceAddress();
-        auto sourceStr = sourceAddr.to_string();
-
-        responseAddresses.emplace(sourceStr);
 
         LOG_T("[{}] {} bytes from {}: icmp_seq={}, ttl={}, time={} ms",
             fmt::streamed(std::this_thread::get_id()),
@@ -271,6 +268,11 @@ void IcmpPing::handleReceive(std::size_t length)
             ipv4Header.getTimeToLive(),
             chrono::duration_cast<chrono::milliseconds>(elapsed).count()
         );
+
+        // Reply state is read from the calling thread; mutate and notify under the lock.
+        std::lock_guard lock(mutexReplies);
+
+        responseAddresses.emplace(sourceAddr.to_string());
 
         if (++numReplies == numRemotes)
         {
@@ -284,11 +286,13 @@ void IcmpPing::handleReceive(std::size_t length)
 
 std::unordered_set<std::string> IcmpPing::getReplyAddresses() const
 {
+    std::lock_guard lock(mutexReplies);
     return responseAddresses;
 }
 
 void IcmpPing::clearReplies()
 {
+    std::lock_guard lock(mutexReplies);
     numReplies = 0;
     responseAddresses.clear();
 }

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -9,6 +9,7 @@
 #include <opendaq/orphaned_modules.h>
 #include <opendaq/device_info_config_ptr.h>
 #include <opendaq/device_info_internal_ptr.h>
+#include <coretypes/ctutils.h>
 #include <coretypes/validation.h>
 #include <opendaq/device_private.h>
 #include <string>
@@ -498,6 +499,8 @@ void ModuleManagerImpl::checkNetworkSettings(ListPtr<IDeviceInfo>& list)
 #endif
     {
         const auto icmp = IcmpPing::Create(ioContext, logger);
+        Finally stopPing([&icmp] { icmp->stop(); });
+
         icmp->setMaxHops(1);
         icmp->start(ipv4Addresses);
         icmp->waitSendAndReply();


### PR DESCRIPTION
# Brief

Fix `IcmpPing` leaking its object, raw ICMP socket and 64 kB reply buffer on every device discovery, plus the data race and dangling send buffer around it.

# Description

- Stop the ping explicitly in `ModuleManagerImpl::checkNetworkSettings`. The re-armed `async_receive` handler captures `shared_from_this()` and `handleReceive` unconditionally re-arms it, so the ping kept a strong reference to itself and releasing the local `shared_ptr` never destroyed it. Every discovery leaked the object, its reply buffer, an open raw ICMP socket and a work guard on the shared `io_context`, and each leaked instance kept processing every ICMP packet the host received.
- Guard the reply state (`responseAddresses`, `numReplies`) with `mutexReplies`. `waitSendAndReply` returns on a fixed 1 s timeout while the receive loop is still running, so `getReplyAddresses` was copying an `unordered_set` on the calling thread while `handleReceive` inserted into it on an `io_context` thread. Mutating under the lock also closes the lost-wakeup window on `allRepliesReceived`.
- Set up everything the async handlers observe (`numRemotes`, `numSent`, `numReplies`, `sequenceNumber`) in `start()` before the first operation is armed, instead of in `startSend()` after `startReceive()` had already been posted.
- Share the encoded request packet with every send handler. It was a stack `boost::asio::streambuf` in `startSend`, but asio requires the buffer to stay valid until `async_send_to` completes, which can be after `startSend` returns.
- Treat `not_connected` from `shutdown()` as expected, since a raw ICMP socket is never connected and would otherwise log an error on every discovery now that `stop()` is actually called.

# Usage example

No usage change — the fix is internal to device discovery. Existing calls are unaffected:

```cpp
auto instance = Instance();
auto devices = instance.getAvailableDevices();   // no longer leaks a socket per call
```

# API changes

None. `IcmpPing` is a concrete internal helper, not an openDAQ interface — no abstract struct or pure virtual function is touched, so module binary compatibility is unaffected. The header changes are member-level only (`numReplies` becomes `std::atomic`, `mutexReplies` becomes `mutable`), and the class is `final` with a private constructor, always built inside the openDAQ library through `IcmpPing::Create`.

```diff
(no interface changes)
```

# Required application changes

None.

# Required module changes

None.

---

## Not addressed here

Two pre-existing behavioural issues in the same code path are left alone, as they are judgement calls rather than defects in this fix:

- `icmp->setMaxHops(1)` caps TTL at 1, so any device more than one hop away can never reply and is classified `Unreachable`.
- A ping timeout maps straight to `AddressReachabilityStatus::Unreachable`. ICMP silence is not evidence of unreachability — firewalls commonly drop echo requests while leaving TCP open — and `setAddressesReachable` skips `Unreachable` addresses when selecting a capability's connection string, so a reachable device can lose its IPv4 connection string.
