### PR TITLE
Replay the last value of a constant signal without a domain signal

### DIFF
--- a/core/opendaq/signal/include/opendaq/data_descriptor_impl.h
+++ b/core/opendaq/signal/include/opendaq/data_descriptor_impl.h
@@ -99,6 +99,7 @@ private:
 
     static DictPtr<IString, IBaseObject> PackBuilder(IDataDescriptorBuilder* dataDescriptorBuilder);
     void calculateSampleMemSize();
+    SizeT calculateElementCount() const;
 };
 
 OPENDAQ_REGISTER_DESERIALIZE_FACTORY(DataDescriptorImpl)

--- a/core/opendaq/signal/include/opendaq/data_rule.h
+++ b/core/opendaq/signal/include/opendaq/data_rule.h
@@ -72,7 +72,8 @@ enum class DataRuleType
  *
  * @subsubsection data_rule_linear Constant rule
  * The parameters contain a `constant` number member. The value described by the constant rule is always equal to the
- * constant.
+ * constant. A signal with a constant rule and no domain signal assigned replays its current value to every input
+ * port that connects to it - see `IInputPort::connect`.
  */
 DECLARE_OPENDAQ_INTERFACE(IDataRule, IBaseObject)
 {

--- a/core/opendaq/signal/include/opendaq/data_rule_calc.h
+++ b/core/opendaq/signal/include/opendaq/data_rule_calc.h
@@ -15,6 +15,8 @@
  */
 
 #pragma once
+#include <cstring>
+
 #include <opendaq/data_rule_ptr.h>
 #include <opendaq/signal_exceptions.h>
 #include <opendaq/range_type.h>
@@ -51,7 +53,7 @@ public:
 };
 
 [[maybe_unused]]
-static DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType);
+static DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType, SizeT elementCount = 1);
 
 template <typename T>
 class DataRuleCalcTyped : public DataRuleCalc
@@ -64,10 +66,10 @@ public:
     void calculateLastSample(const NumberPtr& packetOffset, SizeT sampleCount, void* input, SizeT inputSize, void** output) override;
 
 private:
-    friend DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType);
+    friend DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType, SizeT elementCount);
     static std::vector<T> ParseRuleParameters(const DictPtr<IString, IBaseObject>& ruleParameters, DataRuleType type);
 
-    explicit DataRuleCalcTyped(const DataRulePtr& rule);
+    explicit DataRuleCalcTyped(const DataRulePtr& rule, SizeT elementCount = 1);
 
     void* calculateLinearRule(const NumberPtr& packetOffset, SizeT sampleCount) const;
     void* calculateConstantRule(SizeT sampleCount, void* input, SizeT inputSize);
@@ -86,10 +88,13 @@ private:
 
     DataRuleType type;
     std::vector<T> parameters;
+    // Number of values in one sample; above one the constant rule works on whole vectors.
+    SizeT elementCount;
 };
 
 template <typename T>
