### PR TITLE
fix(gui_demo): skip modules that don't implement available_streaming_types

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo/components/add_config_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/add_config_dialog.py
@@ -80,7 +80,13 @@ class AddConfigDialog(Dialog):
         streaming_protocols = []
         module_manager: daq.IModuleManager = parent_device.context.module_manager
         for _module in module_manager.modules:
-            for streaming in _module.available_streaming_types:
+            # Reporting streaming types is optional: a module may return OPENDAQ_ERR_NOTIMPLEMENTED.
+            # Skip such modules instead of letting one of them break the whole dialog.
+            try:
+                available_streaming_types = _module.available_streaming_types
+            except RuntimeError:
+                continue
+            for streaming in available_streaming_types:
                 streaming_protocols.append(streaming)
 
         if implied_protocol not in streaming_protocols:


### PR DESCRIPTION
# Brief

Guard the streaming-protocol enumeration in the GUI demo's connection-string dialog so a module without `available_streaming_types` doesn't break the whole dialog.

# Description

- In `AddConfigDialog.from_connection_string`, wrap `_module.available_streaming_types` in `try`/`except RuntimeError` and skip the module when it raises; other modules are collected as before.
