### PR TITLE
Python GUI: Added a logger display

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -28,6 +28,7 @@ try:
     from gui_demo.components.add_server_dialog import AddServerDialog
     from gui_demo.components.add_function_block_dialog import AddFunctionBlockDialog
     from gui_demo.components.load_instance_config_dialog import LoadInstanceConfigDialog
+    from gui_demo.components.logs_dialog import LogsDialog
     from gui_demo.app_context import AppContext
     from gui_demo import utils
     from gui_demo.event_port import EventPort
@@ -38,6 +39,7 @@ except Exception as e:
     from opendaq.gui_demo.components.add_server_dialog import AddServerDialog
     from opendaq.gui_demo.components.add_function_block_dialog import AddFunctionBlockDialog
     from opendaq.gui_demo.components.load_instance_config_dialog import LoadInstanceConfigDialog
+    from opendaq.gui_demo.components.logs_dialog import LogsDialog
     from opendaq.gui_demo.app_context import AppContext
     from opendaq.gui_demo import utils
     from opendaq.gui_demo.event_port import EventPort
@@ -139,10 +141,13 @@ class App(tk.Tk):
         nb.pack(fill=tk.X, side=tk.LEFT, expand=True)
         self.nb = nb
 
-        refresh_button = ttk.Button(
-            nb_row, image=self.context.menu_icon('refresh'),
-            command=self.handle_refresh_button_clicked)
-        refresh_button.pack(side=tk.RIGHT, padx=5)
+        refresh_button = self.toolbar_button_create(
+            nb_row, 'refresh', self.handle_refresh_button_clicked)
+        refresh_button.pack(side=tk.RIGHT, padx=(0, 5))
+
+        logs_button = self.toolbar_button_create(
+            nb_row, 'logs', self.logs_dialog_show)
+        logs_button.pack(side=tk.RIGHT)
 
         main_frame_navigator = ttk.PanedWindow(
             main_frame_bottom, orient=tk.HORIZONTAL)
@@ -220,6 +225,31 @@ class App(tk.Tk):
         self.tree_update()
 
     # MARK: - Menu bar
+    # MARK: - Toolbar
+    def toolbar_button_create(self, parent, icon, command=None):
+        background = (ttk.Style().lookup('TFrame', 'background')
+                      or self.cget('background'))
+        hover = self.darken_color(background)
+        pressed = self.darken_color(background, 0.7)
+
+        size = self.context.menu_icon(icon).width() + 8
+        button = tk.Label(parent, image=self.context.menu_icon(icon), bd=0,
+                          width=size, height=size, cursor='hand2',
+                          background=background)
+
+        def on_release(event):
+            inside = (0 <= event.x < button.winfo_width()
+                      and 0 <= event.y < button.winfo_height())
+            button.configure(background=hover if inside else background)
+            if inside and command is not None:
+                command()
+
+        button.bind('<Enter>', lambda e: button.configure(background=hover))
+        button.bind('<Leave>', lambda e: button.configure(background=background))
+        button.bind('<Button-1>', lambda e: button.configure(background=pressed))
+        button.bind('<ButtonRelease-1>', on_release)
+        return button
+
     def menu_bar_create(self):
         menu_bar = tk.Menu(self)
         self.config(menu=menu_bar)
@@ -702,6 +732,17 @@ class App(tk.Tk):
 
         self.right_side_panel = sframe
         self.right_side_canvas = None
+
+    # MARK: - Logs dialog
+    def logs_dialog_show(self):
+        dialog = getattr(self, 'logs_dialog', None)
+        if dialog is not None and dialog.winfo_exists():
+            dialog.deiconify()
+            dialog.lift()
+            dialog.focus_set()
+            return
+        self.logs_dialog = LogsDialog(self, self.context)
+        self.logs_dialog.show_modeless()
 
     # MARK: - Add device dialog
     def add_device_dialog_show(self, component=None):

--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import tempfile
 
 import opendaq as daq
 
@@ -50,6 +51,15 @@ class AppContext(object):
 
         for protocol in getattr(params, 'discovery_servers', []):
             builder.add_discovery_server(protocol)
+
+        self.log_file_path = os.path.join(
+            tempfile.gettempdir(), 'opendaq_gui_demo_{}.log'.format(os.getpid()))
+        try:
+            if os.path.exists(self.log_file_path):
+                os.remove(self.log_file_path)
+            builder.add_logger_sink(daq.BasicFileLoggerSink(self.log_file_path))
+        except Exception:
+            self.log_file_path = None
 
         self.instance = daq.InstanceFromBuilder(builder)
         self.instance.context.on_core_event + daq.QueuedEventHandler(self.on_core_event)

