### PR TITLE
Bound the producer in DataPathTest.StressSendVariantsUnderChurn

### DIFF
--- a/core/opendaq/signal/tests/test_data_path.cpp
+++ b/core/opendaq/signal/tests/test_data_path.cpp
@@ -758,46 +758,50 @@ TEST_F(DataPathTest, StressSendVariantsUnderChurn)
     const auto sigDesc = plainDescriptor(SampleType::Int64);
     const auto signal = makeSignal(sigDesc);
 
+    // Fixed count: an open-ended producer outruns the bursty drains below and the queue grows by gigabytes.
+    constexpr int64_t iterations = 50000;
     std::atomic<int64_t> sent{0};
-    BackgroundLoop producer(
-        [&, i = 0]() mutable
+    std::thread producer(
+        [&]
         {
-            switch (i % 4)
+            for (int64_t i = 0; i < iterations; ++i)
             {
-                case 0:  // single, by const ref
+                switch (i % 4)
                 {
-                    auto p = DataPacket(sigDesc, 4);
-                    signal.sendPacket(p);
-                    break;
+                    case 0:  // single, by const ref
+                    {
+                        auto p = DataPacket(sigDesc, 4);
+                        signal.sendPacket(p);
+                        break;
+                    }
+                    case 1:  // multiple, by const ref
+                    {
+                        auto list = List<IPacket>();
+                        list.pushBack(DataPacket(sigDesc, 4));
+                        list.pushBack(DataPacket(sigDesc, 4));
+                        signal.sendPackets(list);
+                        break;
+                    }
+                    case 2:  // single, steal ref (rvalue overload)
+                        signal.sendPacket(DataPacket(sigDesc, 4));
+                        break;
+                    case 3:  // multiple, steal ref
+                    {
+                        auto list = List<IPacket>();
+                        list.pushBack(DataPacket(sigDesc, 4));
+                        list.pushBack(DataPacket(sigDesc, 4));
+                        signal.sendPackets(std::move(list));
+                        break;
+                    }
                 }
-                case 1:  // multiple, by const ref
-                {
-                    auto list = List<IPacket>();
-                    list.pushBack(DataPacket(sigDesc, 4));
-                    list.pushBack(DataPacket(sigDesc, 4));
-                    signal.sendPackets(list);
-                    break;
-                }
-                case 2:  // single, steal ref (rvalue overload)
-                    signal.sendPacket(DataPacket(sigDesc, 4));
-                    break;
-                case 3:  // multiple, steal ref
-                {
-                    auto list = List<IPacket>();
-                    list.pushBack(DataPacket(sigDesc, 4));
-                    list.pushBack(DataPacket(sigDesc, 4));
-                    signal.sendPackets(std::move(list));
-                    break;
-                }
+                sent.fetch_add(1, std::memory_order_relaxed);
             }
-            ++i;
-            sent.fetch_add(1, std::memory_order_relaxed);
         });
 
     while (sent.load(std::memory_order_relaxed) == 0)
         std::this_thread::yield();
 
-    for (int round = 0; round < 150; ++round)
+    for (int round = 0; round < 150 || sent.load(std::memory_order_relaxed) < iterations; ++round)
     {
         auto ep = attach(signal);
         for (int d = 0; d < 20; ++d)
@@ -806,7 +810,7 @@ TEST_F(DataPathTest, StressSendVariantsUnderChurn)
     }
 
     producer.join();
-    ASSERT_GT(sent.load(), 0);
+    ASSERT_EQ(sent.load(), iterations);
 }
 
 // ===== Tier 2: semantic edges of the new designs =====


### PR DESCRIPTION
# Brief

Bound the producer in `DataPathTest.StressSendVariantsUnderChurn`. Left open-ended, it could grow the connection queue by tens of gigabytes, which is what gets `test_signal` killed on `ubuntu-24.04-x86_64-ninja-clang-18-release`.

# Description

- The test's `BackgroundLoop` producer sent packets flat out for the whole run. It now sends a fixed 50 000 iterations (75 000 packets); the connection churn still runs its 150 rounds, and keeps going until the last packet is out.
- Nothing outside the test changes.

### What goes wrong today

The main thread churns connections: 150 × (attach → 20 × `dequeueAll` → disconnect), while the producer thread sends single packets, lists, and their steal-ref variants without any backpressure. Per packet the consumer does more work than the producer — `drainInbox` reverses the lock-free chain, adopts and recycles each node, appends to the deque; `dequeueAll` copies everything into a `List`, which the test then releases one refcount at a time. Whenever scheduling lets the producer get ahead, each drain takes longer, the producer gets further ahead, and the queue runs away until `disconnect()` drops it.

Measured on Ubuntu 24.04 / clang 18 / Release with the `ci` preset's options, tests pinned to 4 CPUs like a runner:

| | result |
| --- | --- |
| `test_signal` without this test, 20 runs | 0.4 s, 40 MB, every run |
| full `test_signal`, 50 runs | 10 runs took 3.7 s – 295 s and peaked at 0.4 – **28.6 GB**; all "passed" |
| this test alone, 20 runs | bimodal: 0.02 s, or minutes and 2 – **42 GB**; 7 of 20 OOM-killed at a 32 GB cap or hit a 900 s timeout |
| same on `main` | same |
| same with `OPENDAQ_ENABLE_OBJECT_POOLS=OFF` | same — the pools are not the amplifier |

On a 16 GB GitHub runner the OOM killer ends the process, which ctest reports as `test_signal ... Subprocess killed***Exception` at an arbitrary time — 70 s on #1296 (2026-09-10) and 180 s on #1299 (2026-09-12).

### The fix

A fixed packet count bounds the queue whatever the scheduling: at most 75 000 packets can ever be queued, a few tens of MB. The churn loop runs for at least the original 150 rounds and until the producer has finished, so all four send forms still meet attach and disconnect while they are running.

# Usage example

None.

# API changes

None.

# Required application changes

None.

# Required module changes

None.

# Verification

Same container, same pinning:

| | before | after |
| --- | --- | --- |
| this test alone | 7 of 20 killed or timed out, up to 42 GB | **30 of 30** in 0.03 – 0.05 s, 21 – 27 MB |
| full `test_signal` | 10 of 50 runs slow, up to 28.6 GB | **10 of 10** in 0.4 s, 36 – 40 MB, 430 tests passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
