### PR TITLE
Python GUI: Minor fixes to tree view behaviour

### DIFF
--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -437,7 +437,6 @@ class App(tk.Tk):
         def collect(parent):
             for iid in self.tree.get_children(parent):
                 if self.tree_item_matches_search(iid, query):
-                    # keep the whole subtree of a match, do not look deeper
                     matches.append(iid)
                 else:
                     collect(iid)
@@ -445,15 +444,42 @@ class App(tk.Tk):
         collect('')
         match_set = set(matches)
 
-        # pull matches out of their (non-matching) parents
-        for iid in matches:
-            self.tree.move(iid, '', tk.END)
-            self.tree.item(iid, open=True)
+        def prune(parent):
+            kept = False
+            for iid in self.tree.get_children(parent):
+                if iid in match_set:
+                    kept = True
+                elif prune(iid):
+                    self.tree.item(iid, open=True)
+                    kept = True
+                else:
+                    self.tree.delete(iid)
+            return kept
 
-        # whatever is left at the top level holds no match anymore
+        prune('')
+
+        roots = []
+        for iid in matches:
+            row = self.tree_nearest_device_row(iid) or iid
+            if row not in roots:
+                roots.append(row)
+
+        for iid in roots:
+            self.tree.move(iid, '', tk.END)
+
+        root_set = set(roots)
         for iid in self.tree.get_children(''):
-            if iid not in match_set:
+            if iid not in root_set:
                 self.tree.delete(iid)
+
+    def tree_nearest_device_row(self, iid):
+        parent = self.tree.parent(iid)
+        while parent:
+            component = self.context.nodes.get(parent)
+            if component is not None and daq.IDevice.can_cast_from(component):
+                return parent
+            parent = self.tree.parent(parent)
+        return None
 
     def tree_update(self, new_selected_node=None):
         self.tree_root_buttons_hide()

--- a/examples/applications/python/GUI Application/gui_demo.py
+++ b/examples/applications/python/GUI Application/gui_demo.py
@@ -340,9 +340,9 @@ class App(tk.Tk):
         scroll_bar = ttk.Scrollbar(
             frame, orient=tk.VERTICAL, command=tree.yview)
         tree.configure(yscroll=lambda *a: (
-            scroll_bar.set(*a), self.after_idle(self.tree_root_buttons_sync)))
+            scroll_bar.set(*a), self.after_idle(self.tree_row_buttons_sync)))
         tree.bind('<Configure>',
-                  lambda e: self.after_idle(self.tree_root_buttons_sync), add='+')
+                  lambda e: self.after_idle(self.tree_row_buttons_sync), add='+')
         scroll_bar.pack(fill=tk.Y, side=tk.RIGHT)
 
         parent_frame.add(frame)
@@ -364,14 +364,17 @@ class App(tk.Tk):
         plus_icon = self.context.icons['plus']
         self.tree_row_button_size = max(plus_icon.width(), plus_icon.height())
         self.tree_row_button_hovered = None
-        self.tree_row_button_info = {}
+        self.tree_row_button_pool = []
+        self.tree_row_button_rows = {}
+        self.tree_row_can_add_rows = {}
         self.tree_row_menu_open = False
-        # only the root device carries buttons, and it keeps them visible
-        # without hovering, every other row is served by its context menu
-        self.tree_root_buttons = self.tree_row_buttons_create(tree)
 
         tree.bind('<<TreeviewSelect>>',
                   lambda e: self.tree_row_buttons_recolor(), add='+')
+        tree.bind('<<TreeviewOpen>>',
+                  lambda e: self.after_idle(self.tree_row_buttons_sync), add='+')
+        tree.bind('<<TreeviewClose>>',
+                  lambda e: self.after_idle(self.tree_row_buttons_sync), add='+')
 
     def handle_tree_search_focus_in(self, event):
         if self.tree_search_entry.get() == "Filter tree by name, tag or local id":
@@ -482,7 +485,8 @@ class App(tk.Tk):
         return None
 
     def tree_update(self, new_selected_node=None):