-DataRuleCalcTyped<T>::DataRuleCalcTyped(const DataRulePtr& rule)
+DataRuleCalcTyped<T>::DataRuleCalcTyped(const DataRulePtr& rule, SizeT elementCount)
+    : elementCount(elementCount == 0 ? 1 : elementCount)
 {
     type = rule.getType();
     parameters = ParseRuleParameters(rule.getParameters(), type);
@@ -246,7 +251,7 @@ void* DataRuleCalcTyped<T>::calculateLinearRule(const NumberPtr& packetOffset, S
 template <typename T>
 void* DataRuleCalcTyped<T>::calculateConstantRule(SizeT sampleCount, void* input, SizeT inputSize)
 {
-    auto output = std::malloc(sampleCount * sizeof(T));
+    auto output = std::malloc(sampleCount * elementCount * sizeof(T));
     if (!output)
         DAQ_THROW_EXCEPTION(NoMemoryException, "Memory allocation failed.");
 
@@ -279,37 +284,38 @@ void DataRuleCalcTyped<T>::calculateLinearRule(const NumberPtr& packetOffset, Si
 template <typename T>
 void DataRuleCalcTyped<T>::calculateConstantRule(SizeT sampleCount, void* input, SizeT inputSize, void** output)
 {
-    if (inputSize < sizeof(T))
+    const size_t valueSize = elementCount * sizeof(T);
+    if (inputSize < valueSize)
         DAQ_THROW_EXCEPTION(InvalidParameterException, "Constant rule data packet must have at least one value");
 
-    constexpr size_t entrySize = sizeof(T) + sizeof(uint32_t);
-    const size_t entryCount = (inputSize - sizeof(T)) / entrySize;
+    const size_t entrySize = valueSize + sizeof(uint32_t);
+    const size_t entryCount = (inputSize - valueSize) / entrySize;
 
-    T* outputTyped = static_cast<T*>(*output);
-    T constant = *static_cast<T*>(input);
+    auto* outputBytes = reinterpret_cast<uint8_t*>(*output);
+    auto* constant = reinterpret_cast<uint8_t*>(input);
 
     SizeT currentEntry = 0;
-    auto* entryPtr = (reinterpret_cast<uint8_t*>(input) + sizeof(T));
+    auto* entryPtr = (reinterpret_cast<uint8_t*>(input) + valueSize);
 
     SizeT sampleIndex = 0;
     while (sampleIndex < sampleCount)
     {
         SizeT upToSamples;
-        T nextConstantValue{};
+        uint8_t* nextConstant = nullptr;
         if (currentEntry++ == entryCount)
             upToSamples = sampleCount;
         else
         {
             upToSamples = *(reinterpret_cast<uint32_t*>(entryPtr));
             entryPtr += sizeof(uint32_t);
-            nextConstantValue = *(reinterpret_cast<T*>(entryPtr));
-            entryPtr += sizeof(T);
+            nextConstant = entryPtr;
+            entryPtr += valueSize;
         }
 
         for (; sampleIndex < upToSamples; sampleIndex++)
-            outputTyped[sampleIndex] = constant;
+            std::memcpy(outputBytes + sampleIndex * valueSize, constant, valueSize);
 
-        constant = nextConstantValue;
+        constant = nextConstant;
     }
 }
 
@@ -327,7 +333,7 @@ inline void* DataRuleCalcTyped<T>::calculateLinearSample(const NumberPtr& packet
 template <typename T>
 inline void* DataRuleCalcTyped<T>::calculateConstantSample(const SizeT sampleIndex, void* input, SizeT inputSize)
 {
-    auto output = std::malloc(sizeof(T));
+    auto output = std::malloc(elementCount * sizeof(T));
     if (!output)
         DAQ_THROW_EXCEPTION(NoMemoryException, "Memory allocation failed.");
 
@@ -357,23 +363,23 @@ inline void DataRuleCalcTyped<T>::calculateLinearSample(const NumberPtr& packetO
 template <typename T>
 inline void DataRuleCalcTyped<T>::calculateConstantSample(const SizeT sampleIndex, void* input, SizeT inputSize, void** output)
 {
-    if (inputSize < sizeof(T))
+    const size_t valueSize = elementCount * sizeof(T);
+    if (inputSize < valueSize)
         DAQ_THROW_EXCEPTION(InvalidParameterException, "Constant rule data packet must have at least one value");
 
-    constexpr size_t entrySize = sizeof(T) + sizeof(uint32_t);
-    const size_t entryCount = (inputSize - sizeof(T)) / entrySize;
+    const size_t entrySize = valueSize + sizeof(uint32_t);
+    const size_t entryCount = (inputSize - valueSize) / entrySize;
 
-    T* outputTyped = static_cast<T*>(*output);
-    T constant = *static_cast<T*>(input);
+    auto* constant = reinterpret_cast<uint8_t*>(input);
 
     SizeT currentEntry = 0;
-    auto* entryPtr = (reinterpret_cast<uint8_t*>(input) + sizeof(T));
+    auto* entryPtr = (reinterpret_cast<uint8_t*>(input) + valueSize);
 
     SizeT currentSampleIndex = 0;
     while (currentSampleIndex <= sampleIndex)
     {
         SizeT upToSamples;
-        T nextConstantValue{};
+        uint8_t* nextConstant = nullptr;
         if (currentEntry++ == entryCount)
         {
             upToSamples = sampleIndex;
@@ -382,18 +388,18 @@ inline void DataRuleCalcTyped<T>::calculateConstantSample(const SizeT sampleInde
         {
             upToSamples = *(reinterpret_cast<uint32_t*>(entryPtr));
             entryPtr += sizeof(uint32_t);
-            nextConstantValue = *(reinterpret_cast<T*>(entryPtr));
-            entryPtr += sizeof(T);
+            nextConstant = entryPtr;
+            entryPtr += valueSize;
         }
 
         if (upToSamples >= sampleIndex)
             break;
 
         currentSampleIndex = upToSamples;
-        constant = nextConstantValue;
+        constant = nextConstant;
     }
 
-    *outputTyped = constant;
+    std::memcpy(*output, constant, valueSize);
 }
 
 template <typename T>
@@ -405,68 +411,66 @@ inline void DataRuleCalcTyped<T>::calculateLastLinearSample(const NumberPtr& pac
 template <typename T>
 inline void DataRuleCalcTyped<T>::calculateLastConstantSample(const SizeT sampleCount, void* input, SizeT inputSize, void** output)
 {
-    if (inputSize < sizeof(T))
+    const size_t valueSize = elementCount * sizeof(T);
+    if (inputSize < valueSize)
         DAQ_THROW_EXCEPTION(InvalidParameterException, "Constant rule data packet must have at least one value");
 
-    constexpr size_t entrySize = sizeof(T) + sizeof(uint32_t);
-    const size_t entryCount = (inputSize - sizeof(T)) / entrySize;
+    const size_t entrySize = valueSize + sizeof(uint32_t);
+    const size_t entryCount = (inputSize - valueSize) / entrySize;
 
-    T* outputTyped = static_cast<T*>(*output);
     auto* basePtr = reinterpret_cast<uint8_t*>(input);
-    T initialConstant = *reinterpret_cast<T*>(basePtr);
 
     if (entryCount == 0)
     {
-        *outputTyped = initialConstant;
+        std::memcpy(*output, basePtr, valueSize);
         return;
     }
 
-    auto* entriesStart = basePtr + sizeof(T);
+    auto* entriesStart = basePtr + valueSize;
     auto* entryPtr = entriesStart + (entryCount - 1) * entrySize;
 
     // Walk backwards until we find the largest upToSamples < sampleCount
     for (SizeT i = entryCount; i > 0; --i, entryPtr -= entrySize)
     {
         uint32_t upToSamples = *reinterpret_cast<uint32_t*>(entryPtr);
-        T value = *reinterpret_cast<T*>(entryPtr + sizeof(uint32_t));
 
         if (sampleCount - 1 > upToSamples)
         {
-            *outputTyped = value;
+            std::memcpy(*output, entryPtr + sizeof(uint32_t), valueSize);
             return;
         }
     }
 
     // If all upToSamples are >= sampleCount - 1, use the initial constant
-    *outputTyped = initialConstant;
+    std::memcpy(*output, basePtr, valueSize);
 }
 
-static DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType)
+static DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType, SizeT elementCount)
 {
     switch (outputType)
     {
         case SampleType::Float32:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Float32>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Float32>::Type>(outputRule, elementCount);
         case SampleType::Float64:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Float64>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Float64>::Type>(outputRule, elementCount);
         case SampleType::UInt8:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt8>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt8>::Type>(outputRule, elementCount);
         case SampleType::Int8:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int8>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int8>::Type>(outputRule, elementCount);
         case SampleType::UInt16:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt16>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt16>::Type>(outputRule, elementCount);
         case SampleType::Int16:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int16>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int16>::Type>(outputRule, elementCount);
         case SampleType::UInt32:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt32>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt32>::Type>(outputRule, elementCount);
         case SampleType::Int32:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int32>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int32>::Type>(outputRule, elementCount);
         case SampleType::UInt64:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt64>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::UInt64>::Type>(outputRule, elementCount);
         case SampleType::Int64:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int64>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::Int64>::Type>(outputRule, elementCount);
         case SampleType::RangeInt64:
-            return new DataRuleCalcTyped<SampleTypeToType<SampleType::RangeInt64>::Type>(outputRule);
+            return new DataRuleCalcTyped<SampleTypeToType<SampleType::RangeInt64>::Type>(outputRule, elementCount);
         case SampleType::Binary:
         case SampleType::ComplexFloat32:
         case SampleType::ComplexFloat64:

--- a/core/opendaq/signal/include/opendaq/input_port.h
+++ b/core/opendaq/signal/include/opendaq/input_port.h
@@ -66,6 +66,13 @@ DECLARE_OPENDAQ_INTERFACE(IInputPort, IComponent)
      * @retval OPENDAQ_ERR_NOTASSIGNED if the accepted signal criteria is not defined by the input port.
      *
      * The signal is notified of the connection formed between it and the input port.
+     *
+     * A "Data descriptor changed" event packet is enqueued into the new connection before this method returns.
+     * If the signal uses a constant data rule and has no domain signal assigned, its current value is enqueued
+     * right after that event packet, as a single-sample constant data packet with no domain packet. Such a signal
+     * changes rarely, so without it a newly connected input port would learn nothing until the next change.
+     * Nothing is enqueued if the signal has no value yet, if its value predates its current descriptor, if the
+     * signal or the input port is inactive, or if `ISignalPrivate::enableKeepLastValue` is disabled.
      */
     virtual ErrCode INTERFACE_FUNC connect(ISignal* signal) = 0;
 

--- a/core/opendaq/signal/include/opendaq/packet_factory.h
+++ b/core/opendaq/signal/include/opendaq/packet_factory.h
@@ -104,6 +104,33 @@ DataPacketPtr ConstantDataPacketWithDomain(const DataPacketPtr& domainPacket,
 }
 
 /*!
+ * @brief Creates a single-sample constant rule Data packet with no domain packet.
+ * @param descriptor The descriptor of the signal sending the data. Its rule must be a constant rule.
+ * @param value The constant value.
+ *
+ * Intended for signals that carry a level-held value and have no domain signal assigned.
+ */
+template <class T>
+DataPacketPtr ConstantDataPacket(const DataDescriptorPtr& descriptor, T value)
+{
+    DataPacketPtr obj(ConstantDataPacketWithDomain_Create(nullptr, descriptor, 1, reinterpret_cast<void*>(&value), nullptr, 0));
+    return obj;
+}
+
+/*!
+ * @brief Creates a single-sample constant rule Data packet with no domain packet from a raw value.
+ * @param descriptor The descriptor of the signal sending the data. Its rule must be a constant rule.
+ * @param rawValue Pointer to the constant value, laid out as the descriptor's sample type.
+ *
+ * The value is copied into the packet, so the caller keeps ownership of @p rawValue.
+ */
+inline DataPacketPtr ConstantDataPacketWithRawValue(const DataDescriptorPtr& descriptor, void* rawValue)
+{
+    DataPacketPtr obj(ConstantDataPacketWithDomain_Create(nullptr, descriptor, 1, rawValue, nullptr, 0));
+    return obj;
+}
+
+/*!
  * @brief Creates a Data packet with a given descriptor, sample count,
  * a reference to a packet that describes the domain (time) data,
  * pointer to an existing memory location and a deleter, and an optional packet offset.

--- a/core/opendaq/signal/include/opendaq/packet_factory.h
+++ b/core/opendaq/signal/include/opendaq/packet_factory.h
@@ -104,6 +104,31 @@ DataPacketPtr ConstantDataPacketWithDomain(const DataPacketPtr& domainPacket,
 }
 
 /*!
+ * @brief Creates a constant rule Data packet for a non-scalar signal, with a reference to a packet that
+ * describes the domain (time) data.
+ * @param domainPacket The Data packet carrying domain data.
+ * @param descriptor The descriptor of the signal sending the data. Its rule must be a constant rule.
+ * @param sampleCount The number of samples the constant covers.
+ * @param values The constant value, one entry per element of a sample.
+ *
+ * The number of values must match the element count the descriptor's dimensions describe. The value is
+ * held for every sample of the packet, so its size does not grow with the sample count.
+ */
+template <class T>
+DataPacketPtr ConstantDataPacketWithDomain(const DataPacketPtr& domainPacket,
+                                           const DataDescriptorPtr& descriptor,
+                                           uint64_t sampleCount,
+                                           const std::vector<T>& values)
+{
+    if (values.size() * sizeof(T) != descriptor.getSampleSize())
+        DAQ_THROW_EXCEPTION(InvalidParameterException, "Number of constant values does not match the descriptor's sample size.");
+
+    DataPacketPtr obj(ConstantDataPacketWithDomain_Create(
+        domainPacket, descriptor, static_cast<SizeT>(sampleCount), reinterpret_cast<void*>(const_cast<T*>(values.data())), nullptr, 0));
+    return obj;
+}
+
+/*!
  * @brief Creates a single-sample constant rule Data packet with no domain packet.
  * @param descriptor The descriptor of the signal sending the data. Its rule must be a constant rule.
  * @param value The constant value.
@@ -114,6 +139,25 @@ template <class T>
 DataPacketPtr ConstantDataPacket(const DataDescriptorPtr& descriptor, T value)
 {
     DataPacketPtr obj(ConstantDataPacketWithDomain_Create(nullptr, descriptor, 1, reinterpret_cast<void*>(&value), nullptr, 0));
+    return obj;
+}
+
+/*!
+ * @brief Creates a single-sample constant rule Data packet with no domain packet for a non-scalar signal.
+ * @param descriptor The descriptor of the signal sending the data. Its rule must be a constant rule.
+ * @param values The constant value, one entry per element of a sample.
+ *
+ * Intended for signals that carry a level-held vector and have no domain signal assigned. The number of
+ * values must match the element count the descriptor's dimensions describe.
+ */
+template <class T>
+DataPacketPtr ConstantDataPacket(const DataDescriptorPtr& descriptor, const std::vector<T>& values)
+{
+    if (values.size() * sizeof(T) != descriptor.getSampleSize())
+        DAQ_THROW_EXCEPTION(InvalidParameterException, "Number of constant values does not match the descriptor's sample size.");
+
+    DataPacketPtr obj(ConstantDataPacketWithDomain_Create(
+        nullptr, descriptor, 1, reinterpret_cast<void*>(const_cast<T*>(values.data())), nullptr, 0));
     return obj;
 }
 

--- a/core/opendaq/signal/include/opendaq/signal_impl.h
+++ b/core/opendaq/signal/include/opendaq/signal_impl.h
@@ -166,6 +166,8 @@ private:
     void disconnectInputPort(const ConnectionPtr& connection);
     void clearConnections(std::vector<ConnectionPtr>& connections);
     void setKeepLastPacket();
+    bool isConstantWithoutDomain();
+    DataPacketPtr createLastValuePacket();
     TypePtr addToTypeManagerRecursively(const TypeManagerPtr& typeManager,
                                         const DataDescriptorPtr& descriptor) const;
     void buildTempConnections(TempConnections& tempConnections);
@@ -409,6 +411,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDescriptor(IDataDescriptor* de
         auto lock = this->getRecursiveConfigLock2();
 
         dataDescriptor = descriptorPtr;
+        setKeepLastPacket();
         const auto packet = DataDescriptorChangedEventPacket(descriptorToEventPacketParam(dataDescriptor), nullptr);
 
         // Should this return a failure error code or execute all sendPacket calls and return one of the errors?
@@ -507,6 +510,8 @@ ErrCode SignalBase<TInterface, Interfaces...>::setDomainSignal(ISignal* signal)
 
         if (domainSignal.assigned())
             domainSignal.asPtr<ISignalEvents>().domainSignalReferenceSet(this->template borrowPtr<SignalPtr>());
+
+        setKeepLastPacket();
     }
 
     if (!this->coreEventMuted && this->coreEvent.assigned())
@@ -887,6 +892,9 @@ ErrCode SignalBase<TInterface, Interfaces...>::listenerConnectedInternal(IConnec
     
     const auto packet = createDataDescriptorChangedEventPacket();
 
+    // A constant signal without a domain signal changes rarely, so hand the new listener the current value.
+    const auto lastValuePacket = createLastValuePacket();
+
     if (connections.empty())
     {
         const ErrCode errCode = wrapHandler(this, &Self::onListenedStatusChanged, true);
@@ -896,9 +904,17 @@ ErrCode SignalBase<TInterface, Interfaces...>::listenerConnectedInternal(IConnec
     connections.push_back(connectionPtr);
 
     if (!schedule)
+    {
         connectionPtr.enqueueOnThisThread(packet);
+        if (lastValuePacket.assigned())
+            connectionPtr.enqueueOnThisThread(lastValuePacket);
+    }
     else
+    {
         connectionPtr.enqueueWithScheduler(packet);
+        if (lastValuePacket.assigned())
+            connectionPtr.enqueueWithScheduler(lastValuePacket);
+    }
 
     return OPENDAQ_SUCCESS;
 }
@@ -1074,6 +1090,7 @@ ErrCode SignalBase<TInterface, Interfaces...>::clearDomainSignalWithoutNotificat
     auto lock = this->getRecursiveConfigLock2();
 
     domainSignal = nullptr;
+    setKeepLastPacket();
 
     return OPENDAQ_SUCCESS;
 }
@@ -1266,9 +1283,40 @@ ErrCode SignalBase<TInterface, Interfaces...>::enableKeepLastValue(Bool enabled)
 }
 
 template <typename TInterface, typename... Interfaces>
+bool SignalBase<TInterface, Interfaces...>::isConstantWithoutDomain()
+{
+    if (onGetDomainSignal().assigned())
+        return false;
+
+    const auto descriptor = onGetDescriptor();
+    if (!descriptor.assigned())
+        return false;
+
+    const auto rule = descriptor.getRule();
+    return rule.assigned() && rule.getType() == DataRuleType::Constant;
+}
+
+template <typename TInterface, typename... Interfaces>
+DataPacketPtr SignalBase<TInterface, Interfaces...>::createLastValuePacket()
+{
+    if (!this->active || !isConstantWithoutDomain())
+        return nullptr;
+
+    if (!lastValueCache.valueDescriptorCached())
+        return nullptr;
+
+    // A value captured under an older descriptor would contradict the descriptor announced on connect.
+    const auto& cachedDescriptor = lastValueCache.getValueDataDescriptor();
+    if (!BaseObjectPtr::Equals(cachedDescriptor, onGetDescriptor()))
+        return nullptr;
+
+    return ConstantDataPacketWithRawValue(cachedDescriptor, lastValueCache.getRawValueData());
+}
+
+template <typename TInterface, typename... Interfaces>
 void SignalBase<TInterface, Interfaces...>::setKeepLastPacket()
 {
-    keepLastPacket = keepLastValue && isPublic;
+    keepLastPacket = keepLastValue && (isPublic || isConstantWithoutDomain());
 
     if (!keepLastPacket)
     {

--- a/core/opendaq/signal/src/data_descriptor_impl.cpp
+++ b/core/opendaq/signal/src/data_descriptor_impl.cpp
@@ -174,14 +174,18 @@ ErrCode INTERFACE_FUNC DataDescriptorImpl::getReferenceDomainInfo(IReferenceDoma
     return OPENDAQ_SUCCESS;
 }
 
-void DataDescriptorImpl::calculateSampleMemSize()
+SizeT DataDescriptorImpl::calculateElementCount() const
 {
     size_t elementCnt = 1;
     for (const auto& dimension : dimensions)
         elementCnt *= dimension.getSize();
 
-    if (elementCnt == 0)
-        elementCnt = 1;
+    return elementCnt == 0 ? 1 : elementCnt;
+}
+
+void DataDescriptorImpl::calculateSampleMemSize()
+{
+    const size_t elementCnt = calculateElementCount();
 
     if (!structFields.assigned() || structFields.getCount() == 0)
     {
@@ -419,7 +423,7 @@ void DataDescriptorImpl::initCalcs()
         return;
 
     if (dataRule.assigned() && (dataRule.getType() == DataRuleType::Constant || dataRule.getType() == DataRuleType::Linear))
-        dataRuleCalc = std::unique_ptr<DataRuleCalc>(createDataRuleCalcTyped(dataRule, sampleType));
+        dataRuleCalc = std::unique_ptr<DataRuleCalc>(createDataRuleCalcTyped(dataRule, sampleType, calculateElementCount()));
 
     if (scaling.assigned())
         scalingCalc = std::unique_ptr<ScalingCalc>(createScalingCalcTyped(scaling));

--- a/core/opendaq/signal/tests/test_data_packet.cpp
+++ b/core/opendaq/signal/tests/test_data_packet.cpp
@@ -1193,3 +1193,146 @@ TEST_F(DataPacketTest, GetValueByIndex)
         }
     }
 }
+
+// Constant rule signals with dimensions
+
+static DataDescriptorPtr setupVectorDescriptor(SampleType type, size_t elementCount)
+{
+    return DataDescriptorBuilder()
+        .setSampleType(type)
+        .setDimensions(List<IDimension>(Dimension(LinearDimensionRule(1, 0, elementCount))))
+        .setRule(ConstantDataRule())
+        .build();
+}
+
+static DataPacketPtr constantVectorPacket(const DataDescriptorPtr& descriptor,
+                                          SizeT sampleCount,
+                                          void* initialValue,
+                                          void* otherValues = nullptr,
+                                          SizeT otherValueCount = 0)
+{
+    return DataPacketPtr(
+        ConstantDataPacketWithDomain_Create(nullptr, descriptor, sampleCount, initialValue, otherValues, otherValueCount));
+}
+
+TEST_F(DataPacketTest, ConstantRuleVectorExpandsEveryElement)
+{
+    const auto descriptor = setupVectorDescriptor(SampleType::Int32, 4);
+    ASSERT_EQ(descriptor.getSampleSize(), 4u * sizeof(int32_t));
+
+    std::vector<int32_t> value{1, 2, 3, 4};
+    const auto packet = constantVectorPacket(descriptor, 3, value.data());
+
+    ASSERT_EQ(packet.getDataSize(), 3u * 4u * sizeof(int32_t));
+
+    const auto* data = static_cast<const int32_t*>(packet.getData());
+    for (size_t sample = 0; sample < 3; ++sample)
+        for (size_t element = 0; element < 4; ++element)
+            ASSERT_EQ(data[sample * 4 + element], value[element]) << "sample " << sample << " element " << element;
+}
+
+TEST_F(DataPacketTest, ConstantRuleVectorWithValueChanges)
+{
+    const auto descriptor = setupVectorDescriptor(SampleType::Int32, 2);
+
+    std::vector<int32_t> initial{1, 2};
+
+    // [position][value…] entries, laid out by hand because the typed factory only builds scalar entries
+    std::vector<uint8_t> entries(2 * (sizeof(uint32_t) + 2 * sizeof(int32_t)));
+    auto* entry = entries.data();
+    const auto writeEntry = [&entry](uint32_t position, int32_t first, int32_t second)
+    {
+        std::memcpy(entry, &position, sizeof(position));
+        entry += sizeof(position);
+        std::memcpy(entry, &first, sizeof(first));
+        entry += sizeof(first);
+        std::memcpy(entry, &second, sizeof(second));
+        entry += sizeof(second);
+    };
+    writeEntry(2, 3, 4);
+    writeEntry(4, 5, 6);
+
+    const auto packet = constantVectorPacket(descriptor, 6, initial.data(), entries.data(), 2);
+
+    const std::vector<int32_t> expected{1, 2, 1, 2, 3, 4, 3, 4, 5, 6, 5, 6};
+    const auto* data = static_cast<const int32_t*>(packet.getData());
+    for (size_t i = 0; i < expected.size(); ++i)
+        ASSERT_EQ(data[i], expected[i]) << "index " << i;
+}
+
+TEST_F(DataPacketTest, ConstantRuleVectorRawLastValue)
+{
+    const auto descriptor = setupVectorDescriptor(SampleType::Int32, 4);
+
+    std::vector<int32_t> value{7, 8, 9, 10};
+    const auto packet = constantVectorPacket(descriptor, 5, value.data());
+
+    std::vector<int32_t> lastValue(4, 0);
+    void* rawLastValue = lastValue.data();
+    ASSERT_EQ(packet->getRawLastValue(&rawLastValue), OPENDAQ_SUCCESS);
+    ASSERT_EQ(lastValue, value);
+}
+
+TEST_F(DataPacketTest, ConstantRuleVectorGetLastValue)
+{
+    const auto descriptor = setupVectorDescriptor(SampleType::Int64, 3);
+
+    std::vector<int64_t> value{11, 12, 13};
+    const auto packet = constantVectorPacket(descriptor, 2, value.data());
+
+    const ListPtr<IBaseObject> lastValue = packet.getLastValue();
+    ASSERT_EQ(lastValue.getCount(), 3u);
+    ASSERT_EQ(lastValue[0], 11);
+    ASSERT_EQ(lastValue[1], 12);
+    ASSERT_EQ(lastValue[2], 13);
+}
+
+TEST_F(DataPacketTest, ConstantDataPacketVectorFactory)
+{
+    const auto descriptor = setupVectorDescriptor(SampleType::Float64, 2);
+
+    const auto packet = ConstantDataPacket(descriptor, std::vector<double>{1.5, 2.5});
+    const auto* data = static_cast<const double*>(packet.getData());
+    ASSERT_EQ(data[0], 1.5);
+    ASSERT_EQ(data[1], 2.5);
+
+    ASSERT_THROW(ConstantDataPacket(descriptor, std::vector<double>{1.5}), InvalidParameterException);
+    ASSERT_THROW(ConstantDataPacket(descriptor, std::vector<double>{1.5, 2.5, 3.5}), InvalidParameterException);
+}
+
+TEST_F(DataPacketTest, ConstantDataPacketWithDomainVectorFactory)
+{
+    const auto descriptor = setupVectorDescriptor(SampleType::Int32, 3);
+    const auto domainDescriptor = setupDescriptor(SampleType::Int64, LinearDataRule(1, 0), nullptr);
+    const auto domainPacket = DataPacket(domainDescriptor, 4, 0);
+
+    const auto packet = ConstantDataPacketWithDomain(domainPacket, descriptor, 4, std::vector<int32_t>{7, 8, 9});
+
+    ASSERT_EQ(packet.getSampleCount(), 4u);
+    ASSERT_EQ(packet.getDomainPacket(), domainPacket);
+
+    // One value held across every sample of the packet.
+    const auto* data = static_cast<const int32_t*>(packet.getData());
+    for (size_t sample = 0; sample < 4; ++sample)
+    {
+        ASSERT_EQ(data[sample * 3 + 0], 7);
+        ASSERT_EQ(data[sample * 3 + 1], 8);
+        ASSERT_EQ(data[sample * 3 + 2], 9);
+    }
+
+    ASSERT_THROW(ConstantDataPacketWithDomain(domainPacket, descriptor, 4, std::vector<int32_t>{7, 8}), InvalidParameterException);
+}
+
+TEST_F(DataPacketTest, ConstantDataPacketWithDomainScalarOverloadStillResolves)
+{
+    const auto descriptor = setupDescriptor(SampleType::Int32, ConstantDataRule(), nullptr);
+    const auto domainDescriptor = setupDescriptor(SampleType::Int64, LinearDataRule(1, 0), nullptr);
+    const auto domainPacket = DataPacket(domainDescriptor, 2, 0);
+
+    // The scalar overload takes the value by itself, and partial ordering keeps the two apart.
+    const auto packet = ConstantDataPacketWithDomain<int32_t>(domainPacket, descriptor, 2, 5);
+
+    const auto* data = static_cast<const int32_t*>(packet.getData());
+    ASSERT_EQ(data[0], 5);
+    ASSERT_EQ(data[1], 5);
+}

--- a/core/opendaq/signal/tests/test_gap_checks.cpp
+++ b/core/opendaq/signal/tests/test_gap_checks.cpp
@@ -7,6 +7,9 @@
 #include <opendaq/data_descriptor_factory.h>
 #include <opendaq/sample_type_traits.h>
 #include <opendaq/event_packet_params.h>
+#include <opendaq/data_rule_factory.h>
+#include <opendaq/input_port_factory.h>
+#include <opendaq/signal_factory.h>
 
 using namespace daq;
 using namespace testing;
@@ -339,4 +342,24 @@ TYPED_TEST(GapCheckTest, MultiplePackets)
     connection.enqueue(packet7);
     pkt = connection.dequeue();
     ASSERT_EQ(pkt, packet7);
+}
+
+// A constant signal without a domain signal replays its value on connect; gap checking must
+// resolve to "not available" from the descriptor event rather than inspecting a domain packet.
+TEST(GapCheckConstantSignalTest, ConstantNoDomainReplayOnConnect)
+{
+    const auto ctx = NullContext();
+
+    const auto signal = Signal(ctx, nullptr, "sig");
+    const auto descriptor = DataDescriptorBuilder().setSampleType(SampleType::Int64).setRule(ConstantDataRule()).build();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    const auto port = InputPort(ctx, nullptr, "ip", true);
+    ASSERT_NO_THROW(port.connect(signal));
+
+    const auto packets = port.getConnection().dequeueAll();
+    ASSERT_EQ(packets.getCount(), 2u);
+    ASSERT_EQ(packets[0].getType(), PacketType::Event);
+    ASSERT_EQ(packets[1].asPtr<IDataPacket>().getLastValue(), 7);
 }

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -3304,3 +3304,37 @@ TEST_F(SignalTest, ExplicitRuleWithoutDomainSignalDoesNotReplay)
 
     ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
 }
+
+TEST_F(SignalTest, ConstantVectorNoDomainReplaysLastValueOnConnect)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = DataDescriptorBuilder()
+                                .setName("const")
+                                .setSampleType(SampleType::Int32)
+                                .setDimensions(List<IDimension>(Dimension(LinearDimensionRule(1, 0, 3))))
+                                .setRule(ConstantDataRule())
+                                .build();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, std::vector<int32_t>{4, 5, 6}));
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    const auto packets = ip.getConnection().dequeueAll();
+    ASSERT_EQ(packets.getCount(), 2u);
+    ASSERT_EQ(packets[0].getType(), PacketType::Event);
+
+    const auto dataPacket = packets[1].asPtr<IDataPacket>();
+    ASSERT_EQ(dataPacket.getSampleCount(), 1u);
+    ASSERT_FALSE(dataPacket.getDomainPacket().assigned());
+
+    const auto* data = static_cast<const int32_t*>(dataPacket.getData());
+    ASSERT_EQ(data[0], 4);
+    ASSERT_EQ(data[1], 5);
+    ASSERT_EQ(data[2], 6);
+
+    const ListPtr<IBaseObject> lastValue = signal.getLastValue();
+    ASSERT_EQ(lastValue.getCount(), 3u);
+    ASSERT_EQ(lastValue[2], 6);
+}

--- a/core/opendaq/signal/tests/test_signal.cpp
+++ b/core/opendaq/signal/tests/test_signal.cpp
@@ -3134,3 +3134,173 @@ TEST_F(SignalTest, SetDomainDescriptorUnderLock)
     for (int i = 0; i < 10; ++i)
         signal.setPropertyValue("Test", i);
 }
+
+static DataDescriptorPtr ConstantDescriptor(SampleType sampleType = SampleType::Int64)
+{
+    return DataDescriptorBuilder().setName("const").setSampleType(sampleType).setRule(ConstantDataRule()).build();
+}
+
+TEST_F(SignalTest, ConstantNoDomainReplaysLastValueOnConnect)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    const auto packets = ip.getConnection().dequeueAll();
+    ASSERT_EQ(packets.getCount(), 2u);
+    ASSERT_EQ(packets[0].getType(), PacketType::Event);
+
+    const auto dataPacket = packets[1].asPtr<IDataPacket>();
+    ASSERT_EQ(dataPacket.getSampleCount(), 1u);
+    ASSERT_FALSE(dataPacket.getDomainPacket().assigned());
+    ASSERT_EQ(dataPacket.getLastValue(), 7);
+    ASSERT_EQ(signal.getLastValue(), 7);
+}
+
+TEST_F(SignalTest, ConstantNoDomainReplaysToEveryConnection)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    const auto ip1 = InputPort(context, nullptr, "ip1");
+    const auto ip2 = InputPort(context, nullptr, "ip2");
+    ip1.connect(signal);
+    ip2.connect(signal);
+
+    ASSERT_EQ(ip1.getConnection().getPacketCount(), 2u);
+    ASSERT_EQ(ip2.getConnection().getPacketCount(), 2u);
+}
+
+TEST_F(SignalTest, ConstantNoDomainNoReplayWithoutValue)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    signal.setDescriptor(ConstantDescriptor());
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
+}
+
+TEST_F(SignalTest, ConstantNoDomainNoReplayAfterDescriptorChanged)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    signal.setDescriptor(ConstantDescriptor(SampleType::Int32));
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
+}
+
+TEST_F(SignalTest, ConstantNoDomainNoReplayWhenSignalInactive)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+    signal.setActive(false);
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
+}
+
+TEST_F(SignalTest, ConstantNoDomainNoReplayWhenPortInactive)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.setActive(false);
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
+}
+
+TEST_F(SignalTest, ConstantNoDomainNoReplayWhenKeepLastValueDisabled)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    signal.asPtr<ISignalPrivate>().enableKeepLastValue(false);
+
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
+}
+
+TEST_F(SignalTest, ConstantNoDomainReplaysOnPrivateSignal)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    signal.setPublic(false);
+
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    ASSERT_EQ(signal.getLastValue(), 7);
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 2u);
+}
+
+TEST_F(SignalTest, ConstantWithDomainSignalDoesNotReplay)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = ConstantDescriptor();
+    signal.setDescriptor(descriptor);
+    signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));
+
+    const auto domainSignal = Signal(context, nullptr, "time");
+    signal.setDomainSignal(domainSignal);
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
+}
+
+TEST_F(SignalTest, ExplicitRuleWithoutDomainSignalDoesNotReplay)
+{
+    const auto context = NullContext();
+    const auto signal = Signal(context, nullptr, "sig");
+    const auto descriptor = DataDescriptorBuilder().setName("test").setSampleType(SampleType::Int64).build();
+    signal.setDescriptor(descriptor);
+
+    auto dataPacket = DataPacket(descriptor, 1);
+    static_cast<int64_t*>(dataPacket.getData())[0] = 7;
+    signal.sendPacket(dataPacket);
+
+    const auto ip = InputPort(context, nullptr, "ip");
+    ip.connect(signal);
+
+    ASSERT_EQ(ip.getConnection().getPacketCount(), 1u);
+}

