### PR TITLE
Python GUI: Enum Properties can be displayed now

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -153,8 +153,8 @@ class PropertiesTreeview(ttk.Treeview):
                 return 'N/A'
             if value_type == daq.CoreType.ctBool:
                 return utils.yes_no[value]
-            elif value_type == daq.CoreType.ctFloat:
-                return self._format_value(value) 
+            elif value_type in (daq.CoreType.ctFloat, daq.CoreType.ctEnumeration):
+                return self._format_value(value)
             else:
                 return value
         
@@ -739,7 +739,11 @@ class PropertiesTreeview(ttk.Treeview):
         enum = daq.IEnumeration.cast_from(prop.value)
         enum_type = enum.enumeration_type
         keys = [k for k, _ in enum_type.as_dictionary.items()]
-        current_key = keys[enum.value] if 0 <= enum.value < len(keys) else keys[0]
+        if not keys:
+            return
+        # Enumerator values need not be a 0-based range, so the current one is
+        # matched by name rather than used as an index into the names.
+        current_key = enum.name if enum.name in keys else keys[0]
         cb = self._make_combobox(iid, keys, current_key)
         if cb is None:
             return
@@ -917,6 +921,10 @@ class PropertiesTreeview(ttk.Treeview):
 
     @staticmethod
     def _format_value(value):
+        if isinstance(value, daq.IEnumeration):
+            # An Enumeration converts to its integer value, so it has to be
+            # named before the numeric formatting below gets to it.
+            return value.name
         try:
             f = float(value)
             if f == int(f):


### PR DESCRIPTION
# Brief

Uses the enumerator for the name of an enumeration property in the properties view, in the value cell and in the editing combo box.

# Description

## Enumeration properties

- Read the current enumerator by name instead of indexing the name list by its integer value
- Print the enumerator name in the value cell instead of its integer value
- Route `ctEnumeration` through the same formatting as `ctFloat` when a value is printed

# Implementation details

<details>
<summary><b>Per-feature detail, with the functions each one added or changed</b></summary>

### Enumeration properties

An enumerator's value is not its index in the type's dictionary, so any enumeration not numbered from zero showed the wrong label. It is matched by name now, and `_format_value` names the `IEnumeration` before its integer gets printed.

</details>

# Usage example

In terminal use:

```shell
cd "examples/applications/python/GUI Application"
python gui_demo.py
```