### PR TITLE
Load module libraries with the debug heap tracking off

### DIFF
--- a/changelog/changelog_3.40-3.50.md
+++ b/changelog/changelog_3.40-3.50.md
@@ -13,6 +13,7 @@
 
 ## Bug fixes
 
+- [#1296](https://github.com/openDAQ/openDAQ/pull/1296) Module libraries are loaded with MSVC debug heap tracking off, so debug test runs no longer report their statics as memory leaks.
 - [#1295](https://github.com/openDAQ/openDAQ/pull/1295) Fix an intermittent deadlock between `setOperationModeRecursive` and a sub-device's acquisition thread. The device tree lock taken while the operation mode changes no longer locks signals and input ports.
 
 ## Misc

--- a/core/opendaq/device/tests/test_device_info.cpp
+++ b/core/opendaq/device/tests/test_device_info.cpp
@@ -313,7 +313,6 @@ TEST_F(DeviceInfoTest, ServerCapabilities)
 
 TEST_F(DeviceInfoTest, NetworkInterfaces)
 {
-    MemCheckListener::expectMemoryLeak = true;// memory leak in module manager
     const auto moduleManager = ModuleManager("[[none]]");
 
     DeviceInfoPtr info = DeviceInfo("", "");

--- a/core/opendaq/modulemanager/include/opendaq/orphaned_modules.h
+++ b/core/opendaq/modulemanager/include/opendaq/orphaned_modules.h
@@ -23,6 +23,27 @@
 
 BEGIN_NAMESPACE_OPENDAQ
 
+#if defined(_MSC_VER) && !defined(NDEBUG)
+
+// Allocations made while any of these is in scope are not registered with the debug heap.
+class UntrackedAllocations
+{
+public:
+    UntrackedAllocations();
+    ~UntrackedAllocations();
+
+    UntrackedAllocations(const UntrackedAllocations&) = delete;
+    UntrackedAllocations& operator=(const UntrackedAllocations&) = delete;
+};
+
+#else
+
+class UntrackedAllocations
+{
+};
+
+#endif
+
 class OrphanedModules
 {
 public:

--- a/core/opendaq/modulemanager/src/module_manager_impl.cpp
+++ b/core/opendaq/modulemanager/src/module_manager_impl.cpp
@@ -2067,6 +2067,9 @@ ModuleLibrary loadModuleInternal(const LoggerComponentPtr& loggerComponent, cons
 {
     LOG_T("Loading module \"{}\".", path.string());
 
+    // The statics a module library builds live as long as the library does.
+    [[maybe_unused]] const UntrackedAllocations untracked;
+
     std::error_code libraryErrCode;
     boost::dll::shared_library moduleLibrary(path, libraryErrCode, safeLoadingMode ? boost::dll::load_mode::rtld_now : boost::dll::load_mode::default_mode);
 

--- a/core/opendaq/modulemanager/src/orphaned_modules.cpp
+++ b/core/opendaq/modulemanager/src/orphaned_modules.cpp
@@ -2,13 +2,49 @@
 
 #include "coretypes/errors.h"
 
+#if defined(_MSC_VER) && !defined(NDEBUG)
+    #include <crtdbg.h>
+#endif
+
 BEGIN_NAMESPACE_OPENDAQ
 
 static constexpr char daqGetObjectCount[] = "daqGetObjectCount";
 
+#if defined(_MSC_VER) && !defined(NDEBUG)
+
+// Constructed on first use: the orphaned module list opens a scope during static initialization.
+static std::mutex& untrackedSync()
+{
+    static std::mutex sync;
+    return sync;
+}
+
+static int untrackedDepth = 0;
+static int untrackedFlags = 0;
+
+UntrackedAllocations::UntrackedAllocations()
+{
+    std::scoped_lock lock(untrackedSync());
+    if (untrackedDepth++ == 0)
+    {
+        untrackedFlags = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
+        _CrtSetDbgFlag(untrackedFlags & ~_CRTDBG_ALLOC_MEM_DF);
+    }
+}
+
+UntrackedAllocations::~UntrackedAllocations()
+{
+    std::scoped_lock lock(untrackedSync());
+    if (--untrackedDepth == 0)
+        _CrtSetDbgFlag(untrackedFlags);
+}
+
+#endif
+
 OrphanedModules::OrphanedModules()
 {
-    moduleSharedLibs.reserve(20); // To prevent false positive memory leaks in tests
+    [[maybe_unused]] const UntrackedAllocations untracked;
+    moduleSharedLibs.reserve(20);
 }
 
 OrphanedModules::~OrphanedModules()
@@ -19,6 +55,9 @@ OrphanedModules::~OrphanedModules()
 void OrphanedModules::add(boost::dll::shared_library sharedLib)
 {
     std::scoped_lock lock(sync);
+
+    // The buffer this grows into lives as long as the process.
+    [[maybe_unused]] const UntrackedAllocations untracked;
     moduleSharedLibs.push_back(std::move(sharedLib));
 }
 
@@ -33,8 +72,6 @@ void OrphanedModules::tryUnload()
         else
             ++it;
     }
-
-    moduleSharedLibs.shrink_to_fit();
 }
 
 bool OrphanedModules::canUnloadModule(const boost::dll::shared_library& moduleSharedLib)


### PR DESCRIPTION
# Brief

Load module libraries with the MSVC debug heap tracking off, so the statics they build are not counted as leaks by the test listener. This is what makes the `windows-2022-x86_64-msvs-v143-debug` lane red on `main`: every one of the 17 test failures in that job is this false positive.

# Description

- `loadModuleInternal` performs the library load inside an `UntrackedAllocations` scope.
- `OrphanedModules` allocates its list with the same scope, in the constructor and in `add`.
- `DeviceInfoTest.NetworkInterfaces` loses a stale `expectMemoryLeak`.

### What goes wrong today

A module library builds its own copies of the header-inline statics as it loads and as it is first called into, and releases them when it is unloaded. `~ModuleManagerImpl` cannot unload a library that still has live objects (`daqGetObjectCount() != 0`), so it parks it in the process-global `orphanedModules` list and retries only when another module manager is constructed or destroyed — never on a timer. The load and the unload therefore fall in *different* test cases.

`_CrtMemDifference` reports any difference between the listener's two checkpoints, in either direction and in size as well as count, and `MemCheckListener` prints all of it as `Memory leaks detected`. So the test that loads a library fails, and so does the later one that unloads it.

For `ref_device_module` that is 227 blocks / ~15 KB:

| source | blocks |
| --- | --- |
| `ErrorCodeToException` singleton (map nodes + `GenericExceptionFactory<T>`) | 135 |
| `ComponentImpl<...>::componentAvailableAttributes` statics | 53 |
| coretypes registries (deserializer factories, `tsl::ordered_map`, dicts) | 28 |
| coreobjects registries | 4 |

In `test_docs` the ledger runs:

| test | own | inherited | net | result |
| --- | --- | --- | --- | --- |
| `ArchitectureTest.AddDevice` | +227 | 0 | **+227** | **fail** |
| `Statistics` / `DataRule` / `Readers` | +227 | −227 | 0 | pass |
| `ArchitectureTest.GetChannels` | 0 | −227 | **−227** | **fail** |

Which tests take the hit depends only on the order they run in.

### Why untracked rather than unloading earlier

Clearing `_CRTDBG_ALLOC_MEM_DF` makes the allocations *ignore blocks*, which the CRT never links into its block list, so `_CrtMemCheckpoint` cannot see them however long the library stays loaded. They still free correctly — `free_dbg_nolock` has an explicit `_IGNORE_BLOCK` branch. Crucially this changes **nothing** about when a library is loaded or unloaded, and compiles to an empty class outside MSVC debug builds.

The scopes are counted rather than saved and restored per thread: the flag is process wide, so two threads each restoring what they saw on entry would leave tracking off for the rest of the run. The mutex covers only the flag change, never the library load, so nothing holds a lock across `LoadLibrary`.

### The orphan list

`OrphanedModules` reserves room for 20 handles, 160 bytes. The 21st orphaned library grows that to 240 and frees the old buffer — the same number of blocks, 80 bytes more of them, which the comparison reports just as readily. Its buffer lives as long as the process, so it gets the same treatment.

`DeviceInfoTest.NetworkInterfaces` had `expectMemoryLeak = true; // memory leak in module manager`. That "leak" was this reserved buffer being handed back by `shrink_to_fit` on the first `tryUnload`, so the expectation no longer holds.

# Usage example

None — no public API is involved.

# API changes

No interface changes, no new exports. Binary compatibility of modules is unaffected.

# Required application changes

None.

# Required module changes

None.

# Verification

CI, `windows-2022-x86_64-msvs-v143-debug`:

| | main | this PR |
| --- | --- | --- |
| leak check failures | **17** | **0** |

The 17 were `ArchitectureTest.AddDevice`, `ArchitectureTest.GetChannels`, `ComponentsTest.FolderTraversal`, `ConfigProvider.JsonConfigProvider`, `ExamplesTest.{Client,Device,Discovery,StreamReader}`, `HowToAccessControl.CreateServer`, `HowToTest.ConnectToDevice1/2`, `QuickStartTest.QuickStartAppConnect`, `StreamingConfigTest.{AddPseudoDevice,ServerSideConfiguration}` in `test_docs`, plus `NativeDeviceModulesTest.{NonDefaultOpMode,ComponentActiveChangedRecursiveGateway}` in `test_device_modules`, and `LtStreamingTlsTest.ConnectedClientsOnBothChannelsReportTheirOwnProtocol`.

Locally (MSVC Debug, `x64/msvc-26/full`, LT TLS on): full `ctest` run is 46/47, with zero `Memory leaks detected`. The one failure, `QuickStartTest.QuickStartAppReaderWebsocket`, fails the same way on unmodified `main` on that machine and passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