-        self.tree_root_buttons_hide()
+        self.tree_row_buttons_hide(self.tree_row_button_pool)
+        self.tree_row_can_add_rows.clear()
         self.tree.delete(*self.tree.get_children())
         self.right_side_panel_clear()
 
@@ -506,7 +510,7 @@ class App(tk.Tk):
                                  text=self._format_tree_item_text(display_name), open=False)
                 self.modules_map[mod_id] = mod
             self.tree_apply_search_filter()
-            self.after_idle(self.tree_root_buttons_sync)
+            self.after_idle(self.tree_row_buttons_sync)
             return
 
         self.tree_traverse_components_recursive(
@@ -517,7 +521,7 @@ class App(tk.Tk):
         self.set_node_update_status()
         self.set_node_lock_status()
         self.set_node_active_status()
-        self.after_idle(self.tree_root_buttons_sync)
+        self.after_idle(self.tree_row_buttons_sync)
 
     def tree_traverse_components_recursive(
             self, component, display_type=DisplayType.UNSPECIFIED, tree_parent_id=None):
@@ -897,7 +901,6 @@ class App(tk.Tk):
             button.bind('<Button-1>', handlers[name])
             button.bind('<Enter>', self.handle_tree_row_button_enter)
             button.bind('<Leave>', self.handle_tree_row_button_leave)
-            self.tree_row_button_info[button] = name
             buttons[name] = button
         return buttons
 
@@ -913,66 +916,82 @@ class App(tk.Tk):
                      else self.tree_row_background)
         button.configure(background=color)
 
-    def tree_row_buttons_place(self, buttons, iid):
-        row = self.tree.bbox(iid) if iid else None
-        if not row:
-            self.tree_row_buttons_hide(buttons)
-            return False
+    def tree_row_actions(self, iid):
+        if iid not in self.tree_row_can_add_rows:
+            self.tree_row_can_add_rows[iid] = bool(
+                self.menu_add_items(self.context.nodes.get(iid)))
 
-        _, row_y, _, row_height = row
+        actions = ['add'] if self.tree_row_can_add_rows[iid] else []
+        if iid == self.tree_root_row_iid():
+            actions.append('more')
+        return actions
+
+    def tree_row_buttons_place(self, buttons, iid):
+        _, row_y, _, row_height = self.tree.bbox(iid)
+        actions = self.tree_row_actions(iid)
         size = self.tree_row_button_size
         y = row_y + max(0, (row_height - size) // 2)
         x = self.tree.winfo_width() - size - 4
 
         for name in self.TREE_ROW_ACTIONS:
             button = buttons[name]
+            if name not in actions:
+                button.place_forget()
+                continue
             button.place(x=x, y=y, width=size, height=size)
             button.lift()
+            self.tree_row_button_rows[button] = iid
             self.tree_row_button_color(button, iid)
             x -= size + 2
-        return True
 
-    def tree_row_buttons_hide(self, buttons):
-        for button in buttons.values():
-            button.place_forget()
+    def tree_row_buttons_hide(self, pool):
+        for buttons in pool:
+            for button in buttons.values():
+                button.place_forget()
+        self.tree_row_button_rows.clear()
 
     def tree_row_buttons_recolor(self):
-        iid = self.tree_root_row_iid()
-        buttons = getattr(self, 'tree_root_buttons', None)
-        if iid is None or buttons is None:
-            return
-        for button in buttons.values():
+        for button, iid in self.tree_row_button_rows.items():
             self.tree_row_button_color(button, iid)
 
     def tree_root_row_iid(self):
-        """The instance row, the only row that carries inline buttons."""
+        """The instance row, the only row that carries the three dots."""
         instance = self.context.instance
         if instance is None or self.current_tab() == DisplayType.MODULES:
             return None
         iid = instance.global_id
         return iid if self.tree.exists(iid) else None
 
-    def tree_root_buttons_sync(self):
-        buttons = getattr(self, 'tree_root_buttons', None)
-        if buttons is None:
-            return
-        self.tree_row_buttons_place(buttons, self.tree_root_row_iid())
-
-    def tree_root_buttons_hide(self):
-        buttons = getattr(self, 'tree_root_buttons', None)
-        if buttons is not None:
-            self.tree_row_buttons_hide(buttons)
+    def tree_visible_rows(self):
+        stack = list(reversed(self.tree.get_children('')))
+        drawn = False
+        while stack:
+            iid = stack.pop()
+            if self.tree.bbox(iid):
+                drawn = True
+                yield iid
+            elif drawn:
+                return
+            if self.tree.item(iid, 'open'):
+                stack.extend(reversed(self.tree.get_children(iid)))
 
     def tree_row_buttons_sync(self):
         if self.tree_row_menu_open:
             return
         if self.winfo_containing(
-                *self.winfo_pointerxy()) not in self.tree_row_button_info:
+                *self.winfo_pointerxy()) not in self.tree_row_button_rows:
             self.tree_row_button_hovered = None