--- a/examples/applications/python/GUI Application/gui_demo/components/dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/dialog.py
@@ -40,6 +40,14 @@ class Dialog(tk.Toplevel):
         self.focus_set()
         self.grab_set()         # Prevent interaction with other windows
         self.wait_window(self)
+
+    def show_modeless(self):
+        self.initial_update()
+        self.deiconify()
+        self.center_window()
+        self.update_idletasks()
+        self.event_generate('<<DialogReady>>')
+        self.focus_set()
         
     def close(self):
         self.destroy()

--- a/examples/applications/python/GUI Application/gui_demo/components/logs_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/logs_dialog.py
@@ -1,0 +1,55 @@
+import os
+import tkinter as tk
+from tkinter import ttk
+
+from .. import utils
+from ..app_context import AppContext
+from .dialog import Dialog
+
+POLL_INTERVAL_MS = 500
+INITIAL_TAIL_BYTES = 256 * 1024
+MAX_LINES = 5000
+
+
+class LogsDialog(Dialog):
+
+    def __init__(self, parent, context: AppContext, **kwargs):
+        super().__init__(parent, 'Logs', context, **kwargs)
+        self.geometry('{}x{}'.format(int(900 * context.dpi_factor),
+                                     int(520 * context.dpi_factor)))
+        self.log_file_path = getattr(context, 'log_file_path', None)
+        self.offset = 0
+        self.poll_id = None
+        self.line_count = 0
+
+        header = ttk.Frame(self)
+        self.follow_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(header, text='Follow',
+                        variable=self.follow_var).pack(side=tk.LEFT)
+        ttk.Button(header, text='Clear',
+                   command=self.handle_clear_clicked).pack(side=tk.RIGHT, padx=4)
+        header.pack(fill=tk.X, pady=(0, 6))
+
+        footer = ttk.Frame(self)
+        self.status_label = ttk.Label(footer, text='', foreground='gray')
+        self.status_label.pack(side=tk.LEFT)
+        ttk.Button(footer, text='Close',
+                   command=self.close).pack(side=tk.RIGHT)
+        footer.pack(side=tk.BOTTOM, fill=tk.X, pady=(6, 0))
+
+        text_frame = ttk.Frame(self)
+        text = tk.Text(text_frame, wrap=tk.NONE, state=tk.DISABLED,
+                       font=('Consolas', 9), bd=1, relief=tk.SUNKEN)
+        y_scroll = ttk.Scrollbar(text_frame, orient=tk.VERTICAL,
+                                 command=text.yview)
+        x_scroll = ttk.Scrollbar(text_frame, orient=tk.HORIZONTAL,
+                                 command=text.xview)
+        text.configure(yscrollcommand=y_scroll.set, xscrollcommand=x_scroll.set)
+        y_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        x_scroll.pack(side=tk.BOTTOM, fill=tk.X)
+        text.pack(fill=tk.BOTH, expand=True)
+        text_frame.pack(fill=tk.BOTH, expand=True)
+        text.tag_configure('warning', foreground=str(utils.StatusColor.WARNING))
+        text.tag_configure('error', foreground=str(utils.StatusColor.ERROR))
+        text.tag_configure('debug', foreground='gray40')
+        self.text = text

--- a/examples/applications/python/GUI Application/gui_demo/components/logs_dialog.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/logs_dialog.py
@@ -53,3 +53,70 @@ class LogsDialog(Dialog):
         text.tag_configure('error', foreground=str(utils.StatusColor.ERROR))
         text.tag_configure('debug', foreground='gray40')
         self.text = text
