### PR TITLE
Install OpenSSL in all CI

### DIFF
--- a/.github/actions/build-sdk/action.yml
+++ b/.github/actions/build-sdk/action.yml
@@ -130,6 +130,14 @@ runs:
       shell: pwsh
       run: choco install ${{ inputs.additional-dependencies }} -y --no-progress
 
+    - name: Install 32-bit OpenSSL (for 32-bit build)
+      if: runner.os == 'Windows' && inputs.enable-32bit == 'true'
+      shell: pwsh
+      run: |
+        vcpkg install openssl:x86-windows
+        Add-Content -Path $env:GITHUB_ENV -Value "OPENSSL_ROOT_DIR=C:/vcpkg/installed/x86-windows" -Encoding utf8
+        Add-Content -Path $env:GITHUB_PATH -Value "C:\vcpkg\installed\x86-windows\bin" -Encoding utf8
+
     - name: Remove conflicting packages (for 32-bit build)
       if: steps.detect-linux.outputs.pkg-manager == 'apt' && inputs.enable-32bit == 'true'
       shell: bash

--- a/.github/packages/apt-i386.txt
+++ b/.github/packages/apt-i386.txt
@@ -1,4 +1,5 @@
 lld
+libssl-dev:i386
 mono-runtime
 libmono-system-json-microsoft4.0-cil
 libmono-system-data4.0-cil

--- a/.github/packages/apt.txt
+++ b/.github/packages/apt.txt
@@ -1,4 +1,5 @@
 lld
+libssl-dev
 mono-runtime
 libmono-system-json-microsoft4.0-cil
 libmono-system-data4.0-cil

--- a/.github/packages/yum.txt
+++ b/.github/packages/yum.txt
@@ -1,4 +1,5 @@
 mono-core
