### PR TITLE
Python GUI: Added a search to tree view

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -582,7 +582,9 @@ class App(tk.Tk):
 
         # if component is alive and in treeview
         if node and self.tree.exists(desired_iid):
-            if desired_iid != current_iid:  # if component is not already selected
+            if self._is_default_folder(desired_iid):
+                self.tree.selection_set('')
+            elif desired_iid != current_iid:  # if component is not already selected
                 self.tree.selection_set(desired_iid)
                 self.tree.focus(desired_iid)
                 self.tree.see(desired_iid)

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -97,6 +97,7 @@ class App(tk.Tk):
 
         self.context = AppContext(context_params)
         self.event_port = EventPort(self, event_callback=self.on_refresh_event)
+        self.tree_search_query = ''
 
         self.context.ui_scaling_factor = int(args.scale)
         self.context.include_reference_devices = bool(args.demo)
@@ -278,14 +279,29 @@ class App(tk.Tk):
         search_frame = ttk.Frame(frame)
         search_frame.pack(fill=tk.X, side=tk.TOP)
 
-        search_entry = ttk.Entry(search_frame)
+        # leave room on the right for the clear cross drawn inside the entry
+        entry_style = ttk.Style()
+        entry_style.configure('Search.TEntry', padding=(2, 2, 24, 2))
+
+        search_entry = ttk.Entry(search_frame, style='Search.TEntry')
         search_entry.pack(fill=tk.X, padx=(0,16), pady=(0,4), ipady=2)
         self.tree_search_default_foreground = search_entry.cget('foreground')
         search_entry.insert(0, "Filter tree by name, tag or local id")
         search_entry.configure(foreground='gray')
         search_entry.bind('<FocusIn>', self.handle_tree_search_focus_in)
         search_entry.bind('<FocusOut>', self.handle_tree_search_focus_out)
+        search_entry.bind('<KeyRelease>', self.handle_tree_search_changed)
+        search_entry.bind('<Escape>', self.handle_tree_search_clear)
         self.tree_search_entry = search_entry
