### PR TITLE
Bindings and Python examples for the TLStreamingModuleModern with a TLS channel

### DIFF
--- a/bindings/c/include/copendaq/device/server_capability.h
+++ b/bindings/c/include/copendaq/device/server_capability.h
@@ -45,6 +45,7 @@ extern "C"
     daqErrCode EXPORTED daqServerCapability_getConnectionString(daqServerCapability* self, daqString** connectionString);
     daqErrCode EXPORTED daqServerCapability_getConnectionStrings(daqServerCapability* self, daqList** connectionStrings);
     daqErrCode EXPORTED daqServerCapability_getProtocolName(daqServerCapability* self, daqString** protocolName);
+    daqErrCode EXPORTED daqServerCapability_getProtocolGroupId(daqServerCapability* self, daqString** protocolGroupId);
     daqErrCode EXPORTED daqServerCapability_getProtocolId(daqServerCapability* self, daqString** protocolId);
     daqErrCode EXPORTED daqServerCapability_getProtocolType(daqServerCapability* self, daqProtocolType* type);
     daqErrCode EXPORTED daqServerCapability_getPrefix(daqServerCapability* self, daqString** prefix);
@@ -54,6 +55,7 @@ extern "C"
     daqErrCode EXPORTED daqServerCapability_getPort(daqServerCapability* self, daqInteger** port);
     daqErrCode EXPORTED daqServerCapability_getAddressInfo(daqServerCapability* self, daqList** addressInfo);
     daqErrCode EXPORTED daqServerCapability_getProtocolVersion(daqServerCapability* self, daqString** version);
+    daqErrCode EXPORTED daqServerCapability_getProtocolSecurityLevel(daqServerCapability* self, daqInteger** securityLevel);
 
 #ifdef __cplusplus
 }

--- a/bindings/c/include/copendaq/device/server_capability_config.h
+++ b/bindings/c/include/copendaq/device/server_capability_config.h
@@ -44,6 +44,7 @@ extern "C"
 
     daqErrCode EXPORTED daqServerCapabilityConfig_setConnectionString(daqServerCapabilityConfig* self, daqString* connectionString);
     daqErrCode EXPORTED daqServerCapabilityConfig_addConnectionString(daqServerCapabilityConfig* self, daqString* connectionString);
+    daqErrCode EXPORTED daqServerCapabilityConfig_setProtocolGroupId(daqServerCapabilityConfig* self, daqString* protocolGroupId);
     daqErrCode EXPORTED daqServerCapabilityConfig_setProtocolId(daqServerCapabilityConfig* self, daqString* protocolId);
     daqErrCode EXPORTED daqServerCapabilityConfig_setProtocolName(daqServerCapabilityConfig* self, daqString* protocolName);
     daqErrCode EXPORTED daqServerCapabilityConfig_setProtocolType(daqServerCapabilityConfig* self, daqProtocolType type);
@@ -54,6 +55,7 @@ extern "C"
     daqErrCode EXPORTED daqServerCapabilityConfig_setPort(daqServerCapabilityConfig* self, daqInteger* port);
     daqErrCode EXPORTED daqServerCapabilityConfig_addAddressInfo(daqServerCapabilityConfig* self, daqAddressInfo* addressInfo);
     daqErrCode EXPORTED daqServerCapabilityConfig_setProtocolVersion(daqServerCapabilityConfig* self, daqString* version);
+    daqErrCode EXPORTED daqServerCapabilityConfig_setProtocolSecurityLevel(daqServerCapabilityConfig* self, daqInteger* securityLevel);
     daqErrCode EXPORTED daqServerCapabilityConfig_createServerCapability(daqServerCapabilityConfig** obj, daqString* protocolId, daqString* protocolName, daqProtocolType protocolType);
 
 #ifdef __cplusplus

--- a/bindings/c/include/copendaq/streaming/streaming.h
+++ b/bindings/c/include/copendaq/streaming/streaming.h
@@ -53,6 +53,7 @@ extern "C"
     daqErrCode EXPORTED daqStreaming_removeInputPorts(daqStreaming* self, daqList* inputPorts);
     daqErrCode EXPORTED daqStreaming_removeAllInputPorts(daqStreaming* self);
     daqErrCode EXPORTED daqStreaming_getOwnerDeviceRemoteId(daqStreaming* self, daqString** deviceRemoteId);
+    daqErrCode EXPORTED daqStreaming_getProtocolGroupId(daqStreaming* self, daqString** protocolGroupId);
     daqErrCode EXPORTED daqStreaming_getProtocolId(daqStreaming* self, daqString** protocolId);
     daqErrCode EXPORTED daqStreaming_getClientToDeviceStreamingEnabled(daqStreaming* self, daqBool* enabled);
 

--- a/bindings/c/src/copendaq/device/server_capability.cpp
+++ b/bindings/c/src/copendaq/device/server_capability.cpp
@@ -37,6 +37,11 @@ daqErrCode daqServerCapability_getProtocolName(daqServerCapability* self, daqStr
     return reinterpret_cast<daq::IServerCapability*>(self)->getProtocolName(reinterpret_cast<daq::IString**>(protocolName));
 }
 
