### PR TITLE
Fix scheduler shutdown from one of its own worker threads

### DIFF
--- a/changelog/changelog_3.40-3.50.md
+++ b/changelog/changelog_3.40-3.50.md
@@ -13,6 +13,7 @@
 
 ## Bug fixes
 
+- [#1299](https://github.com/openDAQ/openDAQ/pull/1299) Fix a deadlock when a scheduler worker releases the last reference to the context: the scheduler no longer waits on its own thread while destroying the executor. Such a shutdown could also crash at process exit, with Taskflow's node pool destroyed under live workers, which is what made `test_audio_device_module` fail intermittently on the gcc-7 32-bit CI lane.
 - [#1295](https://github.com/openDAQ/openDAQ/pull/1295) Fix an intermittent deadlock between `setOperationModeRecursive` and a sub-device's acquisition thread. The device tree lock taken while the operation mode changes no longer locks signals and input ports.
 
 ## Misc

--- a/core/opendaq/scheduler/src/scheduler_impl.cpp
+++ b/core/opendaq/scheduler/src/scheduler_impl.cpp
@@ -10,6 +10,7 @@
 #include <opendaq/work_factory.h>
 #include <coretypes/function_ptr.h>
 #include <coretypes/validation.h>
+#include <thread>
 #include <utility>
 #include <opendaq/thread_name.h>
 
@@ -206,7 +207,16 @@ ErrCode SchedulerImpl::stop()
     stopped = true;
 
     LOGP_T("Stopping scheduler")
-    executor.reset();
+    if (executor && executor->this_worker_id() != -1)
+    {
+        // Destroyed by one of its own workers (a scheduled callback released the last reference to
+        // the context): the executor cannot join the calling thread, so let another thread do it.
+        std::thread([executor = std::move(executor)]() mutable { executor.reset(); }).detach();
+    }
+    else
+    {
+        executor.reset();
+    }
 
     LOGP_T("Stopping main thread worker")
     mainThreadWorker.reset();

--- a/core/opendaq/scheduler/src/scheduler_impl.cpp
+++ b/core/opendaq/scheduler/src/scheduler_impl.cpp
@@ -209,8 +209,7 @@ ErrCode SchedulerImpl::stop()
     LOGP_T("Stopping scheduler")
     if (executor && executor->this_worker_id() != -1)
     {
-        // Destroyed by one of its own workers (a scheduled callback released the last reference to
-        // the context): the executor cannot join the calling thread, so let another thread do it.
+        // Running on one of the executor's own workers, which it cannot join: another thread destroys it.
         std::thread([executor = std::move(executor)]() mutable { executor.reset(); }).detach();
     }
     else

--- a/core/opendaq/scheduler/tests/test_scheduler.cpp
+++ b/core/opendaq/scheduler/tests/test_scheduler.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <thread>
 #include <future>
+#include <memory>
 #include <opendaq/work_factory.h>
 
 #include <opendaq/logger_factory.h>
@@ -195,6 +196,45 @@ TEST_F(SchedulerTestCommon, StartsAndStopsFromWork)
     scheduler.scheduleWorkOnMainLoop(work);
     scheduler.runMainLoop();
     ASSERT_TRUE(called);
+}
+
+// A callback can drop the last reference to the scheduler, which is then destroyed on one of its
+// own workers. That release has to return: an executor waiting for the task that is destroying it
+// never finishes.
+TEST_F(SchedulerTestCommon, LastReferenceReleasedFromWorker)
+{
+    using namespace std::chrono_literals;
+
+    const auto logger = Logger();
+
+    std::promise<void> mainReleased;
+    auto mainReleasedFuture = mainReleased.get_future().share();
+    std::promise<void> workerReleased;
+    auto workerReleasedFuture = workerReleased.get_future();
+
+    // dies with the callback, i.e. once the worker has finished the task
+    auto token = std::make_shared<int>(0);
+    std::weak_ptr<int> callbackAlive = token;
+
+    {
+        auto scheduler = Scheduler(logger, 2);
+        auto work = Work([scheduler, token = std::move(token), mainReleasedFuture, &workerReleased]() mutable
+        {
+            mainReleasedFuture.wait();
+            scheduler.release();  // the last reference: ~SchedulerImpl runs on this worker
+            workerReleased.set_value();
+        });
+        scheduler.scheduleWork(work);
+    }
+    mainReleased.set_value();
+
+    ASSERT_EQ(workerReleasedFuture.wait_for(5s), std::future_status::ready)
+        << "destroying the scheduler from its own worker deadlocked";
+
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (!callbackAlive.expired() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(1ms);
+    ASSERT_TRUE(callbackAlive.expired());
 }
 
 TEST_F(SchedulerTestCommon, ExecutesOneTimeWorkWithTimeLoop)

--- a/core/opendaq/scheduler/tests/test_scheduler.cpp
+++ b/core/opendaq/scheduler/tests/test_scheduler.cpp
@@ -198,9 +198,7 @@ TEST_F(SchedulerTestCommon, StartsAndStopsFromWork)
     ASSERT_TRUE(called);
 }
 
-// A callback can drop the last reference to the scheduler, which is then destroyed on one of its
-// own workers. That release has to return: an executor waiting for the task that is destroying it
-// never finishes.
+// Releasing the last reference from a work callback destroys the scheduler on its own worker.
 TEST_F(SchedulerTestCommon, LastReferenceReleasedFromWorker)
 {
     using namespace std::chrono_literals;
@@ -212,7 +210,7 @@ TEST_F(SchedulerTestCommon, LastReferenceReleasedFromWorker)
     std::promise<void> workerReleased;
     auto workerReleasedFuture = workerReleased.get_future();
 
-    // dies with the callback, i.e. once the worker has finished the task
+    // destroyed with the callback, once the worker is done with the task
     auto token = std::make_shared<int>(0);
     std::weak_ptr<int> callbackAlive = token;
 

--- a/examples/modules/audio_device_module/tests/test_fb_wav_writer.cpp
+++ b/examples/modules/audio_device_module/tests/test_fb_wav_writer.cpp
@@ -64,6 +64,12 @@ protected:
         writerFb = module.createFunctionBlock("AudioDeviceModuleWavWriter", nullptr, "writer");
         writerRe = writerFb;
     }
+
+    void TearDown() override
+    {
+        // Drain and join the scheduler before the fixture releases its objects.
+        context.getScheduler().stop();
+    }
 };
 
 TEST_F(WavWriterTest, ValidWriteToFile)


### PR DESCRIPTION
# Brief

Nothing in openDAQ stops the scheduler explicitly, so it is destroyed when the last reference to the context is released — which can happen on one of the scheduler's own worker threads if objects are released while work is still queued. 

The worker then waits for itself to finish and hangs forever. If the process exits instead, it can crash because the thread pool's shared memory is torn down while workers are still using it. This is the cause of the intermittent `test_audio_device_module` failures on CI.

# Changes:

- `SchedulerImpl::stop()` now detects when it runs on one of its own workers and hands the executor's destruction off to a separate thread instead of blocking on it.
- The wav writer test now stops the scheduler before teardown, so the process no longer exits with work in flight.
- Added a regression test for releasing the last scheduler reference from a worker.