--- a/docs/Antora/modules/explanations/pages/signals.adoc
+++ b/docs/Antora/modules/explanations/pages/signals.adoc
@@ -126,6 +126,14 @@ calculated depending on the Rule type. Currently, two rules are available in ope
 
 * **Constant Rule**: All values of the signal are equal to the `constant` defined in the packet.
 
+A Signal with a _Constant_ Data Rule and no Domain Signal assigned carries a value that changes rarely, so a newly
+connected Input Port would otherwise have no way of learning the current value until the next change. Such a Signal
+therefore replays its current value on connect: right after the "Data descriptor changed" event packet, it enqueues a
+single-sample constant Data Packet with no domain packet, before `connect` returns. Nothing is replayed if the Signal
+has not produced a value yet, if the value predates the Signal's current Data Descriptor, or if either the Signal or
+the Input Port is inactive. Over Native Streaming the same value reaches every subscribing client, including clients
+that subscribe after the value was produced.
+
 For Domain Signals that have either _Explicit_ and _Linear_ Data rule, Reference Domain Offset is added to each sample if available in Reference Domain Info of the Domain Signal's Data Descriptor.
 
 === Dimensions

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/include/ref_fb_module/constant_value_fb_impl.h
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/include/ref_fb_module/constant_value_fb_impl.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <opendaq/function_block_impl.h>
+#include <opendaq/sample_type.h>
+#include <ref_fb_module/common.h>
+
+BEGIN_NAMESPACE_REF_FB_MODULE
+
+namespace ConstantValue
+{
+
+class ConstantValueFbImpl final : public FunctionBlock
+{
+public:
+    explicit ConstantValueFbImpl(const ModuleInfoPtr& moduleInfo,
+                                 const ContextPtr& ctx,
+                                 const ComponentPtr& parent,
+                                 const StringPtr& localId);
+    ~ConstantValueFbImpl() override = default;
+
+    static FunctionBlockTypePtr CreateType(const ModuleInfoPtr& moduleInfo);
+
+    void onPacketReceived(const InputPortPtr& port) override;
+    void onConnected(const InputPortPtr& port) override;
+    void onDisconnected(const InputPortPtr& port) override;
+
+private:
+    void createSignals();
+    void createInputPorts();
+    void initProperties();
+
+    void configure();
+    DataDescriptorPtr buildDescriptor() const;
+
+    template <typename T, typename Source>
+    void storeValue(const std::vector<Source>& values);
+
+    void emitValue();
+    void processEventPacket(const EventPacketPtr& packet);
+    void processDomainPacket(const DataPacketPtr& packet);
+
+    InputPortConfigPtr inputPort;
+    SignalConfigPtr outputSignal;
+    SignalConfigPtr outputDomainSignal;
+    DataDescriptorPtr dataDescriptor;
+    DataDescriptorPtr domainDescriptor;
+    SampleType sampleType;
+    size_t elementCount;
+    bool domainConnected;
+
+    std::unique_ptr<uint8_t[]> rawValue;
+    size_t rawValueSize;
+
+    bool valueEmitted;
+    SampleType emittedSampleType;
+    std::unique_ptr<uint8_t[]> emittedRawValue;
+    size_t emittedRawValueSize;
+};
+}
+
+END_NAMESPACE_REF_FB_MODULE

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/include/ref_fb_module/renderer_fb_impl.h
@@ -39,6 +39,7 @@
 #include <thread>
 #include <condition_variable>
 #include <queue>
+#include <string>
 #include <variant>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
@@ -82,6 +83,10 @@ struct SignalContext
     std::deque<DataPacketPtr> dataPacketsInFreezeMode;
 
     bool valid{ false };
+    bool domainless{ false };
+    bool constantValueSet{ false };
+    double constantValue{ 0 };
+    std::string constantValueText;
     double max{ 0 };
     double min{ 0 };
     int64_t durationInTicks;
@@ -185,6 +190,15 @@ private:
     template <SampleType DST>
     void renderSignal(SignalContext& signalContext, sf::RenderTarget& renderTarget, const sf::Font& renderFont);
 
+    void renderDomainlessSignal(SignalContext& signalContext, sf::RenderTarget& renderTarget, const sf::Font& renderFont);
+    void renderValueStrip(SignalContext& signalContext, sf::RenderTarget& renderTarget, const sf::Font& renderFont);
+    void renderValueProfile(SignalContext& signalContext, sf::RenderTarget& renderTarget);
+    void renderValueLine(SignalContext& signalContext, sf::RenderTarget& renderTarget);
+    void renderValueLabel(SignalContext& signalContext,
+                          sf::RenderTarget& renderTarget,
+                          const sf::Font& renderFont,
+                          const std::string& valueText);
+
     template <SampleType DST>
     void renderPacket(SignalContext& signalContext,
                       sf::RenderTarget& renderTarget,
@@ -207,17 +221,9 @@ private:
         std::unique_ptr<Polyline>& line,
         bool& end);
 
-    template <SampleType DST>
-    void renderArrayPacketImplicitAndExplicit(
-        SignalContext& signalContext,
-        DataRuleType domainRuleType,
-        sf::RenderTarget& renderTarget,
-        const  sf::Font& renderFont,
-        const DataPacketPtr& packet,
-        bool& havePrevPacket,
-        typename SampleTypeToType<DomainTypeCast<DST>::DomainSampleType>::Type& nextExpectedDomainPacketValue,
-        std::unique_ptr<Polyline>& line,
-        bool& end);
+    // The elements of a sample against their index; the domain says which sample to draw, never where.
+    void renderArrayPacket(
+        SignalContext& signalContext, const DataPacketPtr& packet, bool& havePrevPacket, std::unique_ptr<Polyline>& line, bool& end);
 
     void renderLoop();
     void processSignalContexts();
@@ -238,6 +244,9 @@ private:
     void subscribeToSignalCoreEvent(const SignalPtr& signal);
     void processCoreEvent(ComponentPtr& component, CoreEventArgsPtr& args);
     void configureSignalContext(SignalContext& signalContext);
+    void configureDomainlessSignalContext(SignalContext& signalContext);
+    void updateDomainlessValueRange(SignalContext& signalContext, const DataPacketPtr& dataPacket);
+    void captureDomainlessValue(SignalContext& signalContext, const DataPacketPtr& dataPacket);
     void setSignalContextCaption(SignalContext& signalContext, const std::string& caption = std::string {});
     void processDataPacket(SignalContext& signalContext, const DataPacketPtr& dataPacket);
 
@@ -259,8 +268,6 @@ private:
 
     static std::chrono::system_clock::duration timeValueToDuration(Float timeValue);
 
