### PR TITLE
Fix deadlock in setOperationModeRecursive

### DIFF
--- a/changelog/changelog_3.40-3.50.md
+++ b/changelog/changelog_3.40-3.50.md
@@ -13,6 +13,8 @@
 
 ## Bug fixes
 
+- [#1295](https://github.com/openDAQ/openDAQ/pull/1295) Fix an intermittent deadlock between `setOperationModeRecursive` and a sub-device's acquisition thread. The device tree lock taken while the operation mode changes no longer locks signals and input ports.
+
 ## Misc
 
 - [#1251](https://github.com/openDAQ/openDAQ/pull/1251), [#1269](https://github.com/openDAQ/openDAQ/pull/1269), [#1278](https://github.com/openDAQ/openDAQ/pull/1278) OpenSSL (>= 1.1.1) is a build dependency of the SDK when `OPENDAQ_ENABLE_WEBSOCKET_STREAMING_WITH_TLS` is on. Unlike most other dependencies it is not fetched automatically and has to be installed on the host system: `libssl-dev` on Debian/Ubuntu (`libssl-dev:i386` for 32-bit builds), `openssl-devel` on RHEL-based distributions. The build documentation and all CI, packaging and docs jobs were updated accordingly.

--- a/core/opendaq/device/include/opendaq/device_impl.h
+++ b/core/opendaq/device/include/opendaq/device_impl.h
@@ -1168,8 +1168,11 @@ ListPtr<ILockGuard> GenericDevice<TInterface, Interfaces...>::getTreeLockGuard()
     this->getRecursiveLockGuard(&lockGuard);
     lockGuardList.pushBack(lockGuard);
 
+    auto excludeIds =
+        search::Or(search::Or(search::InterfaceId(IDevice::Id), search::InterfaceId(ISignal::Id)), search::InterfaceId(IInputPort::Id));
+
     ListPtr<IComponent> items;
-    this->getItems(&items, search::Recursive(search::Not(search::InterfaceId(IDevice::Id))));
+    this->getItems(&items, search::Recursive(search::Not(excludeIds)));
     if (!items.assigned())
         return lockGuardList;
 


### PR DESCRIPTION
# Brief

Fix an intermittent deadlock between `setOperationModeRecursive` and a sub-device's acquisition thread: the device tree lock no longer locks signals and input ports.

# Description

- `GenericDevice::getTreeLockGuard` collected the components under the device with `Recursive(Not(InterfaceId(IDevice)))`. That filter leaves the sub-device objects out of the result but still descends into them, so setting the operation mode on a parent device also locked the sub-devices' signals and, through the IO folder that shares its device's mutex, the sub-devices themselves.
- A sub-device's acquisition thread takes the device lock first and then reads its signals (for example `RefDeviceImpl::acqLoop` -> `getDescriptor`). The main thread took the signal locks first and then waited for the device lock, so whenever the two overlapped both blocked forever. The hang showed up intermittently in `NativeDeviceModulesTest.SettingOperationModeWithPermissionsForInvisibleDevice` (`test_device_modules`), with the process idle.
- The tree lock now also excludes `ISignal` and `IInputPort` components. Signals and input ports take no part in `updateOperationMode`, and the acquisition threads are the ones that lock them; the lock order left on both sides is device -> channel.
- Cherry-picked from edb863c69. The `setOperationModeRecursive` body of that commit is left out because the parallel-for helper it uses does not exist on `main`; the sequential loop is unchanged.

# Usage example

No usage changes.

# API changes

None.

# Required application changes

None.

# Required module changes

None.