-        self.tree_row_buttons_recolor()
+
+        rows = [iid for iid in self.tree_visible_rows() if self.tree_row_actions(iid)]
+        while len(self.tree_row_button_pool) < len(rows):
+            self.tree_row_button_pool.append(self.tree_row_buttons_create(self.tree))
+
+        self.tree_row_buttons_hide(self.tree_row_button_pool[len(rows):])
+        for buttons, iid in zip(self.tree_row_button_pool, rows):
+            self.tree_row_buttons_place(buttons, iid)
 
     def handle_tree_mousewheel(self, event):
-        self.after_idle(self.tree_root_buttons_sync)
+        self.after_idle(self.tree_row_buttons_sync)
 
     def handle_tree_row_button_enter(self, event):
         self.tree_row_button_hovered = event.widget
@@ -985,24 +1004,23 @@ class App(tk.Tk):
         self.tree_row_button_hovered = None
         self.tree_row_buttons_recolor()
 
+    def tree_row_button_node(self, button):
+        iid = self.tree_row_button_rows.get(button)
+        return utils.find_component(iid, self.context.instance) if iid else None
+
     def handle_tree_add_button_clicked(self, event):
-        # the plus offers only what the instance can add
-        return self.tree_root_menu_popup(event, add_only=True)
+        node = self.tree_row_button_node(event.widget)
+        return self.tree_row_menu_popup(
+            event, self.menu_build([self.menu_add_items(node)]))
 
     def handle_tree_more_button_clicked(self, event):
-        # the three dots stand in for a right click on the instance row
-        return self.tree_root_menu_popup(event, add_only=False)
-
-    def tree_root_menu_popup(self, event, add_only):
-        iid = self.tree_root_row_iid()
-        node = utils.find_component(iid, self.context.instance) if iid else None
+        node = self.tree_row_button_node(event.widget)
         if node is None:
             return 'break'
+        return self.tree_row_menu_popup(
+            event, self.create_node_menu(node, include_add=False))
 
-        self.tree_row_buttons_recolor()
-
-        popup = (self.menu_build([self.menu_add_items(node)]) if add_only
-                 else self.create_node_menu(node, include_add=False))
+    def tree_row_menu_popup(self, event, popup):
         if popup.index(tk.END) is None:
             return 'break'
 
@@ -1044,16 +1062,11 @@ class App(tk.Tk):
         else:
             return []
 
-        try:
-            has_fb_types = bool(target.available_function_block_types)
-        except RuntimeError:
-            has_fb_types = False
-
         items = []
-        if is_device:
+        if is_device and self.component_has_types(target, 'available_device_types'):
             items.append(('Add device', 'device',
                           lambda: self.add_device_dialog_show(target)))
-        if has_fb_types:
+        if self.component_has_types(target, 'available_function_block_types'):
             items.append(('Add function block', 'add_fb',
                           lambda: self.add_function_block_dialog_show(target)))
         # only the root device accepts servers, IDevice::onAddServer refuses the rest