-    template <typename Iter, typename Cont>
-    bool isLastIter(Iter iter, const Cont& cont);
     void rendererStopRequesteding();
 
     void updateSingleXAxis();

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/include/ref_fb_module/renderer_utils.h
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/include/ref_fb_module/renderer_utils.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+
+#include <opendaq/data_descriptor_factory.h>
+#include <opendaq/data_descriptor_ptr.h>
+#include <opendaq/sample_type.h>
+#include <ref_fb_module/common.h>
+
+BEGIN_NAMESPACE_REF_FB_MODULE
+
+namespace Renderer
+{
+
+/// @brief True for a descriptor parameter that stands for "no descriptor". A signal without a domain signal
+/// announces a stub descriptor with a Null sample type rather than omitting the event packet parameter.
+inline bool isNullDescriptor(const DataDescriptorPtr& descriptor)
+{
+    return !descriptor.assigned() || descriptor == NullDataDescriptor();
+}
+
+/// @brief True for a descriptor whose samples are vectors rather than single values.
+inline bool isVectorDescriptor(const DataDescriptorPtr& descriptor)
+{
+    return descriptor.assigned() && descriptor.getDimensions().assigned() && descriptor.getDimensions().getCount() == 1;
+}
+
+/// @brief Value range spanning the constants, for signals whose descriptor carries no value range of its own.
+/// Values that are all the same span nothing, so they are given room on either side to be scaled into.
+inline void constantValueRange(double low, double high, double& min, double& max)
+{
+    if (low != high)
+    {
+        min = low;
+        max = high;
+        return;
+    }
+
+    const double margin = low == 0.0 ? 1.0 : std::fabs(low) * 0.1;
+    min = low - margin;
+    max = high + margin;
+}
+
+/// @brief Value range around a single constant.
+inline void constantValueRange(double value, double& min, double& max)
+{
+    constantValueRange(value, value, min, max);
+}
+
+/// @brief One element of a sample as a double, whatever the sample type holds it as.
+inline double elementValue(SampleType sampleType, const void* data, std::size_t index)
+{
+    switch (sampleType)
+    {
+        case SampleType::Float32:
+            return static_cast<const float*>(data)[index];
+        case SampleType::Float64:
+            return static_cast<const double*>(data)[index];
+        case SampleType::UInt8:
+            return static_cast<const uint8_t*>(data)[index];
+        case SampleType::Int8:
+            return static_cast<const int8_t*>(data)[index];
+        case SampleType::UInt16:
+            return static_cast<const uint16_t*>(data)[index];
+        case SampleType::Int16:
+            return static_cast<const int16_t*>(data)[index];
+        case SampleType::UInt32:
+            return static_cast<const uint32_t*>(data)[index];
+        case SampleType::Int32:
+            return static_cast<const int32_t*>(data)[index];
+        case SampleType::UInt64:
+            return static_cast<double>(static_cast<const uint64_t*>(data)[index]);
+        case SampleType::Int64:
+            return static_cast<double>(static_cast<const int64_t*>(data)[index]);
+        default:
+            return 0.0;
+    }
+}
+
+/// @brief Height of one plot row once the value strips have taken their share of the available height.
+inline float plotItemHeight(float availableHeight, std::size_t plotCount, std::size_t stripCount, float stripHeight)
+{
+    if (plotCount == 0)
+        return 0.0f;
+
+    const float remaining = availableHeight - static_cast<float>(stripCount) * stripHeight;
+    if (remaining < 0.0f)
+        return 0.0f;
+
+    return remaining / static_cast<float>(plotCount);
+}
+}
+
+END_NAMESPACE_REF_FB_MODULE

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/src/CMakeLists.txt
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRC_Srcs module_dll.cpp
 if (DAQMODULES_REF_FB_MODULE_ENABLE_RENDERER)
     message(STATUS "Renderer function block enabled") 
     set(SRC_Include ${SRC_Include} renderer_fb_impl.h
+                                   renderer_utils.h
                                    video_player_fb_impl.h
                                    polyline.h
                                    polyline_impl.h
@@ -86,6 +87,7 @@ set(MODULE_FILES ${MODULE_HEADERS_DIR}/ref_fb_module_common.h
 
 if (DAQMODULES_REF_FB_MODULE_ENABLE_RENDERER)
     set(MODULE_FILES ${MODULE_FILES} ${MODULE_HEADERS_DIR}/renderer_fb_impl.h
+                                     ${MODULE_HEADERS_DIR}/renderer_utils.h
                                      ${MODULE_HEADERS_DIR}/video_player_fb_impl.h
                                      ${MODULE_BINARY_HEADER_DIR}/arial.ttf.h
                                      renderer_fb_impl.cpp

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/src/CMakeLists.txt
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SRC_Include common.h
                 sum_reader_fb_impl.h
                 struct_decoder_fb_impl.h
                 time_delay_fb_impl.h
+                constant_value_fb_impl.h
 )
 
 set(SRC_Srcs module_dll.cpp
@@ -32,6 +33,7 @@ set(SRC_Srcs module_dll.cpp
              sum_reader_fb_impl.cpp
              struct_decoder_fb_impl.cpp
              time_delay_fb_impl.cpp
+             constant_value_fb_impl.cpp
 )
 
 if (DAQMODULES_REF_FB_MODULE_ENABLE_RENDERER)
@@ -69,6 +71,7 @@ set(MODULE_FILES ${MODULE_HEADERS_DIR}/ref_fb_module_common.h
                             ${MODULE_HEADERS_DIR}/power_reader_fb_impl.h
                             ${MODULE_HEADERS_DIR}/struct_decoder_fb_impl.h
                             ${MODULE_HEADERS_DIR}/time_delay_fb_impl.h
+                            ${MODULE_HEADERS_DIR}/constant_value_fb_impl.h
                             module_dll.cpp
                             power_fb_impl.cpp
                             statistics_fb_impl.cpp
@@ -78,7 +81,8 @@ set(MODULE_FILES ${MODULE_HEADERS_DIR}/ref_fb_module_common.h
                             fft_fb_impl.cpp
                             power_reader_fb_impl.cpp
                             struct_decoder_fb_impl.cpp
-                            time_delay_fb_impl.cpp)
+                            time_delay_fb_impl.cpp
+                            constant_value_fb_impl.cpp)
 
 if (DAQMODULES_REF_FB_MODULE_ENABLE_RENDERER)
     set(MODULE_FILES ${MODULE_FILES} ${MODULE_HEADERS_DIR}/renderer_fb_impl.h

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/src/constant_value_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/src/constant_value_fb_impl.cpp
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <locale>
+#include <sstream>
+#include <string>
+
+#include <opendaq/component_type_private.h>
+#include <opendaq/data_descriptor_factory.h>
+#include <opendaq/data_rule_factory.h>
+#include <opendaq/dimension_factory.h>
+#include <opendaq/event_packet_ids.h>
+#include <opendaq/event_packet_utils.h>
+#include <opendaq/input_port_factory.h>
+#include <opendaq/packet_factory.h>
+#include <opendaq/sample_type_traits.h>
+#include <ref_fb_module/constant_value_fb_impl.h>
+
+BEGIN_NAMESPACE_REF_FB_MODULE
+
+namespace ConstantValue
+{
+
+namespace
+{
+
+struct ParsedElement
+{
+    bool isInteger;
+    Int integerValue;
+    Float floatValue;
+};
+
+// The values the signal carries, in the sample type the way they are written implies.
+struct ParsedValues
+{
+    SampleType sampleType{SampleType::Int32};
+    std::vector<Int> integers;
+    std::vector<Float> floats;
+};
+
+ParsedElement parseElement(const std::string& element)
+{
+    if (element.find_first_of("xX") != std::string::npos)
+        DAQ_THROW_EXCEPTION(InvalidParameterException, R"(Value "{}" is not a decimal number.)", element);
+
+    const char* begin = element.data();
+    const char* end = begin + element.size();
+    if (begin != end && *begin == '+')
+        ++begin;
+
+    Int integerValue{};
+    if (const auto result = std::from_chars(begin, end, integerValue); result.ec == std::errc() && result.ptr == end)
+        return {true, integerValue, static_cast<Float>(integerValue)};
+
+    // The classic locale keeps the decimal point from following whatever locale the host application set.
+    std::istringstream stream(element);
+    stream.imbue(std::locale::classic());
+
+    Float floatValue;
+    stream >> floatValue;
+    if (stream.fail() || !(stream >> std::ws).eof() || !std::isfinite(floatValue))
+        DAQ_THROW_EXCEPTION(InvalidParameterException, R"(Value "{}" is not a finite number.)", element);
+
+    return {false, 0, floatValue};
+}
+
+// One value per element of a sample, separated by semicolons. The number of values is the vector size,
+// and the way they are written decides the sample type.
+ParsedValues parseValues(const std::string& text)
+{
+    std::vector<ParsedElement> elements;
+
+    size_t position = 0;
+    while (true)
+    {
+        const size_t separator = text.find(';', position);
+        const std::string element =
+            text.substr(position, separator == std::string::npos ? std::string::npos : separator - position);
+
+        const size_t first = element.find_first_not_of(" \t");
+        if (first == std::string::npos)
+            DAQ_THROW_EXCEPTION(InvalidParameterException, "Value must not have empty elements.");
+
+        elements.push_back(parseElement(element.substr(first, element.find_last_not_of(" \t") - first + 1)));
+
+        if (separator == std::string::npos)
+            break;
+        position = separator + 1;
+    }
+
+    ParsedValues values;
+
+    // A single value written as a real number makes the whole signal a real one.
+    const bool allIntegers = std::all_of(elements.begin(), elements.end(), [](const auto& element) { return element.isInteger; });
+    if (!allIntegers)
+    {
+        values.sampleType = SampleType::Float64;
+        for (const auto& element : elements)
+            values.floats.push_back(element.floatValue);
+        return values;
+    }
+
+    const bool fitsInt32 = std::all_of(elements.begin(),
+                                       elements.end(),
+                                       [](const auto& element)
+                                       {
+                                           return element.integerValue >= std::numeric_limits<int32_t>::lowest() &&
+                                                  element.integerValue <= std::numeric_limits<int32_t>::max();
+                                       });
+
+    values.sampleType = fitsInt32 ? SampleType::Int32 : SampleType::Int64;
+    for (const auto& element : elements)
+        values.integers.push_back(element.integerValue);
+
+    return values;
+}
+}
+
+ConstantValueFbImpl::ConstantValueFbImpl(const ModuleInfoPtr& moduleInfo,
+                                         const ContextPtr& ctx,
+                                         const ComponentPtr& parent,
+                                         const StringPtr& localId)
+    : FunctionBlock(CreateType(moduleInfo), ctx, parent, localId)
+    , sampleType(SampleType::Int32)
+    , elementCount(1)
+    , domainConnected(false)
+    , rawValueSize(0)
+    , valueEmitted(false)
+    , emittedSampleType(SampleType::Invalid)
+    , emittedRawValueSize(0)
+{
+    initComponentStatus();
+
+    createSignals();
+    createInputPorts();
+    initProperties();
+}
+
+void ConstantValueFbImpl::createSignals()
+{
+    // Without a domain signal a constant rule signal hands its current value to input ports on connect;
+    // the domain signal is attached only while one drives the output, and is reached through it rather
+    // than on its own.
+    outputSignal = createAndAddSignal(String("output"));
+    outputDomainSignal = createAndAddSignal(String("output_domain"), nullptr, false);
+}
+
+void ConstantValueFbImpl::createInputPorts()
+{
+    inputPort = createAndAddInputPort("domain", PacketReadyNotification::SameThread);
+}
+
+void ConstantValueFbImpl::initProperties()
+{
+    objPtr.addProperty(StringProperty("Value", "0"));
+    objPtr.getOnPropertyValueWrite("Value") += [this](PropertyObjectPtr& obj, PropertyValueEventArgsPtr& args) { configure(); };
+
+    configure();
+}
+
+DataDescriptorPtr ConstantValueFbImpl::buildDescriptor() const
+{
+    auto builder = DataDescriptorBuilder().setName("Value").setSampleType(sampleType).setRule(ConstantDataRule());
+    if (elementCount > 1)
+        builder.setDimensions(List<IDimension>(Dimension(LinearDimensionRule(1, 0, elementCount), nullptr, "index")));
+
+    return builder.build();
+}
+
+void ConstantValueFbImpl::configure()
+{
+    // Parsing first leaves the signal untouched when the value cannot be read.
+    const StringPtr value = objPtr.getPropertyValue("Value");
+    const auto values = parseValues(value.toStdString());
+    const size_t newElementCount = values.sampleType == SampleType::Float64 ? values.floats.size() : values.integers.size();
+
+    const bool descriptorChanged = !dataDescriptor.assigned() || values.sampleType != sampleType || newElementCount != elementCount;
+    sampleType = values.sampleType;
+    elementCount = newElementCount;
+
+    if (descriptorChanged)
+    {
+        dataDescriptor = buildDescriptor();
+        outputSignal.setDescriptor(dataDescriptor);
+    }
+
+    switch (sampleType)
+    {
+        case SampleType::Int32:
+            storeValue<SampleTypeToType<SampleType::Int32>::Type>(values.integers);
+            break;
+        case SampleType::Int64:
+            storeValue<SampleTypeToType<SampleType::Int64>::Type>(values.integers);
+            break;
+        case SampleType::Float64:
+            storeValue<SampleTypeToType<SampleType::Float64>::Type>(values.floats);
+            break;
+        default:
+            break;
+    }
+
+    // While a domain drives the output, the new value takes effect with the next domain packet.
+    if (!domainConnected)
+        emitValue();
+}
+
+template <typename T, typename Source>
+void ConstantValueFbImpl::storeValue(const std::vector<Source>& values)
+{
+    // The sample type follows the values, so nothing is lost in the conversion.
+    std::vector<T> converted;
+    converted.reserve(values.size());
+    for (const auto value : values)
+        converted.push_back(static_cast<T>(value));
+
+    rawValueSize = converted.size() * sizeof(T);
+    rawValue = std::make_unique<uint8_t[]>(rawValueSize);
+    std::memcpy(rawValue.get(), converted.data(), rawValueSize);
+}
+
+void ConstantValueFbImpl::emitValue()
+{
+    // Two spellings of the same number are not a change of the constant.
+    if (valueEmitted && sampleType == emittedSampleType && rawValueSize == emittedRawValueSize &&
+        std::memcmp(emittedRawValue.get(), rawValue.get(), rawValueSize) == 0)
+        return;
+
+    outputSignal.sendPacket(ConstantDataPacketWithRawValue(dataDescriptor, rawValue.get()));
+
+    emittedRawValue = std::make_unique<uint8_t[]>(rawValueSize);
+    std::memcpy(emittedRawValue.get(), rawValue.get(), rawValueSize);
+    emittedRawValueSize = rawValueSize;
+    emittedSampleType = sampleType;
+    valueEmitted = true;
+}
+
+void ConstantValueFbImpl::onConnected(const InputPortPtr& port)
+{
+    auto lock = this->getAcquisitionLock();
+
+    // The output follows a domain from here on, so it is no longer a signal whose value can be replayed.
+    domainConnected = true;
+    outputSignal.setDomainSignal(outputDomainSignal);
+}
+
+void ConstantValueFbImpl::onDisconnected(const InputPortPtr& port)
+{
+    auto lock = this->getAcquisitionLock();
+
+    domainConnected = false;
+    domainDescriptor = nullptr;
+
+    // Clearing the domain descriptor first tells consumers the domain is gone while they still reference it.
+    outputDomainSignal.setDescriptor(nullptr);
+    outputSignal.setDomainSignal(nullptr);
+
+    // The signal carries a value again, and with it the value a port connecting later is handed.
+    valueEmitted = false;
+    emitValue();
+}
+
+void ConstantValueFbImpl::onPacketReceived(const InputPortPtr& port)
+{
+    auto lock = this->getAcquisitionLock();
+
+    const auto connection = inputPort.getConnection();
+    if (!connection.assigned())
+        return;
+
+    PacketPtr packet = connection.dequeue();
+    while (packet.assigned())
+    {
+        switch (packet.getType())
+        {
+            case PacketType::Event:
+                processEventPacket(packet);
+                break;
+            case PacketType::Data:
+                processDomainPacket(packet);
+                break;
+            default:
+                break;
+        }
+
+        packet = connection.dequeue();
+    }
+}
+
+void ConstantValueFbImpl::processEventPacket(const EventPacketPtr& packet)
+{
+    if (packet.getEventId() != event_packet_id::DATA_DESCRIPTOR_CHANGED)
+        return;
+
+    const auto [valueChanged, domainChanged, newValueDescriptor, newDomainDescriptor] = parseDataDescriptorEventPacket(packet);
+
+    // A connected value signal describes its domain separately; a domain signal is one itself.
+    const DataDescriptorPtr descriptor = newDomainDescriptor.assigned() ? newDomainDescriptor : newValueDescriptor;
+    if (!descriptor.assigned())
+        return;
+
+    domainDescriptor = descriptor;
+    outputDomainSignal.setDescriptor(domainDescriptor);
+}
+
+void ConstantValueFbImpl::processDomainPacket(const DataPacketPtr& packet)
+{
+    if (!domainDescriptor.assigned() || rawValueSize == 0)
+        return;
+
+    const auto domainPacket = packet.getDomainPacket().assigned() ? packet.getDomainPacket() : packet;
+    const auto sampleCount = domainPacket.getSampleCount();
+    if (sampleCount == 0)
+        return;
+
+    // The raw form, because the value may be a vector, which the typed factories take one sample at a time.
+    const DataPacketPtr valuePacket(
+        ConstantDataPacketWithDomain_Create(domainPacket, dataDescriptor, sampleCount, rawValue.get(), nullptr, 0));
+
+    outputDomainSignal.sendPacket(domainPacket);
+    outputSignal.sendPacket(valuePacket);
+}
+
+FunctionBlockTypePtr ConstantValueFbImpl::CreateType(const ModuleInfoPtr& moduleInfo)
+{
+    auto fbType = FunctionBlockType("RefFBModuleConstantValue", "Constant value", "Outputs a configurable constant value");
+    checkErrorInfo(fbType.asPtr<IComponentTypePrivate>(true)->setModuleInfo(moduleInfo));
+    return fbType;
+}
+}
+
+END_NAMESPACE_REF_FB_MODULE

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/src/ref_fb_module_impl.cpp
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/src/ref_fb_module_impl.cpp
@@ -1,6 +1,7 @@
 #include <coretypes/version_info_factory.h>
 #include <opendaq/custom_log.h>
 #include <ref_fb_module/classifier_fb_impl.h>
+#include <ref_fb_module/constant_value_fb_impl.h>
 #include <ref_fb_module/power_fb_impl.h>
 #include <ref_fb_module/ref_fb_module_impl.h>
 #ifdef OPENDAQ_ENABLE_RENDERER
@@ -77,6 +78,9 @@ DictPtr<IString, IFunctionBlockType> RefFBModule::onGetAvailableFunctionBlockTyp
     const auto timeScaler = TimeDelay::TimeDelayFbImpl::CreateType();
     types.set(timeScaler.getId(), timeScaler);
 
+    const auto typeConstantValue = ConstantValue::ConstantValueFbImpl::CreateType(moduleInfo);
+    types.set(typeConstantValue.getId(), typeConstantValue);
+
     return types;
 }
 
@@ -145,6 +149,12 @@ FunctionBlockPtr RefFBModule::onCreateFunctionBlock(const StringPtr& id,
     if (id == TimeDelay::TimeDelayFbImpl::CreateType().getId())
     {
         FunctionBlockPtr fb = createWithImplementation<IFunctionBlock, TimeDelay::TimeDelayFbImpl>(context, parent, localId, config);
+        return fb;
+    }
+    if (id == ConstantValue::ConstantValueFbImpl::CreateType(moduleInfo).getId())
+    {
+        FunctionBlockPtr fb =
+            createWithImplementation<IFunctionBlock, ConstantValue::ConstantValueFbImpl>(moduleInfo, context, parent, localId);
         return fb;
     }
 

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/src/renderer_fb_impl.cpp
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/src/renderer_fb_impl.cpp
@@ -16,10 +16,19 @@
 #include <opendaq/work_factory.h>
 #include <coreobjects/callable_info_factory.h>
 #include <opendaq/reader_utils.h>
+#include <ref_fb_module/renderer_utils.h>
 
 BEGIN_NAMESPACE_REF_FB_MODULE
 namespace Renderer
 {
+
+namespace
+{
+bool isVectorContext(const SignalContext& signalContext)
+{
+    return isVectorDescriptor(signalContext.inputDataSignalDescriptor);
+}
+}
 
 RendererFbImpl::RendererFbImpl(const ModuleInfoPtr& moduleInfo,
                                const ContextPtr& ctx, 
@@ -262,9 +271,35 @@ void RendererFbImpl::renderSignals(sf::RenderTarget& renderTarget, const sf::Fon
 {
     for (auto& sigCtx : signalContexts)
     {
-        if (sigCtx.valid)
+        if (!sigCtx.valid)
+            continue;
+
+        if (sigCtx.domainless)
+            renderDomainlessSignal(sigCtx, renderTarget, renderFont);
+        else
             SAMPLE_TYPE_DISPATCH(sigCtx.domainSampleType, renderSignal, sigCtx, renderTarget, renderFont);
     }
+}
+
+void RendererFbImpl::renderDomainlessSignal(SignalContext& signalContext, sf::RenderTarget& renderTarget, const sf::Font& renderFont)
+{
+    // A vector has shape across its elements, and that is what there is to see.
+    if (isVectorContext(signalContext))
+    {
+        renderValueProfile(signalContext, renderTarget);
+        return;
+    }
+
+    // Sharing an axis puts the value in scale with the other signals; alone it only reads as a number.
+    if (singleXAxis && singleYAxis)
+    {
+        renderValueLine(signalContext, renderTarget);
+        if (signalContext.constantValueSet && showLastValue)
+            renderValueLabel(signalContext, renderTarget, renderFont, signalContext.constantValueText);
+        return;
+    }
+
+    renderValueStrip(signalContext, renderTarget, renderFont);
 }
 
 sf::Color RendererFbImpl::getColor(const SignalContext& signalContext)
@@ -308,7 +343,7 @@ void RendererFbImpl::renderPacket(
     size_t signalDimension = signalContext.inputDataSignalDescriptor.getDimensions().getCount();
 
     if (signalDimension == 1)
-        renderArrayPacketImplicitAndExplicit<DST>(signalContext, domainRule.getType(), renderTarget, renderFont, packet, havePrevPacket, nextExpectedDomainPacketValue, line, end);
+        renderArrayPacket(signalContext, packet, havePrevPacket, line, end);
     else
         renderPacketImplicitAndExplicit<DST>(signalContext, domainRule.getType(), renderTarget, renderFont, packet, havePrevPacket, nextExpectedDomainPacketValue, line, end);
 }
@@ -481,25 +516,14 @@ void RendererFbImpl::renderPacketImplicitAndExplicit(
         end = true;
 }
 
-template <SampleType DST>
-void RendererFbImpl::renderArrayPacketImplicitAndExplicit(
-    SignalContext& signalContext,
-    DataRuleType domainRuleType,
-    sf::RenderTarget& renderTarget,
-    const sf::Font& renderFont,
-    const DataPacketPtr& packet,
-    bool& havePrevPacket,
-    typename SampleTypeToType<DomainTypeCast<DST>::DomainSampleType>::Type& nextExpectedDomainPacketValue,
-    std::unique_ptr<Polyline>& line,
-    bool& end)
+void RendererFbImpl::renderArrayPacket(
+    SignalContext& signalContext, const DataPacketPtr& packet, bool& havePrevPacket, std::unique_ptr<Polyline>& line, bool& end)
 {
     const float xSize = signalContext.bottomRight.x - signalContext.topLeft.x;
     const float xOffset = signalContext.topLeft.x;
     const float ySize = signalContext.bottomRight.y - signalContext.topLeft.y;
     const float yOffset = signalContext.bottomRight.y;
 
-    auto domainPacket = packet.getDomainPacket();
-    auto domainDataDescriptor = domainPacket.getDataDescriptor();
     const auto samplesInPacket = packet.getSampleCount();
 
     size_t xTickOffset = 0;
@@ -528,45 +552,9 @@ void RendererFbImpl::renderArrayPacketImplicitAndExplicit(
     if (samplesInPacket == 0)
         return;
 
-    double value;
     for (size_t i = 0; i < xTickCount; i++)
     {
-        size_t idx = i + xTickOffset;
-        switch (signalContext.sampleType)
-        {
-            case (SampleType::Float32):
-                value = reinterpret_cast<float*>(data)[idx];
-                break;
-            case (SampleType::Float64):
-                value = reinterpret_cast<double*>(data)[idx];
-                break;
-            case (SampleType::UInt8):
-                value = reinterpret_cast<uint8_t*>(data)[idx];
-                break;
-            case (SampleType::Int8):
-                value = reinterpret_cast<int8_t*>(data)[idx];
-                break;
-            case (SampleType::UInt16):
-                value = reinterpret_cast<uint16_t*>(data)[idx];
-                break;
-            case (SampleType::Int16):
-                value = reinterpret_cast<int16_t*>(data)[idx];
-                break;
-            case (SampleType::UInt32):
-                value = reinterpret_cast<uint32_t*>(data)[idx];
-                break;
-            case (SampleType::Int32):
-                value = reinterpret_cast<int32_t*>(data)[idx];
-                break;
-            case (SampleType::UInt64):
-                value = reinterpret_cast<uint64_t*>(data)[idx];
-                break;
-            case (SampleType::Int64):
-                value = reinterpret_cast<int64_t*>(data)[idx];
-                break;
-            default:
-                value = 0.0;
-        }
+        const double value = elementValue(signalContext.sampleType, data, i + xTickOffset);
 
         float xPos = xOffset + static_cast<float>(1.0 * i / domainFactor);
         float yPos = yOffset - static_cast<float>((value - yMin) / valueFactor);
@@ -617,25 +605,99 @@ void RendererFbImpl::renderSignal(SignalContext& signalContext, sf::RenderTarget
 
     if (signalContext.lastValueSet && showLastValue)
     {
-        sf::Text lastValueText(renderFont);
-        lastValueText.setFillColor(axisColor);
-        lastValueText.setCharacterSize(16);
         std::ostringstream valueStr;
-        if (singleXAxis && singleYAxis)
-            valueStr << signalContext.caption;
-        else
-            valueStr << "Value";
-        valueStr << " = " << std::fixed << std::showpoint << std::setprecision(3) << signalContext.lastValue;
-        lastValueText.setString(valueStr.str());
-        const auto valueBounds = lastValueText.getGlobalBounds();
-        float top = signalContext.topLeft.y - valueBounds.size.y * 2.0f;
-        if (singleXAxis && singleYAxis)
-            top += signalContext.index * valueBounds.size.y * 2.0f;
-
-        lastValueText.setPosition({signalContext.bottomRight.x - valueBounds.size.x, top});
-
-        renderTarget.draw(lastValueText);
+        valueStr << std::fixed << std::showpoint << std::setprecision(3) << signalContext.lastValue;
+        renderValueLabel(signalContext, renderTarget, renderFont, valueStr.str());
     }
+}
+
+void RendererFbImpl::renderValueLabel(SignalContext& signalContext,
+                                      sf::RenderTarget& renderTarget,
+                                      const sf::Font& renderFont,
+                                      const std::string& valueText)
+{
+    sf::Text lastValueText(renderFont);
+    lastValueText.setFillColor(axisColor);
+    lastValueText.setCharacterSize(16);
+
+    std::ostringstream valueStr;
+    if (singleXAxis && singleYAxis)
+        valueStr << signalContext.caption;
+    else
+        valueStr << "Value";
+    valueStr << " = " << valueText;
+
+    lastValueText.setString(valueStr.str());
+    const auto valueBounds = lastValueText.getGlobalBounds();
+    float top = signalContext.topLeft.y - valueBounds.size.y * 2.0f;
+    if (singleXAxis && singleYAxis)
+        top += signalContext.index * valueBounds.size.y * 2.0f;
+
+    lastValueText.setPosition({signalContext.bottomRight.x - valueBounds.size.x, top});
+
+    renderTarget.draw(lastValueText);
+}
+
+void RendererFbImpl::renderValueStrip(SignalContext& signalContext, sf::RenderTarget& renderTarget, const sf::Font& renderFont)
+{
+    sf::Text valueText(renderFont);
+    valueText.setStyle(sf::Text::Style::Bold);
+    valueText.setFillColor(getColor(signalContext));
+    valueText.setCharacterSize(16);
+
+    std::string caption = signalContext.caption;
+    if (signalContext.constantValueSet)
+        caption += " = " + signalContext.constantValueText;
+    valueText.setString(caption);
+
+    const auto bounds = valueText.getGlobalBounds();
+    const float x = (signalContext.topLeft.x + signalContext.bottomRight.x - bounds.size.x) / 2.0f;
+    const float y = (signalContext.topLeft.y + signalContext.bottomRight.y - bounds.size.y) / 2.0f;
+    valueText.setPosition({x, y});
+
+    renderTarget.draw(valueText);
+}
+
+void RendererFbImpl::renderValueProfile(SignalContext& signalContext, sf::RenderTarget& renderTarget)
+{
+    if (signalContext.dataPackets.empty())
+        return;
+
+    auto line = std::make_unique<Polyline>(lineThickness, LineStyle::solid);
+    line->setColor(getColor(signalContext));
+
+    bool havePrevPacket = false;
+    bool end = false;
+    renderArrayPacket(signalContext, signalContext.dataPackets.front(), havePrevPacket, line, end);
+
+    renderTarget.draw(*line);
+}
+
+void RendererFbImpl::renderValueLine(SignalContext& signalContext, sf::RenderTarget& renderTarget)
+{
+    if (!signalContext.constantValueSet)
+        return;
+
+    double yMax, yMin;
+    getYMinMax(signalContext, yMax, yMin);
+    if (yMax <= yMin)
+        return;
+
+    const float ySize = signalContext.bottomRight.y - signalContext.topLeft.y;
+    const auto valueFactor = (yMax - yMin) / static_cast<double>(ySize);
+
+    float yPos = signalContext.bottomRight.y - static_cast<float>((signalContext.constantValue - yMin) / valueFactor);
+    if (yPos < signalContext.topLeft.y)
+        yPos = signalContext.topLeft.y;
+    else if (yPos > signalContext.bottomRight.y)
+        yPos = signalContext.bottomRight.y;
+
+    auto line = std::make_unique<Polyline>(lineThickness, LineStyle::solid);
+    line->setColor(getColor(signalContext));
+    line->addPoint(signalContext.topLeft.x, yPos);
+    line->addPoint(signalContext.bottomRight.x, yPos);
+
+    renderTarget.draw(*line);
 }
 
 void RendererFbImpl::onConnected(const InputPortPtr& inputPort)
@@ -883,15 +945,28 @@ void RendererFbImpl::processSignalContexts()
         processSignalContext(sigCtx);
 }
 
-template <typename Iter, typename Cont>
-bool RendererFbImpl::isLastIter(Iter iter, const Cont& cont)
-{
-    return (iter != cont.end()) && (std::next(iter) != cont.end()) && (std::next(iter, 2) == cont.end());
-}
-
 void RendererFbImpl::renderAxes(sf::RenderTarget& renderTarget, const sf::Font& renderFont)
 {
     const float xAxisLabelHeight = 40.0f;
+    const float valueStripHeight = 40.0f;
+
+    // The axis belongs to a signal that has a domain; a signal without one only borrows the scale.
+    auto lastPlotIt = signalContexts.end();
+    size_t plotCount = 0;
+    size_t stripCount = 0;
+    for (auto sigIt = signalContexts.begin(); sigIt != signalContexts.end() - 1; ++sigIt)
+    {
+        if (sigIt->valid && sigIt->domainless && !isVectorContext(*sigIt))
+        {
+            stripCount++;
+        }
+        else
+        {
+            plotCount++;
+            if (sigIt->valid && !sigIt->domainless)
+                lastPlotIt = sigIt;
+        }
+    }
 
     if (singleYAxis && singleXAxis)
     {
@@ -909,32 +984,39 @@ void RendererFbImpl::renderAxes(sf::RenderTarget& renderTarget, const sf::Font& 
             if (sigIt->max > yMaxValue)
                 yMaxValue = sigIt->max;
 
-            if (isLastIter(sigIt, signalContexts))
+            if (sigIt == lastPlotIt)
                 renderAxis(renderTarget, *sigIt, renderFont, true, false);
         }
         renderMultiTitle(renderTarget, renderFont);
     }
     else
     {
-        const size_t axesCount = signalContexts.size() - 1;
-        float itemHeight;
+        float available = bottomRight.y - topLeft.y;
         if (singleXAxis)
-            itemHeight = (bottomRight.y - topLeft.y - xAxisLabelHeight) / static_cast<float>(axesCount);
-        else
-            itemHeight = (bottomRight.y - topLeft.y) / static_cast<float>(axesCount);
+            available -= xAxisLabelHeight;
+        const float itemHeight = plotItemHeight(available, plotCount, stripCount, valueStripHeight);
         const float width = bottomRight.x - topLeft.x;
         float curTop = 0.0f;
         for (auto sigIt = signalContexts.begin(); sigIt != signalContexts.end() - 1; ++sigIt)
         {
             if (!sigIt->valid)
                 continue;
+            const bool strip = sigIt->domainless && !isVectorContext(*sigIt);
             sigIt->topLeft = sf::Vector2f(75.0f, curTop + xAxisLabelHeight);
-            curTop += itemHeight;
+            curTop += strip ? valueStripHeight : itemHeight;
             float bottom = curTop;
             if (!singleXAxis)
                 bottom -= xAxisLabelHeight;
             sigIt->bottomRight = sf::Vector2f(static_cast<float>(width) - 25.0f, bottom);
-            const auto drawXAxisLabels = !singleXAxis || isLastIter(sigIt, signalContexts);
+            if (strip)
+                continue;
+            if (sigIt->domainless)
+            {
+                // A signal without a domain still has an axis when its elements are the axis.
+                renderAxis(renderTarget, *sigIt, renderFont, true, true);
+                continue;
+            }
+            const auto drawXAxisLabels = !singleXAxis || sigIt == lastPlotIt;
             renderAxis(renderTarget, *sigIt, renderFont, drawXAxisLabels, true);
         }
     }
@@ -954,7 +1036,14 @@ void RendererFbImpl::prepareSingleXAxis()
 
     try
     {
+        // Signals without a domain signal take no part in the common axis, they only borrow its width.
         auto sigIt = signalContexts.begin();
+        while (sigIt != signalContexts.end() - 1 && sigIt->valid && sigIt->domainless)
+            ++sigIt;
+
+        if (sigIt == signalContexts.end() - 1)
+            return;
+
         if (!sigIt->valid)
         {
             DAQ_THROW_EXCEPTION(InvalidStateException, "First signal not valid");
@@ -968,7 +1057,7 @@ void RendererFbImpl::prepareSingleXAxis()
 
         for (; sigIt != signalContexts.end() - 1; ++sigIt)
         {
-            if (!sigIt->valid)
+            if (!sigIt->valid || sigIt->domainless)
                 continue;
 
             if (sigIt->hasTimeOrigin != hasTimeOrigin)
@@ -1005,6 +1094,9 @@ void RendererFbImpl::prepareSingleXAxis()
 
         for (sigIt = signalContexts.begin(); sigIt != signalContexts.end() - 1; ++sigIt)
         {
+            if (!sigIt->valid || sigIt->domainless)
+                continue;
+
             SAMPLE_TYPE_DISPATCH(sigIt->domainSampleType, setSingleXAxis, *sigIt, lastTimeValue, lastDomainValue)
         }
 
@@ -1292,7 +1384,6 @@ void RendererFbImpl::processSignalContext(SignalContext& signalContext)
             LOG_T("Processing {} event", eventPacket.getEventId())
             if (eventPacket.getEventId() == event_packet_id::DATA_DESCRIPTOR_CHANGED)
             {
-                // TODO handle Null-descriptor params ('Null' sample type descriptors)
                 DataDescriptorPtr valueSignalDescriptor = eventPacket.getParameters().get(event_packet_param::DATA_DESCRIPTOR);
                 DataDescriptorPtr domainSignalDescriptor = eventPacket.getParameters().get(event_packet_param::DOMAIN_DATA_DESCRIPTOR);
                 processSignalDescriptorChanged(signalContext, valueSignalDescriptor, domainSignalDescriptor);
@@ -1310,11 +1401,12 @@ void RendererFbImpl::processSignalContext(SignalContext& signalContext)
 
 void RendererFbImpl::processSignalDescriptorChanged(SignalContext& signalContext, const DataDescriptorPtr& valueSignalDescriptor, const DataDescriptorPtr& domainSignalDescriptor)
 {
+    // A stub descriptor means the signal has no descriptor of that kind, as opposed to an unchanged one.
     if (domainSignalDescriptor.assigned())
-        signalContext.inputDomainDataDescriptor = domainSignalDescriptor;
+        signalContext.inputDomainDataDescriptor = isNullDescriptor(domainSignalDescriptor) ? DataDescriptorPtr() : domainSignalDescriptor;
 
     if (valueSignalDescriptor.assigned())
-        signalContext.inputDataSignalDescriptor = valueSignalDescriptor;
+        signalContext.inputDataSignalDescriptor = isNullDescriptor(valueSignalDescriptor) ? DataDescriptorPtr() : valueSignalDescriptor;
 
     configureSignalContext(signalContext);
 }
@@ -1354,9 +1446,16 @@ void RendererFbImpl::processCoreEvent(ComponentPtr& component, CoreEventArgsPtr&
 void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
 {
     signalContext.valid = false;
-    if (!signalContext.inputDataSignalDescriptor.assigned() || !signalContext.inputDomainDataDescriptor.assigned())
+    signalContext.domainless = false;
+    if (!signalContext.inputDataSignalDescriptor.assigned())
     {
         LOG_D("Incomplete input signal descriptors")
+        return;
+    }
+
+    if (!signalContext.inputDomainDataDescriptor.assigned())
+    {
+        configureDomainlessSignalContext(signalContext);
         return;
     }
 
@@ -1473,6 +1572,130 @@ void RendererFbImpl::configureSignalContext(SignalContext& signalContext)
     }
 }
 
+void RendererFbImpl::updateDomainlessValueRange(SignalContext& signalContext, const DataPacketPtr& dataPacket)
+{
+    if (signalContext.inputDataSignalDescriptor.getValueRange().assigned())
+        return;
+
+    const auto elementCount = signalContext.inputDataSignalDescriptor.getDimensions()[0].getSize();
+    if (elementCount == 0)
+        return;
+
+    double low = std::numeric_limits<double>::max();
+    double high = std::numeric_limits<double>::lowest();
+    for (size_t i = 0; i < elementCount; i++)
+    {
+        const double value = elementValue(signalContext.sampleType, dataPacket.getData(), i);
+        low = std::min(low, value);
+        high = std::max(high, value);
+    }
+
+    constantValueRange(low, high, signalContext.min, signalContext.max);
+}
+
+void RendererFbImpl::configureDomainlessSignalContext(SignalContext& signalContext)
+{
+    const auto dataDescriptor = signalContext.inputDataSignalDescriptor;
+
+    signalContext.sampleType = dataDescriptor.getSampleType();
+    signalContext.constantValueSet = false;
+    signalContext.constantValueText.clear();
+    signalContext.constantValue = 0.0;
+
+    const auto valueRange = dataDescriptor.getValueRange();
+    if (valueRange.assigned())
+    {
+        signalContext.min = valueRange.getLowValue();
+        signalContext.max = valueRange.getHighValue();
+    }
+    else
+    {
+        constantValueRange(signalContext.constantValue, signalContext.min, signalContext.max);
+    }
+
+    setSignalContextCaption(signalContext);
+
+    signalContext.domainless = true;
+    signalContext.valid = true;
+    LOGP_D("Signal without a domain signal connected")
+}
+
+void RendererFbImpl::captureDomainlessValue(SignalContext& signalContext, const DataPacketPtr& dataPacket)
+{
+    const auto sampleCount = dataPacket.getSampleCount();
+    if (sampleCount == 0)
+        return;
+
+    if (signalContext.inputDataSignalDescriptor.getDimensions().getCount() > 0)
+    {
+        // The elements are drawn against their index, so the packet is kept rather than a single value.
+        signalContext.dataPackets.clear();
+        signalContext.dataPackets.push_front(dataPacket);
+        signalContext.constantValueSet = true;
+        updateDomainlessValueRange(signalContext, dataPacket);
+        return;
+    }
+
+    const size_t sampleSize = getSampleSize(signalContext.sampleType);
+    auto* data = reinterpret_cast<uint8_t*>(dataPacket.getData()) + (sampleCount - 1) * sampleSize;
+
+    std::ostringstream valueText;
+    double value;
+    switch (signalContext.sampleType)
+    {
+        case SampleType::Float32:
+            value = *(reinterpret_cast<float*>(data));
+            valueText << std::fixed << std::showpoint << std::setprecision(3) << value;
+            break;
+        case SampleType::Float64:
+            value = *(reinterpret_cast<double*>(data));
+            valueText << std::fixed << std::showpoint << std::setprecision(3) << value;
+            break;
+        case SampleType::UInt8:
+            valueText << static_cast<uint64_t>(*(reinterpret_cast<uint8_t*>(data)));
+            value = static_cast<double>(*(reinterpret_cast<uint8_t*>(data)));
+            break;
+        case SampleType::Int8:
+            valueText << static_cast<int64_t>(*(reinterpret_cast<int8_t*>(data)));
+            value = static_cast<double>(*(reinterpret_cast<int8_t*>(data)));
+            break;
+        case SampleType::UInt16:
+            valueText << static_cast<uint64_t>(*(reinterpret_cast<uint16_t*>(data)));
+            value = static_cast<double>(*(reinterpret_cast<uint16_t*>(data)));
+            break;
+        case SampleType::Int16:
+            valueText << static_cast<int64_t>(*(reinterpret_cast<int16_t*>(data)));
+            value = static_cast<double>(*(reinterpret_cast<int16_t*>(data)));
+            break;
+        case SampleType::UInt32:
+            valueText << static_cast<uint64_t>(*(reinterpret_cast<uint32_t*>(data)));
+            value = static_cast<double>(*(reinterpret_cast<uint32_t*>(data)));
+            break;
+        case SampleType::Int32:
+            valueText << static_cast<int64_t>(*(reinterpret_cast<int32_t*>(data)));
+            value = static_cast<double>(*(reinterpret_cast<int32_t*>(data)));
+            break;
+        case SampleType::UInt64:
+            valueText << *(reinterpret_cast<uint64_t*>(data));
+            value = static_cast<double>(*(reinterpret_cast<uint64_t*>(data)));
+            break;
+        case SampleType::Int64:
+            valueText << *(reinterpret_cast<int64_t*>(data));
+            value = static_cast<double>(*(reinterpret_cast<int64_t*>(data)));
+            break;
+        default:
+            LOG_W("Sample type of signal without a domain signal not supported: {}", convertSampleTypeToString(signalContext.sampleType))
+            return;
+    }
+
+    signalContext.constantValue = value;
+    signalContext.constantValueText = valueText.str();
+    signalContext.constantValueSet = true;
+
+    if (!signalContext.inputDataSignalDescriptor.getValueRange().assigned())
+        constantValueRange(value, signalContext.min, signalContext.max);
+}
+
 void RendererFbImpl::setSignalContextCaption(SignalContext& signalContext, const std::string& caption)
 {
     if (caption.empty())
@@ -1495,6 +1718,12 @@ void RendererFbImpl::processDataPacket(SignalContext& signalContext, const DataP
 {
     if (!signalContext.valid)
         return;
+
+    if (signalContext.domainless)
+    {
+        captureDomainlessValue(signalContext, dataPacket);
+        return;
+    }
 
     auto domainPacket = dataPacket.getDomainPacket();
     if (!domainPacket.assigned())

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/tests/CMakeLists.txt
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES test_ref_fb_module.cpp
                  test_fb_struct_decoder.cpp
                  test_fb_time_delay.cpp
                  test_fb_sum.cpp
+                 test_fb_constant_value.cpp
 )
 
 add_executable(${TEST_APP} ${TEST_SOURCES}

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/tests/CMakeLists.txt
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SOURCES test_ref_fb_module.cpp
                  test_fb_time_delay.cpp
                  test_fb_sum.cpp
                  test_fb_constant_value.cpp
+                 test_fb_renderer.cpp
 )
 
 add_executable(${TEST_APP} ${TEST_SOURCES}

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/tests/test_fb_constant_value.cpp
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/tests/test_fb_constant_value.cpp
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include <opendaq/context_factory.h>
+#include <opendaq/event_packet_ids.h>
+#include <opendaq/input_port_factory.h>
+#include <opendaq/module_ptr.h>
+#include <opendaq/opendaq.h>
+#include <ref_fb_module/module_dll.h>
+
+#include <testutils/memcheck_listener.h>
+
+using namespace daq;
+
+using ConstantValueFbTest = testing::Test;
+
+static const char* FB_TYPE_ID = "RefFBModuleConstantValue";
+
+static ModulePtr createModule(const ContextPtr& context)
+{
+    ModulePtr module;
+    createModule(&module, context);
+    return module;
+}
+
+static FunctionBlockPtr createFb(const ModulePtr& module)
+{
+    return module.createFunctionBlock(FB_TYPE_ID, nullptr, "id");
+}
+
+// Connects a port to the function block output; the packets waiting afterwards are what a fresh listener sees.
+static InputPortConfigPtr connectPort(const ContextPtr& ctx, const FunctionBlockPtr& fb)
+{
+    const auto port = InputPort(ctx, nullptr, "ip");
+    port.connect(fb.getSignals()[0]);
+    return port;
+}
+
+static ListPtr<IPacket> dequeue(const InputPortConfigPtr& port)
+{
+    return port.getConnection().dequeueAll();
+}
+
+static void assertDescriptorChangedEvent(const PacketPtr& packet)
+{
+    ASSERT_EQ(packet.getType(), PacketType::Event);
+    ASSERT_EQ(packet.asPtr<IEventPacket>().getEventId(), event_packet_id::DATA_DESCRIPTOR_CHANGED);
+}
+
+template <typename T>
+static void assertConstantSample(const PacketPtr& packet, T expected)
+{
+    ASSERT_EQ(packet.getType(), PacketType::Data);
+
+    const auto dataPacket = packet.asPtr<IDataPacket>();
+    ASSERT_EQ(dataPacket.getSampleCount(), 1u);
+    ASSERT_FALSE(dataPacket.getDomainPacket().assigned());
+    ASSERT_EQ(*static_cast<T*>(dataPacket.getData()), expected);
+}
+
+TEST_F(ConstantValueFbTest, CreateConstantSignalWithoutDomain)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+
+    // One port for a domain to drive the output. The domain signal it carries is reached through the
+    // output signal rather than listed beside it.
+    ASSERT_EQ(fb.getInputPorts().getCount(), 1u);
+    ASSERT_EQ(fb.getSignals().getCount(), 1u);
+    ASSERT_EQ(fb.getSignals(search::Any()).getCount(), 2u);
+
+    ASSERT_TRUE(fb.hasProperty("Value"));
+    ASSERT_EQ(fb.getPropertyValue("Value"), "0");
+    ASSERT_EQ(fb.getAllProperties().getCount(), 1u);
+
+    const auto signal = fb.getSignals()[0];
+    ASSERT_FALSE(signal.getDomainSignal().assigned());
+
+    const auto descriptor = signal.getDescriptor();
+    ASSERT_TRUE(descriptor.assigned());
+    ASSERT_EQ(descriptor.getRule().getType(), DataRuleType::Constant);
+    ASSERT_EQ(descriptor.getSampleType(), SampleType::Int32);
+}
+
+TEST_F(ConstantValueFbTest, ConnectReceivesCurrentValue)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+
+    const auto packets = dequeue(connectPort(ctx, fb));
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+    assertConstantSample<int32_t>(packets[1], 0);
+}
+
+TEST_F(ConstantValueFbTest, ValueChangeSendsSinglePacket)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+    dequeue(port);
+
+    fb.setPropertyValue("Value", "5");
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 1u);
+    assertConstantSample<int32_t>(packets[0], 5);
+}
+
+TEST_F(ConstantValueFbTest, IdenticalValueWriteSendsNothing)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+
+    fb.setPropertyValue("Value", "5");
+    dequeue(port);
+
+    fb.setPropertyValue("Value", "5");
+    ASSERT_EQ(port.getConnection().getPacketCount(), 0u);
+}
+
+TEST_F(ConstantValueFbTest, SampleTypeChangeSendsDescriptorAndValue)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+
+    fb.setPropertyValue("Value", "7");
+    dequeue(port);
+
+    // Written as a real number, the same quantity becomes a Float64 signal.
+    fb.setPropertyValue("Value", "7.0");
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+    assertConstantSample<double>(packets[1], 7.0);
+
+    const auto descriptor = fb.getSignals()[0].getDescriptor();
+    ASSERT_EQ(descriptor.getSampleType(), SampleType::Float64);
+    ASSERT_EQ(descriptor.getRule().getType(), DataRuleType::Constant);
+}
+
+TEST_F(ConstantValueFbTest, SampleTypeChangeWithUnchangedValueSendsValue)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+    dequeue(port);
+
+    // The number is the same, but the sample it is carried in is not.
+    fb.setPropertyValue("Value", "0.0");
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+    assertConstantSample<double>(packets[1], 0.0);
+}
+
+TEST_F(ConstantValueFbTest, LateConnectReceivesLatestValue)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+
+    fb.setPropertyValue("Value", "1");
+    fb.setPropertyValue("Value", "2");
+    fb.setPropertyValue("Value", "3");
+
+    const auto packets = dequeue(connectPort(ctx, fb));
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+    assertConstantSample<int32_t>(packets[1], 3);
+}
+
+TEST_F(ConstantValueFbTest, VectorValueEmitsEveryElement)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+    dequeue(port);
+
+    fb.setPropertyValue("Value", "1;2;3");
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+
+    const auto dataPacket = packets[1].asPtr<IDataPacket>();
+    ASSERT_EQ(dataPacket.getSampleCount(), 1u);
+
+    const auto* data = static_cast<const int32_t*>(dataPacket.getData());
+    ASSERT_EQ(data[0], 1);
+    ASSERT_EQ(data[1], 2);
+    ASSERT_EQ(data[2], 3);
+}
+
+TEST_F(ConstantValueFbTest, VectorValueSetsDimensions)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto signal = fb.getSignals()[0];
+
+    ASSERT_EQ(signal.getDescriptor().getDimensions().getCount(), 0u);
+
+    fb.setPropertyValue("Value", "1;2;3;4");
+
+    const auto descriptor = signal.getDescriptor();
+    ASSERT_EQ(descriptor.getDimensions().getCount(), 1u);
+    ASSERT_EQ(descriptor.getDimensions()[0].getSize(), 4u);
+    ASSERT_EQ(descriptor.getSampleSize(), 4u * sizeof(int32_t));
+    ASSERT_EQ(descriptor.getRule().getType(), DataRuleType::Constant);
+
+    // Back to a single element leaves a scalar descriptor behind, not a vector of one.
+    fb.setPropertyValue("Value", "5");
+    ASSERT_EQ(signal.getDescriptor().getDimensions().getCount(), 0u);
+}
+
+TEST_F(ConstantValueFbTest, VectorValueLastValueIsAList)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+
+    fb.setPropertyValue("Value", "1.5; 2.5; 3.5");
+
+    const ListPtr<IBaseObject> lastValue = fb.getSignals()[0].getLastValue();
+    ASSERT_EQ(lastValue.getCount(), 3u);
+    ASSERT_EQ(lastValue[0], 1.5);
+    ASSERT_EQ(lastValue[2], 3.5);
+}
+
+TEST_F(ConstantValueFbTest, VectorSizeChangeSendsDescriptorAndValue)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+
+    fb.setPropertyValue("Value", "1;2");
+    dequeue(port);
+
+    fb.setPropertyValue("Value", "1;2;3");
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+    ASSERT_EQ(packets[1].asPtr<IDataPacket>().getRawDataSize(), 3u * sizeof(int32_t));
+}
+
+TEST_F(ConstantValueFbTest, IdenticalVectorWriteSendsNothing)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+
+    fb.setPropertyValue("Value", "1;2;3");
+    dequeue(port);
+
+    // Same values, different spelling.
+    fb.setPropertyValue("Value", " 1 ; 2 ; 3 ");
+    ASSERT_EQ(port.getConnection().getPacketCount(), 0u);
+}
+
+TEST_F(ConstantValueFbTest, MalformedValueIsRejected)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+
+    fb.setPropertyValue("Value", "5");
+    dequeue(port);
+
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "1;abc"));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "1;;2"));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "1;2;"));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", ""));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "1,5"));
+
+    // The signal keeps the value that was last accepted, and nothing was emitted.
+    ASSERT_EQ(fb.getPropertyValue("Value"), "5");
+    ASSERT_EQ(port.getConnection().getPacketCount(), 0u);
+}
+
+TEST_F(ConstantValueFbTest, SampleTypeIsInferredFromValue)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto signal = fb.getSignals()[0];
+
+    const auto sampleTypeOf = [&fb, &signal](const std::string& value)
+    {
+        fb.setPropertyValue("Value", value);
+        return signal.getDescriptor().getSampleType();
+    };
+
+    ASSERT_EQ(sampleTypeOf("5"), SampleType::Int32);
+    ASSERT_EQ(sampleTypeOf("-5; 7"), SampleType::Int32);
+    ASSERT_EQ(sampleTypeOf("+5"), SampleType::Int32);
+
+    // Outside the range of an Int32, so the whole vector widens.
+    ASSERT_EQ(sampleTypeOf("3000000000"), SampleType::Int64);
+    ASSERT_EQ(sampleTypeOf("1; 3000000000"), SampleType::Int64);
+
+    // Written as a real number, or beyond what an integer can hold.
+    ASSERT_EQ(sampleTypeOf("5.0"), SampleType::Float64);
+    ASSERT_EQ(sampleTypeOf("1e3"), SampleType::Float64);
+    ASSERT_EQ(sampleTypeOf("1;2.5;3"), SampleType::Float64);
+    ASSERT_EQ(sampleTypeOf("99999999999999999999"), SampleType::Float64);
+}
+
+TEST_F(ConstantValueFbTest, LargeIntegerValueIsExact)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto port = connectPort(ctx, fb);
+    dequeue(port);
+
+    // Beyond 2^53, so a detour through a double would lose the last digits.
+    fb.setPropertyValue("Value", "9223372036854775807");
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+    assertConstantSample<int64_t>(packets[1], 9223372036854775807LL);
+}
+
+TEST_F(ConstantValueFbTest, NotFiniteValueIsRejected)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+
+    fb.setPropertyValue("Value", "5");
+
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "nan"));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "inf"));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "-inf"));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "1;nan"));
+    ASSERT_ANY_THROW(fb.setPropertyValue("Value", "0x10"));
+
+    ASSERT_EQ(fb.getPropertyValue("Value"), "5");
+    ASSERT_EQ(fb.getSignals()[0].getDescriptor().getSampleType(), SampleType::Int32);
+}
+
+// Domain mode: a signal connected to the input port drives the output
+
+static SignalConfigPtr createDomainSignal(const ContextPtr& ctx)
+{
+    const auto signal = Signal(ctx, nullptr, "time");
+    signal.setDescriptor(DataDescriptorBuilder()
+                             .setSampleType(SampleType::Int64)
+                             .setRule(LinearDataRule(1, 0))
+                             .setTickResolution(Ratio(1, 1000))
+                             .setUnit(Unit("s", -1, "seconds", "time"))
+                             .build());
+    return signal;
+}
+
+TEST_F(ConstantValueFbTest, DomainConnectAttachesDomainSignal)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto signal = fb.getSignals()[0];
+
+    ASSERT_EQ(fb.getInputPorts().getCount(), 1u);
+    ASSERT_FALSE(signal.getDomainSignal().assigned());
+
+    const auto domainSignal = createDomainSignal(ctx);
+    fb.getInputPorts()[0].connect(domainSignal);
+
+    ASSERT_TRUE(signal.getDomainSignal().assigned());
+    ASSERT_EQ(signal.getDomainSignal().getDescriptor().getRule().getType(), DataRuleType::Linear);
+}
+
+TEST_F(ConstantValueFbTest, DomainPacketDrivesOutput)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto domainSignal = createDomainSignal(ctx);
+
+    fb.setPropertyValue("Value", "7");
+    fb.getInputPorts()[0].connect(domainSignal);
+
+    const auto port = connectPort(ctx, fb);
+    dequeue(port);
+
+    domainSignal.sendPacket(DataPacket(domainSignal.getDescriptor(), 100, 0));
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 1u);
+
+    const auto dataPacket = packets[0].asPtr<IDataPacket>();
+    ASSERT_EQ(dataPacket.getSampleCount(), 100u);
+    ASSERT_TRUE(dataPacket.getDomainPacket().assigned());
+    ASSERT_EQ(dataPacket.getDomainPacket().getSampleCount(), 100u);
+
+    // The constant expands across the whole span the domain packet covers.
+    const auto* data = static_cast<const int32_t*>(dataPacket.getData());
+    ASSERT_EQ(data[0], 7);
+    ASSERT_EQ(data[99], 7);
+}
+
+TEST_F(ConstantValueFbTest, ValueChangeTakesEffectOnNextDomainPacket)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto domainSignal = createDomainSignal(ctx);
+
+    fb.setPropertyValue("Value", "1");
+    fb.getInputPorts()[0].connect(domainSignal);
+
+    const auto port = connectPort(ctx, fb);
+    dequeue(port);
+
+    // Writing the value emits nothing by itself while a domain drives the output.
+    fb.setPropertyValue("Value", "2");
+    ASSERT_EQ(port.getConnection().getPacketCount(), 0u);
+
+    domainSignal.sendPacket(DataPacket(domainSignal.getDescriptor(), 10, 0));
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 1u);
+    ASSERT_EQ(*static_cast<const int32_t*>(packets[0].asPtr<IDataPacket>().getData()), 2);
+}
+
+TEST_F(ConstantValueFbTest, ValueSignalOnInputPortUsesItsDomain)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+
+    const auto domainSignal = createDomainSignal(ctx);
+    const auto valueSignal = Signal(ctx, nullptr, "value");
+    valueSignal.setDescriptor(DataDescriptorBuilder().setSampleType(SampleType::Float64).setRule(ExplicitDataRule()).build());
+    valueSignal.setDomainSignal(domainSignal);
+
+    fb.setPropertyValue("Value", "3");
+    fb.getInputPorts()[0].connect(valueSignal);
+
+    const auto port = connectPort(ctx, fb);
+    dequeue(port);
+
+    const auto domainPacket = DataPacket(domainSignal.getDescriptor(), 5, 0);
+    valueSignal.sendPacket(DataPacketWithDomain(domainPacket, valueSignal.getDescriptor(), 5));
+
+    const auto packets = dequeue(port);
+    ASSERT_EQ(packets.getCount(), 1u);
+
+    const auto dataPacket = packets[0].asPtr<IDataPacket>();
+    ASSERT_EQ(dataPacket.getSampleCount(), 5u);
+    ASSERT_EQ(dataPacket.getDomainPacket(), domainPacket);
+}
+
+TEST_F(ConstantValueFbTest, DomainDisconnectReturnsToReplay)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto domainSignal = createDomainSignal(ctx);
+    const auto signal = fb.getSignals()[0];
+
+    fb.setPropertyValue("Value", "9");
+    fb.getInputPorts()[0].connect(domainSignal);
+    ASSERT_TRUE(signal.getDomainSignal().assigned());
+
+    fb.getInputPorts()[0].disconnect();
+    ASSERT_FALSE(signal.getDomainSignal().assigned());
+
+    // The value is the block's own again, so a port connecting now is handed it.
+    const auto packets = dequeue(connectPort(ctx, fb));
+    ASSERT_EQ(packets.getCount(), 2u);
+    assertDescriptorChangedEvent(packets[0]);
+    assertConstantSample<int32_t>(packets[1], 9);
+}
+
+TEST_F(ConstantValueFbTest, NoReplayWhileDomainDrivesOutput)
+{
+    const auto ctx = NullContext();
+    const auto fb = createFb(createModule(ctx));
+    const auto domainSignal = createDomainSignal(ctx);
+
+    fb.setPropertyValue("Value", "4");
+    fb.getInputPorts()[0].connect(domainSignal);
+
+    // Replay on connect is for signals without a domain; here the next domain packet carries the value.
+    const auto packets = dequeue(connectPort(ctx, fb));
+    ASSERT_EQ(packets.getCount(), 1u);
+    assertDescriptorChangedEvent(packets[0]);
+}

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/tests/test_fb_renderer.cpp
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/tests/test_fb_renderer.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2022-2025 openDAQ d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef OPENDAQ_ENABLE_RENDERER
+
+#include <thread>
+
+#include <opendaq/data_descriptor_factory.h>
+#include <opendaq/data_rule_factory.h>
+#include <opendaq/dimension_factory.h>
+#include <opendaq/opendaq.h>
+#include <ref_fb_module/renderer_utils.h>
+
+#include <testutils/memcheck_listener.h>
+
+using namespace daq;
+using namespace daq::modules::ref_fb_module::Renderer;
+
+using RendererUtilsTest = testing::Test;
+
+TEST_F(RendererUtilsTest, ConstantValueRangeAroundPositive)
+{
+    double min, max;
+    constantValueRange(5.0, min, max);
+
+    ASSERT_DOUBLE_EQ(min, 4.5);
+    ASSERT_DOUBLE_EQ(max, 5.5);
+}
+
+TEST_F(RendererUtilsTest, ConstantValueRangeAroundNegative)
+{
+    double min, max;
+    constantValueRange(-5.0, min, max);
+
+    ASSERT_DOUBLE_EQ(min, -5.5);
+    ASSERT_DOUBLE_EQ(max, -4.5);
+}
+
+TEST_F(RendererUtilsTest, ConstantValueRangeAroundZeroIsNotEmpty)
+{
+    double min, max;
+    constantValueRange(0.0, min, max);
+
+    // A zero-height range would divide by zero when mapping the value onto the plot.
+    ASSERT_LT(min, max);
+    ASSERT_DOUBLE_EQ(min, -1.0);
+    ASSERT_DOUBLE_EQ(max, 1.0);
+}
+
+TEST_F(RendererUtilsTest, PlotItemHeightWithoutStrips)
+{
+    ASSERT_FLOAT_EQ(plotItemHeight(600.0f, 2, 0, 40.0f), 300.0f);
+}
+
+TEST_F(RendererUtilsTest, PlotItemHeightReservesStrips)
+{
+    ASSERT_FLOAT_EQ(plotItemHeight(600.0f, 2, 2, 40.0f), 260.0f);
+}
+
+TEST_F(RendererUtilsTest, PlotItemHeightWithoutPlots)
+{
+    ASSERT_FLOAT_EQ(plotItemHeight(600.0f, 0, 3, 40.0f), 0.0f);
+}
+
+TEST_F(RendererUtilsTest, PlotItemHeightNeverNegative)
+{
+    ASSERT_FLOAT_EQ(plotItemHeight(100.0f, 1, 4, 40.0f), 0.0f);
+}
+
+TEST_F(RendererUtilsTest, NullDescriptorDetection)
+{
+    ASSERT_TRUE(isNullDescriptor(nullptr));
+    ASSERT_TRUE(isNullDescriptor(NullDataDescriptor()));
+
+    const auto descriptor = DataDescriptorBuilder().setSampleType(SampleType::Int32).setRule(ConstantDataRule()).build();
+    ASSERT_FALSE(isNullDescriptor(descriptor));
+}
+
+TEST_F(RendererUtilsTest, ConstantValueRangeSpansSeveralValues)
+{
+    double min, max;
+    constantValueRange(2.0, 7.0, min, max);
+
+    ASSERT_DOUBLE_EQ(min, 2.0);
+    ASSERT_DOUBLE_EQ(max, 7.0);
+}
+
+TEST_F(RendererUtilsTest, ConstantValueRangeOfEqualValuesIsNotEmpty)
+{
+    double min, max;
+    constantValueRange(5.0, 5.0, min, max);
+
+    // Elements that are all the same span nothing, and a range of no width cannot be scaled.
+    ASSERT_LT(min, max);
+    ASSERT_DOUBLE_EQ(min, 4.5);
+    ASSERT_DOUBLE_EQ(max, 5.5);
+}
+
+TEST_F(RendererUtilsTest, VectorDescriptorDetection)
+{
+    const auto scalar = DataDescriptorBuilder().setSampleType(SampleType::Int32).setRule(ConstantDataRule()).build();
+    ASSERT_FALSE(isVectorDescriptor(scalar));
+    ASSERT_FALSE(isVectorDescriptor(nullptr));
+
+    const auto vector = DataDescriptorBuilder()
+                            .setSampleType(SampleType::Int32)
+                            .setDimensions(List<IDimension>(Dimension(LinearDimensionRule(1, 0, 4))))
+                            .setRule(ConstantDataRule())
+                            .build();
+    ASSERT_TRUE(isVectorDescriptor(vector));
+}
+
+TEST_F(RendererUtilsTest, ElementValueReadsEachSampleType)
+{
+    const int32_t integers[] = {10, -20, 30};
+    ASSERT_DOUBLE_EQ(elementValue(SampleType::Int32, integers, 0), 10.0);
+    ASSERT_DOUBLE_EQ(elementValue(SampleType::Int32, integers, 1), -20.0);
+
+    const double reals[] = {1.5, 2.5};
+    ASSERT_DOUBLE_EQ(elementValue(SampleType::Float64, reals, 1), 2.5);
+
+    const uint8_t bytes[] = {255, 1};
+    ASSERT_DOUBLE_EQ(elementValue(SampleType::UInt8, bytes, 0), 255.0);
+
+    // A sample type the renderer cannot draw reads as zero rather than as whatever the bytes happen to be.
+    ASSERT_DOUBLE_EQ(elementValue(SampleType::Struct, integers, 0), 0.0);
+}
+
+// Opens a renderer window; run with --gtest_also_run_disabled_tests to look at it.
+TEST_F(RendererUtilsTest, DISABLED_ShowConstantWithRealSignal)
+{
+    const auto instance = Instance();
+    const auto refDevice = instance.addDevice("daqref://device0");
+
+    const auto constFb = instance.addFunctionBlock("RefFBModuleConstantValue");
+    constFb.setPropertyValue("Value", "3");
+
+    const auto vectorFb = instance.addFunctionBlock("RefFBModuleConstantValue");
+    vectorFb.setPropertyValue("Value", "1;4;9;16;9;4;1");
+
+    const auto renderer = instance.addFunctionBlock("RefFBModuleRenderer");
+    renderer.setPropertyValue("SingleXAxis", true);
+    renderer.setPropertyValue("SingleYAxis", true);
+
+    const auto deviceSignal = refDevice.getChannelsRecursive()[0].getSignals()[0];
+    renderer.getInputPorts()[0].connect(deviceSignal);
+    renderer.getInputPorts()[1].connect(constFb.getSignals()[0]);
+    renderer.getInputPorts()[2].connect(vectorFb.getSignals()[0]);
+
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+
+    const auto statusContainer = renderer.getStatusContainer();
+    const StringPtr sharedMessage = statusContainer.getStatusMessage("ComponentStatus");
+    std::cout << "shared-axis renderer message: " << sharedMessage.toStdString() << std::endl;
+    ASSERT_NE(statusContainer.getStatus("ComponentStatus"), "Error") << sharedMessage.toStdString();
+
+    renderer.setPropertyValue("SingleXAxis", false);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    const StringPtr ownTileMessage = statusContainer.getStatusMessage("ComponentStatus");
+    std::cout << "own-tile renderer message: " << ownTileMessage.toStdString() << std::endl;
+    ASSERT_NE(statusContainer.getStatus("ComponentStatus"), "Error") << ownTileMessage.toStdString();
+
+    instance.removeFunctionBlock(renderer);
+}
+
+#endif

