### PR TITLE
Treat missing domain tick resolution as 1/1 in readers

### DIFF
--- a/changelog/changelog_3.30-3.40.md
+++ b/changelog/changelog_3.30-3.40.md
@@ -39,6 +39,7 @@
 
 ## Bug fixes
 
+- [#1277](https://github.com/openDAQ/openDAQ/pull/1277) Fix MultiReader leaking its input ports when disposed before being released; readers treat a missing domain tick resolution as 1/1 instead of crashing
 - [#1273](https://github.com/openDAQ/openDAQ/pull/1273) Fix wrong packet-streaming optimization parameters order
 - [#1273](https://github.com/openDAQ/openDAQ/pull/1273) Fix native streaming server crash on access to non-existed packet server
 - [#1268](https://github.com/openDAQ/openDAQ/pull/1268) Fix IcmpPing leaking its object, socket and reply buffer.

--- a/core/opendaq/reader/include/opendaq/reader_domain_info.h
+++ b/core/opendaq/reader/include/opendaq/reader_domain_info.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <coretypes/ratio_factory.h>
 #include <opendaq/custom_log.h>
 #include <opendaq/logger_component_ptr.h>
 #include <opendaq/reader_utils.h>
@@ -71,7 +72,8 @@ public:
         setMaxResolution(maxResolution);
     }
 
-    RatioPtr resolution{};
+    // a signal without a domain tick resolution is treated as having a resolution of 1/1
+    RatioPtr resolution = Ratio(1, 1);
     RatioPtr multiplier{};
     std::int64_t offset{};
     std::chrono::system_clock::time_point epoch{};

--- a/core/opendaq/reader/include/opendaq/reader_utils.h
+++ b/core/opendaq/reader/include/opendaq/reader_utils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <coretypes/formatter.h>
+#include <coretypes/ratio_factory.h>
 #include <opendaq/data_descriptor_ptr.h>
 #include <opendaq/sample_type_traits.h>
 
@@ -138,7 +139,8 @@ namespace reader
 
     inline std::int64_t getSampleRate(const DataDescriptorPtr& dataDescriptor)
     {
-        const auto resolution = dataDescriptor.getTickResolution().simplify();
+        const auto tickResolution = dataDescriptor.getTickResolution();
+        const auto resolution = tickResolution.assigned() ? tickResolution.simplify() : Ratio(1, 1);
 
         NumberPtr delta = 1;
         auto rule = dataDescriptor.getRule();

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -572,12 +572,6 @@ void MultiReaderImpl::setStartInfo()
         if (signal.unused)
             continue;
 
-        // a signal that never delivered a valid domain descriptor has no resolution and cannot be synchronized
-        if (!signal.domainInfo.resolution.assigned())
-            DAQ_THROW_EXCEPTION(InvalidStateException,
-                                "Multi reader signal \"{}\" has no domain tick resolution",
-                                signal.getComponentGlobalId());
-
         if (signal.domainInfo.epoch < minEpoch)
         {
             minEpoch = signal.domainInfo.epoch;

--- a/core/opendaq/reader/src/multi_reader_impl.cpp
+++ b/core/opendaq/reader/src/multi_reader_impl.cpp
@@ -1100,6 +1100,11 @@ MultiReaderStatusPtr MultiReaderImpl::readAndSynchronize(bool zeroDataRead, Size
     }
 
     ErrCode errCode = synchronize(availableSamples, syncStatus);
+    if (OPENDAQ_FAILED(errCode))
+    {
+        LOG_D("Multi reader failed to synchronize: {}", getErrorInfoMessage(errCode));
+        clearErrorInfo();
+    }
     if (OPENDAQ_FAILED(errCode) || eventPackets.getCount() != 0)
     {
         return createReaderStatus(eventPackets);

--- a/core/opendaq/reader/src/signal_reader.cpp
+++ b/core/opendaq/reader/src/signal_reader.cpp
@@ -153,6 +153,8 @@ void SignalReader::handleDescriptorChanged(const EventPacketPtr& eventPacket)
         if (validDomain && newDomainDescriptor.assigned())
         {
             auto newResolution = newDomainDescriptor.getTickResolution();
+            if (!newResolution.assigned())
+                newResolution = Ratio(1, 1);
             if (domainInfo.resolution != newResolution)
             {
                 domainInfo.resolution = newResolution;


### PR DESCRIPTION
# Brief

Multi reader now handles missing tick resolutions as a 1/1 ratio.