@@ -1061,6 +1074,12 @@ class App(tk.Tk):
             items.append(('Add server', 'server',
                           lambda: self.add_server_dialog_show(target)))
         return items
+
+    def component_has_types(self, component, attribute):
+        try:
+            return bool(getattr(component, attribute))
+        except Exception:
+            return False
 
     def menu_update_items(self, node):
         iid = node.global_id if node is not None else None

--- a/examples/applications/python/GUI Application/gui_demo/app_context.py
+++ b/examples/applications/python/GUI Application/gui_demo/app_context.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import platform
 import tempfile
@@ -55,8 +56,7 @@ class AppContext(object):
         self.log_file_path = os.path.join(
             tempfile.gettempdir(), 'opendaq_gui_demo_{}.log'.format(os.getpid()))
         try:
-            if os.path.exists(self.log_file_path):
-                os.remove(self.log_file_path)
+            self._remove_demo_log_files()
             builder.add_logger_sink(daq.BasicFileLoggerSink(self.log_file_path))
         except Exception:
             self.log_file_path = None
@@ -66,6 +66,16 @@ class AppContext(object):
         self.connection_string = ''
         self.signals = {}
         self.needs_refresh = False
+
+    @staticmethod
+    def _remove_demo_log_files():
+        """Clear the map of temporary log files."""
+        pattern = os.path.join(tempfile.gettempdir(), 'opendaq_gui_demo_*.log')
+        for path in glob.glob(pattern):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
     def _detect_dpi_factor(self) -> float:
         """Detect system DPI scaling factor (1.0 = 96 DPI). Used to scale UI elements on high-DPI displays."""

--- a/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
+++ b/examples/applications/python/GUI Application/gui_demo/components/generic_properties_treeview.py
@@ -164,7 +164,7 @@ class PropertiesTreeview(ttk.Treeview):
 
             property_type = property_info.property_type
 
-            if property_type in (daq.PropertyType.IndexSelection, daq.PropertyType.SparseSelection):
+            if self._is_keyed_selection(property_type):
                 if len(property_info.selection_values) > 0:
                     property_value = printed_value(
                         property_info.item_type, node.get_property_selection_value(property_info.name))
@@ -210,8 +210,7 @@ class PropertiesTreeview(ttk.Treeview):
                 values=(property_value, *meta_fields))
 
             is_single_value_selection = (
-                property_type in (daq.PropertyType.Selection, daq.PropertyType.IndexSelection,
-                                  daq.PropertyType.SparseSelection)
+                self._is_selection(property_type)
                 and len(property_info.selection_values) == 1
             )
             if property_type not in (daq.PropertyType.Procedure, daq.PropertyType.Function):
@@ -689,14 +688,10 @@ class PropertiesTreeview(ttk.Treeview):
                     self._overlay_items[iid] = prop
                 elif not prop.read_only:
                     if (property_type == daq.PropertyType.Bool
-                            or (property_type in (daq.PropertyType.Selection,
-                                                 daq.PropertyType.IndexSelection,
-                                                 daq.PropertyType.SparseSelection)
+                            or (self._is_selection(property_type)
                                 and len(prop.selection_values) > 1)
                             or property_type == daq.PropertyType.Enumeration
-                            or (property_type in (daq.PropertyType.Int, daq.PropertyType.Float,
-                                                 daq.PropertyType.String)
-                                and prop.suggested_values is not None and len(prop.suggested_values) > 0)):
+                            or self._has_suggested_values(prop)):
                         self._overlay_items[iid] = prop
             self._collect_overlay_items(iid)
 
@@ -706,14 +701,12 @@ class PropertiesTreeview(ttk.Treeview):
             self._place_method_button(iid, prop)
         elif property_type == daq.PropertyType.Bool:
             self._place_bool_checkbox(iid, prop)