--- a/examples/modules/ref_fb_module/modules/ref_fb_module/tests/test_ref_fb_module.cpp
+++ b/examples/modules/ref_fb_module/modules/ref_fb_module/tests/test_ref_fb_module.cpp
@@ -157,11 +157,11 @@ TEST_F(RefFbModuleTest, GetAvailableComponentTypes)
     ASSERT_TRUE(functionBlockTypes.assigned());
 
 #ifdef OPENDAQ_ENABLE_RENDERER
-    ASSERT_EQ(functionBlockTypes.getCount(), 12u);
+    ASSERT_EQ(functionBlockTypes.getCount(), 13u);
     ASSERT_TRUE(functionBlockTypes.hasKey("RefFBModuleRenderer"));
     ASSERT_EQ("RefFBModuleRenderer", functionBlockTypes.get("RefFBModuleRenderer").getId());
 #else
-    ASSERT_EQ(functionBlockTypes.getCount(), 10u);
+    ASSERT_EQ(functionBlockTypes.getCount(), 11u);
 #endif
 
     ASSERT_TRUE(functionBlockTypes.hasKey("RefFBModuleStatistics"));
@@ -195,6 +195,9 @@ TEST_F(RefFbModuleTest, GetAvailableComponentTypes)
 
     ASSERT_TRUE(functionBlockTypes.hasKey("RefFBModuleTimeDelay"));
     ASSERT_EQ("RefFBModuleTimeDelay", functionBlockTypes.get("RefFBModuleTimeDelay").getId());