+openssl-devel
 freetype-devel
 libudev-devel
 libX11-devel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,11 @@ jobs:
           },
           {
             "match-jobs": ["windows-*-x86-*"],
-            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/Program Files (x86)/OpenSSL-Win32"}
+            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/vcpkg/installed/x86-windows"}
+          },
+          {
+            "match-jobs": ["windows-*-x86_64-*"],
+            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/vcpkg/installed/x64-windows"}
           },
           {
             "match-jobs": ["macos-*"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,15 @@ jobs:
         [
           {
             "match-jobs": ["ubuntu-*-x86_64-*"],
-            "apt-install": ["lld", "libx11-dev", "libxi-dev", "libxcursor-dev", "libxrandr-dev", "libgl-dev", "libudev-dev", "libfreetype6-dev"]
+            "apt-install": ["lld", "libssl-dev", "libx11-dev", "libxi-dev", "libxcursor-dev", "libxrandr-dev", "libgl-dev", "libudev-dev", "libfreetype6-dev"]
           },
           {
             "match-jobs": ["ubuntu-*-x86-*"],
-            "apt-install": ["lld", "libx11-dev:i386", "libxi-dev:i386", "libxcursor-dev:i386", "libxrandr-dev:i386", "libgl-dev:i386", "libudev-dev:i386", "libfreetype6-dev:i386"]
+            "apt-install": ["lld", "libssl-dev:i386", "libx11-dev:i386", "libxi-dev:i386", "libxcursor-dev:i386", "libxrandr-dev:i386", "libgl-dev:i386", "libudev-dev:i386", "libfreetype6-dev:i386"]
+          },
+          {
+            "match-jobs": ["windows-*-x86-*"],
+            "run": "vcpkg install openssl:x86-windows; Add-Content -Path $env:GITHUB_PATH -Value C:\\vcpkg\\installed\\x86-windows\\bin -Encoding utf8"
           },
           {
             "match-jobs": ["windows-*", "*-x86_64-*", "macos-*"],
@@ -71,6 +75,10 @@ jobs:
           {
             "match-jobs": ["windows-*-msvs-*"],
             "cache-variables": {"OPENDAQ_MSVC_SINGLE_PROCESS_BUILD": true}
+          },
+          {
+            "match-jobs": ["windows-*-x86-*"],
+            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/vcpkg/installed/x86-windows"}
           },
           {
             "match-jobs": ["macos-*"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
             "run": "vcpkg install openssl:x86-windows; Add-Content -Path $env:GITHUB_PATH -Value C:\\vcpkg\\installed\\x86-windows\\bin -Encoding utf8"
           },
           {
+            "match-jobs": ["windows-*-x86_64-ninja-clang-*"],
+            "run": "vcpkg install openssl:x64-windows; Add-Content -Path $env:GITHUB_PATH -Value C:\\vcpkg\\installed\\x64-windows\\bin -Encoding utf8"
+          },
+          {
             "match-jobs": ["windows-*", "*-x86_64-*", "macos-*"],
             "pip-install": ["numpy"],
             "use-python-version": "3.14"
@@ -79,6 +83,10 @@ jobs:
           {
             "match-jobs": ["windows-*-x86-*"],
             "cache-variables": {"OPENSSL_ROOT_DIR": "C:/vcpkg/installed/x86-windows"}
+          },
+          {
+            "match-jobs": ["windows-*-x86_64-ninja-clang-*"],
+            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/vcpkg/installed/x64-windows"}
           },
           {
             "match-jobs": ["macos-*"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,11 @@ jobs:
           },
           {
             "match-jobs": ["windows-*-x86-*"],
-            "choco-install": ["openssl --x86"]
+            "run": "vcpkg install openssl:x86-windows; Add-Content -Path $env:GITHUB_PATH -Value C:\\vcpkg\\installed\\x86-windows\\bin -Encoding utf8"
+          },
+          {
+            "match-jobs": ["windows-*-x86_64-*"],
+            "run": "vcpkg install openssl:x64-windows; Add-Content -Path $env:GITHUB_PATH -Value C:\\vcpkg\\installed\\x64-windows\\bin -Encoding utf8"
           },
           {
             "match-jobs": ["windows-*", "*-x86_64-*", "macos-*"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,7 @@ jobs:
           },
           {
             "match-jobs": ["windows-*-x86-*"],
-            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/vcpkg/installed/x86-windows"}
-          },
-          {
-            "match-jobs": ["windows-*-x86_64-ninja-clang-*"],
-            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/vcpkg/installed/x64-windows"}
+            "cache-variables": {"OPENSSL_ROOT_DIR": "C:/Program Files (x86)/OpenSSL-Win32"}
           },
           {
             "match-jobs": ["macos-*"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,7 @@ jobs:
           },
           {
             "match-jobs": ["windows-*-x86-*"],
-            "run": "vcpkg install openssl:x86-windows; Add-Content -Path $env:GITHUB_PATH -Value C:\\vcpkg\\installed\\x86-windows\\bin -Encoding utf8"
-          },
-          {
-            "match-jobs": ["windows-*-x86_64-ninja-clang-*"],
-            "run": "vcpkg install openssl:x64-windows; Add-Content -Path $env:GITHUB_PATH -Value C:\\vcpkg\\installed\\x64-windows\\bin -Encoding utf8"
+            "choco-install": ["openssl --x86"]
           },
           {
             "match-jobs": ["windows-*", "*-x86_64-*", "macos-*"],

--- a/.github/workflows/regression_simulator_generator.yml
+++ b/.github/workflows/regression_simulator_generator.yml
@@ -60,6 +60,7 @@ jobs:
             awscli zip \
             python3-dev python3-numpy python3-distutils python3-pip \
             mono-runtime libmono-system-json-microsoft4.0-cil libmono-system-data4.0-cil \
+            libssl-dev \
             libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev
 
       - name: Install latest CMake

--- a/docs/Antora/modules/tutorials/pages/quick_start_building_opendaq.adoc
+++ b/docs/Antora/modules/tutorials/pages/quick_start_building_opendaq.adoc
@@ -78,9 +78,12 @@ Linux::
 * Ninja-build: https://ninja-build.org/
 * {gpp}
 * X11
+* OpenSSL (>= 1.1.1)
 * LLD (optional)
 
 Ninja is used as the default build system in the `"gcc/full"` preset. X11 is needed for data visualization.
+OpenSSL is needed for the TLS streaming support and, unlike most other dependencies, it is not
+fetched automatically: it has to be installed on the host system.
 LLD speeds up the linker step when building openDAQ(TM).
 
 On Ubuntu and Debian distributions we can run the following terminal commands to install all requirements:
@@ -89,7 +92,7 @@ On Ubuntu and Debian distributions we can run the following terminal commands to
 ----
 sudo apt-get update
 sudo apt-get install -y git build-essential lld cmake ninja-build mono-complete python3
-sudo apt-get install -y libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev
+sudo apt-get install -y libssl-dev libx11-dev libxi-dev libxcursor-dev libxrandr-dev libgl-dev libudev-dev libfreetype6-dev
 ----
 
 **2. Clone the openDAQ(TM) repository**


### PR DESCRIPTION
# Brief

The ws-streaming dependency requires OpenSSL >= 1.1.1 on the host for TLS streaming support and does not fetch it automatically, so every build path now installs it: CI, packaging, regression simulator generation, and the documented build prerequisites.

  # Description

  - `ci.yml`: add `libssl-dev` to the `ubuntu-*-x86_64-*` apt list and `libssl-dev:i386` to the `ubuntu-*-x86-*` one.
  - `ci.yml`: for `windows-*-x86-*` run `vcpkg install openssl:x86-windows`, put its `bin` directory on `PATH`, and set the `OPENSSL_ROOT_DIR` cache variable — the runner image ships only 64-bit OpenSSL.
  - `.github/packages/*.txt`: `libssl-dev` (apt), `libssl-dev:i386` (apt-i386) and `openssl-devel` (yum), which covers the packaging jobs including the manylinux container.
  - `build-sdk` action: new Windows-only step that installs 32-bit OpenSSL via vcpkg and exports `OPENSSL_ROOT_DIR` / `PATH` when `enable-32bit` is set.
  - `regression_simulator_generator.yml`: add `libssl-dev` to the apt install list.
  - `quick_start_building_opendaq.adoc`: list OpenSSL (>= 1.1.1) among the Linux prerequisites, explain that it is not fetched automatically, and add `libssl-dev` to the apt-get command.