+
+    def initial_update(self):
+        if not self.log_file_path:
+            self.set_status('No log file sink, logs are going to the console only')
+            return
+        if os.path.exists(self.log_file_path):
+            self.offset = max(0, os.path.getsize(self.log_file_path)
+                              - INITIAL_TAIL_BYTES)
+        self.poll()
+
+    def poll(self):
+        self.read_new_lines()
+        self.poll_id = self.after(POLL_INTERVAL_MS, self.poll)
+
+    def read_new_lines(self):
+        if not self.log_file_path or not os.path.exists(self.log_file_path):
+            self.set_status('Waiting for %s' % self.log_file_path)
+            return
+        try:
+            with open(self.log_file_path, 'rb') as handle:
+                handle.seek(self.offset)
+                chunk = handle.read()
+                self.offset = handle.tell()
+        except OSError as e:
+            self.set_status('Cannot read log file: %s' % e)
+            return
+        if chunk:
+            self.append_lines(chunk.decode('utf-8', errors='replace').splitlines())
+
+    def append_lines(self, lines):
+        self.text.configure(state=tk.NORMAL)
+        for line in lines:
+            self.text.insert(tk.END, line + '\n', self.tag_for_line(line))
+            self.line_count += 1
+        if self.line_count > MAX_LINES:
+            drop = self.line_count - MAX_LINES
+            self.text.delete('1.0', '%d.0' % (drop + 1))
+            self.line_count -= drop
+        self.text.configure(state=tk.DISABLED)
+        if self.follow_var.get():
+            self.text.see(tk.END)
+        self.set_status('%d lines  |  %s' % (self.line_count, self.log_file_path))
+
+    def tag_for_line(self, line):
+        lowered = line.lower()
+        if '[error]' in lowered or '[critical]' in lowered:
+            return 'error'
+        if '[warning]' in lowered or '[warn]' in lowered:
+            return 'warning'
+        if '[debug]' in lowered or '[trace]' in lowered:
+            return 'debug'
+        return ''
+
+    def set_status(self, text):
+        self.status_label.configure(text=text)
+
+    def handle_clear_clicked(self):
+        self.text.configure(state=tk.NORMAL)
+        self.text.delete('1.0', tk.END)
+        self.text.configure(state=tk.DISABLED)
+        self.line_count = 0
+
+    def close(self):
+        if self.poll_id is not None:
+            self.after_cancel(self.poll_id)
+            self.poll_id = None
+        super().close()


### PR DESCRIPTION
# Brief

Adds a logs window to the Python GUI demo example, tailing a file sink the instance is built with, and a toolbar button beside refresh that opens it.

# Description

## Logs window

- Add a non modal logs window tailing the instance's log file
- Follow tail, a clear button, and the line count and file path in the status line
- Colour a line by its severity token: error and critical, warning, debug and trace
- Read at most 256 KiB from the end of the file on open
- Keep at most 5000 lines, dropping from the top
- Poll every 500 ms from the last read offset, and stop the poll on close
- Report no file sink, a missing file and a read error in the status line
- Reuse the window: a second click on the button deiconifies and raises the open one

## Instance log file

- Add a `BasicFileLoggerSink` writing `opendaq_gui_demo_<pid>.log` in the temp directory, removed first if it exists
- Leave the log file path unset when the sink cannot be added

## Toolbar

- Add a flat toolbar button, the frame's background darkened on hover and further while held
- Use it for refresh and logs
- Run the command only when the release lands inside the button
- Add `Dialog::show_modeless`, the same startup as `show` without the `grab_set` and `wait_window`

# Implementation details

<details>
<summary><b>Per-feature detail, with the functions each one added or changed</b></summary>

### Logs window

The sink is added on the builder, since `add_logger_sink` is bound there and nowhere else, so the file exists before the instance does. It is named after the process id, and the window seeks to the end of it on open rather than reading what is already there.

```diff
+ LogsDialog::__init__(parent, context, **kwargs)  # follow, clear, status line, text view
+ LogsDialog::initial_update()                     # starts one tail window before the end of the file
+ LogsDialog::poll()
+ LogsDialog::read_new_lines()                     # from the kept offset to the end
+ LogsDialog::append_lines(lines)                  # appends and drops from the top past MAX_LINES
+ LogsDialog::tag_for_line(line)                   # colour from the severity token in the line
+ LogsDialog::set_status(text)
+ LogsDialog::handle_clear_clicked()               # clears the view, never the file
+ LogsDialog::close()                              # cancels the pending poll
+ Dialog::show_modeless()                          # show without grab_set and wait_window
+ App::logs_dialog_show()                          # raises the open window instead of a second one
```

### Instance log file and toolbar button

```diff
+ App::toolbar_button_create(parent, icon, command)  # flat label button, background tracks the frame
+ App::toolbar_button_create.on_release(event)       # only fires when the release is inside the button
```

Other:

```diff
  AppContext::__init__(params)  # the file sink and the log file path
  App::__init__(args)           # refresh and logs, both as toolbar buttons
```

</details>

# Usage example

In terminal use:

```shell
cd "examples/applications/python/GUI Application"
python gui_demo.py
```