+
+    ASSERT_TRUE(functionBlockTypes.hasKey("RefFBModuleConstantValue"));
+    ASSERT_EQ("RefFBModuleConstantValue", functionBlockTypes.get("RefFBModuleConstantValue").getId());
 
     // Check module info for module
     ModuleInfoPtr moduleInfo;

--- a/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
+++ b/shared/libraries/native_streaming_protocol/include/native_streaming_protocol/streaming_manager.h
@@ -26,6 +26,10 @@
 #include <packet_streaming/packet_streaming_server.h>
 #include <packet_streaming/packet_streaming_client.h>
 
+#include <cstdint>
+#include <memory>
+#include <vector>
+
 BEGIN_NAMESPACE_OPENDAQ_NATIVE_STREAMING_PROTOCOL
 
 struct PacketBufferData
@@ -206,6 +210,10 @@ private:
         std::unordered_set<std::string> subscribedClientsIds;
         DataDescriptorPtr lastDataDescriptorParam;
         DataDescriptorPtr lastDomainDescriptorParam;
+        // Raw last value of a constant signal without a domain signal, replayed to late subscribers.
+        // Holds one sample of the descriptor it was captured under, or nothing when there is no value to replay.
+        std::unique_ptr<uint8_t[]> lastValueRawData;
+        bool constantWithoutDomain{false};
     };
 
     struct RegisteredClientSignal
