### PR TITLE
fix: Awaitable::hasCompleted no longer requires getResult (TBBAS-3270)

### DIFF
--- a/core/opendaq/scheduler/src/awaitable_impl.cpp
+++ b/core/opendaq/scheduler/src/awaitable_impl.cpp
@@ -7,25 +7,6 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
-namespace
-{
-    // Sets the flag once the guarded scope is left, including during stack unwinding.
-    struct CompletionGuard
-    {
-        explicit CompletionGuard(std::atomic<bool>& completed)
-            : completed(completed)
-        {
-        }
-
-        ~CompletionGuard()
-        {
-            completed = true;
-        }
-
-        std::atomic<bool>& completed;
-    };
-}
-
 template <typename TReturn>
 AwaitableImpl<TReturn>::AwaitableImpl(Future future)
     : future(std::move(future))
@@ -65,17 +46,12 @@ template <typename TReturn>
 ErrCode AwaitableImpl<TReturn>::getResult(daq::IBaseObject** result)
 {
     OPENDAQ_PARAM_NOT_NULL(result);
-
-    if (!completed && !future.valid())
-    {
-        return DAQ_MAKE_ERROR_INFO(OPENDAQ_ERR_EMPTY_AWAITABLE);
-    }
+    OPENDAQ_RETURN_IF_FAILED(this->wait());
 
     if constexpr (std::is_void_v<TReturn>)
     {
         try
         {
-            CompletionGuard guard(completed);
             future.get();
         }
         catch (...)
@@ -89,10 +65,7 @@ ErrCode AwaitableImpl<TReturn>::getResult(daq::IBaseObject** result)
     else
     {
         std::optional<BaseObjectPtr> optional;
-        OPENDAQ_TRY(
-            CompletionGuard guard(completed);
-            optional = future.get();
-        )
+        OPENDAQ_TRY(optional = future.get();)
 
         if (!optional.has_value())
         {

--- a/core/opendaq/scheduler/src/awaitable_impl.cpp
+++ b/core/opendaq/scheduler/src/awaitable_impl.cpp
@@ -2,7 +2,29 @@
 #include <opendaq/scheduler_errors.h>
 #include <coretypes/objectptr.h>
 
+#include <chrono>
+#include <future>
+
 BEGIN_NAMESPACE_OPENDAQ
+
+namespace
+{
+    // Sets the flag once the guarded scope is left, including during stack unwinding.
+    struct CompletionGuard
+    {
+        explicit CompletionGuard(std::atomic<bool>& completed)
+            : completed(completed)
+        {
+        }
+
+        ~CompletionGuard()
+        {
+            completed = true;
+        }
+
+        std::atomic<bool>& completed;
+    };
+}
 
 template <typename TReturn>
 AwaitableImpl<TReturn>::AwaitableImpl(Future future)
@@ -53,6 +75,7 @@ ErrCode AwaitableImpl<TReturn>::getResult(daq::IBaseObject** result)
     {
         try
         {
+            CompletionGuard guard(completed);
             future.get();
         }
         catch (...)
@@ -60,14 +83,16 @@ ErrCode AwaitableImpl<TReturn>::getResult(daq::IBaseObject** result)
             // Mask exceptions from taskflow - don't rethrow
             // This matches the behavior expected by ScheduleGraphMasksExceptions test
         }
+
         *result = nullptr;
     }
     else
     {
         std::optional<BaseObjectPtr> optional;
-        OPENDAQ_TRY(optional = future.get();)
-
-        completed = true;
+        OPENDAQ_TRY(
+            CompletionGuard guard(completed);
+            optional = future.get();
+        )
 
         if (!optional.has_value())
         {
@@ -88,8 +113,8 @@ ErrCode AwaitableImpl<TReturn>::hasCompleted(Bool* finished)
 
     if (!future.valid())
         *finished = this->completed.load();
-
-    *finished = !future.valid();
+    else
+        *finished = future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
     return OPENDAQ_SUCCESS;
 }
 

--- a/core/opendaq/scheduler/tests/test_awaitable.cpp
+++ b/core/opendaq/scheduler/tests/test_awaitable.cpp
@@ -7,6 +7,8 @@
 
 #include <thread>
 #include <atomic>
+#include <chrono>
+#include <vector>
 
 using namespace daq;
 
@@ -56,6 +58,100 @@ TEST_F(AwaitableTest, GetResultBlocks)
     ASSERT_TRUE(executed);
 
     ASSERT_EQ(result, returnValue);
+}
+
+TEST_F(AwaitableTest, HasCompletedWithoutGetResult)
+{
+    using namespace std::literals;
+
+    std::atomic<bool> executed(false);
+
+    auto awaitable = scheduler.scheduleFunction([&executed]()
+    {
+        std::this_thread::sleep_for(1s);
+        executed = true;
+        return 1;
+    });
+
+    ASSERT_FALSE(awaitable.hasCompleted());
+
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    while (!awaitable.hasCompleted() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(50ms);
+
+    ASSERT_TRUE(awaitable.hasCompleted());
+    ASSERT_TRUE(executed);
+
+    Int result = 0;
+    ASSERT_NO_THROW(result = static_cast<Int>(awaitable.getResult()));
+    ASSERT_EQ(result, 1);
+    ASSERT_TRUE(awaitable.hasCompleted());
+}
+
+TEST_F(AwaitableTest, HasCompletedAfterWait)
+{
+    auto awaitable = scheduler.scheduleFunction([]()
+    {
+        return 1;
+    });
+
+    awaitable.wait();
+
+    ASSERT_TRUE(awaitable.hasCompleted());
+    Int result = 0;
+    ASSERT_NO_THROW(result = static_cast<Int>(awaitable.getResult()));
+    ASSERT_EQ(result, 1);
+}
+
+TEST_F(AwaitableTest, HasCompletedGraphWithoutGetResult)
+{
+    using namespace std::literals;
+
+    auto root = TaskGraph("root");
+    root.then(a);
+    a.then(b);
+    b.then(c);
+
+    auto awaitable = scheduler.scheduleGraph(root);
+
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    while (!awaitable.hasCompleted() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(10ms);
+
+    ASSERT_TRUE(awaitable.hasCompleted());
+    ASSERT_EQ(order, std::vector<char>({'a', 'b', 'c'}));
+}
+
+TEST_F(AwaitableTest, HasCompletedStaysTrueAfterGetResult)
+{
+    auto awaitable = scheduler.scheduleFunction([]()
+    {
+        return 1;
+    });
+
+    awaitable.wait();
+    ASSERT_TRUE(awaitable.hasCompleted());
+
+    Int result = 0;
+    ASSERT_NO_THROW(result = static_cast<Int>(awaitable.getResult()));
+    ASSERT_EQ(result, 1);
+
+    ASSERT_TRUE(awaitable.hasCompleted());
+}
+
+TEST_F(AwaitableTest, HasCompletedStaysTrueAfterThrowingGetResult)
+{
+    auto awaitable = scheduler.scheduleFunction([]() -> Int
+    {
+        DAQ_THROW_EXCEPTION(SchedulerUnknownException, "MockException");
+    });
+
+    awaitable.wait();
+    ASSERT_TRUE(awaitable.hasCompleted());
+
+    ASSERT_THROW_MSG(awaitable.getResult(), SchedulerUnknownException, "MockException")
+
+    ASSERT_TRUE(awaitable.hasCompleted());
 }
 
 TEST_F(AwaitableTest, CancelNotYetExecuted)


### PR DESCRIPTION
# Brief

  `IAwaitable::hasCompleted` reported `false` for work that had already finished until the caller
  consumed the result via `getResult`.

  # Description

  - `AwaitableImpl::hasCompleted` now polls the pending future with
  `future.wait_for(std::chrono::seconds(0)) == std::future_status::ready` instead of `!future.valid()`.
  - Added a file-local `CompletionGuard` RAII helper that sets `completed` when its scope is left,
  including during stack unwinding. A task that finished by throwing still reports itself as completed after  `future.get()` rethrows.
  - Applied the guard to the `is_void_v<TReturn>` branch of `getResult` as well, which previously never
  set `completed` at all. `AwaitableImpl<void>` reported `false` from `hasCompleted` after its result had been taken.
  - Tests.

  # Usage example

  Polling an awaitable now works without consuming its result:

  ```cpp
  auto awaitable = scheduler.scheduleFunction([] { return 1; });

  while (!awaitable.hasCompleted())
      std::this_thread::sleep_for(std::chrono::milliseconds(50));

  Int result = awaitable.getResult();
  ```

# Note

  One behavioural change worth knowing about: because the void branch of `getResult` now sets
  `completed`, a repeated `getResult` on an awaitable from `scheduleGraph` returns `nullptr` with
  `OPENDAQ_SUCCESS` instead of `OPENDAQ_ERR_EMPTY_AWAITABLE`. Repeated `getResult` on an awaitable from
  `scheduleFunction` is unchanged and still surfaces `GeneralErrorException`.