-        elif (property_type in (daq.PropertyType.Selection, daq.PropertyType.IndexSelection,
-                                daq.PropertyType.SparseSelection)
+        elif (self._is_selection(property_type)
               and len(prop.selection_values) > 0):
             self._place_selection_combobox(iid, prop)
         elif property_type == daq.PropertyType.Enumeration:
             self._place_enum_combobox(iid, prop)
-        elif (property_type in (daq.PropertyType.Int, daq.PropertyType.Float, daq.PropertyType.String)
-              and prop.suggested_values is not None and len(prop.suggested_values) > 0):
+        elif self._has_suggested_values(prop):
             self._place_suggested_combobox(iid, prop)
 
     def _sync_overlays(self):
@@ -894,8 +887,7 @@ class PropertiesTreeview(ttk.Treeview):
             labels = [f'{l} {unit_symbol}' for l in labels]
         if not labels:
             return
-        is_keyed_selection = prop.property_type in (daq.PropertyType.IndexSelection,
-                                                    daq.PropertyType.SparseSelection)
+        is_keyed_selection = self._is_keyed_selection(prop.property_type)
         if is_keyed_selection:
             current_idx = prop.value
             current_label = labels[indices.index(current_idx)] if current_idx in indices else labels[0]
@@ -1175,13 +1167,12 @@ class PropertiesTreeview(ttk.Treeview):
 
         if property_type == daq.PropertyType.Bool:
             return  # handled by overlay combobox
-        elif property_type in (daq.PropertyType.Selection, daq.PropertyType.IndexSelection,
-                               daq.PropertyType.SparseSelection):
+        elif self._is_selection(property_type):
             return  # handled by overlay combobox
         elif property_type in (daq.PropertyType.Dict, daq.PropertyType.List):
             return
-        elif property_type in (daq.PropertyType.Int, daq.PropertyType.Float,
-                               daq.PropertyType.String, daq.PropertyType.Ratio):
+        elif (self._takes_suggested_values(property_type)
+              or property_type == daq.PropertyType.Ratio):
             if prop.suggested_values is not None and len(prop.suggested_values) > 0:
                 return  # handled by overlay combobox
             self.edit_simple_property(selected_item_id, prop.value, path)
@@ -1192,6 +1183,29 @@ class PropertiesTreeview(ttk.Treeview):
                 self.winfo_toplevel().unbind('<<DialogReady>>', self._toplevel_bind_id)
             except Exception:
                 pass
+
+    @staticmethod
+    def _is_selection(property_type):
+        return property_type in (daq.PropertyType.Selection,
+                                 daq.PropertyType.IndexSelection,
+                                 daq.PropertyType.SparseSelection)
+
+    @staticmethod
+    def _is_keyed_selection(property_type):
+        return property_type in (daq.PropertyType.IndexSelection,
+                                 daq.PropertyType.SparseSelection)
+
+    @staticmethod
+    def _takes_suggested_values(property_type):
+        return property_type in (daq.PropertyType.Int,
+                                 daq.PropertyType.Float,
+                                 daq.PropertyType.String)
+
+    @staticmethod
+    def _has_suggested_values(prop):
+        return (PropertiesTreeview._takes_suggested_values(prop.property_type)
+                and prop.suggested_values is not None
+                and len(prop.suggested_values) > 0)
 
     @staticmethod
     def _format_value(value):


### PR DESCRIPTION
# Brief

Reworks tree filtering and the add button of the Python GUI; a search match now shows path up the tree to the first parent device, and the plus sits on every device and function block row that has something to add.

# Description

## Tree filter

- Show a search match with its path up the tree to the first parent device
- Drop the rows above that device
- Leave a search match with no device above it on its own, as before
- A search match's collapsed and expanded state no longer changes because of the search
- Remove the rows that have no search match under them
- Keep the rows under a search match, so a matching folder still shows what is inside it

## Tree row buttons

- Show the plus on every device and function block row that has something to add, instead of only the instance row
- Offer Add function block where the row has available function block types, Add device where a device has available device types
- Show no plus where the row has neither of those
- Put the plus in the rightmost slot, except on the instance row, where the three dots hold that slot and the plus sits to their left
- Re-place the buttons on expand and collapse, as well as on scroll, resize and rebuild

# Implementation details

<details>
<summary><b>Per-feature detail, with the functions each one added or changed</b></summary>

### Tree filter

The filter used to move every search match to the root of the tree with `move(iid, '', tk.END)` and delete the rest, so a signal that matched was shown by itself, with nothing above it to say which device it belonged to.

`collect` still gathers the search matches without looking inside one, so a match keeps its whole subtree. `prune` then walks what is left, deletes any row with no search match at or below it, and opens the ones it keeps. Only the lift changed: `tree_nearest_device_row` walks up from the search match to the parent device.

A Modules tab row has no component behind it, so there is no device to walk up to and a matching row is shown on its own, as before.

```diff
+ App::tree_apply_search_filter.prune(parent)  # deletes a row with no search match under it, opens the ones it keeps
+ App::tree_nearest_device_row(iid)            # nothing for a row with no device above it
```

Edited:

```diff
  App::tree_apply_search_filter()  # lifts the device row, not the search match
```

### Tree row buttons

The plus and the three dots were built once in `tree_widget_create` and placed on the instance row, no other row had one. `tree_row_buttons_sync` resizes `tree_row_button_pool` to the number of drawn rows that have an action and places one pair per row. `tree_visible_rows` walks the tree in display order and stops at the first row with no `bbox` once a row has one, so the pass is faster to draw, per viewport and not per row.

The plus offers what `menu_add_items` returns for the row, and no items means no plus. The call reads `available_function_block_types`, and `available_device_types` on a device, both returned over the wire by a device reached through the config protocol, and the pass reads them for every drawn row, so `tree_row_can_add_rows` holds the result and `tree_update` drops it with the rows it describes. `Add device` was previously offered on every device row whether or not the device had any device types. `component_has_types` now checks `available_device_types`, and if there is nothing there, the item is not added.

The buttons sit at absolute coordinates over the tree, so anything that moves a row runs the pass again. `handle_tree_click` returns `break` before ttk's own click bindings and sets `open` itself, so no `<<TreeviewOpen>>` or `<<TreeviewClose>>` is generated. `tree_row_toggle` sets it and runs the pass, and the bindings stay for keyboard expansion.

```diff
+ App::tree_row_actions(iid)                      # the actions a row has, and the per build memo behind the plus
+ App::tree_visible_rows()                        # the drawn rows, in display order
+ App::tree_row_button_node(button)               # the component of the row a placed button sits on
+ App::tree_row_toggle(iid)                       # expand and collapse, with the placement pass
+ App::component_has_types(component, attribute)
- App::tree_row_buttons_hide(buttons)             # one pair
+ App::tree_row_buttons_hide(pool)                # the pool, and the placed button map with it
- App::tree_root_buttons_sync()
- App::tree_root_buttons_hide()
- App::tree_root_menu_popup(event, add_only)      # chose the menu itself, instance row only
+ App::tree_row_menu_popup(event, popup)          # takes the menu from the caller
```

Edited (mostly the single instance pair becoming a pool of pairs):

```diff
  App::tree_widget_create(parent_frame)
  App::tree_row_buttons_create(tree)
  App::tree_row_buttons_place(buttons, iid)
  App::tree_row_buttons_recolor()
  App::tree_row_buttons_sync()
  App::handle_tree_mousewheel(event)
  App::handle_tree_add_button_clicked(event)
  App::handle_tree_more_button_clicked(event)
  App::tree_update(new_selected_node=None)        # drops the memo with the rows
  App::handle_tree_click(event)                   # the three toggles go through tree_row_toggle
  App::handle_tree_select(event)                  # the default folder toggle likewise
  App::menu_add_items(node)                       # Add device gated on available_device_types
```

</details>

# Usage example

In terminal use:

```shell
cd "examples/applications/python/GUI Application"
python gui_demo.py
```

# API changes

None.

# Required application changes

None.

# Required module changes

None.