@@ -222,6 +230,9 @@ private:
                               PacketPtr&& packet,
                               const std::string& clientId,
                               SignalNumericIdType singalNumericId);
+
+    static void onDescriptorChanged(RegisteredServerSignal& registeredSignal);
+    static void snapshotConstantValue(RegisteredServerSignal& registeredSignal, const PacketPtr& packet);
 
     static native_streaming::WriteTask cachePacketsToLinearBuffer(const PacketStreamingServerPtr& packetStreamingServer,
                                                                   size_t cacheableGroupId,

--- a/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
+++ b/shared/libraries/native_streaming_protocol/src/streaming_manager.cpp
@@ -40,8 +40,12 @@ void StreamingManager::sendPacketToSubscribers(const std::string& signalStringId
                     registeredSignal.lastDataDescriptorParam = dataDescriptorParam;
                 if (domainDescriptorParam.assigned())
                     registeredSignal.lastDomainDescriptorParam = domainDescriptorParam;
+
+                onDescriptorChanged(registeredSignal);
             }
         }
+
+        snapshotConstantValue(registeredSignal, packet);
 
         if (auto it = registeredSignal.subscribedClientsIds.begin(); it != registeredSignal.subscribedClientsIds.end())
         {
@@ -87,8 +91,12 @@ void StreamingManager::processPackets(const tsl::ordered_map<std::string, Packet
                             registeredSignal.lastDataDescriptorParam = dataDescriptorParam;
                         if (domainDescriptorParam.assigned())
                             registeredSignal.lastDomainDescriptorParam = domainDescriptorParam;
+
+                        onDescriptorChanged(registeredSignal);
                     }
                 }
