### PR TITLE
Fix native streaming server crash on access to non-existed packet server

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,7 @@
 
 ## Bug fixes
 
+- [#1273](https://github.com/openDAQ/openDAQ/pull/1273) Fix native streaming server crash on access to non-existed packet server
 - [#1268](https://github.com/openDAQ/openDAQ/pull/1268) Fix IcmpPing leaking its object, socket and reply buffer.
 - [#1263](https://github.com/openDAQ/openDAQ/pull/1263) Fix client root device not being synchronized correctly after reconnect if "RestoreClientConfigOnReconnect" is enabled
 - [#1266](https://github.com/openDAQ/openDAQ/pull/1266) Native client updates `IProperty` metadata that changed on the server during `onUpdateEnded`

--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,7 @@
 
 ## Bug fixes
 
+- [#1273](https://github.com/openDAQ/openDAQ/pull/1273) Fix wrong packet-streaming optimization parameters order
 - [#1273](https://github.com/openDAQ/openDAQ/pull/1273) Fix native streaming server crash on access to non-existed packet server
 - [#1268](https://github.com/openDAQ/openDAQ/pull/1268) Fix IcmpPing leaking its object, socket and reply buffer.
 - [#1263](https://github.com/openDAQ/openDAQ/pull/1263) Fix client root device not being synchronized correctly after reconnect if "RestoreClientConfigOnReconnect" is enabled

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
@@ -229,6 +229,8 @@ private:
 
     bool removeSignalSubscriberNoLock(const std::string& signalStringId, const std::string& subscribedClientId);
 
+    PacketStreamingServerPtr getPacketStreamingServerNoLock(const std::string& clientId);
+
     ContextPtr context;
     LoggerComponentPtr loggerComponent;
     SignalNumericIdType signalNumericIdCounter;

--- a/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
+++ b/shared/libraries/native_streaming_protocol/src/native_streaming_server_handler.cpp
@@ -744,8 +744,8 @@ void NativeStreamingServerHandler::handleStreamingInit(std::shared_ptr<ServerSes
     streamingManager.registerClient(sessionHandler->getClientId(),
                                     sessionHandler->getReconnected(),
                                     streamingPacketSendTimeout != UNLIMITED_PACKET_SEND_TIME,
-                                    cacheablePacketPayloadSizeMax,
-                                    packetStreamingReleaseThreshold);
+                                    packetStreamingReleaseThreshold,
+                                    cacheablePacketPayloadSizeMax);
 
     OnPacketBufferReceivedCallback packetBufferReceivedHandler =
         [clientId = sessionHandler->getClientId(), thisWeakPtr = this->weak_from_this()](const packet_streaming::PacketBufferPtr& packetBuffer)

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -47,11 +47,13 @@ void StreamingManager::sendPacketToSubscribers(const std::string& signalStringId
         {
             while (std::next(it) != registeredSignal.subscribedClientsIds.end())
             {
-                sendDaqPacket(sendPacketBufferCb, packetStreamingServers.at(*it), PacketPtr(packet), *it, registeredSignal.numericId);  // copy packet ptr
+                if (auto serverIt = packetStreamingServers.find(*it); serverIt != packetStreamingServers.end())
+                    sendDaqPacket(sendPacketBufferCb, serverIt->second, PacketPtr(packet), *it, registeredSignal.numericId);  // copy packet ptr
                 ++it;
             }
 
-            sendDaqPacket(sendPacketBufferCb, packetStreamingServers.at(*it), std::move(packet), *it, registeredSignal.numericId); // move packet ptr
+            if (auto serverIt = packetStreamingServers.find(*it); serverIt != packetStreamingServers.end())
+                sendDaqPacket(sendPacketBufferCb, serverIt->second, std::move(packet), *it, registeredSignal.numericId); // move packet ptr
         }
     }
     else
@@ -94,11 +96,13 @@ void StreamingManager::processPackets(const tsl::ordered_map<std::string, Packet
                 {
                     while (std::next(it2) != registeredSignal.subscribedClientsIds.end())
                     {
-                        packetStreamingServers.at(*it2)->addDaqPacket(registeredSignal.numericId, packet);
+                        if (auto serverIt = packetStreamingServers.find(*it2); serverIt != packetStreamingServers.end())
+                            serverIt->second->addDaqPacket(registeredSignal.numericId, packet);
                         ++it2;
                     }
-        
-                    pushToPacketStreamingServer(packetStreamingServers.at(*it2), std::move(packet), registeredSignal.numericId);
+
+                    if (auto serverIt = packetStreamingServers.find(*it2); serverIt != packetStreamingServers.end())
+                        pushToPacketStreamingServer(serverIt->second, std::move(packet), registeredSignal.numericId);
                 }
             }
         }
@@ -113,8 +117,9 @@ PacketStreamingServerPtr StreamingManager::getPacketServerIfRegistered(const std
 {
     std::scoped_lock lock(sync);
 
-    if (const auto it = streamingClientsIds.find(clientId); it != streamingClientsIds.end())
-        return packetStreamingServers.at(clientId);
+    if (const auto itStreamingClientsIds = streamingClientsIds.find(clientId); itStreamingClientsIds != streamingClientsIds.end())
+        if (const auto itPacketStreamingServers = packetStreamingServers.find(clientId); itPacketStreamingServers != packetStreamingServers.end())
+            return itPacketStreamingServers->second;
 
     return nullptr;
 }
@@ -337,9 +342,11 @@ ListPtr<ISignal> StreamingManager::unregisterClient(const std::string& clientId)
     else
     {
         LOG_I("Client {} was not registered as streaming client", clientId);
-        return List<ISignal>();
     }
 
+    // clean up any leftover packet server/client and subscriptions unconditionally,
+    // regardless of whether the client was found above, so no stale entry referencing
+    // this client id can survive in any of the maps/sets below
     // FIXME keep and reuse packet server when packet retransmission feature will be enabled
     if (auto it = packetStreamingServers.find(clientId); it != packetStreamingServers.end())
         packetStreamingServers.erase(it);
@@ -368,6 +375,11 @@ bool StreamingManager::registerSignalSubscriber(const std::string& signalStringI
 
     std::scoped_lock lock(sync);
 
+    auto packetStreamingServerIt = packetStreamingServers.find(subscribedClientId);
+    if (packetStreamingServerIt == packetStreamingServers.end())
+        throw NativeStreamingProtocolException(
+            fmt::format("Can't register subscriber - client {} is not registered for streaming", subscribedClientId));
+
     if (auto iter = registeredSignals.find(signalStringId); iter != registeredSignals.end())
     {
         auto& registeredSignal = iter->second;
@@ -390,7 +402,7 @@ bool StreamingManager::registerSignalSubscriber(const std::string& signalStringI
                 if (registeredSignal.lastDataDescriptorParam.assigned())
                 {
                     sendDaqPacket(sendPacketBufferCb,
-                                  packetStreamingServers.at(subscribedClientId),
+                                  packetStreamingServerIt->second,
                                   DataDescriptorChangedEventPacket(registeredSignal.lastDataDescriptorParam,
                                                                    registeredSignal.lastDomainDescriptorParam),
                                   subscribedClientId,

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -47,13 +47,12 @@ void StreamingManager::sendPacketToSubscribers(const std::string& signalStringId
         {
             while (std::next(it) != registeredSignal.subscribedClientsIds.end())
             {
-                if (auto serverIt = packetStreamingServers.find(*it); serverIt != packetStreamingServers.end())
-                    sendDaqPacket(sendPacketBufferCb, serverIt->second, PacketPtr(packet), *it, registeredSignal.numericId);  // copy packet ptr
+                if (const auto streamingPacketServer = getPacketStreamingServerNoLock(*it))
+                    sendDaqPacket(sendPacketBufferCb, streamingPacketServer, PacketPtr(packet), *it, registeredSignal.numericId); // copy packet ptr
                 ++it;
             }
-
-            if (auto serverIt = packetStreamingServers.find(*it); serverIt != packetStreamingServers.end())
-                sendDaqPacket(sendPacketBufferCb, serverIt->second, std::move(packet), *it, registeredSignal.numericId); // move packet ptr
+            if (const auto streamingPacketServer = getPacketStreamingServerNoLock(*it))
+                sendDaqPacket(sendPacketBufferCb, streamingPacketServer, std::move(packet), *it, registeredSignal.numericId); // move packet ptr
         }
     }
     else
@@ -96,13 +95,13 @@ void StreamingManager::processPackets(const tsl::ordered_map<std::string, Packet
                 {
                     while (std::next(it2) != registeredSignal.subscribedClientsIds.end())
                     {
-                        if (auto serverIt = packetStreamingServers.find(*it2); serverIt != packetStreamingServers.end())
-                            serverIt->second->addDaqPacket(registeredSignal.numericId, packet);
+                        if (const auto streamingPacketServer = getPacketStreamingServerNoLock(*it2))
+                            streamingPacketServer->addDaqPacket(registeredSignal.numericId, packet);
                         ++it2;
                     }
 
-                    if (auto serverIt = packetStreamingServers.find(*it2); serverIt != packetStreamingServers.end())
-                        pushToPacketStreamingServer(serverIt->second, std::move(packet), registeredSignal.numericId);
+                    if (const auto streamingPacketServer = getPacketStreamingServerNoLock(*it2))
+                        pushToPacketStreamingServer(streamingPacketServer, std::move(packet), registeredSignal.numericId);
                 }
             }
         }
@@ -118,8 +117,7 @@ PacketStreamingServerPtr StreamingManager::getPacketServerIfRegistered(const std
     std::scoped_lock lock(sync);
 
     if (const auto itStreamingClientsIds = streamingClientsIds.find(clientId); itStreamingClientsIds != streamingClientsIds.end())
-        if (const auto itPacketStreamingServers = packetStreamingServers.find(clientId); itPacketStreamingServers != packetStreamingServers.end())
-            return itPacketStreamingServers->second;
+        return getPacketStreamingServerNoLock(clientId);
 
     return nullptr;
 }
@@ -375,8 +373,8 @@ bool StreamingManager::registerSignalSubscriber(const std::string& signalStringI
 
     std::scoped_lock lock(sync);
 
-    auto packetStreamingServerIt = packetStreamingServers.find(subscribedClientId);
-    if (packetStreamingServerIt == packetStreamingServers.end())
+    const auto streamingPacketServer = getPacketStreamingServerNoLock(subscribedClientId);
+    if (!streamingPacketServer)
         throw NativeStreamingProtocolException(
             fmt::format("Can't register subscriber - client {} is not registered for streaming", subscribedClientId));
 
@@ -402,7 +400,7 @@ bool StreamingManager::registerSignalSubscriber(const std::string& signalStringI
                 if (registeredSignal.lastDataDescriptorParam.assigned())
                 {
                     sendDaqPacket(sendPacketBufferCb,
-                                  packetStreamingServerIt->second,
+                                  streamingPacketServer,
                                   DataDescriptorChangedEventPacket(registeredSignal.lastDataDescriptorParam,
                                                                    registeredSignal.lastDomainDescriptorParam),
                                   subscribedClientId,
@@ -451,6 +449,14 @@ bool StreamingManager::removeSignalSubscriberNoLock(const std::string& signalStr
     }
 
     return doSignalUnsubscribe;
+}
+
+PacketStreamingServerPtr StreamingManager::getPacketStreamingServerNoLock(const std::string& clientId)
+{
+    if (const auto serverIt = packetStreamingServers.find(clientId); serverIt != packetStreamingServers.end())
+        return serverIt->second;
+    else
+        return nullptr;
 }
 
 SignalNumericIdType StreamingManager::findSignalNumericId(const SignalPtr& signal)


### PR DESCRIPTION
# Brief

Fixes a SIGABRT in the native streaming server caused by an unchecked `std::unordered_map::at()` in `StreamingManager::processPackets()`. Adds safer lookups via `find()` instead of `at()`.

Fixes wrong packet-streaming optimization parameters order