+
+        clear_label = tk.Label(search_frame, text='×', bd=0, padx=4, cursor='hand2',
+                               font=('TkDefaultFont', 12), background='white',
+                               foreground='gray30')
+        clear_label.place(in_=search_entry, relx=1.0, rely=0.5, anchor=tk.E, x=-4)
+        clear_label.bind('<Button-1>', self.handle_tree_search_clear)
+        clear_label.bind('<Enter>', lambda e: clear_label.configure(background='gray85'))
+        clear_label.bind('<Leave>', lambda e: clear_label.configure(background='white'))
+        self.tree_search_clear_label = clear_label
 
         # define columns
         tree = ttk.Treeview(frame, columns=('name', 'hash'), displaycolumns=(
@@ -327,6 +343,77 @@ class App(tk.Tk):
             self.tree_search_entry.insert(0, "Filter tree by name, tag or local id")
             self.tree_search_entry.configure(foreground='gray')
 
+    def handle_tree_search_changed(self, event=None):
+        text = self.tree_search_entry.get()
+        if text == "Filter tree by name, tag or local id":
+            text = ''
+        query = text.strip().lower()
+        if query == self.tree_search_query:
+            return
+        self.tree_search_query = query
+        self.tree_update(self.context.selected_node)
+
+    def handle_tree_search_clear(self, event=None):
+        self.tree_search_entry.delete(0, tk.END)
+        self.tree_search_entry.configure(
+            foreground=self.tree_search_default_foreground)
+        self.handle_tree_search_changed()
+        # drop the focus so the entry shows the hint again instead of an empty field
+        self.focus_set()
+        self.handle_tree_search_focus_out(None)
+
+    def tree_item_matches_search(self, iid, query):
+        if query in self.tree.item(iid, 'text').lower():
+            return True
+
+        component = self.context.nodes.get(iid)
+        if component is None:
+            return False
+
+        for getter in (lambda: component.name, lambda: component.local_id):
+            try:
+                if query in str(getter()).lower():
+                    return True
+            except Exception:
+                pass
+
+        try:
+            for tag in component.tags.list:
+                if query in str(tag).lower():
+                    return True
+        except Exception:
+            pass
+
+        return False
+
+    def tree_apply_search_filter(self):
+        query = self.tree_search_query
+        if not query:
+            return
+
+        matches = []
+
+        def collect(parent):
+            for iid in self.tree.get_children(parent):
+                if self.tree_item_matches_search(iid, query):
+                    # keep the whole subtree of a match, do not look deeper
+                    matches.append(iid)
+                else:
+                    collect(iid)
+
+        collect('')
+        match_set = set(matches)
+
+        # pull matches out of their (non-matching) parents
+        for iid in matches:
+            self.tree.move(iid, '', tk.END)
+            self.tree.item(iid, open=True)
+
+        # whatever is left at the top level holds no match anymore
+        for iid in self.tree.get_children(''):
+            if iid not in match_set:
+                self.tree.delete(iid)
+
     def tree_update(self, new_selected_node=None):
         self.tree.delete(*self.tree.get_children())
         self.right_side_panel_clear()
@@ -350,10 +437,12 @@ class App(tk.Tk):
                 self.tree.insert('', tk.END, iid=mod_id,
                                  text=self._format_tree_item_text(display_name), open=False)
                 self.modules_map[mod_id] = mod
+            self.tree_apply_search_filter()
             return
 
         self.tree_traverse_components_recursive(
             self.context.instance, self.current_tab())
+        self.tree_apply_search_filter()
         self.tree_restore_selection(
             self.context.selected_node)  # reset in case the selected node outdates
         self.set_node_update_status()

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -283,7 +283,7 @@ class App(tk.Tk):
         entry_style = ttk.Style()
         entry_style.configure('Search.TEntry', padding=(2, 2, 24, 2))
 
-        search_entry = ttk.Entry(search_frame, style='Search.TEntry')
+        search_entry = ttk.Entry(search_frame, style='Search.TEntry', takefocus=False)
         search_entry.pack(fill=tk.X, padx=(0,16), pady=(0,4), ipady=2)
         self.tree_search_default_foreground = search_entry.cget('foreground')
         search_entry.insert(0, "Filter tree by name, tag or local id")
@@ -358,8 +358,8 @@ class App(tk.Tk):
         self.tree_search_entry.configure(
             foreground=self.tree_search_default_foreground)
         self.handle_tree_search_changed()
-        # drop the focus so the entry shows the hint again instead of an empty field
-        self.focus_set()
+        # hand the focus to the tree, not the toplevel, so it cannot land back here
+        self.tree.focus_set()
         self.handle_tree_search_focus_out(None)
 
     def tree_item_matches_search(self, iid, query):

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -275,6 +275,18 @@ class App(tk.Tk):
     def tree_widget_create(self, parent_frame):
         frame = ttk.Frame(parent_frame)
 
+        search_frame = ttk.Frame(frame)
+        search_frame.pack(fill=tk.X, side=tk.TOP)
+
+        search_entry = ttk.Entry(search_frame)
+        search_entry.pack(fill=tk.X, padx=(0,16), pady=(0,4), ipady=2)
+        self.tree_search_default_foreground = search_entry.cget('foreground')
+        search_entry.insert(0, "Filter tree by name, tag or local id")
+        search_entry.configure(foreground='gray')
+        search_entry.bind('<FocusIn>', self.handle_tree_search_focus_in)
+        search_entry.bind('<FocusOut>', self.handle_tree_search_focus_out)
+        self.tree_search_entry = search_entry
+
         # define columns
         tree = ttk.Treeview(frame, columns=('name', 'hash'), displaycolumns=(
             'name'), show='tree', selectmode=tk.BROWSE)
@@ -303,6 +315,17 @@ class App(tk.Tk):
         tree.tag_configure('error', foreground=utils.StatusColor.ERROR)
         tree.tag_configure('inactive', foreground='gray')
         self.tree = tree
+
+    def handle_tree_search_focus_in(self, event):
+        if self.tree_search_entry.get() == "Filter tree by name, tag or local id":
+            self.tree_search_entry.delete(0, tk.END)
+            self.tree_search_entry.configure(
+                foreground=self.tree_search_default_foreground)
+
+    def handle_tree_search_focus_out(self, event):
+        if not self.tree_search_entry.get():
+            self.tree_search_entry.insert(0, "Filter tree by name, tag or local id")
+            self.tree_search_entry.configure(foreground='gray')
 
     def tree_update(self, new_selected_node=None):
         self.tree.delete(*self.tree.get_children())
@@ -776,6 +799,9 @@ class App(tk.Tk):
         node.disable_discovery()
 
     def handle_tree_right_button_release(self, event):
+        if self.current_tab() == DisplayType.MODULES:
+            return
+
         iid = utils.treeview_get_first_selection(self.tree)
 
         node = None


### PR DESCRIPTION
# Brief

Adds a filter box above the component tree of the Python GUI demo example, matching a row's text, its component name, local id and tags.

# Description

## Tree filter

- Add a filter box above the tree, matching row text, name, local id and tags
- Keep the whole subtree of a match and stop searching below it
- Lift matches to the top level, open them, and drop what holds no match
- Hold the hint as gray text inside the box while it is empty, since ttk has no placeholder
- Add a clear cross inside the box, with the entry padded on the right for it
- Clear on Escape
- Hand the focus to the tree on clear
- Stop the filter box taking focus on start
- Refilter only when the query text changed, rebuilding the tree from the instance each time
- Filter the Modules tab from the same query

## Tree

- Stop folders collapsing when a component is added to or removed from an object
- Ignore a right click on the tree while the Modules tab is open

# Implementation details

<details>
<summary><b>Per-feature detail, with the functions each one added or changed</b></summary>

### Filtering the tree

The row text is matched first, then the component's name, local id and tags, each read behind a `try`, since a component that has gone away raises rather than answering. Deleting the non matching rows is safe because every query change rebuilds the tree from the instance. A match inside another match is not lifted out of it.

Algorithem:
- Strip and lowercase the query, and test each field as a case insensitive substring
- Test the row's text first, then the component's `name`, its `local_id`, then each entry of `tags.list`, stopping at the first field that holds the query
- Test the row's text alone where `context.nodes` holds no component for the row
- Leave the global id out of the tested fields

`tree_restore_selection` leaves the selection empty for a default folder row (`Sig`, `FB`, `Dev`, `IP`, `IO`, `Srv`).

```diff
+ App::handle_tree_search_focus_in(event)        # clears the hint before typing
+ App::handle_tree_search_focus_out(event)       # puts the hint back when left empty
+ App::handle_tree_search_changed(event)         # rebuilds only when the query text changed
+ App::handle_tree_search_clear(event)           # also the Escape binding and the cross
+ App::tree_item_matches_search(iid, query)      # row text, name, local id, tags
+ App::tree_apply_search_filter()
+ App::tree_apply_search_filter.collect(parent)  # keeps a match's subtree, does not look deeper
```

Other:

```diff
  App::tree_widget_create(parent_frame)         # the search row, its style and the clear cross
  App::tree_update(new_selected_node)           # applies the filter, on the Modules tab too
  App::tree_restore_selection(old_node)         # a default folder row is left unselected, so it is not collapsed
  App::handle_tree_right_button_release(event)  # no context menu on the Modules tab
```

</details>

# Usage example

In terminal use:

```shell
cd "examples/applications/python/GUI Application"
python gui_demo.py
```