+
+                snapshotConstantValue(registeredSignal, packet);
 
                 if (auto it2 = registeredSignal.subscribedClientsIds.begin(); it2 != registeredSignal.subscribedClientsIds.end())
                 {
@@ -130,6 +138,39 @@ void StreamingManager::sendDaqPacket(const SendPacketBufferCallback& sendPacketB
     {
         sendPacketBufferCb(clientId, std::move(packetBuffer));
     }
+}
+
+void StreamingManager::onDescriptorChanged(RegisteredServerSignal& registeredSignal)
+{
+    // A snapshotted value belongs to the descriptor it was captured under.
+    registeredSignal.lastValueRawData.reset();
+    registeredSignal.constantWithoutDomain = false;
+
+    const auto& domainParam = registeredSignal.lastDomainDescriptorParam;
+    if (domainParam.assigned() && domainParam != NullDataDescriptor())
+        return;
+
+    const auto& descriptor = registeredSignal.lastDataDescriptorParam;
+    if (!descriptor.assigned() || descriptor == NullDataDescriptor())
+        return;
+
+    const auto rule = descriptor.getRule();
+    registeredSignal.constantWithoutDomain = rule.assigned() && rule.getType() == DataRuleType::Constant;
+}
+
+void StreamingManager::snapshotConstantValue(RegisteredServerSignal& registeredSignal, const PacketPtr& packet)
+{
+    if (!registeredSignal.constantWithoutDomain || packet.getType() != PacketType::Data)
+        return;
+
+    const auto dataPacket = packet.asPtrOrNull<IDataPacket>(true);
+    if (!dataPacket.assigned() || dataPacket.getSampleCount() == 0)
+        return;
+
+    registeredSignal.lastValueRawData = std::make_unique<uint8_t[]>(registeredSignal.lastDataDescriptorParam.getSampleSize());
+    void* rawValue = registeredSignal.lastValueRawData.get();
+    if (OPENDAQ_FAILED(dataPacket->getRawLastValue(&rawValue)))
+        registeredSignal.lastValueRawData.reset();
 }
 
 void StreamingManager::linearCachingAssertion(const std::string& condition,
@@ -395,6 +436,18 @@ bool StreamingManager::registerSignalSubscriber(const std::string& signalStringI
                                                                    registeredSignal.lastDomainDescriptorParam),
                                   subscribedClientId,
                                   registeredSignal.numericId);
+
+                    // No reader is created for this subscriber, so the value the first subscriber got on connect
+                    // has to be replayed here.
+                    if (registeredSignal.constantWithoutDomain && registeredSignal.lastValueRawData)
+                    {
+                        sendDaqPacket(sendPacketBufferCb,
+                                      packetStreamingServers.at(subscribedClientId),
+                                      ConstantDataPacketWithRawValue(registeredSignal.lastDataDescriptorParam,
+                                                                     registeredSignal.lastValueRawData.get()),
+                                      subscribedClientId,
+                                      registeredSignal.numericId);
+                    }
                 }
             }
             subscribers.insert(subscribedClientId);

--- a/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
+++ b/shared/libraries/native_streaming_protocol/tests/test_streaming_protocol.cpp
@@ -7,6 +7,8 @@
 
 #include <memory>
 #include <future>
+#include <thread>
+#include <chrono>
 
 using namespace daq;
 using namespace daq::opendaq_native_streaming_protocol;
@@ -899,6 +901,159 @@ TEST_P(StreamingProtocolTest, SendMultipleDataPackets)
         ASSERT_EQ(signalId, serverSignal.getGlobalId());
         ASSERT_EQ(serverDataPackets, packets);
     }
+}
+
+TEST_P(StreamingProtocolTest, ConstantValueReplayedToLateSubscriber)
+{
+    if (clients.size() < 2)
+        return;
+
+    const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Int64).setRule(ConstantDataRule()).build();
+    auto serverEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, NullDataDescriptor());
+    auto serverDataPacket = ConstantDataPacket(valueDescriptor, int64_t{7});
+    auto serverSignal = SignalWithDescriptor(serverContext, valueDescriptor, nullptr, "signal");
+
+    startServer(List<ISignal>(serverSignal), serverEventPacket);
+
+    // the first subscriber gets the descriptor and then the value the signal produced
+    auto& firstClient = clients[0];
+    firstClient.clientHandler = createClient(firstClient, firstClient.signalAvailableHandler);
+    ASSERT_TRUE(firstClient.clientHandler->connect(SERVER_ADDRESS, NATIVE_STREAMING_LISTENING_PORT));
+    firstClient.clientHandler->sendStreamingRequest();
+    ASSERT_EQ(firstClient.streamingInitFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(firstClient.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
+    const auto firstClientSignalId = std::get<0>(firstClient.signalAvailableFuture.get());
+
+    firstClient.clientHandler->subscribeSignal(firstClientSignalId);
+    ASSERT_EQ(firstClient.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
+
+    ASSERT_EQ(firstClient.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(std::get<1>(firstClient.packetReceivedFuture.get()), serverEventPacket);
+    firstClient.packetReceivedPromise = std::promise<std::tuple<StringPtr, PacketPtr>>();
+    firstClient.packetReceivedFuture = firstClient.packetReceivedPromise.get_future();
+
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), serverDataPacket);
+    ASSERT_EQ(firstClient.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(std::get<1>(firstClient.packetReceivedFuture.get()), serverDataPacket);
+
+    // every later subscriber gets the descriptor and the value without the server sending anything new
+    for (size_t i = 1; i < clients.size(); ++i)
+    {
+        auto& client = clients[i];
+        client.clientHandler = createClient(client, client.signalAvailableHandler);
+        ASSERT_TRUE(client.clientHandler->connect(SERVER_ADDRESS, NATIVE_STREAMING_LISTENING_PORT));
+        client.clientHandler->sendStreamingRequest();
+        ASSERT_EQ(client.streamingInitFuture.wait_for(timeout), std::future_status::ready);
+        ASSERT_EQ(client.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
+        const auto clientSignalId = std::get<0>(client.signalAvailableFuture.get());
+
+        // both packets arrive back to back, so collect them instead of resetting a promise in between
+        auto packetsPromise = std::make_shared<std::promise<ListPtr<IPacket>>>();
+        auto packetsFuture = packetsPromise->get_future();
+        auto receivedPackets = List<IPacket>();
+        client.packetHandler =
+            [packetsPromise = packetsPromise, receivedPackets = receivedPackets](const StringPtr&, const PacketPtr& packet) mutable
+        {
+            receivedPackets.pushBack(packet);
+            if (receivedPackets.getCount() == 2)
+                packetsPromise->set_value(receivedPackets);
+        };
+        client.clientHandler->setStreamingHandlers(client.signalAvailableHandler,
+                                                   client.signalUnavailableHandler,
+                                                   client.packetHandler,
+                                                   client.signalSubscriptionAckHandler,
+                                                   client.connectionStatusChangedHandler,
+                                                   client.streamingInitDoneHandler);
+
+        client.clientHandler->subscribeSignal(clientSignalId);
+        ASSERT_EQ(client.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
+
+        ASSERT_EQ(packetsFuture.wait_for(timeout), std::future_status::ready);
+        const auto packets = packetsFuture.get();
+        ASSERT_EQ(packets[0].getType(), PacketType::Event);
+
+        const auto dataPacket = packets[1].asPtr<IDataPacket>();
+        ASSERT_EQ(dataPacket.getSampleCount(), 1u);
+        ASSERT_FALSE(dataPacket.getDomainPacket().assigned());
+        ASSERT_EQ(dataPacket.getLastValue(), 7);
+    }
+}
+
+TEST_P(StreamingProtocolTest, ConstantValueNotReplayedAfterDescriptorChanged)
+{
+    if (clients.size() < 2)
+        return;
+
+    const auto valueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Int64).setRule(ConstantDataRule()).build();
+    auto serverEventPacket = DataDescriptorChangedEventPacket(valueDescriptor, NullDataDescriptor());
+    auto serverDataPacket = ConstantDataPacket(valueDescriptor, int64_t{7});
+    auto serverSignal = SignalWithDescriptor(serverContext, valueDescriptor, nullptr, "signal");
+
+    const auto newValueDescriptor = DataDescriptorBuilder().setSampleType(SampleType::Int32).setRule(ConstantDataRule()).build();
+    auto newEventPacket = DataDescriptorChangedEventPacket(newValueDescriptor, NullDataDescriptor());
+
+    startServer(List<ISignal>(serverSignal), serverEventPacket);
+
+    auto& firstClient = clients[0];
+    firstClient.clientHandler = createClient(firstClient, firstClient.signalAvailableHandler);
+    ASSERT_TRUE(firstClient.clientHandler->connect(SERVER_ADDRESS, NATIVE_STREAMING_LISTENING_PORT));
+    firstClient.clientHandler->sendStreamingRequest();
+    ASSERT_EQ(firstClient.streamingInitFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(firstClient.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
+    const auto firstClientSignalId = std::get<0>(firstClient.signalAvailableFuture.get());
+
+    firstClient.clientHandler->subscribeSignal(firstClientSignalId);
+    ASSERT_EQ(firstClient.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(signalSubscribedFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(firstClient.packetReceivedFuture.wait_for(timeout), std::future_status::ready);
+
+    // this client receives two more packets below, and its default handler fulfills a one-shot promise
+    firstClient.packetHandler = [](const StringPtr&, const PacketPtr&) {};
+    firstClient.clientHandler->setStreamingHandlers(firstClient.signalAvailableHandler,
+                                                    firstClient.signalUnavailableHandler,
+                                                    firstClient.packetHandler,
+                                                    firstClient.signalSubscriptionAckHandler,
+                                                    firstClient.connectionStatusChangedHandler,
+                                                    firstClient.streamingInitDoneHandler);
+
+    // a value, and then a descriptor the value does not belong to
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), serverDataPacket);
+    serverHandler->sendPacket(serverSignal.getGlobalId().toStdString(), newEventPacket);
+
+    // the late subscriber gets the descriptor only - replaying the stale value would contradict it
+    auto& lateClient = clients[1];
+    lateClient.clientHandler = createClient(lateClient, lateClient.signalAvailableHandler);
+    ASSERT_TRUE(lateClient.clientHandler->connect(SERVER_ADDRESS, NATIVE_STREAMING_LISTENING_PORT));
+    lateClient.clientHandler->sendStreamingRequest();
+    ASSERT_EQ(lateClient.streamingInitFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(lateClient.signalAvailableFuture.wait_for(timeout), std::future_status::ready);
+    const auto lateClientSignalId = std::get<0>(lateClient.signalAvailableFuture.get());
+
+    auto firstPacketPromise = std::make_shared<std::promise<void>>();
+    auto firstPacketFuture = firstPacketPromise->get_future();
+    auto receivedPackets = List<IPacket>();
+    lateClient.packetHandler =
+        [firstPacketPromise = firstPacketPromise, receivedPackets = receivedPackets](const StringPtr&, const PacketPtr& packet) mutable
+    {
+        receivedPackets.pushBack(packet);
+        if (receivedPackets.getCount() == 1)
+            firstPacketPromise->set_value();
+    };
+    lateClient.clientHandler->setStreamingHandlers(lateClient.signalAvailableHandler,
+                                                   lateClient.signalUnavailableHandler,
+                                                   lateClient.packetHandler,
+                                                   lateClient.signalSubscriptionAckHandler,
+                                                   lateClient.connectionStatusChangedHandler,
+                                                   lateClient.streamingInitDoneHandler);
+
+    lateClient.clientHandler->subscribeSignal(lateClientSignalId);
+    ASSERT_EQ(lateClient.subscribedAckFuture.wait_for(timeout), std::future_status::ready);
+    ASSERT_EQ(firstPacketFuture.wait_for(timeout), std::future_status::ready);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ASSERT_EQ(receivedPackets.getCount(), 1u);
+    ASSERT_EQ(receivedPackets[0].getType(), PacketType::Event);
 }
 
 TEST_P(StreamingProtocolTest, AddNotPublicSignal)


### PR DESCRIPTION
# Brief

A constant rule signal with no domain signal now hands its current value to an input port on connect, constant values may be vectors, and a reference function block demonstrates both.

# Description

- Replay the last value of a constant signal that has no domain signal, immediately after an input port connects. Changes to such a signal are rare, so a port connecting between changes would otherwise wait indefinitely without knowing the current value.
- Replay the same value to native streaming subscribers after the first. Only the first subscriber creates a reader, so the later ones never saw the value handed over locally on connect.
- Fix constant rule signals with dimensions. The rule calculator was built from the rule and sample type alone, so it treated one sample as one value and left the rest of each buffer uninitialised. It now receives the element count from the descriptor that owns it.
- Add a `ConstantValue` reference function block with a single `Value` property, holding semicolon separated values whose count is the vector size and whose notation decides the sample type. Connecting a signal to its input port makes the output follow that domain instead.
- Render signals that have no domain signal. The renderer discarded them entirely: their context stayed invalid because a domain descriptor was required, and every packet without a domain packet was dropped.

# Usage example

A constant that a consumer can read at any time, without waiting for the next change:

```cpp
const auto descriptor = DataDescriptorBuilder().setSampleType(SampleType::Int64).setRule(ConstantDataRule()).build();
signal.setDescriptor(descriptor);
signal.sendPacket(ConstantDataPacket(descriptor, int64_t{7}));

// Connecting at any later point yields the descriptor event and then the value 7.
port.connect(signal);
```

Vectors, with the element count taken from the descriptor's dimensions:

```cpp
const auto descriptor = DataDescriptorBuilder()
                            .setSampleType(SampleType::Int32)
                            .setDimensions(List<IDimension>(Dimension(LinearDimensionRule(1, 0, 3))))
                            .setRule(ConstantDataRule())
                            .build();

signal.sendPacket(ConstantDataPacket(descriptor, std::vector<int32_t>{4, 5, 6}));
```

The reference function block, where the text decides both the vector size and the sample type:

```cpp
auto fb = instance.addFunctionBlock("RefFBModuleConstantValue");

fb.setPropertyValue("Value", "2.5");     // one Float64 element
fb.setPropertyValue("Value", "1;2;3");   // three Int32 elements

// With nothing connected to its input port, a consumer connecting here is handed the current value.
port.connect(fb.getSignals()[0]);

// Connect a domain and the output follows it instead, one constant packet per domain packet.
fb.getInputPorts()[0].connect(device.getSignalsRecursive()[0]);
```

# API changes

Binary compatibility holds. `IDataRuleCalcPrivate` is unchanged; the element count reaches the calculator from the descriptor that owns it. The additions below are header-only factories and internal types.

```diff
+ DataPacketPtr ConstantDataPacket(const DataDescriptorPtr& descriptor, T value)
+ DataPacketPtr ConstantDataPacket(const DataDescriptorPtr& descriptor, const std::vector<T>& values)
+ DataPacketPtr ConstantDataPacketWithDomain(const DataPacketPtr& domainPacket, const DataDescriptorPtr& descriptor, uint64_t sampleCount, const std::vector<T>& values)
+ DataPacketPtr ConstantDataPacketWithRawValue(const DataDescriptorPtr& descriptor, void* rawValue)
+ static DataRuleCalc* createDataRuleCalcTyped(const DataRulePtr& outputRule, SampleType outputType, SizeT elementCount = 1)
+ DataRuleCalcTyped<T>::DataRuleCalcTyped(const DataRulePtr& rule, SizeT elementCount = 1)
```

# Required application changes

None.

# Required module changes

None.

---

Two related defects were found while doing this and are deliberately **not** addressed here:

- A linear rule combined with dimensions has the same defect the constant rule had, writing one value per sample into a buffer sized for a whole vector. Rejecting the combination in `validate()` was implemented and withdrawn, because `DataDescriptorTest.DeserializeBackwardsCompat` deserializes a descriptor written by an older version that pairs three dimensions with a linear rule. That makes it a data compatibility decision rather than an API one.
- `OrdinalObjectImpl::compareTo` returns `OPENDAQ_EQUAL` when neither operand is greater or lower, which is every NaN comparison, so `ObjectPtr::operator==` reports NaN as equal to everything. The property system then treats a NaN write as a no-op: no listener runs, the value is unchanged, and `setPropertyValue` still reports success.
