### PR TITLE
Re-enable SettingOperationMode tests in Native and OPC UA device module suites

### DIFF
--- a/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_native_device_modules.cpp
@@ -3762,11 +3762,7 @@ TEST_F(NativeDeviceModulesTest, GetAvailableDevicesCheck)
     }
 }
 
-// Hangs: lock-order inversion between setOperationMode → getTreeLockGuard
-// (signal-lock then device-lock via items+InheritLock) and RefDevice::acqLoop →
-// Signal::getDescriptor (device-lock then signal-lock). Shared mechanism for all
-// SettingOperationMode* variants below.
-TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationMode)
+TEST_F(NativeDeviceModulesTest, SettingOperationMode)
 {
     auto server = CreateServerInstance();
     auto client = CreateClientInstance();
@@ -3828,8 +3824,7 @@ TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationMode)
     test_helpers::checkDeviceOperationMode(client.getDevices()[0].getDevices()[0], daq::OperationModeType::Idle);
 }
 
-// Hangs: same setOperationMode / RefDevice::acqLoop lock-order inversion as SettingOperationMode.
-TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationModeWithoutPermissions)
+TEST_F(NativeDeviceModulesTest, SettingOperationModeWithoutPermissions)
 {
     auto CreateUsers = []()
     {
@@ -3963,8 +3958,7 @@ TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationModeWithoutPerm
     }
 }
 
-// Hangs: same setOperationMode / RefDevice::acqLoop lock-order inversion as SettingOperationMode.
-TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationModeWithPermissions)
+TEST_F(NativeDeviceModulesTest, SettingOperationModeWithPermissions)
 {
     auto CreateUsers = []()
     {
@@ -4038,8 +4032,7 @@ TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationModeWithPermiss
     }
 }
 
-// Hangs: same setOperationMode / RefDevice::acqLoop lock-order inversion as SettingOperationMode.
-TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationModeWithPermissionsForInvisibleDevice)
+TEST_F(NativeDeviceModulesTest, SettingOperationModeWithPermissionsForInvisibleDevice)
 {
     auto CreateUsers = []()
     {
@@ -4124,8 +4117,7 @@ TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationModeWithPermiss
     }
 }
 
-// Hangs: same setOperationMode / RefDevice::acqLoop lock-order inversion as SettingOperationMode.
-TEST_F_UNSTABLE_SKIPPED(NativeDeviceModulesTest, SettingOperationModeWithPermissionsNestedDevice)
+TEST_F(NativeDeviceModulesTest, SettingOperationModeWithPermissionsNestedDevice)
 {
     auto CreateUsers = []()
     {

--- a/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
+++ b/tests/integration/test_opendaq_device_modules/test_opcua_device_modules.cpp
@@ -1762,9 +1762,7 @@ TEST_F(OpcuaDeviceModulesTest, GetSetNonCheangableUserNameLocation)
     }
 }
 
-// Hangs: setOperationMode / RefDevice::acqLoop lock-order inversion (transport-agnostic;
-// also reproduces in the Native variant of this test).
-TEST_F_UNSTABLE_SKIPPED(OpcuaDeviceModulesTest, SettingOperationMode)
+TEST_F(OpcuaDeviceModulesTest, SettingOperationMode)
 {
     auto server = CreateServerInstance();
     auto client = CreateClientInstance();


### PR DESCRIPTION
# Brief

Turn the six `SettingOperationMode*` integration tests back on. They were skipped as unstable because of the `setOperationMode` / `RefDevice::acqLoop` lock-order inversion that #1295 fixed.

# Description

- `test_native_device_modules.cpp`: switch `SettingOperationMode`, `SettingOperationModeWithoutPermissions`, `SettingOperationModeWithPermissions`, `SettingOperationModeWithPermissionsForInvisibleDevice` and `SettingOperationModeWithPermissionsNestedDevice` from `TEST_F_UNSTABLE_SKIPPED` back to `TEST_F`.
- `test_opcua_device_modules.cpp`: do the same for `OpcuaDeviceModulesTest.SettingOperationMode`.
- Remove the "Hangs: lock-order inversion…" comments above each test. They described the deadlock that #1295 fixed: `GenericDevice::getTreeLockGuard` no longer locks signals and input ports.