### PR TITLE
Python GUI: Property View uses PropertyType

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo/components/data_descriptor_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/data_descriptor_treeview.py
@@ -38,7 +38,7 @@ class DataDescriptorTreeview(ttk.Treeview):
         # for user to see property value without expanding the tree
         if isinstance(value, daq.IProperty):
             display_value = value.value
-            if value.value_type == daq.CoreType.ctBool:
+            if value.property_type == daq.PropertyType.Bool:
                 display_value = utils.yes_no[display_value]
         else:
             display_value = utils.metadata_converters[key](

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_attributes_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_attributes_treeview.py
@@ -202,7 +202,7 @@ class AttributesTreeview(ttk.Treeview):
         # for user to see property value without expanding the tree
         if isinstance(value, daq.IProperty):
             display_value = value.value
-            if value.value_type == daq.CoreType.ctBool:
+            if value.property_type == daq.PropertyType.Bool:
                 display_value = utils.yes_no[display_value]
         else:
             display_value = utils.metadata_converters[key](

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -616,9 +616,7 @@ class PropertiesTreeview(ttk.Treeview):
             cb.bind('<FocusOut>', _clear_active_if_needed)
             cb.bind('<KeyPress>', lambda e : 'break')
 
-        cb.bind('<MouseWheel>', lambda e: 'break')
-        cb.bind('<Button-4>', lambda e: 'break')
-        cb.bind('<Button-5>', lambda e: 'break')
+        utils.bind_mousewheel_to(cb, self, self._sync_overlays)
         return cb
 
     def _place_bool_checkbox(self, iid, prop):
@@ -639,12 +637,7 @@ class PropertiesTreeview(ttk.Treeview):
             self.refresh()
 
         cb.configure(command=on_change)
-        def _on_mousewheel(e):
-            self.yview_scroll(int(-1 * (e.delta / 120)), 'units')
-            self._sync_overlays()
-            return 'break'
-
-        cb.bind('<MouseWheel>', _on_mousewheel)
+        utils.bind_mousewheel_to(cb, self, self._sync_overlays)
         self._overlay_comboboxes[iid] = cb
 
     def _place_method_button(self, iid, prop):
@@ -692,6 +685,7 @@ class PropertiesTreeview(ttk.Treeview):
                 
         btn = ttk.Button(self, text=prop.name, command=execute)
         btn.place(x=x, y=y, width=width, height=height)
+        utils.bind_mousewheel_to(btn, self, self._sync_overlays)
         self._overlay_comboboxes[iid] = btn
         
     def _tree_indent(self):

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -163,21 +163,19 @@ class PropertiesTreeview(ttk.Treeview):
                 # This property was marked as hidden
                 continue
 
-            if property_info.selection_values is not None and property_info.item_type != daq.CoreType.ctUndefined:
+            property_type = property_info.property_type
+
+            if property_type in (daq.PropertyType.IndexSelection, daq.PropertyType.SparseSelection):
                 if len(property_info.selection_values) > 0:
                     property_value = printed_value(
                         property_info.item_type, node.get_property_selection_value(property_info.name))
                 else:
                     property_value = 'Selection list is empty'
-            elif property_info.value_type == daq.CoreType.ctProc:
+            elif property_type in (daq.PropertyType.Procedure, daq.PropertyType.Function):
                 property_value = self._last_method_results.get(property_info.name, '')
-            elif property_info.value_type == daq.CoreType.ctFunc:
-                property_value = self._last_method_results.get(property_info.name, '')
-            elif property_info.value_type == daq.CoreType.ctStruct:
+            elif property_type in (daq.PropertyType.Struct, daq.PropertyType.Object):
                 property_value = ''
-            elif property_info.value_type == daq.CoreType.ctObject:
-                property_value = ''
-            elif property_info.value_type in (daq.CoreType.ctList, daq.CoreType.ctDict):
+            elif property_type in (daq.PropertyType.List, daq.PropertyType.Dict):
                 property_value = str(node.get_property_value(property_info.name))
             else:
                 property_value = printed_value(
@@ -198,7 +196,7 @@ class PropertiesTreeview(ttk.Treeview):
                 print(e)
 
             # Insert a treeview entry widget for the property
-            if property_info.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+            if property_type in (daq.PropertyType.Procedure, daq.PropertyType.Function):
                 display_name = '          ' + property_info.name
             else:
                 display_name = property_info.name
@@ -210,26 +208,27 @@ class PropertiesTreeview(ttk.Treeview):
                 text=display_name,
                 values=(property_value, *meta_fields))
 
-            container_types = (daq.CoreType.ctObject, daq.CoreType.ctStruct, daq.CoreType.ctList, daq.CoreType.ctDict)
             is_single_value_selection = (
-                property_info.selection_values is not None
+                property_type in (daq.PropertyType.Selection, daq.PropertyType.IndexSelection,
+                                  daq.PropertyType.SparseSelection)
                 and len(property_info.selection_values) == 1
             )
-            if property_info.value_type not in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
-                if property_info.value_type not in container_types:
+            if property_type not in (daq.PropertyType.Procedure, daq.PropertyType.Function):
+                if property_type not in (daq.PropertyType.Object, daq.PropertyType.Struct,
+                                         daq.PropertyType.List, daq.PropertyType.Dict):
                     if property_info.read_only or self.read_only or is_single_value_selection:
                         self.item(iid, tags=('readonly',))
 
-            if property_info.value_type == daq.CoreType.ctObject:
+            if property_type == daq.PropertyType.Object:
                 hidden_children = [s.removeprefix(f"{property_info.name}.") for s in hidden if s.startswith(f"{property_info.name}.")]
                 self.fill_properties(
                     iid, node.get_property_value(property_info.name), hidden_children)  
-            elif property_info.value_type == daq.CoreType.ctStruct:
+            elif property_type == daq.PropertyType.Struct:
                 self.fill_struct(
                     iid, node.get_property_value(property_info.name), property_info.read_only)
-            elif property_info.value_type == daq.CoreType.ctList:
+            elif property_type == daq.PropertyType.List:
                 self.fill_list(iid, node.get_property_value(property_info.name), property_info.read_only)
-            elif property_info.value_type == daq.CoreType.ctDict:
+            elif property_type == daq.PropertyType.Dict:
                 self.fill_dict(iid, node.get_property_value(property_info.name), property_info.read_only)
 
     def handle_copy(self):
@@ -277,20 +276,21 @@ class PropertiesTreeview(ttk.Treeview):
             return
 
         value = prop.value
+        property_type = prop.property_type
         try:
-            if prop.value_type == daq.CoreType.ctObject:
+            if property_type == daq.PropertyType.Object:
                 pass  # ignoring paste to objects
-            elif prop.value_type == daq.CoreType.ctStruct:
+            elif property_type == daq.PropertyType.Struct:
                 field_type = [
                     field for field in prop.struct_type.field_types if field.name == path_diff[0]][0].core_type
                 setattr(value, path_diff[0], utils.value_to_coretype(
                     self.clipboard_get(), field_type))
                 prop.value = value
-            elif prop.value_type == daq.CoreType.ctList:
+            elif property_type == daq.PropertyType.List:
                 value[int(path_diff[0])] = utils.value_to_coretype(
                     self.clipboard_get(), prop.item_type)
                 prop.value = value
-            elif prop.value_type == daq.CoreType.ctDict:
+            elif property_type == daq.PropertyType.Dict:
                 value[utils.value_to_coretype(path_diff[0], prop.key_type)] = utils.value_to_coretype(
                     self.clipboard_get(), prop.item_type)
                 prop.value = value
@@ -332,7 +332,7 @@ class PropertiesTreeview(ttk.Treeview):
         if prop is None:
             return
 
-        if prop.value_type == daq.CoreType.ctObject and daq.IPropertyObject.can_cast_from(prop.value):
+        if prop.property_type == daq.PropertyType.Object and daq.IPropertyObject.can_cast_from(prop.value):
             obj = daq.IPropertyObject.cast_from(prop.value)
             obj.clear_property_values()
         elif daq.IPropertyObject.can_cast_from(self.node):
@@ -367,9 +367,9 @@ class PropertiesTreeview(ttk.Treeview):
             
             is_container = False
             if prop:
-                container_types = (daq.CoreType.ctObject, daq.CoreType.ctStruct, 
-                                   daq.CoreType.ctList, daq.CoreType.ctDict)
-                is_container = prop.value_type in container_types
+                is_container = prop.property_type in (
+                    daq.PropertyType.Object, daq.PropertyType.Struct,
+                    daq.PropertyType.List, daq.PropertyType.Dict)
 
             is_readonly = 'readonly' in self.item(selected_item_id, 'tags')
             if not is_container:
@@ -492,27 +492,35 @@ class PropertiesTreeview(ttk.Treeview):
             path = utils.get_item_path(self, iid)
             prop = utils.get_property_for_path(self.context, path, self.node)
             if prop:
-                if prop.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+                property_type = prop.property_type
+                if property_type in (daq.PropertyType.Procedure, daq.PropertyType.Function):
                     self._overlay_items[iid] = prop
                 elif not prop.read_only:
-                    if (prop.value_type == daq.CoreType.ctBool
-                            or (prop.selection_values is not None and len(prop.selection_values) > 1)
-                            or prop.value_type == daq.CoreType.ctEnumeration
-                            or (prop.value_type in (daq.CoreType.ctString, daq.CoreType.ctFloat, daq.CoreType.ctInt)
+                    if (property_type == daq.PropertyType.Bool
+                            or (property_type in (daq.PropertyType.Selection,
+                                                 daq.PropertyType.IndexSelection,
+                                                 daq.PropertyType.SparseSelection)
+                                and len(prop.selection_values) > 1)
+                            or property_type == daq.PropertyType.Enumeration
+                            or (property_type in (daq.PropertyType.Int, daq.PropertyType.Float,
+                                                 daq.PropertyType.String)
                                 and prop.suggested_values is not None and len(prop.suggested_values) > 0)):
                         self._overlay_items[iid] = prop
             self._collect_overlay_items(iid)
 
     def _create_overlay_for_item(self, iid, prop):
-        if prop.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
+        property_type = prop.property_type
+        if property_type in (daq.PropertyType.Procedure, daq.PropertyType.Function):
             self._place_method_button(iid, prop)
-        elif prop.value_type == daq.CoreType.ctBool:
+        elif property_type == daq.PropertyType.Bool:
             self._place_bool_checkbox(iid, prop)
-        elif prop.selection_values is not None and len(prop.selection_values) > 0:
+        elif (property_type in (daq.PropertyType.Selection, daq.PropertyType.IndexSelection,
+                                daq.PropertyType.SparseSelection)
+              and len(prop.selection_values) > 0):
             self._place_selection_combobox(iid, prop)
-        elif prop.value_type == daq.CoreType.ctEnumeration:
+        elif property_type == daq.PropertyType.Enumeration:
             self._place_enum_combobox(iid, prop)
-        elif (prop.value_type in (daq.CoreType.ctString, daq.CoreType.ctFloat, daq.CoreType.ctInt)
+        elif (property_type in (daq.PropertyType.Int, daq.PropertyType.Float, daq.PropertyType.String)
               and prop.suggested_values is not None and len(prop.suggested_values) > 0):
             self._place_suggested_combobox(iid, prop)
 
@@ -530,7 +538,8 @@ class PropertiesTreeview(ttk.Treeview):
             visible_h = self.winfo_height() - sb_x_h
 
             for iid, item_prop in self._overlay_items.items():
-                is_method = item_prop.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc)
+                is_method = item_prop.property_type in (daq.PropertyType.Procedure,
+                                                        daq.PropertyType.Function)
                 bbox = self.bbox(iid, '#0' if is_method else '#1')
                 if bbox:
                     if iid not in self._overlay_comboboxes:
@@ -648,11 +657,13 @@ class PropertiesTreeview(ttk.Treeview):
         x += indent
         width = max(1, width - indent)
 
-        def execute(_prop=prop, _iid=iid):
+        is_function = prop.property_type == daq.PropertyType.Function
+
+        def execute(_prop=prop, _iid=iid, _is_function=is_function):
             result = None
             has_args = bool(_prop.callable_info.arguments)
             
-            method_class = daq.IFunction if _prop.value_type == daq.CoreType.ctFunc else daq.IProcedure
+            method_class = daq.IFunction if _is_function else daq.IProcedure
             method = method_class.cast_from(_prop.value)
 
             if has_args:
@@ -662,7 +673,7 @@ class PropertiesTreeview(ttk.Treeview):
             else:
                 try:
                     res = method()
-                    result = res if _prop.value_type == daq.CoreType.ctFunc else True
+                    result = res if _is_function else True
                 except Exception as e:
                     result = e
 
@@ -697,7 +708,9 @@ class PropertiesTreeview(ttk.Treeview):
             labels = [f'{l} {unit_symbol}' for l in labels]
         if not labels:
             return
-        if prop.item_type != daq.CoreType.ctUndefined:
+        is_keyed_selection = prop.property_type in (daq.PropertyType.IndexSelection,
+                                                    daq.PropertyType.SparseSelection)
+        if is_keyed_selection:
             current_idx = prop.value
             current_label = labels[indices.index(current_idx)] if current_idx in indices else labels[0]
         else:
@@ -707,9 +720,9 @@ class PropertiesTreeview(ttk.Treeview):
         if cb is None:
             return
 
-        def on_change(event, _prop=prop, _labels=labels, _indices=indices, _cb=cb):
+        def on_change(event, _prop=prop, _labels=labels, _indices=indices, _cb=cb, _is_keyed=is_keyed_selection):
             try:
-                if _prop.item_type != daq.CoreType.ctUndefined:
+                if _is_keyed:
                     _prop.value = _indices[_labels.index(_cb.get())]
                 else:
                     _prop.value = _cb.get()
@@ -827,12 +840,14 @@ class PropertiesTreeview(ttk.Treeview):
             if 'readonly' in self.item(selected_item_id, 'tags'):
                 return
  
+            parent_property_type = parent.property_type
+
             if type(parent.value) is complex or type(parent.value) is Fraction:
                 return 
-            elif parent.value_type == daq.CoreType.ctStruct:
+            elif parent_property_type == daq.PropertyType.Struct:
                 self.edit_struct_property(selected_item_id, name, parent)
                 return
-            elif parent.value_type == daq.CoreType.ctList:
+            elif parent_property_type == daq.PropertyType.List:
                 EditContainerPropertyDialog(self, parent, self.context).show()
                 self.refresh()
                 return
@@ -842,11 +857,13 @@ class PropertiesTreeview(ttk.Treeview):
         if not prop:
             return
 
-        if prop.value_type == daq.CoreType.ctEnumeration:
+        property_type = prop.property_type
+
+        if property_type == daq.PropertyType.Enumeration:
             return  # handled by overlay combobox
 
-        if prop.value_type in (daq.CoreType.ctFunc, daq.CoreType.ctProc):
-            method_class = daq.IFunction if prop.value_type == daq.CoreType.ctFunc else daq.IProcedure
+        if property_type in (daq.PropertyType.Procedure, daq.PropertyType.Function):
+            method_class = daq.IFunction if property_type == daq.PropertyType.Function else daq.IProcedure
             method = method_class.cast_from(prop.value)
             
             if prop.callable_info.arguments:
@@ -856,7 +873,7 @@ class PropertiesTreeview(ttk.Treeview):
             else:
                 try:
                     res = method()
-                    result = res if prop.value_type == daq.CoreType.ctFunc else True
+                    result = res if property_type == daq.PropertyType.Function else True
                 except Exception as e:
                     result = e
 
@@ -877,14 +894,15 @@ class PropertiesTreeview(ttk.Treeview):
         if prop.read_only:
             return
 
-        if prop.value_type == daq.CoreType.ctBool:
+        if property_type == daq.PropertyType.Bool:
             return  # handled by overlay combobox
-        elif prop.selection_values is not None:
+        elif property_type in (daq.PropertyType.Selection, daq.PropertyType.IndexSelection,
+                               daq.PropertyType.SparseSelection):
             return  # handled by overlay combobox
-        elif prop.value_type in (daq.CoreType.ctDict, daq.CoreType.ctList):
+        elif property_type in (daq.PropertyType.Dict, daq.PropertyType.List):
             EditContainerPropertyDialog(self, prop, self.context).show()
             self.refresh()
-        elif prop.value_type in (daq.CoreType.ctString, daq.CoreType.ctFloat, daq.CoreType.ctInt):
+        elif property_type in (daq.PropertyType.Int, daq.PropertyType.Float, daq.PropertyType.String):
             if prop.suggested_values is not None and len(prop.suggested_values) > 0:
                 return  # handled by overlay combobox
             self.edit_simple_property(selected_item_id, prop.value, path)

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -175,8 +175,10 @@ class PropertiesTreeview(ttk.Treeview):
                 property_value = self._last_method_results.get(property_info.name, '')
             elif property_type in (daq.PropertyType.Struct, daq.PropertyType.Object):
                 property_value = ''
-            elif property_type in (daq.PropertyType.List, daq.PropertyType.Dict):
+            elif property_type == daq.PropertyType.List:
                 property_value = str(node.get_property_value(property_info.name))
+            elif property_type == daq.PropertyType.Dict:
+                property_value = ''
             else:
                 property_value = printed_value(
                     property_info.value_type, node.get_property_value(property_info.name))

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -403,6 +403,9 @@ class PropertiesTreeview(ttk.Treeview):
     def save_simple_value(self, entry, path):
         new_value = entry.get()
         try:
+            prop = utils.get_property_for_path(self.context, path, self.node)
+            if prop is not None and prop.value_type == daq.CoreType.ctRatio:
+                new_value = utils.value_to_coretype(new_value, daq.CoreType.ctRatio)
             self.update_property(self.node, path, new_value)
             self.refresh()
         except Exception:
@@ -898,7 +901,9 @@ class PropertiesTreeview(ttk.Treeview):
         elif property_type in (daq.PropertyType.Dict, daq.PropertyType.List):
             EditContainerPropertyDialog(self, prop, self.context).show()
             self.refresh()
-        elif property_type in (daq.PropertyType.Int, daq.PropertyType.Float, daq.PropertyType.String):
+            return
+        elif property_type in (daq.PropertyType.Int, daq.PropertyType.Float,
+                               daq.PropertyType.String, daq.PropertyType.Ratio):
             if prop.suggested_values is not None and len(prop.suggested_values) > 0:
                 return  # handled by overlay combobox
             self.edit_simple_property(selected_item_id, prop.value, path)

--- a/examples/applications/python/GUI Application/gui_demo/components/load_instance_config_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/load_instance_config_dialog.py
@@ -130,12 +130,7 @@ class LoadInstanceConfigDialog(Dialog):
             self.refresh()
 
         cb.configure(command=on_change)
-        def _on_mousewheel(e):
-            self.yview_scroll(int(-1 * (e.delta / 120)), 'units')
-            self._sync_overlays()
-            return 'break'
-
-        cb.bind('<MouseWheel>', _on_mousewheel)
+        utils.bind_mousewheel_to(cb, self.tree, self._sync_overlays)
         self._overlay_widgets[iid] = cb
 
     def _make_combobox(self, iid, values, current_value, column, editable=False):
@@ -180,9 +175,7 @@ class LoadInstanceConfigDialog(Dialog):
             cb.bind('<Escape>', _clear_active_if_needed)
             cb.bind('<FocusOut>', _clear_active_if_needed)
 
-        cb.bind('<MouseWheel>', lambda e: 'break')
-        cb.bind('<Button-4>', lambda e: 'break')
-        cb.bind('<Button-5>', lambda e: 'break')
+        utils.bind_mousewheel_to(cb, self.tree, self._sync_overlays)
         return cb
 
     def _place_enum_combobox(self, iid, option, meta):

--- a/examples/applications/python/GUI Application/gui_demo/components/load_instance_config_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/load_instance_config_dialog.py
@@ -93,8 +93,8 @@ class LoadInstanceConfigDialog(Dialog):
     # Display helpers
     # ----------------------------
 
-    def _printed_value(self, value_type, value):
-        if value_type == daq.CoreType.ctBool:
+    def _printed_value(self, property_type, value):
+        if property_type == daq.PropertyType.Bool:
             return ''
         if value is None:
             return ''
@@ -211,7 +211,7 @@ class LoadInstanceConfigDialog(Dialog):
         return x, place_y, width, place_height
 
     def _sync_option(self, iid, meta):
-        # Filter - only IDeviceOption.update_mode and IProperty.value_type == ctBool get overlays
+        # Filter - only IDeviceOption.update_mode and IProperty.property_type == Bool get overlays
         if meta['kind'] not in ['device_option', 'property']:
             return
         is_property = meta['kind'] == 'property'
@@ -284,13 +284,15 @@ class LoadInstanceConfigDialog(Dialog):
         # Show PropertyObject contents
         for property in self.context.properties_of_component(prop_object):
             prop = prop_object.get_property_value(property.name)
-            if isinstance(prop, daq.IBaseObject) and daq.IPropertyObject.can_cast_from(prop):
+            property_type = property.property_type
+            if (property_type == daq.PropertyType.Object
+                    and isinstance(prop, daq.IBaseObject) and daq.IPropertyObject.can_cast_from(prop)):
                 cast_property = daq.IPropertyObject.cast_from(prop)
                 node_id = self.tree.insert(
                     parent_node, tk.END, text=property.name, open=True)
                 self.display_config_options(node_id, cast_property)
             else:
-                property_value = self._printed_value(property.item_type, prop)
+                property_value = self._printed_value(property_type, prop)
                 item_id = self.tree.insert(parent_node, tk.END,
                                            text=property.name, values=(property_value, '')
                 )
@@ -298,7 +300,7 @@ class LoadInstanceConfigDialog(Dialog):
                     'kind': 'property',
                     'path': utils.get_item_path(self.tree, item_id),
                     'editable_column': '#1',
-                    'type': 'bool' if property.value_type == daq.CoreType.ctBool else 'other',
+                    'type': 'bool' if property_type == daq.PropertyType.Bool else 'other',
                     'readonly': property.read_only
                 }
 
@@ -487,11 +489,13 @@ class LoadInstanceConfigDialog(Dialog):
             path = meta['path']
             prop = utils.get_property_for_path(self.context, path, self.update_params)
 
-            if prop.value_type in (daq.CoreType.ctDict, daq.CoreType.ctList):
+            property_type = prop.property_type
+
+            if property_type in (daq.PropertyType.Dict, daq.PropertyType.List):
                 EditContainerPropertyDialog(self, prop, self.update_params).show()
                 return
 
-            if prop.value_type == daq.CoreType.ctBool:
+            if property_type == daq.PropertyType.Bool:
                 prop.value = not prop.value
                 self.tree.set(row_id, column, str(prop.value))
                 return

--- a/examples/applications/python/GUI Application/gui_demo/components/metadata_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/metadata_dialog.py
@@ -53,7 +53,7 @@ class MetadataDialog(Dialog):
             # for user to see property value without expanding the tree
             if isinstance(value, daq.IProperty):
                 display_value = value.value
-                if value.value_type == daq.CoreType.ctBool:
+                if value.property_type == daq.PropertyType.Bool:
                     display_value = utils.yes_no[display_value]
             else:
                 display_value = utils.metadata_converters[key](

--- a/examples/applications/python/GUI Application/gui_demo/utils.py
+++ b/examples/applications/python/GUI Application/gui_demo/utils.py
@@ -353,13 +353,14 @@ def update_properties(target: daq.IPropertyObject, source: daq.IPropertyObject):
         source_prop = source.get_property(prop_name)
         target_prop = target.get_property(prop_name)
 
-        if source_prop.value_type != target_prop.value_type:
+        source_property_type = source_prop.property_type
+        if source_property_type != target_prop.property_type:
             continue
 
         if target_prop.read_only:
             continue
 
-        if source_prop.value_type == daq.CoreType.ctObject:
+        if source_property_type == daq.PropertyType.Object:
             update_properties(target_prop.value, source_prop.value)
         else:
             target.set_property_value(prop_name, source_prop.value)

--- a/examples/applications/python/GUI Application/gui_demo/utils.py
+++ b/examples/applications/python/GUI Application/gui_demo/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tkinter as tk
 import enum
 from tkinter import ttk
@@ -248,7 +249,7 @@ def str_to_num_or_eval(num_str: str):
 def value_to_coretype(value, coretype: daq.CoreType):
     # removing unit symbols
     if coretype in (daq.CoreType.ctBool, daq.CoreType.ctInt, daq.CoreType.ctFloat):
-        value = str.split(str.strip(value), ' ')[0]
+        value = str.split(str.strip(str(value)), ' ')[0]
     if coretype == daq.CoreType.ctBool:
         value = value.lower()
         if value in yes_no_inv.keys():
@@ -261,6 +262,12 @@ def value_to_coretype(value, coretype: daq.CoreType):
         return daq.Float(float(value))
     if coretype == daq.CoreType.ctString:
         return daq.String(str(value))
+    if coretype == daq.CoreType.ctRatio:
+        match = re.match(r'\s*(-?\d+)\s*(?:/\s*(-?\d+))?', str(value))
+        if match is None:
+            raise ValueError(f'Not a ratio: {value}')
+        return daq.Ratio(int(match.group(1)),
+                         int(match.group(2)) if match.group(2) else 1)
     raise ValueError(f'Unsupported core type: {coretype}')
 
 

--- a/examples/applications/python/GUI Application/gui_demo/utils.py
+++ b/examples/applications/python/GUI Application/gui_demo/utils.py
@@ -264,6 +264,36 @@ def value_to_coretype(value, coretype: daq.CoreType):
     raise ValueError(f'Unsupported core type: {coretype}')
 
 
+def mousewheel_steps(event) -> int:
+    '''
+    Scroll steps for a mouse wheel event: negative scrolls up, positive down.
+    Covers both the Windows <MouseWheel> delta and X11 <Button-4>/<Button-5>.
+    '''
+    if event.num == 4:
+        return -1
+    if event.num == 5:
+        return 1
+    return int(-event.delta / 120) or (-1 if event.delta > 0 else 1)
+
+
+def bind_mousewheel_to(widget, scrollable, after_scroll=None):
+    '''
+    Scroll `scrollable` when the wheel is used over `widget`.
+
+    A widget placed on top of a scrollable one keeps the wheel to itself, so the
+    scroll has to be passed on by hand. `after_scroll` is called once the view
+    has moved, for callers that have to reposition anything placed on top of it.
+    '''
+    def on_mousewheel(event):
+        scrollable.yview_scroll(mousewheel_steps(event), 'units')
+        if after_scroll is not None:
+            after_scroll()
+        return 'break'
+
+    for sequence in ('<MouseWheel>', '<Button-4>', '<Button-5>'):
+        widget.bind(sequence, on_mousewheel)
+
+
 def get_item_path(tree, item_id):
     path = []
     while item_id:


### PR DESCRIPTION
# Brief

Switches the properties view of the Python GUI demo example from `CoreType` to `IProperty::getPropertyType` for deciding how properties are displayed and how they can be edited, makes ratio properties editable, and hands mouse wheel events over the overlay widgets to the tree behind them.

# Description

## Property type

- Replace `value_type`, `item_type` and `selection_values` with `property_type` in the properties view, the attributes and data descriptor views, the metadata dialog and the instance config dialog
- Selection types are now checked by property type: `Selection` for a plain value list, `IndexSelection` and `SparseSelection`
- Read if a method property is a func/proc once, when the button is built, instead of off the property on every invocation
- Added IDict to the exception to keep empty row instead of displaying `daq::IDict`
- Stop folders collapsing when a component is added to or removed from an object
- Pass the property type to the config dialog printer instead of `item_type`

## Ratio properties

- Make ratio properties editable
- Convert `n/d` and `n` to `daq.Ratio` in `value_to_coretype`
- Accept a non-string value in `value_to_coretype`

## Mouse wheel over overlay widgets

- Fix the properties tree not scrolling while the pointer sits on an overlay combo box or a method button
- Add `utils.bind_mousewheel_to`, binding the Windows `<MouseWheel>` delta and the X11 `<Button-4>` and `<Button-5>` on a widget to scroll the tree behind it

# Implementation details

<details>
<summary><b>Per-feature detail, with the functions each one added or changed</b></summary>

### Property type

Previously there was no deterministic way to check a property's type. `PropertyType` was added in the new release, so the task was to replace `CoreType` and the rest of the fields with it.

The method button and the selection combo boxes used to read the type off the property every time they were used. `execute` did it twice per press, once to check if it was an `IFunction` or an `IProcedure` and again to see if it returned a result. When the view refreshes, the overlay widgets are destroyed and rebuilt, so the type is now read only at building and carried in a default argument, `_is_function` on the button and `_is_keyed` on the combo box.

A minor error was found during this, `daq::IDict` still showed up in cells despite the daq I types being done away with in a previous update. `List` and `Dict` shared an elif arm that put `str(node.get_property_value(name))` in the value cell, and a dict stringifies to `daq::IDict`. `Dict` has its own arm now and leaves the cell empty.

```diff
- LoadInstanceConfigDialog::_printed_value(value_type, value)
+ LoadInstanceConfigDialog::_printed_value(property_type, value)                                             # removed artifact under checkbox (text printed)
- PropertiesTreeview::_place_method_button.execute(_prop, _iid)
+ PropertiesTreeview::_place_method_button.execute(_prop, _iid, _is_function)                                # added to not need to double read the type
- PropertiesTreeview::_place_selection_combobox.on_change(event, _prop, _labels, _indices, _cb)
+ PropertiesTreeview::_place_selection_combobox.on_change(event, _prop, _labels, _indices, _cb, _is_keyed)    # writes the index or key, not the label, for IndexSelection and SparseSelection
```

Edited, mostly switching out `value_type`, `item_type` and the `CoreType` members for `property_type`:

```diff
  PropertiesTreeview::fill_properties(parent_iid, node, hidden)                    # value cell elif chain, the duplicate Proc and Func arms collapsed into one, Struct and Object likewise, List and Dict split apart
  PropertiesTreeview::_collect_overlay_items(parent_iid)                           # selection_values only read once the type says selection
  PropertiesTreeview::_create_overlay_for_item(iid, prop)
  PropertiesTreeview::_sync_overlays()
  PropertiesTreeview::handle_paste()
  PropertiesTreeview::handle_clear_property_value()
  PropertiesTreeview::show_menu(event)
  PropertiesTreeview::edit_value(event)
  LoadInstanceConfigDialog::display_config_options(parent_node, prop_object)       # Object test added ahead of the cast
  LoadInstanceConfigDialog::edit_value(event)
  DataDescriptorTreeview::fill_tree(key, value, parent='')
  AttributesTreeview::fill_tree(key, value, parent='', display_attributes=False)
  MetadataDialog::update.fill_tree(key, value, parent='')
  utils::update_properties(target, source)
```

### Ratio properties

Ratio properties were not editable. `value_to_coretype` had no `ctRatio` case, so nothing turned entry text into a `daq.Ratio`.

The `ctRatio` case takes `n/d` or `n`, pulls the numbers out with `re.match(r'\s*(-?\d+)\s*(?:/\s*(-?\d+))?')` and defaults the denominator to 1. No match raises `ValueError`.

`update_property` hands `new_value` straight to `set_property_value`, so the conversion sits in `save_simple_value` ahead of that call. `Ratio` also joined `Int`, `Float` and `String` in the `edit_value` arm that opens a plain entry.

The unit symbol strip for bool, int and float runs on `str(value)` now. It called `str.strip(value)` directly before, which raises `TypeError` on anything that is not a string.

Edited:

```diff
  utils::value_to_coretype(value, coretype)             # ctRatio branch, and the strip runs on str(value)
  PropertiesTreeview::save_simple_value(entry, path)    # converts a ratio entry before update_property
  PropertiesTreeview::edit_value(event)                 # Ratio added to the plain entry arm
```

### Mouse wheel over overlay widgets

A widget placed on top of a scrollable one takes the wheel event and the tree behind it never sees it. The bool checkboxes bound their own closure that scrolled the tree and re-synced the overlays, on `<MouseWheel>` only. The combo boxes bound `lambda e: 'break'` on `<MouseWheel>`, `<Button-4>` and `<Button-5>`, which swallowed the wheel and left the tree still. The method button bound nothing.

`bind_mousewheel_to` binds all three sequences on one widget, scrolls the widget passed as `scrollable`, calls `after_scroll` if it was given, and returns `'break'`. `mousewheel_steps` returns -1 for `<Button-4>` and 1 for `<Button-5>`, which carry no delta, and otherwise `-event.delta / 120`, falling back to a single step when that rounds to zero.

The overlays are placed by pixel over tree rows, so both callers pass `_sync_overlays` as `after_scroll` to move them once the view has shifted.

```diff
+ utils::mousewheel_steps(event)                                      # Button-4/5 carry no delta, a small Windows delta still moves one step
+ utils::bind_mousewheel_to(widget, scrollable, after_scroll=None)    # one binding set for all three sequences
- PropertiesTreeview::_place_bool_checkbox._on_mousewheel(e)          # scrolled, Windows sequence only
- LoadInstanceConfigDialog::_place_bool_checkbox._on_mousewheel(e)    # the same closure, second copy
```

Edited, local wheel bindings replaced with `utils.bind_mousewheel_to`:

```diff
  PropertiesTreeview::_make_combobox(iid, values, current_value, editable=False)
  LoadInstanceConfigDialog::_make_combobox(iid, values, current_value, column, editable=False)
  PropertiesTreeview::_place_method_button(iid, prop)                                             # had none before, the wheel over the button did nothing
```

</details>

# Usage example

In terminal use:

```shell
cd "examples/applications/python/GUI Application"
python gui_demo.py
```