+daqErrCode daqServerCapability_getProtocolGroupId(daqServerCapability* self, daqString** protocolGroupId)
+{
+    return reinterpret_cast<daq::IServerCapability*>(self)->getProtocolGroupId(reinterpret_cast<daq::IString**>(protocolGroupId));
+}
+
 daqErrCode daqServerCapability_getProtocolId(daqServerCapability* self, daqString** protocolId)
 {
     return reinterpret_cast<daq::IServerCapability*>(self)->getProtocolId(reinterpret_cast<daq::IString**>(protocolId));
@@ -80,4 +85,9 @@ daqErrCode daqServerCapability_getAddressInfo(daqServerCapability* self, daqList
 daqErrCode daqServerCapability_getProtocolVersion(daqServerCapability* self, daqString** version)
 {
     return reinterpret_cast<daq::IServerCapability*>(self)->getProtocolVersion(reinterpret_cast<daq::IString**>(version));
+}
+
+daqErrCode daqServerCapability_getProtocolSecurityLevel(daqServerCapability* self, daqInteger** securityLevel)
+{
+    return reinterpret_cast<daq::IServerCapability*>(self)->getProtocolSecurityLevel(reinterpret_cast<daq::IInteger**>(securityLevel));
 }

--- a/bindings/c/src/copendaq/device/server_capability_config.cpp
+++ b/bindings/c/src/copendaq/device/server_capability_config.cpp
@@ -32,6 +32,11 @@ daqErrCode daqServerCapabilityConfig_addConnectionString(daqServerCapabilityConf
     return reinterpret_cast<daq::IServerCapabilityConfig*>(self)->addConnectionString(reinterpret_cast<daq::IString*>(connectionString));
 }
 
+daqErrCode daqServerCapabilityConfig_setProtocolGroupId(daqServerCapabilityConfig* self, daqString* protocolGroupId)
+{
+    return reinterpret_cast<daq::IServerCapabilityConfig*>(self)->setProtocolGroupId(reinterpret_cast<daq::IString*>(protocolGroupId));
+}
+
 daqErrCode daqServerCapabilityConfig_setProtocolId(daqServerCapabilityConfig* self, daqString* protocolId)
 {
     return reinterpret_cast<daq::IServerCapabilityConfig*>(self)->setProtocolId(reinterpret_cast<daq::IString*>(protocolId));
@@ -80,6 +85,11 @@ daqErrCode daqServerCapabilityConfig_addAddressInfo(daqServerCapabilityConfig* s
 daqErrCode daqServerCapabilityConfig_setProtocolVersion(daqServerCapabilityConfig* self, daqString* version)
 {
     return reinterpret_cast<daq::IServerCapabilityConfig*>(self)->setProtocolVersion(reinterpret_cast<daq::IString*>(version));
+}
+
+daqErrCode daqServerCapabilityConfig_setProtocolSecurityLevel(daqServerCapabilityConfig* self, daqInteger* securityLevel)
+{
+    return reinterpret_cast<daq::IServerCapabilityConfig*>(self)->setProtocolSecurityLevel(reinterpret_cast<daq::IInteger*>(securityLevel));
 }
 
 daqErrCode daqServerCapabilityConfig_createServerCapability(daqServerCapabilityConfig** obj, daqString* protocolId, daqString* protocolName, daqProtocolType protocolType)

--- a/bindings/c/src/copendaq/streaming/streaming.cpp
+++ b/bindings/c/src/copendaq/streaming/streaming.cpp
@@ -77,6 +77,11 @@ daqErrCode daqStreaming_getOwnerDeviceRemoteId(daqStreaming* self, daqString** d
     return reinterpret_cast<daq::IStreaming*>(self)->getOwnerDeviceRemoteId(reinterpret_cast<daq::IString**>(deviceRemoteId));
 }
 
+daqErrCode daqStreaming_getProtocolGroupId(daqStreaming* self, daqString** protocolGroupId)
+{
+    return reinterpret_cast<daq::IStreaming*>(self)->getProtocolGroupId(reinterpret_cast<daq::IString**>(protocolGroupId));
+}
+
 daqErrCode daqStreaming_getProtocolId(daqStreaming* self, daqString** protocolId)
 {
     return reinterpret_cast<daq::IStreaming*>(self)->getProtocolId(reinterpret_cast<daq::IString**>(protocolId));

--- a/bindings/python/core_objects/generated/py_argument_info.cpp
+++ b/bindings/python/core_objects/generated/py_argument_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_authentication_provider.cpp
+++ b/bindings/python/core_objects/generated/py_authentication_provider.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_callable_info.cpp
+++ b/bindings/python/core_objects/generated/py_callable_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_coercer.cpp
+++ b/bindings/python/core_objects/generated/py_coercer.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_core_event_args.cpp
+++ b/bindings/python/core_objects/generated/py_core_event_args.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_eval_value.cpp
+++ b/bindings/python/core_objects/generated/py_eval_value.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_ownable.cpp
+++ b/bindings/python/core_objects/generated/py_ownable.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_permission_manager.cpp
+++ b/bindings/python/core_objects/generated/py_permission_manager.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_permission_mask_builder.cpp
+++ b/bindings/python/core_objects/generated/py_permission_mask_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_permissions.cpp
+++ b/bindings/python/core_objects/generated/py_permissions.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_permissions_builder.cpp
+++ b/bindings/python/core_objects/generated/py_permissions_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_property.cpp
+++ b/bindings/python/core_objects/generated/py_property.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_property_builder.cpp
+++ b/bindings/python/core_objects/generated/py_property_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_property_object.cpp
+++ b/bindings/python/core_objects/generated/py_property_object.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_property_object_class.cpp
+++ b/bindings/python/core_objects/generated/py_property_object_class.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_property_object_class_builder.cpp
+++ b/bindings/python/core_objects/generated/py_property_object_class_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_property_object_protected.cpp
+++ b/bindings/python/core_objects/generated/py_property_object_protected.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_property_value_event_args.cpp
+++ b/bindings/python/core_objects/generated/py_property_value_event_args.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_search_filter.cpp
+++ b/bindings/python/core_objects/generated/py_search_filter.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_unit.cpp
+++ b/bindings/python/core_objects/generated/py_unit.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_unit_builder.cpp
+++ b/bindings/python/core_objects/generated/py_unit_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_user.cpp
+++ b/bindings/python/core_objects/generated/py_user.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_objects/generated/py_validator.cpp
+++ b/bindings/python/core_objects/generated/py_validator.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_development_version_info.cpp
+++ b/bindings/python/core_types/generated/py_development_version_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_enumeration.cpp
+++ b/bindings/python/core_types/generated/py_enumeration.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_enumeration_type.cpp
+++ b/bindings/python/core_types/generated/py_enumeration_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_event.cpp
+++ b/bindings/python/core_types/generated/py_event.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_event_args.cpp
+++ b/bindings/python/core_types/generated/py_event_args.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_event_handler.cpp
+++ b/bindings/python/core_types/generated/py_event_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_search_filter.cpp
+++ b/bindings/python/core_types/generated/py_search_filter.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_simple_type.cpp
+++ b/bindings/python/core_types/generated/py_simple_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_struct.cpp
+++ b/bindings/python/core_types/generated/py_struct.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_struct_builder.cpp
+++ b/bindings/python/core_types/generated/py_struct_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_struct_type.cpp
+++ b/bindings/python/core_types/generated/py_struct_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_type.cpp
+++ b/bindings/python/core_types/generated/py_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_type_manager.cpp
+++ b/bindings/python/core_types/generated/py_type_manager.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/generated/py_version_info.cpp
+++ b/bindings/python/core_types/generated/py_version_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/core_types/src/py_queued_event_handler_impl.cpp
+++ b/bindings/python/core_types/src/py_queued_event_handler_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_component.cpp
+++ b/bindings/python/opendaq/generated/component/py_component.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_component_private.cpp
+++ b/bindings/python/opendaq/generated/component/py_component_private.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_component_status_container.cpp
+++ b/bindings/python/opendaq/generated/component/py_component_status_container.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_component_status_container_private.cpp
+++ b/bindings/python/opendaq/generated/component/py_component_status_container_private.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_component_type.cpp
+++ b/bindings/python/opendaq/generated/component/py_component_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_folder.cpp
+++ b/bindings/python/opendaq/generated/component/py_folder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_folder_config.cpp
+++ b/bindings/python/opendaq/generated/component/py_folder_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_removable.cpp
+++ b/bindings/python/opendaq/generated/component/py_removable.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_search_filter.cpp
+++ b/bindings/python/opendaq/generated/component/py_search_filter.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_tags.cpp
+++ b/bindings/python/opendaq/generated/component/py_tags.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_tags_private.cpp
+++ b/bindings/python/opendaq/generated/component/py_tags_private.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/component/py_update_parameters.cpp
+++ b/bindings/python/opendaq/generated/component/py_update_parameters.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/context/py_context.cpp
+++ b/bindings/python/opendaq/generated/context/py_context.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_address_info.cpp
+++ b/bindings/python/opendaq/generated/device/py_address_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_address_info_builder.cpp
+++ b/bindings/python/opendaq/generated/device/py_address_info_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_connected_client_info.cpp
+++ b/bindings/python/opendaq/generated/device/py_connected_client_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_connection_status_container_private.cpp
+++ b/bindings/python/opendaq/generated/device/py_connection_status_container_private.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_device.cpp
+++ b/bindings/python/opendaq/generated/device/py_device.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_device_domain.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_domain.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_device_info.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_device_info_config.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_info_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_device_network_config.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_network_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_device_private.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_private.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_device_type.cpp
+++ b/bindings/python/opendaq/generated/device/py_device_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_log_file_info.cpp
+++ b/bindings/python/opendaq/generated/device/py_log_file_info.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_log_file_info_builder.cpp
+++ b/bindings/python/opendaq/generated/device/py_log_file_info_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_network_interface.cpp
+++ b/bindings/python/opendaq/generated/device/py_network_interface.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_server_capability.cpp
+++ b/bindings/python/opendaq/generated/device/py_server_capability.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/device/py_server_capability.cpp
+++ b/bindings/python/opendaq/generated/device/py_server_capability.cpp
@@ -71,6 +71,14 @@ void defineIServerCapability(pybind11::module_ m, PyDaqIntf<daq::IServerCapabili
             return objectPtr.getProtocolName().toStdString();
         },
         "Gets the name of the protocol supported by the device.");
+    cls.def_property_readonly("protocol_group_id",
+        [](daq::IServerCapability *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::ServerCapabilityPtr::Borrow(object);
+            return objectPtr.getProtocolGroupId().toStdString();
+        },
+        "Gets the id of the protocol group supported by the device. Should not contain spaces or special characters except for '_' and '-'. Could be empty if the protocol is not part of any group.");
     cls.def_property_readonly("protocol_id",
         [](daq::IServerCapability *object)
         {
@@ -146,4 +154,13 @@ void defineIServerCapability(pybind11::module_ m, PyDaqIntf<daq::IServerCapabili
             return objectPtr.getProtocolVersion().toStdString();
         },
         "Gets the protocol version supported by the device's protocol.");
+    cls.def_property_readonly("protocol_security_level",
+        [](daq::IServerCapability *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::ServerCapabilityPtr::Borrow(object);
+            return objectPtr.getProtocolSecurityLevel().detach();
+        },
+        py::return_value_policy::take_ownership,
+        "Gets the security level of the protocol.");
 }

--- a/bindings/python/opendaq/generated/functionblock/py_channel.cpp
+++ b/bindings/python/opendaq/generated/functionblock/py_channel.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/functionblock/py_function_block.cpp
+++ b/bindings/python/opendaq/generated/functionblock/py_function_block.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/functionblock/py_function_block_type.cpp
+++ b/bindings/python/opendaq/generated/functionblock/py_function_block_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/functionblock/py_recorder.cpp
+++ b/bindings/python/opendaq/generated/functionblock/py_recorder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/logger/py_logger.cpp
+++ b/bindings/python/opendaq/generated/logger/py_logger.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/logger/py_logger_component.cpp
+++ b/bindings/python/opendaq/generated/logger/py_logger_component.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/logger/py_logger_sink.cpp
+++ b/bindings/python/opendaq/generated/logger/py_logger_sink.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/logger/py_logger_thread_pool.cpp
+++ b/bindings/python/opendaq/generated/logger/py_logger_thread_pool.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/modulemanager/py_discovery_server.cpp
+++ b/bindings/python/opendaq/generated/modulemanager/py_discovery_server.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/modulemanager/py_module.cpp
+++ b/bindings/python/opendaq/generated/modulemanager/py_module.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/modulemanager/py_module_info.cpp
+++ b/bindings/python/opendaq/generated/modulemanager/py_module_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/modulemanager/py_module_manager.cpp
+++ b/bindings/python/opendaq/generated/modulemanager/py_module_manager.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/opendaq/py_config_provider.cpp
+++ b/bindings/python/opendaq/generated/opendaq/py_config_provider.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/opendaq/py_instance.cpp
+++ b/bindings/python/opendaq/generated/opendaq/py_instance.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/opendaq/py_instance_builder.cpp
+++ b/bindings/python/opendaq/generated/opendaq/py_instance_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/opendaq/py_module_authenticator.cpp
+++ b/bindings/python/opendaq/generated/opendaq/py_module_authenticator.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_block_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_block_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_block_reader_builder.cpp
+++ b/bindings/python/opendaq/generated/reader/py_block_reader_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_block_reader_status.cpp
+++ b/bindings/python/opendaq/generated/reader/py_block_reader_status.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_multi_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_multi_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_multi_reader_builder.cpp
+++ b/bindings/python/opendaq/generated/reader/py_multi_reader_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_multi_reader_status.cpp
+++ b/bindings/python/opendaq/generated/reader/py_multi_reader_status.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_packet_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_packet_reader.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_reader.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_reader_status.cpp
+++ b/bindings/python/opendaq/generated/reader/py_reader_status.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_sample_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_sample_reader.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_stream_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_stream_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_stream_reader_builder.cpp
+++ b/bindings/python/opendaq/generated/reader/py_stream_reader_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_tail_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_tail_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_tail_reader_builder.cpp
+++ b/bindings/python/opendaq/generated/reader/py_tail_reader_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_tail_reader_status.cpp
+++ b/bindings/python/opendaq/generated/reader/py_tail_reader_status.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/reader/py_time_reader.cpp
+++ b/bindings/python/opendaq/generated/reader/py_time_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/scheduler/py_awaitable.cpp
+++ b/bindings/python/opendaq/generated/scheduler/py_awaitable.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/scheduler/py_graph_visualization.cpp
+++ b/bindings/python/opendaq/generated/scheduler/py_graph_visualization.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/scheduler/py_scheduler.cpp
+++ b/bindings/python/opendaq/generated/scheduler/py_scheduler.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/scheduler/py_task.cpp
+++ b/bindings/python/opendaq/generated/scheduler/py_task.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/scheduler/py_task_graph.cpp
+++ b/bindings/python/opendaq/generated/scheduler/py_task_graph.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/server/py_server.cpp
+++ b/bindings/python/opendaq/generated/server/py_server.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/server/py_server_type.cpp
+++ b/bindings/python/opendaq/generated/server/py_server_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_connection.cpp
+++ b/bindings/python/opendaq/generated/signal/py_connection.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_data_descriptor.cpp
+++ b/bindings/python/opendaq/generated/signal/py_data_descriptor.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_data_descriptor_builder.cpp
+++ b/bindings/python/opendaq/generated/signal/py_data_descriptor_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_data_packet.cpp
+++ b/bindings/python/opendaq/generated/signal/py_data_packet.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_data_rule.cpp
+++ b/bindings/python/opendaq/generated/signal/py_data_rule.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_data_rule_builder.cpp
+++ b/bindings/python/opendaq/generated/signal/py_data_rule_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_dimension.cpp
+++ b/bindings/python/opendaq/generated/signal/py_dimension.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_dimension_builder.cpp
+++ b/bindings/python/opendaq/generated/signal/py_dimension_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_dimension_rule.cpp
+++ b/bindings/python/opendaq/generated/signal/py_dimension_rule.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_dimension_rule_builder.cpp
+++ b/bindings/python/opendaq/generated/signal/py_dimension_rule_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_event_packet.cpp
+++ b/bindings/python/opendaq/generated/signal/py_event_packet.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_input_port.cpp
+++ b/bindings/python/opendaq/generated/signal/py_input_port.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_input_port_config.cpp
+++ b/bindings/python/opendaq/generated/signal/py_input_port_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_input_port_notifications.cpp
+++ b/bindings/python/opendaq/generated/signal/py_input_port_notifications.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_mock_signal.cpp
+++ b/bindings/python/opendaq/generated/signal/py_mock_signal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_packet.cpp
+++ b/bindings/python/opendaq/generated/signal/py_packet.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_packet_destruct_callback.cpp
+++ b/bindings/python/opendaq/generated/signal/py_packet_destruct_callback.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_range.cpp
+++ b/bindings/python/opendaq/generated/signal/py_range.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_reference_domain_info.cpp
+++ b/bindings/python/opendaq/generated/signal/py_reference_domain_info.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_reference_domain_info_builder.cpp
+++ b/bindings/python/opendaq/generated/signal/py_reference_domain_info_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_scaling.cpp
+++ b/bindings/python/opendaq/generated/signal/py_scaling.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_scaling_builder.cpp
+++ b/bindings/python/opendaq/generated/signal/py_scaling_builder.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_signal.cpp
+++ b/bindings/python/opendaq/generated/signal/py_signal.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_signal_config.cpp
+++ b/bindings/python/opendaq/generated/signal/py_signal_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/signal/py_signal_events.cpp
+++ b/bindings/python/opendaq/generated/signal/py_signal_events.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_mirrored_device.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_mirrored_device.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_mirrored_device_config.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_mirrored_device_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_mirrored_input_port_config.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_mirrored_input_port_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_mirrored_signal_config.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_mirrored_signal_config.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_mirrored_signal_private.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_mirrored_signal_private.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_streaming.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_streaming.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_streaming.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_streaming.cpp
@@ -131,6 +131,14 @@ void defineIStreaming(pybind11::module_ m, PyDaqIntf<daq::IStreaming, daq::IBase
             return objectPtr.getOwnerDeviceRemoteId().toStdString();
         },
         "Gets the global ID of the device (as it appears on the remote instance) to which this streaming object establishes a connection.");
+    cls.def_property_readonly("protocol_group_id",
+        [](daq::IStreaming *object)
+        {
+            py::gil_scoped_release release;
+            const auto objectPtr = daq::StreamingPtr::Borrow(object);
+            return objectPtr.getProtocolGroupId().toStdString();
+        },
+        "Gets the group identifier of the data transfer protocol (e.g., \"OpenDAQNativeStreamingGroup\", \"OpenDAQLTStreamingGroup\") used by this streaming object.");
     cls.def_property_readonly("protocol_id",
         [](daq::IStreaming *object)
         {

--- a/bindings/python/opendaq/generated/streaming/py_streaming_type.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_streaming_type.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/streaming/py_subscription_event_args.cpp
+++ b/bindings/python/opendaq/generated/streaming/py_subscription_event_args.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/synchronization/py_sync_component.cpp
+++ b/bindings/python/opendaq/generated/synchronization/py_sync_component.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/synchronization/py_sync_component_private.cpp
+++ b/bindings/python/opendaq/generated/synchronization/py_sync_component_private.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/python/opendaq/generated/utility/py_device_update_options.cpp
+++ b/bindings/python/opendaq/generated/utility/py_device_update_options.cpp
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/applications/python/Integration Examples/README_lt_tls.md
+++ b/examples/applications/python/Integration Examples/README_lt_tls.md
@@ -1,0 +1,77 @@
+# LT streaming over TLS — `lt_tls_server.py` / `lt_tls_client.py`
+
+A pair of examples demonstrating the secure (TLS) channel of the LT streaming module.
+
+* **`lt_tls_server.py`** — publishes the signals of a reference device over `daq.lts://` only. The
+  plaintext `daq.lt://` channel and the control port stay closed.
+* **`lt_tls_client.py`** — discovers the server over mDNS, prints its server capabilities
+  (protocol group ID, security level, prefix, port), connects to the most secure one and reads a
+  signal.
+* **`generate_certificates.sh`** — creates the throwaway certificates both of them need.
+
+## 1. Certificates
+
+```bash
+./generate_certificates.sh
+```
+
+Writes `secrets/` next to the script: `ca`, `server`, `client` and `other-ca` (an unrelated
+authority used by the negative demo). Existing files are kept; use `--force` to regenerate and
+`--out DIR` to write elsewhere. These are development certificates — never use them anywhere else.
+
+## 2. Server (terminal 1)
+
+```bash
+python3 lt_tls_server.py --cert secrets/server.crt --key secrets/server.key --ca secrets/ca.crt
+```
+
+| Option | Meaning |
+| --- | --- |
+| `--cert`, `--key` | server certificate and private key (required) |
+| `--ca` | CA verifying the client certificates; required unless `--no-mutual-tls` |
+| `--no-mutual-tls` | do not request a certificate from the client |
+
+The channel always listens on the default TLS port, 7415.
+
+Stop it with `Ctrl+C`. The device is always published as `LT TLS streaming server` with local ID
+`LtTlsServer` and serial number `lt-tls-01`, so only one instance may run at a time — a second one
+clashes during discovery.
+
+## 3. Client (terminal 2)
+
+```bash
+python3 lt_tls_client.py --ca secrets/ca.crt --cert secrets/client.crt --key secrets/client.key
+```
+
+Reads the first signal the device publishes for 10 seconds and exits. On the reference device that
+is the analog input of channel `RefCh0` — a 10 Hz sine sampled at 1 kHz.
+
+| Option | Meaning |
+| --- | --- |
+| `--ca` | CA the client trusts when verifying the server |
+| `--cert`, `--key` | client certificate and key, sent when mutual TLS is on |
+| `--no-mutual-tls` | do not send a client certificate |
+| `--no-verify-server-cert` | encrypt without authenticating the server (no client certificate is sent either) |
+| `--host HOST[:PORT]` | connect directly, skipping discovery |
+| `--duration SECONDS` | how long to read (default 10) |
+| `--demo-negative` | run the failing-configuration matrix instead of reading data |
+| `--other-ca` | the untrusted CA for that matrix (default: `other-ca.crt` next to `--ca`) |
+
+### Negative demo
+
+```bash
+python3 lt_tls_client.py --ca secrets/ca.crt --cert secrets/client.crt --key secrets/client.key --demo-negative
+```
+
+Tries six client configurations against a running server and prints why each one is accepted or
+rejected: valid secrets, an untrusted CA, mutual TLS turned off, server verification turned off, no
+CA configured, and a plaintext `daq.lt://` connection to the TLS port. Exits non-zero if any of them
+behaves unexpectedly. The expectations assume a server with mutual TLS enabled (the default).
+
+## Running against a build tree
+
+Both scripts follow the same convention as the GUI example: if `import opendaq` resolves to the
+installed Python package they use its module directory, and otherwise they load modules from the
+current directory. So either use an installed `opendaq` package, or copy the two scripts (plus
+`generate_certificates.sh` and `secrets/`) into the `bin` directory of a build and run them from
+there.

--- a/examples/applications/python/Integration Examples/generate_certificates.sh
+++ b/examples/applications/python/Integration Examples/generate_certificates.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Creates a self-signed set of TLS secrets for the "lt_tls_server.py" and "lt_tls_client.py"
+# examples:
+#
+#   ca.crt / ca.key            the authority signing both certificates below
+#   server.crt / server.key    the server identity, valid for localhost, 127.0.0.1 and ::1
+#   client.crt / client.key    the client identity, presented when mutual TLS is enabled
+#   other-ca.crt / other-ca.key    an unrelated authority, used by "lt_tls_client.py --demo-negative"
+#
+# These are throwaway development certificates. Never use them for anything but running the
+# examples.
+
+set -euo pipefail
+
+OUT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/secrets"
+DAYS=825
+FORCE=0
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [--out DIR] [--force]
+
+  --out DIR   where to write the secrets (default: ./secrets next to this script)
+  --force     overwrite existing files instead of leaving them alone
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out) OUT_DIR="$2"; shift 2 ;;
+        --force) FORCE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+command -v openssl >/dev/null 2>&1 || { echo "openssl is required but was not found" >&2; exit 1; }
+
+mkdir -p "$OUT_DIR"
+
+if [ "$FORCE" -eq 0 ] && [ -e "$OUT_DIR/ca.crt" ]; then
+    echo "Secrets already exist in $OUT_DIR. Re-run with --force to regenerate them."
+    exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# The certificate authority signing the server and the client
+openssl req -x509 -newkey rsa:2048 -nodes -days "$DAYS" \
+    -keyout "$OUT_DIR/ca.key" -out "$OUT_DIR/ca.crt" \
+    -subj "/O=openDAQ LT TLS example/CN=openDAQ LT TLS example CA" \
+    -addext "basicConstraints=critical,CA:TRUE" \
+    -addext "keyUsage=critical,keyCertSign,cRLSign" 2>/dev/null
+
+# An unrelated authority, so that the negative demo has a certificate the server does not trust
+openssl req -x509 -newkey rsa:2048 -nodes -days "$DAYS" \
+    -keyout "$OUT_DIR/other-ca.key" -out "$OUT_DIR/other-ca.crt" \
+    -subj "/O=openDAQ LT TLS example/CN=openDAQ LT TLS example untrusted CA" \
+    -addext "basicConstraints=critical,CA:TRUE" \
+    -addext "keyUsage=critical,keyCertSign,cRLSign" 2>/dev/null
+
+sign() {
+    local name="$1" common_name="$2" extensions="$3"
+
+    openssl req -newkey rsa:2048 -nodes \
+        -keyout "$OUT_DIR/$name.key" -out "$WORK_DIR/$name.csr" \
+        -subj "/O=openDAQ LT TLS example/CN=$common_name" 2>/dev/null
+
+    printf '%s\n' "$extensions" > "$WORK_DIR/$name.ext"
+
+    openssl x509 -req -days "$DAYS" \
+        -in "$WORK_DIR/$name.csr" -out "$OUT_DIR/$name.crt" \
+        -CA "$OUT_DIR/ca.crt" -CAkey "$OUT_DIR/ca.key" -CAcreateserial \
+        -extfile "$WORK_DIR/$name.ext" 2>/dev/null
+}
+
+# The server certificate must cover every address a client may use to reach it, otherwise the
+# hostname check fails even though the certificate itself is trusted
+sign server localhost "$(cat <<'EXT'
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1,IP:0:0:0:0:0:0:0:1
+EXT
+)"
+
+sign client "openDAQ LT TLS example client" "$(cat <<'EXT'
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=clientAuth
+EXT
+)"
+
+chmod 600 "$OUT_DIR"/*.key
+rm -f "$OUT_DIR/ca.srl"
+
+echo "TLS secrets written to $OUT_DIR:"
+ls -1 "$OUT_DIR"

--- a/examples/applications/python/Integration Examples/lt_tls_client.py
+++ b/examples/applications/python/Integration Examples/lt_tls_client.py
@@ -1,0 +1,355 @@
+##
+# Connects to an LT streaming server over the secure (TLS) channel and reads a Signal from it.
+#
+# The example first looks the server up through mDNS discovery and prints the Server Capabilities it
+# advertises. Capabilities carry a protocol group ID and a protocol security level, so a client can
+# pick the most secure channel a server offers on its own: the LT streaming channels share the
+# "LTStreaming" group, and the secure one ("OpenDAQLTStreamingSecure", "daq.lts") has the higher
+# security level. The client then connects to the selected capability with its own TLS configuration
+# and reads the Signal for a few seconds.
+#
+# Start "lt_tls_server.py" in another terminal first, and use the certificates created by
+# "generate_certificates.sh":
+#
+#     python lt_tls_client.py --ca secrets/ca.crt --cert secrets/client.crt --key secrets/client.key
+#
+# Pass --host to skip discovery and connect to a known address instead. Pass --demo-negative to run
+# a set of deliberately broken TLS configurations and see how each of them is rejected.
+##
+
+import argparse
+import os
+import re
+import sys
+import time
+
+import opendaq as daq
+
+SECURE_PROTOCOL_ID = 'OpenDAQLTStreamingSecure'
+LT_PROTOCOL_GROUP_ID = 'LTStreaming'
+SECURE_PREFIX = 'daq.lts'
+PLAIN_PREFIX = 'daq.lt'
+DEFAULT_TLS_PORT = 7415
+
+# The server publishes its Signals asynchronously right after the connection is established, so they
+# are not necessarily there the moment add_device() returns.
+SIGNAL_WAIT_TIMEOUT = 5.0
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description='Connects to an openDAQ LT streaming server over the secure (TLS) channel.')
+    parser.add_argument('--ca', metavar='PATH',
+                        help='CA certificate the client trusts when verifying the server')
+    parser.add_argument('--cert', metavar='PATH',
+                        help='client certificate in PEM format, used for mutual TLS')
+    parser.add_argument('--key', metavar='PATH',
+                        help='client private key in PEM format, used for mutual TLS')
+    parser.add_argument('--no-mutual-tls', dest='mutual_tls', action='store_false',
+                        help='do not send a client certificate '
+                             '(mutual TLS is enabled by default)')
+    parser.add_argument('--no-verify-server-cert', dest='verify_server_cert', action='store_false',
+                        help='encrypt the connection without authenticating the server; '
+                             'the client sends no certificate of its own either')
+    parser.add_argument('--host', metavar='HOST[:PORT]',
+                        help='connect to this address directly instead of discovering the server')
+    parser.add_argument('--duration', type=float, default=10.0, metavar='SECONDS',
+                        help='how long to read the signal (default: %(default)s)')
+    parser.add_argument('--demo-negative', action='store_true',
+                        help='run a matrix of failing TLS configurations instead of reading data')
+    parser.add_argument('--other-ca', metavar='PATH',
+                        help='an unrelated CA certificate used by --demo-negative '
+                             '(default: "other-ca.crt" next to --ca)')
+    return parser.parse_args()
+
+
+def set_module_path(builder):
+    # "import opendaq" resolves to the Python package when it is installed, and to the bare
+    # extension module when this example is run from a build's bin directory. Only the package
+    # defines OPENDAQ_MODULES_DIR; next to the extension the modules sit in the current directory.
+    try:
+        builder.module_path = daq.OPENDAQ_MODULES_DIR
+    except AttributeError:
+        builder.module_path = '.'
+
+
+def create_instance():
+    builder = daq.InstanceBuilder()
+    set_module_path(builder)
+    return builder.build()
+
+
+def existing_file(path, description):
+    if path is None:
+        return None
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f'{description} not found: {path}')
+    return os.path.abspath(path)
+
+
+def create_client_config(instance, ca=None, cert=None, key=None,
+                         mutual_tls=True, verify_server_cert=True):
+    if SECURE_PROTOCOL_ID not in instance.available_device_types:
+        raise RuntimeError(f'The "{SECURE_PROTOCOL_ID}" device type is not available. '
+                           'The LT streaming client module is either missing or too old to '
+                           'support the secure channel.')
+
+    device_type = daq.IDeviceType.cast_from(instance.available_device_types[SECURE_PROTOCOL_ID])
+    config = device_type.create_default_config()
+
+    # With verification turned off the connection is still encrypted, but the server is not
+    # authenticated and the client sends no certificate of its own
+    config.set_property_value('VerifyServerCertificate', verify_server_cert)
+    if not verify_server_cert:
+        return config
+
+    config.set_property_value('EnableMutualTls', mutual_tls)
+    if ca is not None:
+        config.set_property_value('CaCertificateFilePath', existing_file(ca, 'CA certificate'))
+    if mutual_tls:
+        if cert is not None:
+            config.set_property_value('CertificateFilePath',
+                                      existing_file(cert, 'Client certificate'))
+        if key is not None:
+            config.set_property_value('KeyFilePath', existing_file(key, 'Client private key'))
+
+    return config
+
+
+def error_message(error):
+    first_line = str(error).split('\n')[0]
+    return re.sub(r'\s*\[ [^\]]*\]\s*$', '', first_line).strip()
+
+
+def to_int(value, default=-1):
+    if value is None:
+        return default
+    return value.value if hasattr(value, 'value') else int(value)
+
+
+def print_capability(capability, indent='    '):
+    print(f'{indent}{capability.protocol_id}')
+    print(f'{indent}  protocol group id:      {capability.protocol_group_id}')
+    print(f'{indent}  protocol security level:{to_int(capability.protocol_security_level):>3}')
+    print(f'{indent}  prefix:                 {capability.prefix}')
+    print(f'{indent}  port:                   {to_int(capability.port)}')
+    print(f'{indent}  connection string:      {capability.connection_string}')
+
+
+def lt_capabilities(device_info):
+    capabilities = []
+    for capability in device_info.server_capabilities:
+        try:
+            group_id = capability.protocol_group_id
+        except AttributeError:
+            raise RuntimeError(
+                'These Python bindings predate the protocol group ID / security level API. '
+                'Rebuild them from this branch (ninja py_opendaq_daq), or pass --host to connect '
+                'without inspecting the capabilities.') from None
+        if group_id == LT_PROTOCOL_GROUP_ID:
+            capabilities.append(capability)
+    return capabilities
+
+
+def discover_capability(instance):
+    """Finds an LT streaming server through mDNS and returns its most secure capability."""
+    print('Discovering LT streaming servers...')
+
+    selected = None
+    for device_info in instance.available_devices:
+        capabilities = lt_capabilities(device_info)
+        if not capabilities:
+            continue
+
+        print(f'\n  {device_info.name} (serial number: {device_info.serial_number})')
+        for capability in capabilities:
+            print_capability(capability)
+
+        if selected is None:
+            # Ordering the capabilities of a protocol group by their security level is what makes a
+            # client prefer the secure channel without knowing anything about the protocols
+            selected = max(capabilities,
+                           key=lambda capability: to_int(capability.protocol_security_level))
+
+    if selected is None:
+        raise RuntimeError('No LT streaming server was discovered. Start "lt_tls_server.py" first, '
+                           'or pass --host to connect to a known address.')
+
+    if selected.protocol_id != SECURE_PROTOCOL_ID:
+        raise RuntimeError(f'The most secure LT capability offered is "{selected.protocol_id}", '
+                           'not the TLS one. Make sure the server was started with the secure '
+                           'channel enabled.')
+
+    print(f'\nSelected "{selected.protocol_id}" (security level '
+          f'{to_int(selected.protocol_security_level)})')
+    return selected.connection_string
+
+
+def connection_string_from_host(host):
+    remainder = host[host.rindex(']') + 1:] if ']' in host else host
+    if ':' not in remainder:
+        host = f'{host}:{DEFAULT_TLS_PORT}'
+    return f'{SECURE_PREFIX}://{host}/'
+
+
+def wait_for_signals(device, timeout=SIGNAL_WAIT_TIMEOUT):
+    deadline = time.monotonic() + timeout
+    while True:
+        signals = [signal for signal in device.signals_recursive
+                   if signal.domain_signal is not None]
+        if signals or time.monotonic() >= deadline:
+            return signals
+        time.sleep(0.1)
+
+
+def active_streaming_source(signal, timeout=SIGNAL_WAIT_TIMEOUT):
+    mirrored_signal = daq.IMirroredSignalConfig.cast_from(signal)
+    deadline = time.monotonic() + timeout
+    while True:
+        source = mirrored_signal.active_streaming_source
+        if source is not None or time.monotonic() >= deadline:
+            return source
+        time.sleep(0.1)
+
+
+def read_signal(signal, duration):
+    print(f'\nReading "{signal.name}" for {duration:g} seconds\n')
+
+    reader = daq.StreamReader(signal)
+    total = 0
+    end_time = time.monotonic() + duration
+    while time.monotonic() < end_time:
+        time.sleep(0.25)
+        samples = reader.read(1000)
+        if len(samples) > 0:
+            total += len(samples)
+            print(f'  {len(samples):5d} samples, last value: {samples[-1]}')
+
+    return total
+
+
+def connect_and_read(instance, connection_string, config, args):
+    print(f'\nConnecting to {connection_string}')
+    device = instance.add_device(connection_string, config)
+
+    connection_info = device.info.configuration_connection_info
+    print(f'Connected over "{connection_info.protocol_id}" '
+          f'(port {to_int(connection_info.port)})')
+
+    signals = wait_for_signals(device)
+    if not signals:
+        raise RuntimeError('The device published no signals within '
+                           f'{SIGNAL_WAIT_TIMEOUT:g} seconds.')
+
+    print(f'Signals available: {", ".join(signal.name for signal in signals)}')
+
+    signal = signals[0]
+    source = active_streaming_source(signal)
+    if source is None:
+        raise RuntimeError(f'Signal "{signal.name}" has no active streaming source.')
+
+    print(f'Active streaming source: {source}')
+    if not source.startswith(f'{SECURE_PREFIX}://'):
+        raise RuntimeError(f'The data is not streamed over the secure channel: {source}')
+
+    total = read_signal(signal, args.duration)
+
+    print(f'\nRead {total} samples over the secure channel.')
+    instance.remove_device(device)
+
+
+def negative_cases(args, connection_string):
+    """The attempts made by --demo-negative, as (title, connection string, config kwargs, expected).
+
+    A config of None means connecting without any TLS configuration at all.
+    """
+    other_ca = args.other_ca
+    if other_ca is None and args.ca is not None:
+        other_ca = os.path.join(os.path.dirname(os.path.abspath(args.ca)), 'other-ca.crt')
+
+    valid = {'ca': args.ca, 'cert': args.cert, 'key': args.key}
+    plain_connection_string = connection_string.replace(
+        f'{SECURE_PREFIX}://', f'{PLAIN_PREFIX}://', 1)
+
+    cases = [
+        ('Valid CA, certificate and key',
+         connection_string, dict(valid), True),
+        ('Untrusted CA: the server certificate is signed by another authority',
+         connection_string, dict(valid, ca=other_ca), False),
+        ('Mutual TLS disabled on the client: no certificate is sent to the server',
+         connection_string, dict(valid, mutual_tls=False), False),
+        ('Server verification disabled: encrypted, but neither peer is authenticated',
+         connection_string, dict(valid, verify_server_cert=False), False),
+        ('No CA certificate configured: rejected before any network traffic',
+         connection_string, dict(valid, ca=None), False),
+        (f'Plaintext {PLAIN_PREFIX}:// connection to the TLS port',
+         plain_connection_string, None, False),
+    ]
+
+    if other_ca is None or not os.path.isfile(other_ca):
+        # Without an unrelated CA there is nothing to present as untrusted
+        cases.pop(1)
+
+    return cases
+
+
+def run_negative_demo(args, connection_string):
+    print('\nTrying a set of client TLS configurations against the server.')
+    print('The expectations below assume a server with mutual TLS enabled (the default).\n')
+
+    results = []
+    for title, target, config_kwargs, expect_success in negative_cases(args, connection_string):
+        print(f'* {title}')
+        try:
+            # A fresh instance per attempt keeps a failed connection from affecting the next one
+            instance = create_instance()
+            config = None
+            if config_kwargs is not None:
+                config = create_client_config(instance, **config_kwargs)
+            device = instance.add_device(target, config)
+            instance.remove_device(device)
+            succeeded, detail = True, 'the connection was established'
+        except Exception as error:
+            succeeded, detail = False, error_message(error)
+
+        as_expected = succeeded == expect_success
+        print(f'    {"connected" if succeeded else "rejected"}: {detail}')
+        print(f'    {"as expected" if as_expected else "UNEXPECTED"}\n')
+        results.append((title, as_expected))
+
+    print('Summary:')
+    for title, as_expected in results:
+        print(f'  [{"OK  " if as_expected else "FAIL"}] {title}')
+
+    return 0 if all(as_expected for _, as_expected in results) else 1
+
+
+def main():
+    args = parse_arguments()
+
+    try:
+        instance = create_instance()
+
+        if args.host is not None:
+            connection_string = connection_string_from_host(args.host)
+        else:
+            connection_string = discover_capability(instance)
+
+        if args.demo_negative:
+            return run_negative_demo(args, connection_string)
+
+        config = create_client_config(instance,
+                                      ca=args.ca,
+                                      cert=args.cert,
+                                      key=args.key,
+                                      mutual_tls=args.mutual_tls,
+                                      verify_server_cert=args.verify_server_cert)
+        connect_and_read(instance, connection_string, config, args)
+    except KeyboardInterrupt:
+        print('\nInterrupted')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/examples/applications/python/Integration Examples/lt_tls_server.py
+++ b/examples/applications/python/Integration Examples/lt_tls_server.py
@@ -1,0 +1,155 @@
+##
+# Starts an openDAQ(TM) LT streaming server that publishes the Signals of a reference Device over
+# the secure (TLS) channel only. The plaintext "daq.lt://" channel is left disabled, so clients can
+# reach the Device through "daq.lts://" alone.
+#
+# The server needs its own certificate and private key. With mutual TLS enabled (the default) it
+# also needs the CA certificate that signed the client certificates. The "generate_certificates.sh"
+# script next to this example creates a self-signed set of all of them:
+#
+#     ./generate_certificates.sh
+#     python lt_tls_server.py --cert secrets/server.crt --key secrets/server.key --ca secrets/ca.crt
+#
+# Connect to the running server with "lt_tls_client.py" from another terminal.
+#
+# IMPORTANT: The reference Device identity is overridden to a fixed serial number and local ID, so
+# only 1 instance of this example should be active at any given time to avoid discovery clashes.
+##
+
+import argparse
+import os
+import sys
+import time
+
+import opendaq as daq
+
+# The LT streaming server serves both the plaintext and the secure channel. Which of the two are
+# actually opened is decided by the EnableStreamingPort / EnableTlsStreamingPort properties.
+SERVER_TYPE_ID = 'OpenDAQLTStreaming'
+DEFAULT_TLS_PORT = 7415
+
+DEVICE_NAME = 'LT TLS streaming server'
+DEVICE_LOCAL_ID = 'LtTlsServer'
+DEVICE_SERIAL_NUMBER = 'lt-tls-01'
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description='openDAQ LT streaming server serving the secure (TLS) channel only.')
+    parser.add_argument('--cert', required=True, metavar='PATH',
+                        help='server certificate in PEM format')
+    parser.add_argument('--key', required=True, metavar='PATH',
+                        help='server private key in PEM format')
+    parser.add_argument('--ca', metavar='PATH',
+                        help='CA certificate used to verify the client certificates, '
+                             'required unless --no-mutual-tls is given')
+    parser.add_argument('--no-mutual-tls', dest='mutual_tls', action='store_false',
+                        help='do not request a certificate from the client '
+                             '(mutual TLS is enabled by default)')
+    return parser.parse_args()
+
+
+def existing_file(path, description):
+    # The TLS secrets are opened by the streaming module itself, deep inside add_server(). Checking
+    # them here turns a mangled OpenSSL error into a readable one, and absolute paths keep the
+    # module independent of the working directory.
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f'{description} not found: {path}')
+    return os.path.abspath(path)
+
+
+def set_module_path(builder):
+    # "import opendaq" resolves to the Python package when it is installed, and to the bare
+    # extension module when this example is run from a build's bin directory. Only the package
+    # defines OPENDAQ_MODULES_DIR; next to the extension the modules sit in the current directory.
+    try:
+        builder.module_path = daq.OPENDAQ_MODULES_DIR
+    except AttributeError:
+        builder.module_path = '.'
+
+
+def create_instance():
+    root_device_config = daq.PropertyObject()
+    root_device_config.add_property(daq.StringProperty(
+        daq.String('Name'), daq.String(DEVICE_NAME), daq.Boolean(True)))
+    root_device_config.add_property(daq.StringProperty(
+        daq.String('LocalId'), daq.String(DEVICE_LOCAL_ID), daq.Boolean(True)))
+    root_device_config.add_property(daq.StringProperty(
+        daq.String('SerialNumber'), daq.String(DEVICE_SERIAL_NUMBER), daq.Boolean(True)))
+
+    instance_builder = daq.InstanceBuilder()
+    set_module_path(instance_builder)
+    # mDNS discovery lets lt_tls_client.py find this server without being told its address
+    instance_builder.add_discovery_server('mdns')
+    instance_builder.set_root_device('daqref://device0', root_device_config)
+    return instance_builder.build()
+
+
+def create_server_config(instance, args):
+    if SERVER_TYPE_ID not in instance.available_server_types:
+        raise RuntimeError(f'The "{SERVER_TYPE_ID}" server type is not available. '
+                           'The LT streaming server module is either missing or too old to '
+                           'support the secure channel.')
+
+    server_type = daq.IServerType.cast_from(instance.available_server_types[SERVER_TYPE_ID])
+    config = server_type.create_default_config()
+
+    # Serve the secure channel only. The plaintext streaming port stays closed, and so must the
+    # control port: the module rejects a configuration that enables the control port without the
+    # plaintext streaming port.
+    config.set_property_value('EnableTlsStreamingPort', True)
+    config.set_property_value('EnableStreamingPort', False)
+    config.set_property_value('EnableControlPort', False)
+    config.set_property_value('TlsWebsocketStreamingPort', DEFAULT_TLS_PORT)
+
+    config.set_property_value('CertificateFilePath', existing_file(args.cert, 'Server certificate'))
+    config.set_property_value('KeyFilePath', existing_file(args.key, 'Server private key'))
+
+    # With mutual TLS the client is authenticated as well, and its certificate is verified against
+    # this CA. Without it the client stays anonymous, but the channel is still encrypted.
+    config.set_property_value('EnableMutualTls', args.mutual_tls)
+    if args.mutual_tls:
+        if args.ca is None:
+            raise ValueError('Mutual TLS is enabled but no CA certificate was given. '
+                             'Pass --ca <file>, or turn mutual TLS off with --no-mutual-tls.')
+        config.set_property_value('CaCertificateFilePath', existing_file(args.ca, 'CA certificate'))
+
+    return config
+
+
+def print_summary(instance, args, config):
+    print('LT streaming server started')
+    print(f'  device:            {instance.root_device.name}')
+    port = config.get_property_value('TlsWebsocketStreamingPort')
+    print(f'  TLS channel:       daq.lts:// on port {port}')
+    print('  plaintext channel: disabled')
+    print(f'  mutual TLS:        {"enabled" if args.mutual_tls else "disabled"}')
+    print(f'  certificate:       {config.get_property_value("CertificateFilePath")}')
+    print(f'  private key:       {config.get_property_value("KeyFilePath")}')
+    if args.mutual_tls:
+        print(f'  CA certificate:    {config.get_property_value("CaCertificateFilePath")}')
+    print(f'  signals served:    {len(instance.root_device.signals_recursive)}')
+    print('\nPress Ctrl+C to stop the server.')
+
+
+def main():
+    args = parse_arguments()
+
+    instance = create_instance()
+    server_config = create_server_config(instance, args)
+    # enable_discovery() advertises the secure channel as the "_streaming-lts._tcp" mDNS service
+    instance.add_server(SERVER_TYPE_ID, server_config).enable_discovery()
+
+    print_summary(instance, args, server_config)
+
+    try:
+        while True:
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        print('\nStopping the server')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/shared/tools/RTGen/bin/Templates/c.header.template
+++ b/shared/tools/RTGen/bin/Templates/c.header.template
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/tools/RTGen/bin/Templates/python.template
+++ b/shared/tools/RTGen/bin/Templates/python.template
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/tools/RTGen/src/project/RTGen.C/RTGen.C.csproj
+++ b/shared/tools/RTGen/src/project/RTGen.C/RTGen.C.csproj
@@ -57,6 +57,9 @@
     <None Include="Templates\c.header.method.template">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Templates\c.method.definition.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Templates\c.method.template">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/shared/tools/RTGen/src/project/RTGen.C/Templates/c.header.template
+++ b/shared/tools/RTGen/src/project/RTGen.C/Templates/c.header.template
@@ -5,7 +5,7 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 //
-//     RTGen ($GeneratorName$ $GeneratorVersion$) on $DateAndTime$.
+//     RTGen ($GeneratorName$ $GeneratorVersion$).
 // </auto-generated>
 //------------------------------------------------------------------------------
 

--- a/shared/tools/RTGen/src/project/RTGen.C/Templates/c.header.template
+++ b/shared/tools/RTGen/src/project/RTGen.C/Templates/c.header.template
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /*
- * Copyright 2022-2025 openDAQ d.o.o.
+ * Copyright 2022-2026 openDAQ d.o.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/tools/RTGen/src/project/RTGen.C/Templates/c.method.definition.template
+++ b/shared/tools/RTGen/src/project/RTGen.C/Templates/c.method.definition.template
@@ -1,0 +1,5 @@
+void $CallingConvention$ $Name$($Arguments$);
+$ReturnType$ $CallingConvention$ $Name$($Arguments$);
+$ArgTypeName$** $ArgName$
+$ArgTypeName$* $ArgName$
+, 

--- a/shared/tools/RTGen/src/project/RTGen.C/Templates/c.template
+++ b/shared/tools/RTGen/src/project/RTGen.C/Templates/c.template
@@ -5,7 +5,7 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 //
-//     RTGen ($GeneratorName$ $GeneratorVersion$) on $DateAndTime$.
+//     RTGen ($GeneratorName$ $GeneratorVersion$).
 // </auto-generated>
 //------------------------------------------------------------------------------
 

--- a/shared/tools/RTGen/src/project/RTGen.Cpp/Templates/cpp.ptr.template
+++ b/shared/tools/RTGen/src/project/RTGen.Cpp/Templates/cpp.ptr.template
@@ -75,9 +75,6 @@ $MoveEventWrappers$
     
     $PtrNameOnly$& operator=(const $PtrName$& other)
     {
-        if (this == &other)
-            return *this;
-
         $BasePtrNameFull$$BasePtrInterfaceTemplate$::operator =(other);
 
 $EventWrappersCopyAssign$
@@ -86,11 +83,6 @@ $EventWrappersCopyAssign$
 
     $PtrNameOnly$& operator=($PtrName$&& other) noexcept
     {
-        if (this == std::addressof(other))
-        {
-            return *this;
-        }
-
 $EventWrappersMoveAssign$
         $BasePtrNameFull$$BasePtrInterfaceTemplate$::operator =(std::move(other));
 $EventWrappersMoveAssignRebind$


### PR DESCRIPTION
# Brief

Expose `ProtocolGroupId` and `ProtocolSecurityLevel` in the C and Python bindings, bump generated-file copyright to 2026, and realign the RTGen source templates with the `bin/Templates` copies they had drifted from. 
The Python integration examples demonstrate how the TLStreamingModuleModern module's TLS channel works.

  # Description

  - Regenerate C and Python bindings for `IServerCapability::getProtocolGroupId`/`getProtocolSecurityLevel`, `IServerCapabilityConfig::setProtocolGroupId`/`setProtocolSecurityLevel`, and  `IStreaming::getProtocolGroupId`.
  - Bump copyright to 2026 in the RTGen header templates, regenerating the 144 Python binding files that carry the header.
  - Sync `RTGen/src/.../Templates` with `RTGen/bin/Templates`, which is what `rtgen.exe` actually loads — a rebuild would otherwise have silently changed generated output. Drops `on $DateAndTime$` from `c.header.template`/`c.template` (removed in `bin/` by #1134), drops the redundant self-assignment guards from `cpp.ptr.template`, and adds `c.method.definition.template` plus its `RTGen.C.csproj` entry.
  - `lt_tls_client.py`,  `lt_tls_server.py` are python examples that demonstrate communication between a client and a server using a TLS channel.
  - `generate_certificates.sh` is a helper to create TLS secrets for testing purposes.

  # Usage example

  ```python
  print(cap.protocol_group_id, cap.protocol_security_level.value)
  ```

  ```c
  daqServerCapability_getProtocolGroupId(capability, &groupId);
  daqServerCapability_getProtocolSecurityLevel(capability, &securityLevel);
  ```

```bash
python3 lt_tls_server.py --cert secrets/server.crt --key secrets/server.key --ca secrets/ca.crt
```

```bash
python lt_tls_client.py --ca secrets/ca.crt --cert secrets/client.crt --key secrets/client.key
```

  # API changes

  No core interface changes — the interfaces were already extended upstream; this only exposes them. 

  # Required application changes

  None.

  # Required module changes

  None. 